### PR TITLE
Ensure npc copy command updates creature name

### DIFF
--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -685,6 +685,9 @@ public:
             return false;
         }
 
+        creature->SetName(player.GetName());
+        creature->SetPetNameTimestamp(uint32(GameTime::GetGameTime()));
+
         handler->PSendSysMessage("Copied appearance of %s onto the selected creature and saved it.", player.GetName().c_str());
         return true;
     }


### PR DESCRIPTION
## Summary
- set the selected creature's name to the copied player's name when using `.npc set copyplayer`
- refresh the pet name timestamp so nearby clients learn about the rename immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e59b7bfa1c8327a83c3e1f55866d53