### PR TITLE
Fix ReplayBot initialization order

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -223,7 +223,6 @@ namespace
             2, 0, Minutes(0), LOCALE_enUS, 0, false);
         Player* bot = new Player(botSession);
         botSession->SetPlayer(bot);
-        bot->GetMotionMaster()->Initialize();
 
         struct ReplayBotCreateInfo : CharacterCreateInfo
         {
@@ -237,6 +236,7 @@ namespace
         } createInfo;
 
         bot->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo);
+        bot->GetMotionMaster()->Initialize();
 
         bot->SetGameMaster(true);
         bot->SetGMVisible(false);


### PR DESCRIPTION
## Summary
- avoid calling MotionMaster before Player::Create in BGReplay

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849dc92db2483279e441b4f776a100c