### PR TITLE
Auto-queue battleground ghosts for spirit healers

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -44,6 +44,7 @@
 #include "WorldSession.h"
 #include "Item.h"
 #include <cstdarg>
+#include <limits>
 
 void BattlegroundScore::AppendToPacket(WorldPacket& data)
 {
@@ -1871,6 +1872,36 @@ void Battleground::SetBgRaid(uint32 TeamID, Group* bg_raid)
 WorldSafeLocsEntry const* Battleground::GetClosestGraveyard(Player* player)
 {
     return sObjectMgr->GetClosestGraveyard(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetMapId(), player->GetTeam());
+}
+
+Creature* Battleground::GetClosestSpiritGuideForTeam(Position const& position, TeamId teamId) const
+{
+    if (teamId != TEAM_ALLIANCE && teamId != TEAM_HORDE)
+        return nullptr;
+
+    uint32 spiritGuideEntry = teamId == TEAM_ALLIANCE ? BG_CREATURE_ENTRY_A_SPIRITGUIDE : BG_CREATURE_ENTRY_H_SPIRITGUIDE;
+
+    Creature* closestGuide = nullptr;
+    float closestDistanceSq = std::numeric_limits<float>::max();
+
+    for (ObjectGuid const& guid : BgCreatures)
+    {
+        if (!guid)
+            continue;
+
+        Creature* creature = GetBgMap()->GetCreature(guid);
+        if (!creature || creature->GetEntry() != spiritGuideEntry)
+            continue;
+
+        float distanceSq = creature->GetExactDistSq(position.GetPositionX(), position.GetPositionY(), position.GetPositionZ());
+        if (distanceSq < closestDistanceSq)
+        {
+            closestDistanceSq = distanceSq;
+            closestGuide = creature;
+        }
+    }
+
+    return closestGuide;
 }
 
 void Battleground::StartTimedAchievement(AchievementCriteriaTimedTypes type, uint32 entry)

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -459,6 +459,7 @@ class TC_GAME_API Battleground
 
         // Death related
         virtual WorldSafeLocsEntry const* GetClosestGraveyard(Player* player);
+        Creature* GetClosestSpiritGuideForTeam(Position const& position, TeamId teamId) const;
 
         virtual void AddPlayer(Player* player);                // must be implemented in BG subclass
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4994,7 +4994,8 @@ void Player::RepopAtGraveyard()
     WorldSafeLocsEntry const* ClosestGrave;
 
     // Special handle for battleground maps
-    if (Battleground* bg = GetBattleground())
+    Battleground* bg = GetBattleground();
+    if (bg)
         ClosestGrave = bg->GetClosestGraveyard(this);
     else
     {
@@ -5018,6 +5019,34 @@ void Player::RepopAtGraveyard()
             packet.MapID = ClosestGrave->Continent;
             packet.Loc = Position(ClosestGrave->Loc.X, ClosestGrave->Loc.Y, ClosestGrave->Loc.Z);
             GetSession()->SendPacket(packet.Write());
+
+            if (bg && !shouldResurrect)
+            {
+                uint32 team = GetBGTeam();
+                if (!team)
+                    team = GetTeam();
+
+                Creature* spiritGuide = nullptr;
+
+                if (team == ALLIANCE || team == HORDE)
+                {
+                    TeamId teamId = Battleground::GetTeamIndexByTeamId(team);
+                    Position gravePosition(ClosestGrave->Loc.X, ClosestGrave->Loc.Y, ClosestGrave->Loc.Z, 0.0f);
+                    spiritGuide = bg->GetClosestSpiritGuideForTeam(gravePosition, teamId);
+                }
+
+                if (!spiritGuide)
+                {
+                    uint32 spiritGuideEntry = team == ALLIANCE ? BG_CREATURE_ENTRY_A_SPIRITGUIDE : BG_CREATURE_ENTRY_H_SPIRITGUIDE;
+                    spiritGuide = FindNearestCreature(spiritGuideEntry, 200.0f, false);
+                }
+
+                if (spiritGuide)
+                {
+                    bg->AddPlayerToResurrectQueue(spiritGuide->GetGUID(), GetGUID());
+                    sBattlegroundMgr->SendAreaSpiritHealerQueryOpcode(this, bg, spiritGuide->GetGUID());
+                }
+            }
         }
     }
     else if (GetPositionZ() < GetMap()->GetMinHeight(GetPositionX(), GetPositionY()))


### PR DESCRIPTION
## Summary
- automatically add dead battleground players to the nearest spirit guide when they release at a graveyard
- send the resurrection timer packet so the battleground UI opens without manual interaction
- look up the closest team spirit guide from battleground spawns when releasing to guarantee the queue is filled even if the ghost spawns far away

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9fbe7bc488327ad909db9e488cca6