### PR TITLE
Allow self ghost without GUID conflicts

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -237,9 +237,21 @@ public:
         if (record.startTime == 0)
         {
             record.startTime = GameTime::GetGameTimeMS() - bg->GetStartTime();
-            Player* bot = replayBots[bg->GetInstanceID()];
-            record.allianceRecorder = bot->GetGUID();
-            record.hordeRecorder = bot->GetGUID();
+            for (auto const& itr : bg->GetPlayers())
+            {
+                ObjectGuid guid = itr.first;
+                if (Player* plr = ObjectAccessor::FindPlayer(guid))
+                {
+                    uint32 team = plr->GetBGTeam();
+                    if (team == ALLIANCE && record.allianceRecorder.IsEmpty())
+                        record.allianceRecorder = plr->GetGUID();
+                    else if (team == HORDE && record.hordeRecorder.IsEmpty())
+                        record.hordeRecorder = plr->GetGUID();
+
+                    if (!record.allianceRecorder.IsEmpty() && !record.hordeRecorder.IsEmpty())
+                        break;
+                }
+            }
         }
 
         uint32 timestamp = GameTime::GetGameTimeMS() - record.startTime;


### PR DESCRIPTION
## Summary
- store actual player GUIDs when recording arena replays
- always remap a spectator's GUID if they were recorded
- drop the unused `Replay.ShowSelfGhost` option

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_68491a8500508327a80b47491254e892