### PR TITLE
Ensure offline player clones sync appearance bytes

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2034,6 +2034,12 @@ void Creature::ApplyPlayerAppearance(CreaturePlayerBytes const& appearance, bool
     _playerAppearance = appearance;
     _hasPlayerAppearance = true;
 
+    if (GetValuesCount() > PLAYER_BYTES)
+        SetUInt32Value(PLAYER_BYTES, appearance.playerBytes);
+
+    if (GetValuesCount() > PLAYER_BYTES_2)
+        SetUInt32Value(PLAYER_BYTES_2, appearance.playerBytes2);
+
     SetRace(appearance.race);
     SetClass(appearance.playerClass);
     SetGender(Gender(appearance.gender));
@@ -2150,12 +2156,6 @@ bool Creature::CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool c
 
     if (!_hasPlayerAppearance)
         return false;
-
-    SetByteValue(PLAYER_BYTES, PLAYER_BYTES_OFFSET_SKIN_ID, skin);
-    SetByteValue(PLAYER_BYTES, PLAYER_BYTES_OFFSET_FACE_ID, face);
-    SetByteValue(PLAYER_BYTES, PLAYER_BYTES_OFFSET_HAIR_STYLE_ID, hairStyle);
-    SetByteValue(PLAYER_BYTES, PLAYER_BYTES_OFFSET_HAIR_COLOR_ID, hairColor);
-    SetByteValue(PLAYER_BYTES_2, PLAYER_BYTES_2_OFFSET_FACIAL_STYLE, facialStyle);
 
     SetObjectScale(1.0f);
 


### PR DESCRIPTION
## Summary
- stop setting player byte fields when copying an offline player's appearance to a creature to avoid assertions
- copy packed appearance bytes into the creature's update fields when those slots exist so cloned models keep their stored textures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1c74d42c48327b73014f87b0544cd