### PR TITLE
Fix category cooldown tracking when erasing cooldowns

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -457,10 +457,9 @@ void SpellHistory::ResetCooldown(CooldownStorageType::iterator& itr, bool update
 uint32 SpellHistory::ResetCategoryCooldown(uint32 categoryId, bool update /*= false*/)
 {
     auto categoryItr = _categoryCooldowns.find(categoryId);
-    if (categoryItr == _categoryCooldowns.end())
-        return 0;
+    uint32 removedSpellId = categoryItr != _categoryCooldowns.end() ? categoryItr->second->SpellId : 0;
 
-    uint32 removedSpellId = categoryItr->second->SpellId;
+    bool foundCategoryCooldown = false;
 
     std::vector<int32> resetCooldowns;
     resetCooldowns.reserve(_spellCooldowns.size());
@@ -473,11 +472,19 @@ uint32 SpellHistory::ResetCategoryCooldown(uint32 categoryId, bool update /*= fa
             continue;
         }
 
+        foundCategoryCooldown = true;
+
+        if (!removedSpellId)
+            removedSpellId = itr->first;
+
         if (update)
             resetCooldowns.push_back(itr->first);
 
         itr = EraseCooldown(itr);
     }
+
+    if (!foundCategoryCooldown)
+        return 0;
 
     _categoryCooldowns.erase(categoryId);
 

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -140,8 +140,36 @@ private:
     void SendClearCooldowns(std::vector<int32> const& cooldowns) const;
     CooldownStorageType::iterator EraseCooldown(CooldownStorageType::iterator itr)
     {
-        _categoryCooldowns.erase(itr->second.CategoryId);
-        return _spellCooldowns.erase(itr);
+        uint32 const categoryId = itr->second.CategoryId;
+        bool categoryNeedsUpdate = false;
+        if (categoryId)
+        {
+            auto categoryItr = _categoryCooldowns.find(categoryId);
+            if (categoryItr != _categoryCooldowns.end() && categoryItr->second == &itr->second)
+                categoryNeedsUpdate = true;
+        }
+
+        CooldownStorageType::iterator next = _spellCooldowns.erase(itr);
+
+        if (categoryNeedsUpdate)
+        {
+            CooldownEntry* replacement = nullptr;
+            for (auto& cooldownPair : _spellCooldowns)
+            {
+                if (cooldownPair.second.CategoryId == categoryId)
+                {
+                    replacement = &cooldownPair.second;
+                    break;
+                }
+            }
+
+            if (replacement)
+                _categoryCooldowns[categoryId] = replacement;
+            else
+                _categoryCooldowns.erase(categoryId);
+        }
+
+        return next;
     }
 
     typedef std::unordered_map<uint32, uint32> PacketCooldowns;


### PR DESCRIPTION
## Summary
- ensure ResetCategoryCooldown can clear trap cooldowns even if the cached category entry is missing
- keep category cooldown pointers in sync when individual spell cooldowns are erased

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e149c384248327943b294a4172154f