### PR TITLE
Restrict Heroic Leap to navigable destinations

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4403,6 +4403,26 @@ void Spell::EffectLeap()
         return;
 
     Position pos = destTarget->GetPosition();
+
+    // Prevent Heroic Leap from reaching invalid terrain by requiring a valid
+    // path to the destination when mmaps data is available.
+    if (unitTarget->GetTypeId() == TYPEID_PLAYER && m_spellInfo->Id == 6544)
+    {
+        PathGenerator path(unitTarget);
+        if (path.HasNavigationData())
+        {
+            if (!path.CalculatePath(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ()))
+                return;
+
+            PathType const type = path.GetPathType();
+            if (!(type & PATHFIND_NORMAL) || (type & (PATHFIND_SHORTCUT | PATHFIND_INCOMPLETE | PATHFIND_NOPATH)))
+                return;
+
+            G3D::Vector3 const& actualEnd = path.GetActualEndPosition();
+            pos.Relocate(actualEnd.x, actualEnd.y, actualEnd.z);
+        }
+    }
+
     unitTarget->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation(), unitTarget == m_caster);
 }
 


### PR DESCRIPTION
## Summary
- ensure Heroic Leap only completes when a valid navigation mesh path to the destination exists
- reuse the calculated path end position to keep players on reachable terrain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2032b19dc83279a415e855472d9e0