### PR TITLE
Keep traps active when spell cast fails

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -39,6 +39,7 @@
 #include "QueryPackets.h"
 #include "ScriptMgr.h"
 #include "SpellMgr.h"
+#include "SpellDefines.h"
 #include "Transport.h"
 #include "UpdateFieldFlags.h"
 #include "World.h"
@@ -775,7 +776,13 @@ void GameObject::Update(uint32 diff)
                         CastSpellExtraArgs args;
                         args.SetOriginalCaster(GetOwnerGUID());
                         if (goInfo->trap.spellId)
-                            CastSpell(target, goInfo->trap.spellId, args);
+                        {
+                            if (CastSpell(target, goInfo->trap.spellId, args) != SPELL_CAST_OK)
+                            {
+                                SetLootState(GO_READY);
+                                break;
+                            }
+                        }
 
                         // Template value or 4 seconds
                         m_cooldownTime = GameTime::GetGameTimeMS() + (goInfo->trap.cooldown ? goInfo->trap.cooldown : uint32(4)) * IN_MILLISECONDS;


### PR DESCRIPTION
## Summary
- re-arm trap gameobjects if their spell cast check fails so they no longer despawn without triggering
- include the spell cast result definition needed for the new logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f32a5e90e08327837bf67da0d1c6f5