### PR TITLE
Ensure energy regeneration sends client updates immediately

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2198,7 +2198,12 @@ void Player::Regenerate(Powers power)
         else
             m_powerFraction[power] = addvalue - integerValue;
     }
-    if (m_regenTimerCount >= 2000)
+    if (power == POWER_ENERGY)
+    {
+        // Energy regeneration must always notify the client immediately to avoid stale button states
+        SetPower(power, curValue);
+    }
+    else if (m_regenTimerCount >= 2000)
         SetPower(power, curValue);
     else
         UpdateUInt32Value(UNIT_FIELD_POWER1 + AsUnderlyingType(power), curValue);


### PR DESCRIPTION
## Summary
- ensure Player::Regenerate always calls SetPower for energy updates so the client receives the refresh immediately and avoids stale action buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f28a769930832798af071216faa5c5