### PR TITLE
Remove Nature's Grasp buff after Wrath root trigger

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2121,6 +2121,11 @@ class spell_dru_wrath : public SpellScript
             return;
 
         caster->CastSpell(target, *rootSpellId, true);
+
+        for (uint32 natureGraspAuraId : NatureGraspAuraSpells)
+            caster->RemoveAurasDueToSpell(natureGraspAuraId);
+
+        caster->RemoveAurasDueToSpell(SPELL_DRUID_WRATH_NATURES_GRASP_BUFF);
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- remove active Nature's Grasp auras once Wrath triggers the guaranteed root
- clear the Wrath-specific Nature's Grasp buff so the guaranteed critical no longer persists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb2296f3b88327aa67fb8485ad6218