### PR TITLE
Fix Duration header to use standard chrono

### DIFF
--- a/src/common/Utilities/Duration.h
+++ b/src/common/Utilities/Duration.h
@@ -19,9 +19,6 @@
 #define _DURATION_H_
 
 // HACKS TERRITORY
-#if __has_include(<__msvc_chrono.hpp>)
-#include <__msvc_chrono.hpp> // skip all the formatting/istream/locale/mutex bloat
-#endif
 #include <chrono>
 
 /// Milliseconds shorthand typedef.
@@ -48,7 +45,7 @@ using namespace std::chrono_literals;
 
 constexpr std::chrono::hours operator""_days(unsigned long long days)
 {
-    return std::chrono::hours(days * 24h);
+    return std::chrono::hours(24) * days;
 }
 
 #endif // _DURATION_H_

--- a/src/server/database/Updater/UpdateFetcher.cpp
+++ b/src/server/database/Updater/UpdateFetcher.cpp
@@ -23,6 +23,7 @@
 #include "Log.h"
 #include "QueryResult.h"
 #include "Util.h"
+#include <chrono>
 #include <boost/filesystem/operations.hpp>
 #include <fstream>
 #include <sstream>
@@ -347,7 +348,7 @@ UpdateResult UpdateFetcher::Update(bool const redundancyChecks,
 
 uint32 UpdateFetcher::Apply(Path const& path) const
 {
-    using Time = std::chrono::high_resolution_clock;
+    using Time = std::chrono::steady_clock;
 
     // Benchmark query speed
     auto const begin = Time::now();

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -42,6 +42,10 @@
 #include "Weather.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 
 // Trait which indicates whether this script type
 // must be assigned in the database.
@@ -338,24 +342,30 @@ template<typename ObjectType, typename ScriptType, typename Base>
 class CreatureGameObjectScriptRegistrySwapHooks
     : public ScriptRegistrySwapHookBase
 {
-    template<typename W>
-    class AIFunctionMapWorker
+    template<typename VisitorType>
+    class AISwapVisitor
     {
     public:
-        template<typename T>
-        AIFunctionMapWorker(T&& worker)
-            : _worker(std::forward<T>(worker)) { }
+        AISwapVisitor(std::unordered_set<uint32> const& ids, VisitorType&& visitor)
+            : idsToRemove_(ids), visitor_(std::move(visitor)) { }
 
         void Visit(std::unordered_map<ObjectGuid, ObjectType*>& objects)
         {
-            _worker(objects);
+            for (auto const& object : objects)
+            {
+                // When the script Id of the script isn't removed in this
+                // context change, do nothing.
+                if (idsToRemove_.find(object.second->GetScriptId()) != idsToRemove_.end())
+                    visitor_(object.second);
+            }
         }
 
         template<typename O>
         void Visit(std::unordered_map<ObjectGuid, O*>&) { }
 
     private:
-        W _worker;
+        std::unordered_set<uint32> const& idsToRemove_;
+        VisitorType visitor_;
     };
 
     class AsyncCastHotswapEffectEvent : public BasicEvent
@@ -471,21 +481,13 @@ class CreatureGameObjectScriptRegistrySwapHooks
     }
 
     template<typename T>
-    static void VisitObjectsToSwapOnMap(Map* map, std::unordered_set<uint32> const& idsToRemove, T visitor)
+    static void VisitObjectsToSwapOnMap(Map* map, std::unordered_set<uint32> const& idsToRemove, T&& visitor)
     {
-        auto evaluator = [&](std::unordered_map<ObjectGuid, ObjectType*>& objects)
-        {
-            for (auto object : objects)
-            {
-                // When the script Id of the script isn't removed in this
-                // context change, do nothing.
-                if (idsToRemove.find(object.second->GetScriptId()) != idsToRemove.end())
-                    visitor(object.second);
-            }
-        };
+        using VisitorType = std::decay_t<T>;
 
-        AIFunctionMapWorker<typename std::decay<decltype(evaluator)>::type> worker(std::move(evaluator));
-        TypeContainerVisitor<decltype(worker), MapStoredObjectTypesContainer> containerVisitor(worker);
+        VisitorType visitorWrapper(std::forward<T>(visitor));
+        AISwapVisitor<VisitorType> worker(idsToRemove, std::move(visitorWrapper));
+        TypeContainerVisitor<AISwapVisitor<VisitorType>, MapStoredObjectTypesContainer> containerVisitor(worker);
 
         containerVisitor.Visit(map->GetObjectsStore());
     }


### PR DESCRIPTION
## Summary
- include the standard `<chrono>` header instead of the internal MSVC implementation header
- rework the `_days` literal to use standard chrono arithmetic so MSVC can locate required symbols
- include `<chrono>` in the database updater and use `steady_clock` so MSVC finds the timing utilities it needs
- refactor the script swap visitor to use an explicit worker class and add the STL headers MSVC requires for overload resolution

## Testing
- not run (Visual Studio toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d30a986f348327b9d41f6fc10c7830