### PR TITLE
Add dedicated disconnect and crash logging

### DIFF
--- a/src/common/Debugging/Errors.cpp
+++ b/src/common/Debugging/Errors.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Errors.h"
+#include "Log.h"
 #include "StringFormat.h"
 #include <cstdio>
 #include <cstdlib>
@@ -71,6 +72,7 @@ namespace Trinity
 void Assert(char const* file, int line, char const* function, std::string debugInfo, char const* message)
 {
     std::string formattedMessage = StringFormat("\n{}:{} in {} ASSERTION FAILED:\n  {}\n", file, line, function, message) + debugInfo + '\n';
+    TC_LOG_FATAL("server.crash", "{}", formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
     Crash(formattedMessage.c_str());
@@ -84,6 +86,7 @@ void Assert(char const* file, int line, char const* function, std::string debugI
     std::string formattedMessage = StringFormat("\n{}:{} in {} ASSERTION FAILED:\n  {}\n", file, line, function, message) + FormatAssertionMessage(format, args) + '\n' + debugInfo + '\n';
     va_end(args);
 
+    TC_LOG_FATAL("server.crash", "{}", formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
 
@@ -98,6 +101,7 @@ void Fatal(char const* file, int line, char const* function, char const* message
     std::string formattedMessage = StringFormat("\n{}:{} in {} FATAL ERROR:\n", file, line, function) + FormatAssertionMessage(message, args) + '\n';
     va_end(args);
 
+    TC_LOG_FATAL("server.crash", "{}", formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
 
@@ -108,6 +112,7 @@ void Fatal(char const* file, int line, char const* function, char const* message
 void Error(char const* file, int line, char const* function, char const* message)
 {
     std::string formattedMessage = StringFormat("\n{}:{} in {} ERROR:\n  {}\n", file, line, function, message);
+    TC_LOG_FATAL("server.crash", "{}", formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
     Crash(formattedMessage.c_str());
@@ -122,6 +127,7 @@ void Warning(char const* file, int line, char const* function, char const* messa
 void Abort(char const* file, int line, char const* function)
 {
     std::string formattedMessage = StringFormat("\n{}:{} in {} ABORTED.\n", file, line, function);
+    TC_LOG_FATAL("server.crash", "{}", formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
     Crash(formattedMessage.c_str());
@@ -135,6 +141,7 @@ void Abort(char const* file, int line, char const* function, char const* message
     std::string formattedMessage = StringFormat("\n{}:{} in {} ABORTED:\n", file, line, function) + FormatAssertionMessage(message, args) + '\n';
     va_end(args);
 
+    TC_LOG_FATAL("server.crash", "{}", formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
 
@@ -145,6 +152,7 @@ void AbortHandler(int sigval)
 {
     // nothing useful to log here, no way to pass args
     std::string formattedMessage = StringFormat("Caught signal {}\n", sigval);
+    TC_LOG_FATAL("server.crash", "{}", formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
     Crash(formattedMessage.c_str());

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -640,6 +640,7 @@ void WorldSession::KickPlayer(std::string const& reason)
     {
         TC_LOG_INFO("network.kick", "Account: {} Character: '{}' {} kicked with reason: {}", GetAccountId(), _player ? _player->GetName() : "<none>",
             _player ? _player->GetGUID().ToString() : "", reason);
+        TC_LOG_INFO("network.disconnect", "{} kicked from server (IP: {}) Reason: {}", GetPlayerInfo(), GetRemoteAddress(), reason);
 
         m_Socket->CloseSocket();
         forceExit = true;

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -137,8 +137,12 @@ void WorldSocket::HandleSendAuthSession()
 
 void WorldSocket::OnClose()
 {
+    std::string const remoteIp = GetRemoteIpAddress().to_string();
+
+    std::lock_guard<std::mutex> sessionGuard(_worldSessionLock);
+    if (_worldSession)
     {
-        std::lock_guard<std::mutex> sessionGuard(_worldSessionLock);
+        TC_LOG_INFO("network.disconnect", "{} connection closed (IP: {}).", _worldSession->GetPlayerInfo(), remoteIp);
         _worldSession = nullptr;
     }
 }

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3933,6 +3933,7 @@ Appender.Console=1,3,0
 Appender.Server=2,2,0,Server.log,w
 Appender.GM=2,2,1,GM.log
 Appender.DBErrors=2,2,0,DBErrors.log
+Appender.Disconnect=2,3,0,Disconnects.log
 
 #  Logger config values: Given a logger "name"
 #    Logger.name
@@ -3958,6 +3959,8 @@ Logger.commands.gm=3,Console GM
 Logger.scripts.hotswap=3,Console Server
 Logger.sql.sql=5,Console DBErrors
 Logger.sql.updates=3,Console Server
+Logger.network.disconnect=3,Console Server Disconnect
+Logger.server.crash=6,Console Server Disconnect
 Logger.mmaps=3,Server
 
 #Logger.achievement=3,Console Server


### PR DESCRIPTION
## Summary
- log player disconnects through a new `network.disconnect` logger so they can be captured in a dedicated file
- forward fatal/assert/abort crash messages to the logging system via the `server.crash` logger
- add configuration for the new `Disconnects.log` appender and associated loggers in `worldserver.conf.dist`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db081cd548832796939a5d30782adf