### PR TITLE
Fix Psychic Scream cooldown reduction

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1441,7 +1441,11 @@ class spell_ps_cd_reduce : public SpellScript
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
         uint32 cdreduce = GetEffectValue();
-        GetCaster()->GetSpellHistory()->ModifyCooldown(19577, cdreduce);
+        static constexpr uint32 PsychicScreamSpellIds[] = { 8122, 8124, 10888, 10890 };
+
+        SpellHistory* spellHistory = GetCaster()->GetSpellHistory();
+        for (uint32 spellId : PsychicScreamSpellIds)
+            spellHistory->ModifyCooldown(spellId, cdreduce);
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- ensure the Psychic Scream cooldown reduction spell targets all classic ranks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e35448f8c08327a526e803da5325b3