### PR TITLE
Restrict pet stay commands to navigable terrain

### DIFF
--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -688,8 +688,11 @@ void PathGenerator::UpdateFilter()
         }
 
         if (Creature const* _sourceCreature = _source->ToCreature())
-            if (_sourceCreature->IsInCombat() || _sourceCreature->IsInEvadeMode())
-                _filter.setIncludeFlags(_filter.getIncludeFlags() | NAV_GROUND_STEEP);
+        {
+            if (!_sourceCreature->IsPet() && !_sourceCreature->IsControlledByPlayer())
+                if (_sourceCreature->IsInCombat() || _sourceCreature->IsInEvadeMode())
+                    _filter.setIncludeFlags(_filter.getIncludeFlags() | NAV_GROUND_STEEP);
+        }
     }
 }
 
@@ -1025,6 +1028,11 @@ void PathGenerator::ShortenPathUntilDist(G3D::Vector3 const& target, float dist)
 bool PathGenerator::IsInvalidDestinationZ(Unit const* target) const
 {
     return (target->GetPositionZ() - GetActualEndPosition().z) > 5.0f;
+}
+
+bool PathGenerator::HasNavigationData() const
+{
+    return _navMesh != nullptr && _navMeshQuery != nullptr;
 }
 
 void PathGenerator::AddFarFromPolyFlags(bool startFarFromPoly, bool endFarFromPoly)

--- a/src/server/game/Movement/PathGenerator.h
+++ b/src/server/game/Movement/PathGenerator.h
@@ -63,6 +63,7 @@ class TC_GAME_API PathGenerator
         // return: true if new path was calculated, false otherwise (no change needed)
         bool CalculatePath(float destX, float destY, float destZ, bool forceDest = false);
         bool IsInvalidDestinationZ(Unit const* target) const;
+        bool HasNavigationData() const;
 
         // option setters - use optional
         void SetUseStraightPath(bool useStraightPath) { _useStraightPath = useStraightPath; }

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -253,10 +253,32 @@ namespace Movement
         {
             PathGenerator path(unit);
             bool result = path.CalculatePath(dest.x, dest.y, dest.z, forceDestination);
-            if (result && !(path.GetPathType() & PATHFIND_NOPATH))
+            if (result)
             {
-                MovebyPath(path.GetPath());
-                return;
+                PathType const pathType = path.GetPathType();
+                bool const playerControlled = unit->IsControlledByPlayer() || unit->GetOwnerGUID().IsPlayer();
+                bool const navmeshAvailable = path.HasNavigationData();
+
+                if (!(pathType & PATHFIND_NOPATH))
+                {
+                    if (!(playerControlled && ((pathType & PATHFIND_INCOMPLETE) ||
+                        (navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))))
+                    {
+                        MovebyPath(path.GetPath());
+                        return;
+                    }
+                }
+
+                if (playerControlled && ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+                    (navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT)))))
+                {
+                    args.path_Idx_offset = 0;
+                    args.path.resize(2);
+                    TransportPathTransform transform(unit, args.TransformForTransport);
+                    Vector3 stay(unit->GetPositionX(), unit->GetPositionY(), unit->GetPositionZ());
+                    args.path[1] = transform(stay);
+                    return;
+                }
             }
         }
 

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -37,6 +37,7 @@
 #include "MotionMaster.h"
 #include "ObjectMgr.h"
 #include "Pet.h"
+#include "PathGenerator.h"
 #include "ReputationMgr.h"
 #include "SkillDiscovery.h"
 #include "SpellAuraEffects.h"
@@ -116,7 +117,17 @@ class spell_pet_moveto : public SpellScript
         if (!pet->IsPet() || !pet->IsAlive())
             return SPELL_FAILED_NO_PET;
         // The client shows an area as unreachable once the target destination is 4 yards above your position
-        if (!GetExplTargetDest() || GetExplTargetDest()->GetPositionZ() - GetCaster()->GetPositionZ() > 8.f)
+        WorldLocation const* destination = GetExplTargetDest();
+        if (!destination || destination->GetPositionZ() - GetCaster()->GetPositionZ() > 8.f)
+            return SPELL_FAILED_NOPATH;
+
+        PathGenerator path(pet);
+        if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
+            return SPELL_FAILED_NOPATH;
+
+        PathType const pathType = path.GetPathType();
+        if ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+            (path.HasNavigationData() && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))
             return SPELL_FAILED_NOPATH;
         // Do a mini Spell::CheckCasterAuras on the pet, no other way of doing this
         SpellCastResult result = SPELL_CAST_OK;


### PR DESCRIPTION
## Summary
- add a helper to PathGenerator for checking when navigation data is available
- block MoveSpline fallback shortcuts for player-controlled units when navigation is present
- validate spell_pet_moveto destinations with pathfinding before issuing the stay command

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e050b31da08327be242df0aa44d7bc