### PR TITLE
Fix hunter trap cooldown compilation issues

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1348,14 +1348,14 @@ void Creature::SaveToDB(uint32 mapid, uint8 spawnMask, uint32 phaseMask)
     uint32 npcflag = GetNpcFlags();
     uint32 unit_flags = GetUnitFlags();
     uint32 dynamicflags = GetDynamicFlags();
-    uint32 const playerBytes = GetUInt32Value(PLAYER_BYTES);
-    uint32 const playerBytes2 = GetUInt32Value(PLAYER_BYTES_2);
+    uint32 const currentPlayerBytes = GetUInt32Value(PLAYER_BYTES);
+    uint32 const currentPlayerBytes2 = GetUInt32Value(PLAYER_BYTES_2);
 
     uint8 playerRace = RACE_NONE;
     uint8 playerClass = CLASS_NONE;
     uint8 playerGender = GENDER_NONE;
-    uint32 playerBytes = 0;
-    uint32 playerBytes2 = 0;
+    uint32 playerBytes = currentPlayerBytes;
+    uint32 playerBytes2 = currentPlayerBytes2;
 
     if (_hasPlayerAppearance)
     {

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1756,9 +1756,8 @@ class spell_hun_trap_cd_reduce : public SpellScript
 
             if (!effectiveCooldown)
             {
-                int32 baseCooldown = 0;
-                int32 categoryCooldown = 0;
-                SpellHistory::GetCooldownDurations(trapInfo, 0, &baseCooldown, nullptr, &categoryCooldown);
+                int32 const baseCooldown = int32(trapInfo->RecoveryTime);
+                int32 const categoryCooldown = int32(trapInfo->CategoryRecoveryTime);
 
                 if (baseCooldown > 0)
                     effectiveCooldown = uint32(baseCooldown);
@@ -1766,8 +1765,8 @@ class spell_hun_trap_cd_reduce : public SpellScript
                     effectiveCooldown = uint32(categoryCooldown);
                 else if (trapInfo->GetRecoveryTime() > 0)
                     effectiveCooldown = trapInfo->GetRecoveryTime();
-                else if (trapInfo->GetCategoryRecoveryTime() > 0)
-                    effectiveCooldown = trapInfo->GetCategoryRecoveryTime();
+                else if (trapInfo->CategoryRecoveryTime > 0)
+                    effectiveCooldown = trapInfo->CategoryRecoveryTime;
             }
 
             if (!effectiveCooldown)


### PR DESCRIPTION
## Summary
- adjust the hunter trap cooldown reduction script to use SpellInfo data directly
- keep existing player appearance bytes when saving creatures to avoid const redefinition issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1c3507e688327895a97946ecfc8b3