### PR TITLE
Block direct fallback movement for player-controlled units

### DIFF
--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -688,8 +688,11 @@ void PathGenerator::UpdateFilter()
         }
 
         if (Creature const* _sourceCreature = _source->ToCreature())
-            if (_sourceCreature->IsInCombat() || _sourceCreature->IsInEvadeMode())
-                _filter.setIncludeFlags(_filter.getIncludeFlags() | NAV_GROUND_STEEP);
+        {
+            if (!_sourceCreature->IsPet() && !_sourceCreature->IsControlledByPlayer())
+                if (_sourceCreature->IsInCombat() || _sourceCreature->IsInEvadeMode())
+                    _filter.setIncludeFlags(_filter.getIncludeFlags() | NAV_GROUND_STEEP);
+        }
     }
 }
 

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -253,10 +253,25 @@ namespace Movement
         {
             PathGenerator path(unit);
             bool result = path.CalculatePath(dest.x, dest.y, dest.z, forceDestination);
-            if (result && !(path.GetPathType() & PATHFIND_NOPATH))
+            if (result)
             {
-                MovebyPath(path.GetPath());
-                return;
+                PathType const pathType = path.GetPathType();
+                if (!(pathType & PATHFIND_NOPATH))
+                {
+                    MovebyPath(path.GetPath());
+                    return;
+                }
+
+                bool const playerControlled = unit->IsControlledByPlayer() || unit->GetOwnerGUID().IsPlayer();
+                if (playerControlled && (pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)))
+                {
+                    args.path_Idx_offset = 0;
+                    args.path.resize(2);
+                    TransportPathTransform transform(unit, args.TransformForTransport);
+                    Vector3 stay(unit->GetPositionX(), unit->GetPositionY(), unit->GetPositionZ());
+                    args.path[1] = transform(stay);
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- prevent MoveSpline fallback from forcing player-controlled creatures along invalid direct paths when pathfinding reports no route

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e050b31da08327be242df0aa44d7bc