### PR TITLE
Enforce Heroic Leap reachability in warrior script

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -24,6 +24,7 @@
 #include "ScriptMgr.h"
 #include "ItemTemplate.h"
 #include "Optional.h"
+#include "PathGenerator.h"
 #include "Player.h"
 #include "Random.h"
 #include "SpellAuraEffects.h"
@@ -99,7 +100,17 @@ class spell_warr_leap : public SpellScript
         if (caster->GetTypeId() == TYPEID_PLAYER && !caster->IsInCombat())
             return SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW;
         // The client shows an area as unreachable once the target destination is 4 yards above your position
-        if (!GetExplTargetDest() || GetExplTargetDest()->GetPositionZ() - GetCaster()->GetPositionZ() > 8.f)
+        WorldLocation const* destination = GetExplTargetDest();
+        if (!destination || destination->GetPositionZ() - caster->GetPositionZ() > 8.f)
+            return SPELL_FAILED_NOPATH;
+
+        PathGenerator path(caster);
+        if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
+            return SPELL_FAILED_NOPATH;
+
+        PathType const pathType = path.GetPathType();
+        if ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+            (path.HasNavigationData() && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))
             return SPELL_FAILED_NOPATH;
 
         return SPELL_CAST_OK;


### PR DESCRIPTION
## Summary
- remove the core-level Heroic Leap validation added previously so checks live in script code
- update the warrior Heroic Leap spell script to reuse the pet Move To pathfinding rules when validating leap destinations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2032b19dc83279a415e855472d9e0