### PR TITLE
Handle totem cooldown categories

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -415,7 +415,14 @@ void SpellHistory::ModifyCooldown(uint32 spellId, int32 cooldownModMs)
     Clock::time_point now = GameTime::GetSystemTime();
     Clock::duration offset = std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(cooldownModMs));
     if (itr->second.CooldownEnd + offset > now)
+    {
         itr->second.CooldownEnd += offset;
+        if (itr->second.CategoryId)
+        {
+            Clock::time_point newCategoryEnd = itr->second.CategoryEnd + offset;
+            itr->second.CategoryEnd = newCategoryEnd > now ? newCategoryEnd : now;
+        }
+    }
     else
         EraseCooldown(itr);
 
@@ -427,6 +434,15 @@ void SpellHistory::ModifyCooldown(uint32 spellId, int32 cooldownModMs)
         modifyCooldown << int32(cooldownModMs);
         playerOwner->SendDirectMessage(&modifyCooldown);
     }
+}
+
+uint32 SpellHistory::GetCategoryCooldownSpellId(uint32 categoryId) const
+{
+    auto itr = _categoryCooldowns.find(categoryId);
+    if (itr == _categoryCooldowns.end() || !itr->second)
+        return 0;
+
+    return itr->second->SpellId;
 }
 
 void SpellHistory::ResetCooldown(uint32 spellId, bool update /*= false*/)

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -95,6 +95,7 @@ public:
     void ResetCooldown(uint32 spellId, bool update = false);
     void ResetCooldown(CooldownStorageType::iterator& itr, bool update = false);
     uint32 ResetCategoryCooldown(uint32 categoryId, bool update = false);
+    uint32 GetCategoryCooldownSpellId(uint32 categoryId) const;
     template<typename Predicate>
     void ResetCooldowns(Predicate predicate, bool update = false)
     {

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -2158,8 +2158,58 @@ class spell_totem_cd_reduce : public SpellScript
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
-        uint32 cdreduce = GetEffectValue();
-        GetCaster()->GetSpellHistory()->ModifyCooldown(19577, cdreduce);
+        int32 const cooldownReduction = GetEffectValue();
+        if (!cooldownReduction)
+            return;
+
+        SpellHistory* spellHistory = GetCaster()->GetSpellHistory();
+        if (!spellHistory)
+            return;
+
+        uint32 const candidateTotemSpellIds[] =
+        {
+            2484,  // Earthbind Totem
+            8177,  // Grounding Totem
+            1535,  // Fire Nova Totem (Rank 1)
+            8498,  // Fire Nova Totem (Rank 2)
+            8499,  // Fire Nova Totem (Rank 3)
+            11314, // Fire Nova Totem (Rank 4)
+            11315  // Fire Nova Totem (Rank 5)
+        };
+
+        SpellInfo const* bestSpellInfo = nullptr;
+        uint32 bestRemainingCooldown = 0;
+
+        for (uint32 spellId : candidateTotemSpellIds)
+        {
+            SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(spellId);
+            SpellInfo const* effectiveSpellInfo = spellInfo;
+
+            if (!spellHistory->HasCooldown(spellId, 0, true))
+            {
+                uint32 const categoryId = spellInfo->GetCategory();
+                if (!categoryId)
+                    continue;
+
+                uint32 const categorySpellId = spellHistory->GetCategoryCooldownSpellId(categoryId);
+                if (!categorySpellId)
+                    continue;
+
+                effectiveSpellInfo = sSpellMgr->AssertSpellInfo(categorySpellId);
+            }
+
+            uint32 const remainingCooldown = spellHistory->GetRemainingCooldown(effectiveSpellInfo);
+            if (remainingCooldown > bestRemainingCooldown)
+            {
+                bestRemainingCooldown = remainingCooldown;
+                bestSpellInfo = effectiveSpellInfo;
+            }
+        }
+
+        if (!bestSpellInfo || !bestRemainingCooldown)
+            return;
+
+        spellHistory->ModifyCooldown(bestSpellInfo->Id, cooldownReduction);
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- expose the active spell id for category cooldowns
- ensure SpellHistory::ModifyCooldown also adjusts the shared category timer
- update spell_totem_cd_reduce to pick the spell actually holding the cooldown before reducing it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ce836c748327b8f958e602222000