### PR TITLE
Normalize replay packet timeline

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -664,6 +664,21 @@ public:
 
                 record.packets.push_back({ packetTimestamp, packet });
             }
+
+            if (!record.packets.empty())
+            {
+                uint32 const firstTimestamp = record.packets.front().timestamp;
+                if (firstTimestamp)
+                {
+                    for (PacketRecord& packetRecord : record.packets)
+                    {
+                        if (packetRecord.timestamp <= firstTimestamp)
+                            packetRecord.timestamp = 0;
+                        else
+                            packetRecord.timestamp -= firstTimestamp;
+                    }
+                }
+            }
         }
     };
     CreatureAI* GetAI(Creature* creature) const override


### PR DESCRIPTION
## Summary
- normalize loaded replay packet timestamps so playback begins immediately instead of after long queue delays

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ec29ca04848327b105467cee42351f