### PR TITLE
Implement NPC appearance copy command

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1566,6 +1566,41 @@ void Creature::SaveToDB(uint32 mapid, std::vector<Difficulty> const& spawnDiffic
     WorldDatabase.CommitTransaction(trans);
 }
 
+bool Creature::CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool copyName, bool copyEquipment, bool persist)
+{
+    Player* player = ObjectAccessor::FindConnectedPlayer(playerGuid);
+    if (!player)
+        return false;
+
+    if (copyName)
+        SetName(player->GetName());
+
+    SetRace(player->GetRace());
+    SetClass(player->GetClass());
+    SetGender(player->GetGender());
+    SetPowerType(player->GetPowerType());
+    SetLevel(player->GetLevel());
+    SetSheath(player->GetSheath());
+
+    SetDisplayId(player->GetDisplayId(), true);
+    SetObjectScale(player->GetObjectScale());
+
+    if (copyEquipment)
+    {
+        for (uint8 slot = 0; slot < MAX_EQUIPMENT_ITEMS; ++slot)
+        {
+            UF::VisibleItem const& visibleItem = player->m_unitData->VirtualItems[slot];
+            SetVirtualItem(slot, *visibleItem.ItemID, *visibleItem.ItemAppearanceModID, *visibleItem.ItemVisual,
+                *visibleItem.SecondaryItemModifiedAppearanceID, *visibleItem.ConditionalItemAppearanceID);
+        }
+    }
+
+    if (persist)
+        SaveToDB();
+
+    return true;
+}
+
 void Creature::SelectLevel()
 {
     // Level

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -238,6 +238,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void SaveToDB();
                                                             // overriden in Pet
         virtual void SaveToDB(uint32 mapid, std::vector<Difficulty> const& spawnDifficulties);
+        bool CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool copyName, bool copyEquipment, bool persist);
         static bool DeleteFromDB(ObjectGuid::LowType spawnId);
 
         bool CanHaveLoot() const { return !_staticFlags.HasFlag(CREATURE_STATIC_FLAG_NO_LOOT); }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13685,13 +13685,15 @@ uint16 Unit::GetVirtualItemAppearanceMod(uint32 slot) const
     return m_unitData->VirtualItems[slot].ItemAppearanceModID;
 }
 
-void Unit::SetVirtualItem(uint32 slot, uint32 itemId, uint16 appearanceModId /*= 0*/, uint16 itemVisual /*= 0*/)
+void Unit::SetVirtualItem(uint32 slot, uint32 itemId, uint16 appearanceModId /*= 0*/, uint16 itemVisual /*= 0*/, int32 secondaryItemModifiedAppearanceId /*= 0*/, int32 conditionalItemAppearanceId /*= 0*/)
 {
     if (slot >= MAX_EQUIPMENT_ITEMS)
         return;
 
     auto virtualItemField = m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::VirtualItems, slot);
     SetUpdateFieldValue(virtualItemField.ModifyValue(&UF::VisibleItem::ItemID), itemId);
+    SetUpdateFieldValue(virtualItemField.ModifyValue(&UF::VisibleItem::SecondaryItemModifiedAppearanceID), secondaryItemModifiedAppearanceId);
+    SetUpdateFieldValue(virtualItemField.ModifyValue(&UF::VisibleItem::ConditionalItemAppearanceID), conditionalItemAppearanceId);
     SetUpdateFieldValue(virtualItemField.ModifyValue(&UF::VisibleItem::ItemAppearanceModID), appearanceModId);
     SetUpdateFieldValue(virtualItemField.ModifyValue(&UF::VisibleItem::ItemVisual), itemVisual);
 }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1891,7 +1891,7 @@ class TC_GAME_API Unit : public WorldObject
         float GetCollisionHeight() const override;
         uint32 GetVirtualItemId(uint32 slot) const;
         uint16 GetVirtualItemAppearanceMod(uint32 slot) const;
-        void SetVirtualItem(uint32 slot, uint32 itemId, uint16 appearanceModId = 0, uint16 itemVisual = 0);
+        void SetVirtualItem(uint32 slot, uint32 itemId, uint16 appearanceModId = 0, uint16 itemVisual = 0, int32 secondaryItemModifiedAppearanceId = 0, int32 conditionalItemAppearanceId = 0);
 
         // returns if the unit can't enter combat
         bool IsCombatDisallowed() const { return _isCombatDisallowed; }

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -80,6 +80,7 @@ public:
             { "flag",           HandleNpcSetFlagCommand,           rbac::RBAC_PERM_COMMAND_NPC_SET_FLAG,       Console::No },
             { "level",          HandleNpcSetLevelCommand,          rbac::RBAC_PERM_COMMAND_NPC_SET_LEVEL,      Console::No },
             { "link",           HandleNpcSetLinkCommand,           rbac::RBAC_PERM_COMMAND_NPC_SET_LINK,       Console::No },
