### PR TITLE
Fix chrono literal support on MSVC

### DIFF
--- a/src/common/Utilities/Duration.h
+++ b/src/common/Utilities/Duration.h
@@ -21,9 +21,8 @@
 // HACKS TERRITORY
 #if __has_include(<__msvc_chrono.hpp>)
 #include <__msvc_chrono.hpp> // skip all the formatting/istream/locale/mutex bloat
-#else
-#include <chrono>
 #endif
+#include <chrono>
 
 /// Milliseconds shorthand typedef.
 typedef std::chrono::milliseconds Milliseconds;
@@ -41,8 +40,11 @@ typedef std::chrono::hours Hours;
 typedef std::chrono::steady_clock::time_point TimePoint;
 typedef std::chrono::system_clock::time_point SystemTimePoint;
 
-/// Makes std::chrono_literals globally available.
+/// Makes chrono user-defined literals globally available.
+using namespace std::literals::chrono_literals;
+#if !defined(_MSC_VER)
 using namespace std::chrono_literals;
+#endif
 
 constexpr std::chrono::hours operator""_days(unsigned long long days)
 {


### PR DESCRIPTION
## Summary
- always include `<chrono>` even when `<__msvc_chrono.hpp>` is available so that chrono literal namespaces are declared
- expose chrono literals globally through `std::literals::chrono_literals` with a fallback guard for `std::chrono_literals` on non-MSVC builds

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd610548f08327a9ae82d47f6e644d