### PR TITLE
Fix BGReplay protected member access

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -161,11 +161,16 @@ namespace
         botSession->SetPlayer(bot);
         bot->GetMotionMaster()->Initialize();
 
-        CharacterCreateInfo createInfo;
-        createInfo.Name = "ReplayBot";
-        createInfo.Race = RACE_HUMAN;
-        createInfo.Class = CLASS_MAGE;
-        createInfo.Gender = GENDER_MALE;
+        struct ReplayBotCreateInfo : CharacterCreateInfo
+        {
+            ReplayBotCreateInfo()
+            {
+                Name = "ReplayBot";
+                Race = RACE_HUMAN;
+                Class = CLASS_MAGE;
+                Gender = GENDER_MALE;
+            }
+        } createInfo;
 
         bot->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo);
 


### PR DESCRIPTION
## Summary
- subclass CharacterCreateInfo in BGReplay to set replay bot data

## Testing
- `bash contrib/check_codestyle.sh` *(fails: Remove whitespace at the end of the lines above)*
- `cmake ..` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_68490c3db3f88327b0e387a98524343d