### PR TITLE
Record crash reasons to Crash.log

### DIFF
--- a/doc/LoggingHOWTO.txt
+++ b/doc/LoggingHOWTO.txt
@@ -119,8 +119,13 @@ Depending on the type, elements optional1 and optional2 will take different
         Allows to use one "%u" to create dynamic files
 
     Mode: Mode to open the file (read as optional2 if Type = File)
-        a - (Append)
+        a - (Append)  (default in sample configs so server restarts do not wipe previous logs)
         w - (Overwrite)
+
+The sample authserver and worldserver configurations also define a dedicated
+`server.crash` logger that writes the fatal assertion and signal messages
+recorded by TrinityCore's crash handler to `Crash.log`, helping you diagnose
+why the process exited even after a restart.
 
 Example:
     Appender.Console1=1,2,6

--- a/src/common/Debugging/Errors.cpp
+++ b/src/common/Debugging/Errors.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Errors.h"
+#include "Log.h"
 #include "StringFormat.h"
 #include <cstdio>
 #include <cstdlib>
@@ -49,6 +50,14 @@ extern "C" { TC_COMMON_API char const* TrinityAssertionFailedMessage = nullptr; 
 
 namespace
 {
+    void LogCrashMessage(std::string const& message)
+    {
+        if (message.empty())
+            return;
+
+        TC_LOG_FATAL("server.crash", "{}", message);
+    }
+
     std::string FormatAssertionMessage(char const* format, va_list args)
     {
         std::string formatted;
@@ -71,6 +80,7 @@ namespace Trinity
 void Assert(char const* file, int line, char const* function, std::string debugInfo, char const* message)
 {
     std::string formattedMessage = StringFormat("\n{}:{} in {} ASSERTION FAILED:\n  {}\n", file, line, function, message) + debugInfo + '\n';
+    LogCrashMessage(formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
     Crash(formattedMessage.c_str());
@@ -84,6 +94,7 @@ void Assert(char const* file, int line, char const* function, std::string debugI
     std::string formattedMessage = StringFormat("\n{}:{} in {} ASSERTION FAILED:\n  {}\n", file, line, function, message) + FormatAssertionMessage(format, args) + '\n' + debugInfo + '\n';
     va_end(args);
 
+    LogCrashMessage(formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
 
@@ -98,6 +109,7 @@ void Fatal(char const* file, int line, char const* function, char const* message
     std::string formattedMessage = StringFormat("\n{}:{} in {} FATAL ERROR:\n", file, line, function) + FormatAssertionMessage(message, args) + '\n';
     va_end(args);
 
+    LogCrashMessage(formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
 
@@ -108,6 +120,7 @@ void Fatal(char const* file, int line, char const* function, char const* message
 void Error(char const* file, int line, char const* function, char const* message)
 {
     std::string formattedMessage = StringFormat("\n{}:{} in {} ERROR:\n  {}\n", file, line, function, message);
+    LogCrashMessage(formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
     Crash(formattedMessage.c_str());
@@ -122,6 +135,7 @@ void Warning(char const* file, int line, char const* function, char const* messa
 void Abort(char const* file, int line, char const* function)
 {
     std::string formattedMessage = StringFormat("\n{}:{} in {} ABORTED.\n", file, line, function);
+    LogCrashMessage(formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
     Crash(formattedMessage.c_str());
@@ -135,6 +149,7 @@ void Abort(char const* file, int line, char const* function, char const* message
     std::string formattedMessage = StringFormat("\n{}:{} in {} ABORTED:\n", file, line, function) + FormatAssertionMessage(message, args) + '\n';
     va_end(args);
 
+    LogCrashMessage(formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
 
@@ -145,6 +160,7 @@ void AbortHandler(int sigval)
 {
     // nothing useful to log here, no way to pass args
     std::string formattedMessage = StringFormat("Caught signal {}\n", sigval);
+    LogCrashMessage(formattedMessage);
     fprintf(stderr, "%s", formattedMessage.c_str());
     fflush(stderr);
     Crash(formattedMessage.c_str());

--- a/src/server/authserver/authserver.conf.dist
+++ b/src/server/authserver/authserver.conf.dist
@@ -373,7 +373,11 @@ Updates.CleanDeadRefMaxCount = 3
 #
 
 Appender.Console=1,2,0
-Appender.Auth=2,2,0,Auth.log,w
+# Append to Auth.log by default to retain crash information between restarts.
+# Crash.log stores the fatal assertions and signal handlers that lead to a shutdown.
+# Change the last parameter back to "w" if you prefer either file to be overwritten on startup.
+Appender.Auth=2,2,0,Auth.log,a
+Appender.Crash=2,6,7,Crash.log,a
 
 #  Logger config values: Given a logger "name"
 #    Logger.name
@@ -394,6 +398,7 @@ Appender.Auth=2,2,0,Auth.log,w
 #
 
 Logger.root=3,Console Auth
+Logger.server.crash=6,Crash
 
 #
 ###################################################################################################

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3930,7 +3930,11 @@ AuctionHouseBot.Buyer.Recheck.Interval = 20
 #
 
 Appender.Console=1,3,0
-Appender.Server=2,2,0,Server.log,w
+# By default keep appending to Server.log so crash details from previous sessions are preserved.
+# Crash.log stores the fatal assertions and signal handlers that lead to a shutdown.
+# Change the last parameter back to "w" if you prefer either file to be overwritten on startup.
+Appender.Server=2,2,0,Server.log,a
+Appender.Crash=2,6,7,Crash.log,a
 Appender.GM=2,2,1,GM.log
 Appender.DBErrors=2,2,0,DBErrors.log
 
@@ -3954,6 +3958,7 @@ Appender.DBErrors=2,2,0,DBErrors.log
 
 Logger.root=5,Console Server
 Logger.server=3,Console Server
+Logger.server.crash=6,Crash
 Logger.commands.gm=3,Console GM
 Logger.scripts.hotswap=3,Console Server
 Logger.sql.sql=5,Console DBErrors


### PR DESCRIPTION
## Summary
- emit fatal/assertion messages from the crash handler through the logging system
- add a Crash.log appender and server.crash logger to the authserver and worldserver sample configs
- document the Crash.log default so administrators know where to find crash reasons after a restart

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebacebb3108327b53f8952b077e65e