### PR TITLE
Fix npc copyplayer command to use player customizations

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2096,13 +2096,20 @@ bool Creature::CopyAppearanceFromPlayer(Player const* player, bool copyName, boo
     if (copyName)
         SetName(player->GetName());
 
-    SetDisplayId(player->GetDisplayId());
-    SetNativeDisplayId(player->GetNativeDisplayId());
+    SetPlayerAppearance(player->GetRace(), player->GetClass(), player->GetGender(), player->GetUInt32Value(PLAYER_BYTES), player->GetUInt32Value(PLAYER_BYTES_2));
+    if (!_hasPlayerAppearance)
+        return false;
+
+    // Ensure the creature uses the customized player model instead of relying on PLAYER_BYTES.
+    SetDisplayId(GetNativeDisplayId());
+
     SetObjectScale(player->GetFloatValue(OBJECT_FIELD_SCALE_X));
     SetFloatValue(UNIT_FIELD_BOUNDINGRADIUS, player->GetFloatValue(UNIT_FIELD_BOUNDINGRADIUS));
     SetFloatValue(UNIT_FIELD_COMBATREACH, player->GetFloatValue(UNIT_FIELD_COMBATREACH));
 
-    SetPlayerAppearance(player->GetRace(), player->GetClass(), player->GetGender(), player->GetUInt32Value(PLAYER_BYTES), player->GetUInt32Value(PLAYER_BYTES_2), false);
+    if (player->GetDisplayId() != player->GetNativeDisplayId())
+        SetDisplayId(player->GetDisplayId());
+
     SetPowerType(player->GetPowerType(), false);
 
     SetStandState(player->GetStandState());


### PR DESCRIPTION
## Summary
- ensure creatures copied from players build their display from player appearance data
- preserve shapeshift displays while saving the correct native customization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1e5e936c88327b204074508d35fe2