### PR TITLE
Prevent pets from using steep ground paths

### DIFF
--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -688,8 +688,11 @@ void PathGenerator::UpdateFilter()
         }
 
         if (Creature const* _sourceCreature = _source->ToCreature())
-            if (_sourceCreature->IsInCombat() || _sourceCreature->IsInEvadeMode())
-                _filter.setIncludeFlags(_filter.getIncludeFlags() | NAV_GROUND_STEEP);
+        {
+            if (!_sourceCreature->IsPet() && !_sourceCreature->IsControlledByPlayer())
+                if (_sourceCreature->IsInCombat() || _sourceCreature->IsInEvadeMode())
+                    _filter.setIncludeFlags(_filter.getIncludeFlags() | NAV_GROUND_STEEP);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid expanding pet pathfinding filters to include steep ground polygons when the creature is pet or otherwise player controlled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e050b31da08327be242df0aa44d7bc