### PR TITLE
Implement Lightning Shield defensive aura scaling

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -1177,6 +1177,64 @@ class spell_sha_lava_lash : public SpellScript
 
 };
 
+// 81459 - Lightning Shield Defense
+class spell_sha_lightning_shield_defense : public AuraScript
+{
+    PrepareAuraScript(spell_sha_lightning_shield_defense);
+
+public:
+    static void UpdateEffectAmounts(Unit* owner)
+    {
+        if (!owner)
+            return;
+
+        if (Aura* aura = owner->GetAura(SPELL_SHAMAN_LIGHTNING_SHIELD_DEFENSIVE_AURA))
+        {
+            if (AuraEffect* snareMod = aura->GetEffect(EFFECT_1))
+                snareMod->RecalculateAmount();
+
+            if (AuraEffect* damageMod = aura->GetEffect(EFFECT_2))
+                damageMod->RecalculateAmount();
+        }
+    }
+
+private:
+    static AuraEffect const* GetLightningShieldEffect(Unit* owner)
+    {
+        if (!owner)
+            return nullptr;
+
+        return owner->GetAuraEffect(SPELL_AURA_PROC_TRIGGER_SPELL, SPELLFAMILY_SHAMAN, 0x00000400, 0x00000000, 0x00000000, owner->GetGUID());
+    }
+
+    static uint8 GetLightningShieldCharges(Unit* owner)
+    {
+        if (AuraEffect const* lightningShield = GetLightningShieldEffect(owner))
+            if (Aura* lightningShieldAura = lightningShield->GetBase())
+                return lightningShieldAura->GetCharges();
+
+        return 0;
+    }
+
+    void CalculateSnareReduction(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
+    {
+        canBeRecalculated = true;
+        amount = -static_cast<int32>(GetLightningShieldCharges(GetTarget())) * 15;
+    }
+
+    void CalculateDamageReduction(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
+    {
+        canBeRecalculated = true;
+        amount = -static_cast<int32>(GetLightningShieldCharges(GetTarget())) * 2;
+    }
+
+    void Register() override
+    {
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_sha_lightning_shield_defense::CalculateSnareReduction, EFFECT_1, SPELL_AURA_MECHANIC_MOD);
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_sha_lightning_shield_defense::CalculateDamageReduction, EFFECT_2, SPELL_AURA_MOD_DAMAGE_PERCENT_TAKE);
+    }
+};
+
 // -324 - Lightning Shield
 class spell_sha_lightning_shield : public AuraScript
 {
@@ -1318,18 +1376,7 @@ private:
         else
             RestoreSnareDurations(GetTarget());
 
-        if (DamageInfo* damageInfo = eventInfo.GetDamageInfo())
-        {
-            if (damageInfo->GetDamage() && hasDefensiveAura)
-            {
-                int32 damageReductionPct = static_cast<int32>(chargesForReduction) * 2;
-                if (damageReductionPct > 0)
-                {
-                    int32 damageReduction = CalculatePct(static_cast<int32>(damageInfo->GetDamage()), damageReductionPct);
-                    damageInfo->ModifyDamage(-damageReduction);
-                }
-            }
-        }
+        spell_sha_lightning_shield_defense::UpdateEffectAmounts(auraOwner);
 
         uint32 triggerSpell = sSpellMgr->GetSpellWithRank(SPELL_SHAMAN_LIGHTNING_SHIELD_R1, aurEff->GetSpellInfo()->GetRank());
 
@@ -1346,6 +1393,8 @@ private:
             ApplySnareReduction(GetTarget(), aurEff->GetBase()->GetCharges(), auraOwner);
         else
             RestoreSnareDurations(GetTarget());
+
+        spell_sha_lightning_shield_defense::UpdateEffectAmounts(auraOwner);
     }
 
     void HandleApply(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
@@ -1358,11 +1407,14 @@ private:
             ApplySnareReduction(GetTarget(), aurEff->GetBase()->GetCharges(), auraOwner);
         else
             RestoreSnareDurations(GetTarget());
+
+        spell_sha_lightning_shield_defense::UpdateEffectAmounts(auraOwner);
     }
 
     void HandleRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         RestoreSnareDurations(GetTarget());
+        spell_sha_lightning_shield_defense::UpdateEffectAmounts(GetTarget());
     }
 
     void Register() override
@@ -1708,6 +1760,7 @@ class spell_sha_static_shock : public AuraScript
         eventInfo.GetActor()->CastSpell(eventInfo.GetProcTarget(), spellId, aurEff);
         lightningShield->GetBase()->DropCharge();
         spell_sha_lightning_shield::UpdateSnareState(caster, lightningShield->GetBase()->GetCharges());
+        spell_sha_lightning_shield_defense::UpdateEffectAmounts(caster);
     }
 
     void Register() override
@@ -2470,6 +2523,7 @@ void AddSC_shaman_spell_scripts()
     RegisterSpellScript(spell_sha_item_t6_trinket);
     RegisterSpellScript(spell_sha_item_t10_elemental_2p_bonus);
     RegisterSpellScript(spell_sha_lava_lash);
+    RegisterSpellScript(spell_sha_lightning_shield_defense);
     RegisterSpellScript(spell_sha_lightning_shield);
     RegisterSpellScript(spell_sha_maelstrom_weapon);
     RegisterSpellScript(spell_sha_mana_spring_totem);


### PR DESCRIPTION
## Summary
- add a Lightning Shield Defense aura script that scales snare and damage reduction with active Lightning Shield charges
- refresh defensive aura modifiers when Lightning Shield charges change in Lightning Shield and Static Shock scripts, removing manual damage tweaks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c00f0bd4832781b13f1d4f22e19c