### PR TITLE
Fix spectator cleanup in arena replay

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -313,8 +313,8 @@ public:
 
         //ignore packet when no bg or casual games
         if (bg == nullptr || bg->IsReplay()) return;
-        //ignore packets until arena started
-        if (bg->GetStatus() != BattlegroundStatus::STATUS_IN_PROGRESS) return;
+        // ignore packets before players have entered the battleground
+        if (bg->GetStatus() <= BattlegroundStatus::STATUS_WAIT_QUEUE) return;
 
 
         // ensure the record container exists for this battleground instance
@@ -401,31 +401,30 @@ public:
             bg->SetStartDelayTime(5000);
             bg->SetStartTime(bg->GetStartTime() + (startDelayTime - 5000));
         }
-        if (bg->GetStatus() != BattlegroundStatus::STATUS_IN_PROGRESS) return;
+        if (bg->GetStatus() < BattlegroundStatus::STATUS_WAIT_JOIN) return;
 
         //retrieve replay data
         auto it = loadedReplays.find(bg->GetReplayId());
         if (it == loadedReplays.end()) return;
         MatchRecord& match = it->second;
 
-        //if replay ends or spectator left > free replay data and/or kick player
-        if (match.packets.empty() || bg->GetPlayers().empty()) {
+        // free data once all spectators have left or the replay is finished
+        if (match.packets.empty() || !bg->HaveSpectators()) {
             loadedReplays.erase(it);
-
-            if (!bg->GetPlayers().empty())
+            if (bg->HaveSpectators())
             {
                 uint32 playerGUID = bg->GetReplayId();
                 bg->EndNow();
                 bg->toggleReplay(0);
-                Player* player = ObjectAccessor::FindPlayerByLowGUID(playerGUID);
-                player->LeaveBattleground(bg);
+                if (Player* player = ObjectAccessor::FindPlayerByLowGUID(playerGUID))
+                    player->LeaveBattleground(bg);
             }
             return;
         }
 
         //send replay data to spectator
         while (!match.packets.empty() && match.packets.front().timestamp <= bg->GetStartTime()) {
-            if (bg->GetPlayers().empty())
+            if (!bg->HaveSpectators())
                 break;
             uint32 playerGUID = bg->GetReplayId();
             Player* player = ObjectAccessor::FindPlayerByLowGUID(playerGUID);


### PR DESCRIPTION
## Summary
- avoid ending replays just because no players are in the battleground
- continue sending packets while spectators remain in the arena

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_684a6471ede883278e6cb390414ba3fd