### PR TITLE
Add aura script to hasten key shaman totem pulses

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -33,6 +33,7 @@
 #include "SpellScript.h"
 #include "Unit.h"
 #include <algorithm>
+#include <array>
 #include <unordered_map>
 #include "SharedDefines.h"
 
@@ -42,6 +43,10 @@ enum ShamanSpells
     SPELL_SHAMAN_ANCESTRAL_AWAKENING_PROC       = 52752,
     SPELL_SHAMAN_BIND_SIGHT                     = 6277,
     SPELL_SHAMAN_CLEANSING_TOTEM_EFFECT         = 52025,
+    SPELL_SHAMAN_TREMOR_TOTEM_PULSE             = 8146,
+    SPELL_SHAMAN_POISON_CLEANSING_TOTEM_PULSE   = 8168,
+    SPELL_SHAMAN_GROUNDING_TOTEM_EFFECT         = 8178,
+    SPELL_SHAMAN_POISON_CLEANSING_TOTEM_PULSE_R2 = 10538,
     SPELL_SHAMAN_EARTH_SHIELD_HEAL              = 379,
     SPELL_SHAMAN_ELEMENTAL_MASTERY              = 16166,
     SPELL_SHAMAN_ELEMENTAL_OATH                 = 51466,
@@ -359,6 +364,41 @@ class spell_sha_cleansing_totem_pulse : public SpellScript
     void Register() override
     {
         OnEffectHitTarget += SpellEffectFn(spell_sha_cleansing_totem_pulse::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
+namespace
+{
+    static constexpr std::array<uint32, 4> HastedTotemPulseSpellIds =
+    {
+        SPELL_SHAMAN_TREMOR_TOTEM_PULSE,
+        SPELL_SHAMAN_POISON_CLEANSING_TOTEM_PULSE,
+        SPELL_SHAMAN_POISON_CLEANSING_TOTEM_PULSE_R2,
+        SPELL_SHAMAN_GROUNDING_TOTEM_EFFECT
+    };
+}
+
+// 8146, 8168, 10538, 8178 - Tremor Totem, Poison Cleansing Totem, Poison Cleansing Totem (Rank 2), Grounding Totem
+class spell_sha_hastened_totem_tick : public AuraScript
+{
+    PrepareAuraScript(spell_sha_hastened_totem_tick);
+
+    bool Validate(SpellInfo const* spellInfo) override
+    {
+        return std::find(HastedTotemPulseSpellIds.begin(), HastedTotemPulseSpellIds.end(), spellInfo->Id) != HastedTotemPulseSpellIds.end();
+    }
+
+    void CalcPeriodic(AuraEffect const* /*aurEff*/, bool& isPeriodic, int32& amplitude)
+    {
+        if (!isPeriodic)
+            return;
+
+        amplitude = std::max<int32>(int32(IN_MILLISECONDS), amplitude - 2 * IN_MILLISECONDS);
+    }
+
+    void Register() override
+    {
+        DoEffectCalcPeriodic += AuraEffectCalcPeriodicFn(spell_sha_hastened_totem_tick::CalcPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_TRIGGER_SPELL);
     }
 };
 
@@ -2356,6 +2396,7 @@ void AddSC_shaman_spell_scripts()
     RegisterSpellScript(spell_sha_bloodlust);
     RegisterSpellScript(spell_sha_chain_heal);
     RegisterSpellScript(spell_sha_cleansing_totem_pulse);
+    RegisterSpellScript(spell_sha_hastened_totem_tick);
     RegisterSpellScript(spell_sha_clearcasting);
     RegisterSpellScript(spell_sha_earth_shield);
     RegisterSpellScript(spell_sha_earthbind_totem);


### PR DESCRIPTION
## Summary
- add spell identifiers for tremor, poison cleansing, and grounding totem pulses
- implement an aura script that shortens the periodic tick interval for those pulses by 2 seconds
- register the new script so the aura is available in game

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c7edfb608327b6842ca02475135a