### PR TITLE
Preserve NPC stand state when copying player appearance

### DIFF
--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -679,6 +679,7 @@ public:
         }
 
         float const originalScale = creature->GetObjectScale();
+        UnitStandStateType const originalStandState = creature->GetStandState();
 
         if (!creature->CopyAppearanceFromPlayerGuid(player.GetGUID(), true, true, true))
         {
@@ -688,6 +689,7 @@ public:
         }
 
         creature->SetObjectScale(originalScale);
+        creature->SetStandState(originalStandState);
 
         std::string const newName = player.GetName();
 


### PR DESCRIPTION
## Summary
- capture the NPC's current stand state before copying a player's appearance
- restore the original stand state after the copy so the command no longer alters it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee955f723c8327ab0a4232976dec9f