### PR TITLE
Fix arena pet resummon on zone in

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -25659,6 +25659,16 @@ void Player::ResummonPetTemporaryUnSummonedIfAny()
     if (GetPetGUID())
         return;
 
+    if (Map* map = FindMap())
+    {
+        if (map->IsBattleArena() && GetLastPetNumber())
+        {
+            CastSpell(this, 6962, true);
+            m_temporaryUnsummonedPetNumber = 0;
+            return;
+        }
+    }
+
     Pet* NewPet = new Pet(this);
     if (!NewPet->LoadPetFromDB(this, 0, m_temporaryUnsummonedPetNumber, true))
         delete NewPet;


### PR DESCRIPTION
## Summary
- ensure temporarily unsummoned pets are restored via the arena pet summon spell when entering an arena
- keep existing fallback logic for other maps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eac74791c88327ab779a346d01d74e