### PR TITLE
Fix flag drop when Spirit of Redemption triggers

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1586,6 +1586,9 @@ void AuraEffect::HandleSpiritOfRedemption(AuraApplication const* aurApp, uint8 m
             // set stand state (expected in this form)
             if (!target->IsStandState())
                 target->SetStandState(UNIT_STAND_STATE_STAND);
+
+            // drop any carried battleground or outdoor PvP flags
+            target->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_IMMUNE_OR_LOST_SELECTION);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure Spirit of Redemption removes any carried PvP flags when applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f282fdbdc0832797a2d6c075e57523