### PR TITLE
Fix ReplaySocket connect to loopback

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -233,7 +233,8 @@ namespace
             tcp::acceptor acceptor(io, tcp::endpoint(tcp::v4(), 0));
             tcp::socket server(io);
             tcp::socket client(io);
-            client.connect(acceptor.local_endpoint());
+            client.connect(tcp::endpoint(boost::asio::ip::address_v4::loopback(),
+                                         acceptor.local_endpoint().port()));
             acceptor.accept(server);
             io.poll();
             acceptor.close();


### PR DESCRIPTION
## Summary
- fix ReplaySocket connection endpoint

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_684a3bf5dcbc832797fd8876e61de47a