### PR TITLE
Adjust hunter trap cooldown reduction timing

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -24,6 +24,7 @@
 #include "ScriptMgr.h"
 #include "CellImpl.h"
 #include "GridNotifiersImpl.h"
+#include "ObjectAccessor.h"
 #include "Pet.h"
 #include "SpellAuraEffects.h"
 #include "SpellHistory.h"
@@ -32,6 +33,7 @@
 #include "GameTime.h"
 #include "WorldPacket.h"
 #include <algorithm>
+#include <array>
 
 enum HunterSpells
 {
@@ -1683,6 +1685,11 @@ class spell_hun_weaving : public AuraScript
 };
 
 // 81382 - trap cd remove
+namespace
+{
+    constexpr std::array<uint32, 8> ImmolationTrapSpellIds = { 49056, 49055, 27023, 14305, 14304, 14303, 14302, 13795 };
+}
+
 class spell_hun_trap_cd_reduce : public SpellScript
 {
     PrepareSpellScript(spell_hun_trap_cd_reduce);
@@ -1698,52 +1705,73 @@ class spell_hun_trap_cd_reduce : public SpellScript
         if (!caster)
             return;
 
-        SpellHistory* spellHistory = caster->GetSpellHistory();
-        if (!spellHistory)
+        if (!caster->GetSpellHistory())
             return;
 
-        static constexpr uint32 ImmolationTrapSpellIds[] = { 49056, 49055, 27023, 14305, 14304, 14303, 14302, 13795 };
-
-        SpellInfo const* categorySource = sSpellMgr->AssertSpellInfo(ImmolationTrapSpellIds[0]);
+        SpellInfo const* categorySource = sSpellMgr->AssertSpellInfo(ImmolationTrapSpellIds.front());
         uint32 trapCategory = categorySource->GetCategory();
         if (!trapCategory)
             return;
 
-        uint32 trapSpellId = spellHistory->ResetCategoryCooldown(trapCategory, true);
-        if (!trapSpellId)
+        uint32 const cooldownReduction = uint32(std::max<int32>(0, GetEffectValue())) * IN_MILLISECONDS;
+        ObjectGuid const casterGuid = caster->GetGUID();
+
+        using namespace std::chrono_literals;
+        caster->m_Events.AddEventAtOffset([casterGuid, trapCategory, cooldownReduction]()
         {
+            Player* player = ObjectAccessor::FindConnectedPlayer(casterGuid);
+            if (!player)
+                return;
+
+            SpellHistory* history = player->GetSpellHistory();
+            if (!history)
+                return;
+
+            SpellInfo const* trapInfo = nullptr;
+            uint32 trapSpellId = 0;
+
             for (uint32 trapSpellCandidate : ImmolationTrapSpellIds)
             {
-                if (!caster->HasSpell(trapSpellCandidate))
+                if (!player->HasSpell(trapSpellCandidate))
+                    continue;
+
+                SpellInfo const* candidateInfo = sSpellMgr->GetSpellInfo(trapSpellCandidate);
+                if (!candidateInfo)
+                    continue;
+
+                if (candidateInfo->GetCategory() != trapCategory)
                     continue;
 
                 trapSpellId = trapSpellCandidate;
-                break;
+                trapInfo = candidateInfo;
+
+                if (history->HasCooldown(candidateInfo))
+                    break;
             }
-        }
 
-        if (!trapSpellId)
-            return;
+            if (!trapInfo)
+                return;
 
-        SpellInfo const* trapInfo = sSpellMgr->GetSpellInfo(trapSpellId);
-        if (!trapInfo)
-            return;
+            uint32 const remainingCooldown = history->GetRemainingCooldown(trapInfo);
+            if (!remainingCooldown)
+                return;
 
-        uint32 const baseCooldown = trapInfo->GetRecoveryTime();
-        uint32 const cooldownReduction = uint32(std::max<int32>(0, GetEffectValue())) * IN_MILLISECONDS;
-        if (baseCooldown <= cooldownReduction)
-            return;
+            uint32 const newCooldown = cooldownReduction >= remainingCooldown ? 0 : remainingCooldown - cooldownReduction;
 
-        uint32 const newCooldown = baseCooldown - cooldownReduction;
+            SpellHistory::Clock::time_point const now = GameTime::GetSystemTime();
 
-        SpellHistory::Clock::time_point const now = GameTime::GetSystemTime();
-        SpellHistory::Clock::time_point const cooldownEnd = now + std::chrono::milliseconds(newCooldown);
+            history->ResetCategoryCooldown(trapCategory, true);
 
-        spellHistory->AddCooldown(trapSpellId, 0, cooldownEnd, trapCategory, cooldownEnd);
+            if (!newCooldown)
+                return;
 
-        WorldPacket data;
-        spellHistory->BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_NONE, trapSpellId, newCooldown);
-        caster->SendDirectMessage(&data);
+            SpellHistory::Clock::time_point const cooldownEnd = now + std::chrono::milliseconds(newCooldown);
+            history->AddCooldown(trapSpellId, 0, cooldownEnd, trapCategory, cooldownEnd);
+
+            WorldPacket data;
+            history->BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_NONE, trapSpellId, newCooldown);
+            player->SendDirectMessage(&data);
+        }, 1ms);
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- schedule the trap cooldown reduction script to run after trap cooldowns are applied
- base the new cooldown on the remaining trap cooldown instead of the base recovery time

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e167f916688327be026658eb942d3c