### PR TITLE
Fix character creation crash caused by createCopyOfChar prepared statement

### DIFF
--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -31,7 +31,11 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_SEL_CHECK_GUID, "SELECT 1 FROM characters WHERE guid = ?", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_SUM_CHARS, "SELECT COUNT(guid) FROM characters WHERE account = ? AND deleteDate IS NULL", CONNECTION_BOTH);
     PrepareStatement(CHAR_SEL_CHAR_CREATE_INFO, "SELECT level, race, class FROM characters WHERE account = ? LIMIT 0, ?", CONNECTION_ASYNC);
-    PrepareStatement(CHAR_CALL_CREATE_COPY_OF_CHAR, "CALL createCopyOfChar(?, ?, ?, ?, ?)", CONNECTION_ASYNC);
+    // Stored procedure createCopyOfChar is executed via DirectExecute on a synchronous connection
+    // during character creation, therefore the prepared statement must be available to synchronous
+    // connections. Using CONNECTION_SYNCH avoids triggering assertions when the synchronous
+    // connection tries to access an async-only prepared statement.
+    PrepareStatement(CHAR_CALL_CREATE_COPY_OF_CHAR, "CALL createCopyOfChar(?, ?, ?, ?, ?)", CONNECTION_SYNCH);
     PrepareStatement(CHAR_INS_CHARACTER_BAN, "INSERT INTO character_banned (guid, bandate, unbandate, bannedby, banreason, active) VALUES (?, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()+?, ?, ?, 1)", CONNECTION_ASYNC);
     PrepareStatement(CHAR_UPD_CHARACTER_BAN, "UPDATE character_banned SET active = 0 WHERE guid = ? AND active != 0", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_CHARACTER_BAN, "DELETE cb FROM character_banned cb INNER JOIN characters c ON c.guid = cb.guid WHERE c.account = ?", CONNECTION_ASYNC);


### PR DESCRIPTION
## Summary
- prepare the createCopyOfChar stored procedure for synchronous connections so DirectExecute during character creation no longer asserts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2a5fa1c78832787fe1785927259dc