### PR TITLE
Fix vanish short immunity script compile issues

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -848,63 +848,31 @@ class spell_rog_vanish_short_immunity : public AuraScript
 {
     PrepareAuraScript(spell_rog_vanish_short_immunity);
 
-    // 100% absorb of all damage while the aura is up (includes periodic ticks)
-    bool Absorb(AuraEffect const* /*aurEff*/, DamageInfo& dmgInfo, uint32& absorbAmount)
+    void Absorb(AuraEffect const* /*aurEff*/, DamageInfo& dmgInfo, uint32& absorbAmount)
     {
-        // absorb full amount
         absorbAmount = dmgInfo.GetDamage();
-        return true;
     }
 
-    bool IsNegativeSpell(SpellInfo const* info)
+    static bool IsNegativeSpell(SpellInfo const* info)
     {
-        // Trinity marks positivity per effect, but this is a good fast-path:
-        if (info->IsPositive())
+        if (!info)
             return false;
 
-        // Safety: consider hostile mechanics or explicit negative dispel types as negative.
-        if (info->IsChanneled() && !info->IsPositive())
-            return true;
+        return !info->IsPositive();
+    }
 
-        // Many negative effects are caught by !IsPositive(); keep it simple.
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        if (IsNegativeSpell(eventInfo.GetSpellInfo()))
+            return false;
+
         return true;
     }
 
-    // Prevent negative spells from applying while this aura is active.
-    // Trinity checks immunities through IsImmunedToSpell/Effect; we can hook via this callback:
-    // EffectAbsorb is for damage; for aura application immunity, use CheckEffectProc / FilterTarget?
-    // In practice, overriding DoCheckEffectProc is enough to ?refuse? hostile aura applications routed as procs.
-    // To be thorough, we also use OnEffectApply to set a flag on the Unit that we read via a lightweight hook.
-
-    void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
-    {
-        if (Unit* u = GetTarget())
-            u->SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_REGENERATE_POWER); // harmless flag to mark state (optional)
-    }
-
-    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
-    {
-        if (Unit* u = GetTarget())
-            u->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_REGENERATE_POWER);
-    }
-
-    // Deny negative aura application routed as a proc toward us while active
-    bool CheckProc(ProcEventInfo const& eventInfo)
-    {
-        // If someone tries to apply a negative spell during the 0.5s window, reject it.
-        if (auto* spell = eventInfo.GetSpellInfo())
-            if (IsNegativeSpell(spell))
-                return false;
-        return true;
-    }
-
-    // Wire up: absorb hook + generic proc gate
     void Register() override
     {
         OnEffectAbsorb += AuraEffectAbsorbFn(spell_rog_vanish_short_immunity::Absorb, EFFECT_0);
         DoCheckProc += AuraCheckProcFn(spell_rog_vanish_short_immunity::CheckProc);
-        OnEffectApply += AuraEffectApplyFn(spell_rog_vanish_short_immunity::OnApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
-        OnEffectRemove += AuraEffectRemoveFn(spell_rog_vanish_short_immunity::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 


### PR DESCRIPTION
## Summary
- update the vanish short immunity absorb handler to use the correct callback signature
- simplify the proc check so it matches the expected handler type and filters only hostile spells

## Testing
- not run (compile-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e36dbf96f48327b999cabce9b96b36