### PR TITLE
Fix BGReplay bot spawn when battleground map isn't ready

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -326,12 +326,18 @@ public:
 
         MatchRecord& record = records[bg->GetInstanceID()];
 
+        BattlegroundMap* map = bg->FindBgMap();
+        if (!map)
+            return; // map hasn't been created yet
+
+        // player hasn't teleported into the battleground instance
+        if (session->GetPlayer()->GetMap() != map)
+            return;
+
         uint32 instanceId = bg->GetInstanceID();
         if (!replayBots[instanceId])
         {
             if (creatingReplayBots.count(instanceId))
-                return;
-            if (!bg->FindBgMap())
                 return;
 
             creatingReplayBots.insert(instanceId);

--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -251,6 +251,8 @@ namespace
 
     Player* CreateReplayBot(Battleground* bg)
     {
+        if (!bg->FindBgMap())
+            return nullptr;
         WorldSession* botSession = new WorldSession(0, "ReplayBot", std::make_shared<ReplaySocket>(), SEC_ADMINISTRATOR,
             2, 0, Minutes(0), LOCALE_enUS, 0, false);
         Player* bot = new Player(botSession);
@@ -328,6 +330,8 @@ public:
         if (!replayBots[instanceId])
         {
             if (creatingReplayBots.count(instanceId))
+                return;
+            if (!bg->FindBgMap())
                 return;
 
             creatingReplayBots.insert(instanceId);


### PR DESCRIPTION
## Summary
- avoid creating replay bot before the battleground map exists
- guard CreateReplayBot against null map

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_684b2f1620dc832788421019cd7de447