### PR TITLE
Add engine support for reducing active global cooldowns

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -647,6 +647,80 @@ void SpellHistory::CancelGlobalCooldown(SpellInfo const* spellInfo)
     _globalCooldowns[spellInfo->StartRecoveryCategory] = Clock::time_point(Clock::duration(0));
 }
 
+void SpellHistory::ReduceGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds reduction)
+{
+    if (!spellInfo || !spellInfo->StartRecoveryCategory || !spellInfo->StartRecoveryTime || reduction.count() <= 0)
+        return;
+
+    auto itr = _globalCooldowns.find(spellInfo->StartRecoveryCategory);
+    if (itr == _globalCooldowns.end())
+        return;
+
+    Clock::time_point now = GameTime::GetSystemTime();
+    Clock::time_point currentEnd = itr->second;
+    if (currentEnd <= now)
+        return;
+
+    Clock::duration reductionDuration = std::chrono::duration_cast<Clock::duration>(reduction);
+    Clock::duration currentDuration = currentEnd - now;
+    Clock::time_point newEnd = reductionDuration >= currentDuration ? now : currentEnd - reductionDuration;
+
+    itr->second = newEnd;
+
+    Player* player = GetPlayerOwner();
+    if (!player)
+        return;
+
+    SpellInfo const* const baseSpellInfo = spellInfo;
+    uint32 const gcdCategory = baseSpellInfo->StartRecoveryCategory;
+
+    std::chrono::milliseconds remaining(0);
+    if (newEnd > now)
+        remaining = std::chrono::duration_cast<std::chrono::milliseconds>(newEnd - now);
+
+    PacketCooldowns cooldowns;
+
+    auto tryAddCooldown = [&](SpellInfo const* info)
+    {
+        if (!info)
+            return;
+
+        if (!info->StartRecoveryTime)
+            return;
+
+        if (info->StartRecoveryCategory != gcdCategory)
+            return;
+
+        if (HasCooldown(info, 0, true))
+            return;
+
+        cooldowns.emplace(info->Id, remaining.count());
+    };
+
+    tryAddCooldown(baseSpellInfo);
+
+    PlayerSpellMap const& playerSpells = player->GetSpellMap();
+    for (auto const& playerSpellPair : playerSpells)
+    {
+        if (playerSpellPair.second.state == PLAYERSPELL_REMOVED)
+            continue;
+
+        uint32 const knownSpellId = playerSpellPair.first;
+        if (knownSpellId == baseSpellInfo->Id)
+            continue;
+
+        SpellInfo const* knownSpellInfo = sSpellMgr->GetSpellInfo(knownSpellId);
+        tryAddCooldown(knownSpellInfo);
+    }
+
+    if (cooldowns.empty())
+        return;
+
+    WorldPacket data;
+    BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_INCLUDE_GCD, cooldowns);
+    player->SendDirectMessage(&data);
+}
+
 Player* SpellHistory::GetPlayerOwner() const
 {
     return _owner->GetCharmerOrOwnerPlayerOrPlayerItself();

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -21,6 +21,7 @@
 #include "SharedDefines.h"
 #include "DatabaseEnvFwd.h"
 #include "GameTime.h"
+#include <chrono>
 #include <deque>
 #include <vector>
 #include <unordered_map>
@@ -129,6 +130,7 @@ public:
     bool HasGlobalCooldown(SpellInfo const* spellInfo) const;
     void AddGlobalCooldown(SpellInfo const* spellInfo, uint32 duration);
     void CancelGlobalCooldown(SpellInfo const* spellInfo);
+    void ReduceGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds reduction);
 
     void BuildCooldownPacket(WorldPacket& data, uint8 flags, uint32 spellId, uint32 cooldown) const;
 

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -32,6 +32,7 @@
 #include "SpellMgr.h"
 #include "SpellScript.h"
 #include "Spell.h"
+#include <chrono>
 
 enum DruidSpells
 {
@@ -2130,6 +2131,60 @@ class spell_dru_wrath : public SpellScript
     }
 };
 
+// 16689 - Nature's Grasp (and ranks)
+class spell_dru_natures_grasp : public SpellScript
+{
+    PrepareSpellScript(spell_dru_natures_grasp);
+
+    bool Validate(SpellInfo const* spellInfo) override
+    {
+        if (!ValidateSpellInfo({ SPELL_DRUID_WRATH_NATURES_GRASP_BUFF }))
+            return false;
+
+        if (!spellInfo)
+            return false;
+
+        for (uint32 natureGraspAuraId : NatureGraspAuraSpells)
+            if (natureGraspAuraId == spellInfo->Id)
+                return true;
+
+        return false;
+    }
+
+    void HandleBeforeCast()
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !caster->HasAura(SPELL_DRUID_WRATH_NATURES_GRASP_BUFF))
+            return;
+
+        if (Spell* spell = GetSpell())
+            spell->_triggeredCastFlags = TriggerCastFlags(spell->_triggeredCastFlags | TRIGGERED_IGNORE_GCD);
+    }
+
+    void HandleAfterCast()
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !caster->HasAura(SPELL_DRUID_WRATH_NATURES_GRASP_BUFF))
+            return;
+
+        SpellInfo const* spellInfo = GetSpellInfo();
+        if (!spellInfo || !spellInfo->StartRecoveryTime)
+            return;
+
+        SpellHistory* spellHistory = caster->GetSpellHistory();
+        if (!spellHistory)
+            return;
+
+        spellHistory->ReduceGlobalCooldown(spellInfo, std::chrono::milliseconds(1000));
+    }
+
+    void Register() override
+    {
+        BeforeCast += SpellCastFn(spell_dru_natures_grasp::HandleBeforeCast);
+        AfterCast += SpellCastFn(spell_dru_natures_grasp::HandleAfterCast);
+    }
+};
+
 //claw 1082
 class spell_dru_claw : public SpellScript
 {
@@ -2193,6 +2248,7 @@ void AddSC_druid_spell_scripts()
     RegisterSpellAndAuraScriptPair(spell_dru_savage_roar, spell_dru_savage_roar_aura);
     RegisterSpellScript(spell_dru_starfall_aoe);
     RegisterSpellScript(spell_dru_starfall_dummy);
+    RegisterSpellScript(spell_dru_natures_grasp);
     RegisterSpellAndAuraScriptPair(spell_dru_survival_instincts, spell_dru_survival_instincts_aura);
     RegisterSpellScript(spell_dru_swift_flight_passive);
     RegisterSpellScript(spell_dru_tiger_s_fury);


### PR DESCRIPTION
## Summary
- add SpellHistory::ReduceGlobalCooldown to shorten active global cooldowns and notify players whose spells share the recovery category
- update Nature's Grasp to subtract one second from its active global cooldown using the new helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb21dd75c88327b3494ccc88d7c133