### PR TITLE
Improve trap cooldown reduction resolution

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -32,6 +32,7 @@
 #include "GameTime.h"
 #include "WorldPacket.h"
 #include <algorithm>
+#include <array>
 
 enum HunterSpells
 {
@@ -1692,35 +1693,70 @@ class spell_hun_trap_cd_reduce : public SpellScript
         return GetCaster()->GetTypeId() == TYPEID_PLAYER;
     }
 
-    void HandleDummy()
+    static constexpr std::array<uint32, 22> TrapSpellIds = {
+        49056, 49055, 27023, 14305, 14304, 14303, 14302, 13795,         // Immolation Trap
+        49067, 49066, 27025, 14317, 14316, 13813,                       // Explosive Trap
+        14311, 14310, 1499,                                             // Freezing Trap
+        60192, 60194,                                                   // Freezing Arrow (trap launcher variants)
+        13809,                                                          // Frost Trap
+        34600, 57846                                                    // Snake Trap and its triggered spell
+    };
+
+    static bool TryResolveTrapData(Player* caster, uint32 triggeringSpellId, uint32& trapCategory, uint32& trapSpellId)
     {
-        Player* caster = GetCaster()->ToPlayer();
-        if (!caster)
+        trapCategory = 0;
+        trapSpellId = 0;
+
+        if (triggeringSpellId)
+        {
+            if (SpellInfo const* triggeringInfo = sSpellMgr->GetSpellInfo(triggeringSpellId))
+            {
+                trapCategory = triggeringInfo->GetCategory();
+                if (trapCategory)
+                    trapSpellId = triggeringInfo->Id;
+            }
+        }
+
+        if (trapCategory && trapSpellId)
+            return true;
+
+        for (uint32 trapCandidate : TrapSpellIds)
+        {
+            if (!caster->HasSpell(trapCandidate))
+                continue;
+
+            SpellInfo const* trapInfo = sSpellMgr->GetSpellInfo(trapCandidate);
+            if (!trapInfo)
+                continue;
+
+            uint32 const category = trapInfo->GetCategory();
+            if (!category)
+                continue;
+
+            trapCategory = category;
+            trapSpellId = trapCandidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    static void ApplyTrapCooldownReduction(Player* caster, uint32 cooldownReduction, uint32 triggeringSpellId)
+    {
+        if (!caster || !cooldownReduction)
             return;
 
         SpellHistory* spellHistory = caster->GetSpellHistory();
         if (!spellHistory)
             return;
 
-        static constexpr uint32 ImmolationTrapSpellIds[] = { 49056, 49055, 27023, 14305, 14304, 14303, 14302, 13795 };
-
-        SpellInfo const* categorySource = sSpellMgr->AssertSpellInfo(ImmolationTrapSpellIds[0]);
-        uint32 trapCategory = categorySource->GetCategory();
-        if (!trapCategory)
+        uint32 trapCategory;
+        uint32 trapSpellId;
+        if (!TryResolveTrapData(caster, triggeringSpellId, trapCategory, trapSpellId))
             return;
 
-        uint32 trapSpellId = spellHistory->ResetCategoryCooldown(trapCategory, true);
-        if (!trapSpellId)
-        {
-            for (uint32 trapSpellCandidate : ImmolationTrapSpellIds)
-            {
-                if (!caster->HasSpell(trapSpellCandidate))
-                    continue;
-
-                trapSpellId = trapSpellCandidate;
-                break;
-            }
-        }
+        if (uint32 resetSpellId = spellHistory->ResetCategoryCooldown(trapCategory, true))
+            trapSpellId = resetSpellId;
 
         if (!trapSpellId)
             return;
@@ -1730,7 +1766,6 @@ class spell_hun_trap_cd_reduce : public SpellScript
             return;
 
         uint32 const baseCooldown = trapInfo->GetRecoveryTime();
-        uint32 const cooldownReduction = uint32(std::max<int32>(0, GetEffectValue())) * IN_MILLISECONDS;
         if (baseCooldown <= cooldownReduction)
             return;
 
@@ -1744,6 +1779,24 @@ class spell_hun_trap_cd_reduce : public SpellScript
         WorldPacket data;
         spellHistory->BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_NONE, trapSpellId, newCooldown);
         caster->SendDirectMessage(&data);
+    }
+
+    void HandleDummy()
+    {
+        Player* caster = GetCaster()->ToPlayer();
+        if (!caster)
+            return;
+
+        uint32 const cooldownReduction = uint32(std::max<int32>(0, GetEffectValue())) * IN_MILLISECONDS;
+        if (!cooldownReduction)
+            return;
+
+        uint32 const triggeringSpellId = GetTriggeringSpell() ? GetTriggeringSpell()->Id : 0;
+
+        caster->m_Events.AddEventAtOffset([caster, cooldownReduction, triggeringSpellId]()
+        {
+            ApplyTrapCooldownReduction(caster, cooldownReduction, triggeringSpellId);
+        }, 1ms);
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- resolve the trap category using the triggering spell or any trap the player knows before applying the cooldown reduction
- defer the reduction by one tick with the triggering spell id captured so it applies reliably regardless of which trap was used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1dfaa0b4c832782800fe2a2bad530