### PR TITLE
Fix npc copy appearance crash

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1348,8 +1348,8 @@ void Creature::SaveToDB(uint32 mapid, uint8 spawnMask, uint32 phaseMask)
     uint32 npcflag = GetNpcFlags();
     uint32 unit_flags = GetUnitFlags();
     uint32 dynamicflags = GetDynamicFlags();
-    uint32 const currentPlayerBytes = GetUInt32Value(PLAYER_BYTES);
-    uint32 const currentPlayerBytes2 = GetUInt32Value(PLAYER_BYTES_2);
+    uint32 const currentPlayerBytes = GetValuesCount() > PLAYER_BYTES ? GetUInt32Value(PLAYER_BYTES) : 0;
+    uint32 const currentPlayerBytes2 = GetValuesCount() > PLAYER_BYTES_2 ? GetUInt32Value(PLAYER_BYTES_2) : 0;
 
     uint8 playerRace = RACE_NONE;
     uint8 playerClass = CLASS_NONE;


### PR DESCRIPTION
## Summary
- avoid accessing player byte fields when they are not available on creatures during SaveToDB

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1df743be08327b6f7c51f52015f3d