### PR TITLE
Add shock cooldown reduction dummy spell

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -33,6 +33,7 @@
 #include "SpellScript.h"
 #include "Unit.h"
 #include <algorithm>
+#include <array>
 #include <unordered_map>
 #include "SharedDefines.h"
 
@@ -117,7 +118,11 @@ enum ShamanSpells
     SPELL_SHAMAN_SUMMERS_SWELTER                = 81389,
     SPELL_SHAMAN_FIRE_STUN                      = 81390,
     SPELL_SHAMAN_FROSTBRAND_ATTACK_TRIGGER      = 81851,
-    SPELL_SHAMAN_FROSTBRAND_ATTACK_SELF_BUFF    = 81852
+    SPELL_SHAMAN_FROSTBRAND_ATTACK_SELF_BUFF    = 81852,
+    SPELL_SHAMAN_EARTH_SHOCK_R1                 = 8042,
+    SPELL_SHAMAN_FLAME_SHOCK_R1                 = 8050,
+    SPELL_SHAMAN_FROST_SHOCK_R1                 = 8056,
+    SPELL_SHAMAN_WIND_SHEAR                     = 57994
 };
 
 enum ShamanSpellIcons
@@ -2324,6 +2329,63 @@ class spell_sha_old_purge : public SpellScript
     }
 };
 
+class spell_sha_shock_cooldown_reduction : public SpellScript
+{
+    PrepareSpellScript(spell_sha_shock_cooldown_reduction);
+
+    bool Load() override
+    {
+        return GetCaster()->GetTypeId() == TYPEID_PLAYER;
+    }
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({
+            SPELL_SHAMAN_EARTH_SHOCK_R1,
+            SPELL_SHAMAN_FLAME_SHOCK_R1,
+            SPELL_SHAMAN_FROST_SHOCK_R1,
+            SPELL_SHAMAN_WIND_SHEAR
+        });
+    }
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        Player* caster = GetCaster()->ToPlayer();
+        if (!caster)
+            return;
+
+        SpellHistory* spellHistory = caster->GetSpellHistory();
+        if (!spellHistory)
+            return;
+
+        int32 cooldownReduction = GetEffectValue();
+        if (cooldownReduction <= 0)
+            return;
+
+        if (cooldownReduction < IN_MILLISECONDS)
+            cooldownReduction *= IN_MILLISECONDS;
+
+        static constexpr std::array<uint32, 4> ShockBaseSpellIds = {
+            SPELL_SHAMAN_EARTH_SHOCK_R1,
+            SPELL_SHAMAN_FLAME_SHOCK_R1,
+            SPELL_SHAMAN_FROST_SHOCK_R1,
+            SPELL_SHAMAN_WIND_SHEAR
+        };
+
+        for (uint32 spellId : ShockBaseSpellIds)
+        {
+            SpellInfo const* rankSpellInfo = sSpellMgr->AssertSpellInfo(spellId);
+            for (SpellInfo const* currentRank = rankSpellInfo; currentRank; currentRank = currentRank->GetNextRankSpell())
+                spellHistory->ModifyCooldown(currentRank->Id, -cooldownReduction);
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_sha_shock_cooldown_reduction::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
 class spell_totem_cd_reduce : public SpellScript
 {
     PrepareSpellScript(spell_totem_cd_reduce);
@@ -2527,6 +2589,7 @@ void AddSC_shaman_spell_scripts()
     RegisterSpellScript(spell_sha_purge);
     RegisterSpellScript(spell_sha_old_purge);
     RegisterSpellScript(spell_sha_fire_nova_trig);
+    RegisterSpellScript(spell_sha_shock_cooldown_reduction);
     RegisterSpellScript(spell_totem_cd_reduce);
     RegisterSpellScript(spell_sha_lightning_shield_mana_restore);
 


### PR DESCRIPTION
## Summary
- add a spell script that reduces all shaman shock spell cooldowns via a dummy effect
- cover all shock spell ranks and register the new script for use

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed1b5686708327aceb75d364de9553