### PR TITLE
Add Frostbrand proc trigger spells

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -115,7 +115,9 @@ enum ShamanSpells
     SPELL_SHAMAN_BRAIN_DRAIN                    = 81327,
     SPELL_SHAMAN_SHOCKING                       = 81328,
     SPELL_SHAMAN_SUMMERS_SWELTER                = 81389,
-    SPELL_SHAMAN_FIRE_STUN                      = 81390
+    SPELL_SHAMAN_FIRE_STUN                      = 81390,
+    SPELL_SHAMAN_FROSTBRAND_ATTACK_TRIGGER      = 81851,
+    SPELL_SHAMAN_FROSTBRAND_ATTACK_SELF_BUFF    = 81852
 };
 
 enum ShamanSpellIcons
@@ -688,6 +690,34 @@ class spell_sha_flametongue_weapon : public AuraScript
     {
         DoCheckProc += AuraCheckProcFn(spell_sha_flametongue_weapon::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_sha_flametongue_weapon::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+    }
+};
+
+// 8034 - Frostbrand Attack
+class spell_sha_frostbrand_attack : public SpellScript
+{
+    PrepareSpellScript(spell_sha_frostbrand_attack);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_SHAMAN_FROSTBRAND_ATTACK_TRIGGER, SPELL_SHAMAN_FROSTBRAND_ATTACK_SELF_BUFF });
+    }
+
+    void HandleAfterHit()
+    {
+        Unit* caster = GetCaster();
+        Unit* target = GetHitUnit();
+
+        if (!caster || !target)
+            return;
+
+        caster->CastSpell(target, SPELL_SHAMAN_FROSTBRAND_ATTACK_TRIGGER, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
+        caster->CastSpell(caster, SPELL_SHAMAN_FROSTBRAND_ATTACK_SELF_BUFF, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
+    }
+
+    void Register() override
+    {
+        AfterHit += SpellHitFn(spell_sha_frostbrand_attack::HandleAfterHit);
     }
 };
 
@@ -2454,6 +2484,7 @@ void AddSC_shaman_spell_scripts()
     RegisterSpellScript(spell_sha_fire_nova);
     RegisterSpellScript(spell_sha_flame_shock);
     RegisterSpellScript(spell_sha_flametongue_weapon);
+    RegisterSpellScript(spell_sha_frostbrand_attack);
     RegisterSpellScript(spell_sha_frozen_power);
     RegisterSpellScript(spell_sha_glyph_of_earth_shield);
     RegisterSpellScript(spell_sha_glyph_of_healing_wave);


### PR DESCRIPTION
## Summary
- add supporting spell constants for the new Frostbrand proc behavior
- cast the required triggered spells on both target and caster when Frostbrand Attack hits
- register the new Frostbrand Attack spell script

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed194a63a48327967a7d5667b320c7