### PR TITLE
Fix trap cooldown category removal

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -454,6 +454,39 @@ void SpellHistory::ResetCooldown(CooldownStorageType::iterator& itr, bool update
     itr = EraseCooldown(itr);
 }
 
+uint32 SpellHistory::ResetCategoryCooldown(uint32 categoryId, bool update /*= false*/)
+{
+    auto categoryItr = _categoryCooldowns.find(categoryId);
+    if (categoryItr == _categoryCooldowns.end())
+        return 0;
+
+    uint32 removedSpellId = categoryItr->second->SpellId;
+
+    std::vector<int32> resetCooldowns;
+    resetCooldowns.reserve(_spellCooldowns.size());
+
+    for (auto itr = _spellCooldowns.begin(); itr != _spellCooldowns.end();)
+    {
+        if (itr->second.CategoryId != categoryId)
+        {
+            ++itr;
+            continue;
+        }
+
+        if (update)
+            resetCooldowns.push_back(itr->first);
+
+        itr = EraseCooldown(itr);
+    }
+
+    _categoryCooldowns.erase(categoryId);
+
+    if (update && !resetCooldowns.empty())
+        SendClearCooldowns(resetCooldowns);
+
+    return removedSpellId;
+}
+
 void SpellHistory::ResetAllCooldowns()
 {
     if (GetPlayerOwner())

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -94,6 +94,7 @@ public:
     void ModifyCooldown(uint32 spellId, int32 cooldownModMs);
     void ResetCooldown(uint32 spellId, bool update = false);
     void ResetCooldown(CooldownStorageType::iterator& itr, bool update = false);
+    uint32 ResetCategoryCooldown(uint32 categoryId, bool update = false);
     template<typename Predicate>
     void ResetCooldowns(Predicate predicate, bool update = false)
     {

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1691,16 +1691,42 @@ class spell_hun_trap_cd_reduce : public SpellScript
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
-        uint32 cdreduce = GetEffectValue();
-        GetCaster()->GetSpellHistory()->ResetAllCooldowns();
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(13813, cdreduce);
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(14316, cdreduce);
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(14317, cdreduce);
+        Player* caster = GetCaster()->ToPlayer();
+        if (!caster)
+            return;
 
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(1499, cdreduce);
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(14310, cdreduce);
+        SpellHistory* spellHistory = caster->GetSpellHistory();
+        if (!spellHistory)
+            return;
 
-        //GetCaster()->GetSpellHistory()->ModifyCooldown(14809, cdreduce);
+        static constexpr uint32 ImmolationTrapSpellIds[] = { 49056, 49055, 27023, 14305, 14304, 14303, 14302, 13795 };
+
+        SpellInfo const* categorySource = sSpellMgr->AssertSpellInfo(ImmolationTrapSpellIds[0]);
+        uint32 trapCategory = categorySource->GetCategory();
+        if (!trapCategory)
+            return;
+
+        if (!spellHistory->ResetCategoryCooldown(trapCategory, true))
+            return;
+
+        uint32 immolationTrapSpellId = 0;
+        for (uint32 trapSpellId : ImmolationTrapSpellIds)
+        {
+            if (!caster->HasSpell(trapSpellId))
+                continue;
+
+            immolationTrapSpellId = trapSpellId;
+            break;
+        }
+
+        if (!immolationTrapSpellId)
+            return;
+
+        if (SpellInfo const* immolationTrapInfo = sSpellMgr->GetSpellInfo(immolationTrapSpellId))
+        {
+            if (uint32 cooldown = immolationTrapInfo->GetRecoveryTime())
+                spellHistory->AddCooldown(immolationTrapSpellId, 0, std::chrono::milliseconds(cooldown));
+        }
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- ensure `SpellHistory::ResetCategoryCooldown` removes the tracked category entry and collects affected spells before notifying clients
- update the hunter trap cooldown script to always reapply Immolation Trap's personal cooldown after clearing the shared category

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0bbea44348327a260d3920ae4ec67