### PR TITLE
Fix ReplayBot initialization order

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -222,7 +222,6 @@ namespace
         WorldSession* botSession = new WorldSession(0, "ReplayBot", nullptr, SEC_ADMINISTRATOR,
             2, 0, Minutes(0), LOCALE_enUS, 0, false);
         Player* bot = new Player(botSession);
-        botSession->SetPlayer(bot);
 
         struct ReplayBotCreateInfo : CharacterCreateInfo
         {
@@ -236,6 +235,7 @@ namespace
         } createInfo;
 
         bot->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo);
+        botSession->SetPlayer(bot);
         bot->GetMotionMaster()->Initialize();
 
         bot->SetGameMaster(true);


### PR DESCRIPTION
## Summary
- fix new ReplayBot crash by setting the session's player after creation

## Testing
- `bash contrib/check_codestyle.sh` *(fails: Remove whitespace at the end of the lines above)*

------
https://chatgpt.com/codex/tasks/task_e_6849f409701083278f879e198673d8ce