### PR TITLE
Fix npc copy crash when persisting player appearance

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1348,8 +1348,17 @@ void Creature::SaveToDB(uint32 mapid, uint8 spawnMask, uint32 phaseMask)
     uint32 npcflag = GetNpcFlags();
     uint32 unit_flags = GetUnitFlags();
     uint32 dynamicflags = GetDynamicFlags();
-    uint32 const currentPlayerBytes = GetValuesCount() > PLAYER_BYTES ? GetUInt32Value(PLAYER_BYTES) : 0;
-    uint32 const currentPlayerBytes2 = GetValuesCount() > PLAYER_BYTES_2 ? GetUInt32Value(PLAYER_BYTES_2) : 0;
+
+    uint32 currentPlayerBytes = 0;
+    uint32 currentPlayerBytes2 = 0;
+    if (!_hasPlayerAppearance)
+    {
+        if (GetValuesCount() > PLAYER_BYTES)
+            currentPlayerBytes = GetUInt32Value(PLAYER_BYTES);
+
+        if (GetValuesCount() > PLAYER_BYTES_2)
+            currentPlayerBytes2 = GetUInt32Value(PLAYER_BYTES_2);
+    }
 
     uint8 playerRace = RACE_NONE;
     uint8 playerClass = CLASS_NONE;


### PR DESCRIPTION
## Summary
- avoid reading player-only update fields when a creature already has cached player appearance data
- prevent Creature::SaveToDB from asserting during `.npc set copy` when persisting changes

## Testing
- not run (logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1e243255883279b045e6846561959