### PR TITLE
Ensure battleground object respawns refresh active clients

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1531,7 +1531,11 @@ void Battleground::SpawnBGObject(uint32 type, uint32 respawntime)
                 obj->SetLootState(GO_READY);
             }
             obj->SetRespawnTime(respawntime);
-            map->AddToMap(obj);
+
+            if (!obj->IsInWorld())
+                map->AddToMap(obj);
+            else if (!respawntime)
+                obj->UpdateObjectVisibility(true);
         }
 }
 


### PR DESCRIPTION
## Summary
- refresh battleground game objects that respawn immediately so already connected players receive the spawn update

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9fc4b43248327ac218a223712a4a3