### PR TITLE
Fix replay socket blocking and extend replay visibility

### DIFF
--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -351,6 +351,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         virtual void Update(uint32);
 
         float GetVisibilityRange() const { return m_VisibleDistance; }
+        void SetVisibilityRange(float range) { m_VisibleDistance = range; }
         //function for setting up visibility distance for maps on per-type/per-Id basis
         virtual void InitVisibilityDistance();
 

--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -8,8 +8,10 @@
 #include "BattlegroundMgr.h"
 #include "ScriptMgr.h"
 #include "WorldSession.h"
+#include "WorldSocket.h"
 #include "Log.h"
 #include "Map.h"
+#include "ObjectDefines.h"
 #include "ObjectMgr.h"
 #include "GameTime.h"
 #include "Random.h"
@@ -231,8 +233,8 @@ namespace
             tcp::acceptor acceptor(io, tcp::endpoint(tcp::v4(), 0));
             tcp::socket server(io);
             tcp::socket client(io);
-            acceptor.async_accept(server);
             client.connect(acceptor.local_endpoint());
+            acceptor.accept(server);
             io.poll();
             acceptor.close();
             server.close();
@@ -529,6 +531,7 @@ public:
             player->SetIsSpectator(true);
             bg->toggleReplay(player->GetGUID());
             player->SetPendingSpectatorForBG(bg->GetInstanceID());
+            bg->GetBgMap()->SetVisibilityRange(MAX_VISIBILITY_DISTANCE);
             bg->StartBattleground();
 
             BattlegroundTypeId bgTypeId = bg->GetTypeID();


### PR DESCRIPTION
## Summary
- add `SetVisibilityRange` helper in Map
- expand includes and enlarge replay map visibility
- fix ReplaySocket creation order to avoid blocking

## Testing
- `cmake .. -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1` *(fails to find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ac3368883278b8fa7bb23a929c6