### PR TITLE
Add humanoid speed bonus to Leader of the Pack

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -803,7 +803,7 @@ class spell_dru_insect_swarm : public AuraScript
     }
 };
 
-// 24932 - Leader of the Pack
+// 17007 - Leader of the Pack
 class spell_dru_leader_of_the_pack : public AuraScript
 {
     PrepareAuraScript(spell_dru_leader_of_the_pack);
@@ -848,9 +848,22 @@ class spell_dru_leader_of_the_pack : public AuraScript
         caster->CastSpell(nullptr, SPELL_DRUID_IMP_LEADER_OF_THE_PACK_MANA, args2);
     }
 
+    void CalculateMovement(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
+    {
+        Unit* target = GetUnitOwner();
+        if (!target || target->GetCreatureType() != CREATURE_TYPE_HUMANOID)
+        {
+            amount = 0;
+            return;
+        }
+
+        amount = 15;
+    }
+
     void Register() override
     {
         OnEffectProc += AuraEffectProcFn(spell_dru_leader_of_the_pack::HandleProc, EFFECT_1, SPELL_AURA_DUMMY);
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_leader_of_the_pack::CalculateMovement, EFFECT_2, SPELL_AURA_MOD_SPEED_NOT_STACK);
     }
 };
 


### PR DESCRIPTION
## Summary
- add a movement speed calculation hook to the Leader of the Pack aura
- grant humanoid targets a 15% movement speed increase while affected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3845b80e08327bd43d693eb75c3db