### PR TITLE
Add trap category cooldown reset helper and update hunter trap script

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -454,6 +454,31 @@ void SpellHistory::ResetCooldown(CooldownStorageType::iterator& itr, bool update
     itr = EraseCooldown(itr);
 }
 
+uint32 SpellHistory::ResetCategoryCooldown(uint32 categoryId, bool update /*= false*/)
+{
+    auto categoryItr = _categoryCooldowns.find(categoryId);
+    if (categoryItr == _categoryCooldowns.end())
+        return 0;
+
+    CooldownEntry* categoryEntry = categoryItr->second;
+    if (!categoryEntry)
+    {
+        _categoryCooldowns.erase(categoryItr);
+        return 0;
+    }
+
+    auto spellItr = _spellCooldowns.find(categoryEntry->SpellId);
+    if (spellItr == _spellCooldowns.end())
+    {
+        _categoryCooldowns.erase(categoryItr);
+        return 0;
+    }
+
+    uint32 spellId = spellItr->first;
+    ResetCooldown(spellItr, update);
+    return spellId;
+}
+
 void SpellHistory::ResetAllCooldowns()
 {
     if (GetPlayerOwner())

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -94,6 +94,7 @@ public:
     void ModifyCooldown(uint32 spellId, int32 cooldownModMs);
     void ResetCooldown(uint32 spellId, bool update = false);
     void ResetCooldown(CooldownStorageType::iterator& itr, bool update = false);
+    uint32 ResetCategoryCooldown(uint32 categoryId, bool update = false);
     template<typename Predicate>
     void ResetCooldowns(Predicate predicate, bool update = false)
     {

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1691,16 +1691,43 @@ class spell_hun_trap_cd_reduce : public SpellScript
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
-        uint32 cdreduce = GetEffectValue();
-        GetCaster()->GetSpellHistory()->ResetAllCooldowns();
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(13813, cdreduce);
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(14316, cdreduce);
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(14317, cdreduce);
+        Player* caster = GetCaster()->ToPlayer();
+        if (!caster)
+            return;
 
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(1499, cdreduce);
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(14310, cdreduce);
+        SpellHistory* spellHistory = caster->GetSpellHistory();
+        if (!spellHistory)
+            return;
 
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(14809, cdreduce);
+        static constexpr uint32 ImmolationTrapSpellIds[] = { 49056, 49055, 27023, 14305, 14304, 14303, 14302, 13795 };
+
+        SpellInfo const* categorySource = sSpellMgr->AssertSpellInfo(ImmolationTrapSpellIds[0]);
+        uint32 trapCategory = categorySource->GetCategory();
+        if (!trapCategory)
+            return;
+
+        uint32 removedSpellId = spellHistory->ResetCategoryCooldown(trapCategory);
+        if (!removedSpellId)
+            return;
+
+        bool isImmolationTrap = false;
+        for (uint32 trapSpellId : ImmolationTrapSpellIds)
+        {
+            if (trapSpellId == removedSpellId)
+            {
+                isImmolationTrap = true;
+                break;
+            }
+        }
+
+        if (!isImmolationTrap)
+            return;
+
+        if (SpellInfo const* removedSpellInfo = sSpellMgr->GetSpellInfo(removedSpellId))
+        {
+            if (uint32 cooldown = removedSpellInfo->GetRecoveryTime())
+                spellHistory->AddCooldown(removedSpellId, 0, std::chrono::milliseconds(cooldown));
+        }
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- add a SpellHistory::ResetCategoryCooldown helper that removes cooldowns tied to a given category
- update spell_hun_trap_cd_reduce to clear the trap category cooldown and restore the Immolation Trap spell cooldown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0bbea44348327a260d3920ae4ec67