+            { "copy",           HandleNpcSetCopyCommand,           rbac::RBAC_PERM_COMMAND_NPC_SET_MODEL,      Console::No },
             { "model",          HandleNpcSetModelCommand,          rbac::RBAC_PERM_COMMAND_NPC_SET_MODEL,      Console::No },
             { "movetype",       HandleNpcSetMoveTypeCommand,       rbac::RBAC_PERM_COMMAND_NPC_SET_MOVETYPE,   Console::No },
             { "phase",          HandleNpcSetPhaseCommand,          rbac::RBAC_PERM_COMMAND_NPC_SET_PHASE,      Console::No },
@@ -1307,6 +1308,126 @@ public:
         }
 
         handler->PSendSysMessage("LinkGUID '" UI64FMTD "' added to creature with DBTableGUID: '" UI64FMTD "'", linkguid, creature->GetSpawnId());
+        return true;
+    }
+
+    static bool HandleNpcSetCopyCommand(ChatHandler* handler, Tail arguments)
+    {
+        Creature* creature = handler->getSelectedCreature();
+        if (!creature || creature->IsPet())
+        {
+            handler->SendSysMessage(LANG_SELECT_CREATURE);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        auto isOptionToken = [](std::string_view token)
+        {
+            return token == "noname" || token == "noequip" || token == "save" || token == "persist";
+        };
+
+        std::string_view optionArguments = arguments;
+        std::string_view preview = optionArguments;
+        std::string_view firstToken;
+
+        while (!preview.empty())
+        {
+            Trinity::Impl::ChatCommands::TokenizeResult tokenized = Trinity::Impl::ChatCommands::tokenize(preview);
+            if (tokenized.token.empty())
+            {
+                preview = tokenized.tail;
+                continue;
+            }
+
+            firstToken = tokenized.token;
+            break;
+        }
+
+        Optional<PlayerIdentifier> sourceIdentifier;
+        if (!firstToken.empty() && !isOptionToken(firstToken))
+        {
+            PlayerIdentifier candidate;
+            Trinity::Impl::ChatCommands::ChatCommandResult parseResult = candidate.TryConsume(handler, optionArguments);
+            if (!parseResult)
+            {
+                if (parseResult.HasErrorMessage())
+                    Trinity::Impl::ChatCommands::SendErrorMessageToHandler(handler, parseResult.GetErrorMessage());
+
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+
+            sourceIdentifier = candidate;
+            optionArguments = *parseResult;
+        }
+
+        bool copyName = true;
+        bool copyEquipment = true;
+        bool persist = false;
+
+        std::string_view remaining = optionArguments;
+        while (!remaining.empty())
+        {
+            Trinity::Impl::ChatCommands::TokenizeResult tokenized = Trinity::Impl::ChatCommands::tokenize(remaining);
+            std::string_view token = tokenized.token;
+
+            if (token.empty())
+            {
+                remaining = tokenized.tail;
+                continue;
+            }
+
+            if (token == "noname")
+                copyName = false;
+            else if (token == "noequip")
+                copyEquipment = false;
+            else if (token == "save" || token == "persist")
+                persist = true;
+            else
+            {
+                std::string tokenString(token);
+                handler->PSendSysMessage(LANG_COMMAND_INVALID_PARAM, tokenString.c_str());
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+
+            remaining = tokenized.tail;
+        }
+
+        if (!sourceIdentifier)
+        {
+            sourceIdentifier = PlayerIdentifier::FromTargetOrSelf(handler);
+
+            if (!sourceIdentifier)
+            {
+                handler->SendSysMessage(LANG_PLAYER_NOT_FOUND);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+        }
+
+        Player* sourcePlayer = sourceIdentifier->GetConnectedPlayer();
+        if (!sourcePlayer)
+        {
+            handler->SendSysMessage(LANG_PLAYER_NOT_FOUND);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        bool persistAppearance = persist;
+        if (persist && !creature->GetSpawnId())
+        {
+            handler->SendSysMessage("Selected creature must exist in the world database to persist appearance changes.");
+            persistAppearance = false;
+        }
+
+        if (!creature->CopyAppearanceFromPlayerGuid(sourcePlayer->GetGUID(), copyName, copyEquipment, persistAppearance))
+        {
+            handler->SendSysMessage(LANG_ERROR);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Summary
- add Creature::CopyAppearanceFromPlayerGuid so NPCs can mirror a player's appearance and optional equipment
- extend Unit::SetVirtualItem to propagate secondary appearance fields used by the copy routine
- expose a `.npc set copy` chat command with flags to skip name/equipment and optionally persist changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1dcab801c8327975862ed93e47f46