### PR TITLE
Extend Cold Snap cooldown resets for Time Rift aura

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -310,7 +310,14 @@ class spell_mage_cold_snap : public SpellScript
         if (GetCaster()->HasAura(81399))
         {
             GetCaster()->AddAura(81397, GetCaster());
-            //reset cooldown on fireball, evocate, and blink.
+            static constexpr uint32 const spellsToReset[] = {
+                2136, 2137, 2138, 8412, 8413, 10197, 10199, // Fire Blast (ranks 1-7)
+                1953,                                       // Blink
+                12051                                       // Evocation
+            };
+
+            for (uint32 spellId : spellsToReset)
+                GetCaster()->GetSpellHistory()->ResetCooldown(spellId, true);
         }
     }
 


### PR DESCRIPTION
## Summary
- reset Fire Blast, Blink, and Evocation cooldowns when Cold Snap is cast while aura 81399 is active
- ensure the auxiliary 81397 aura is still applied in this condition

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3425ee5788327915bfad63ffbfbba