### PR TITLE
Refresh trainer list after teaching spells

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -77,7 +77,7 @@ namespace Trainer
         player->SendDirectMessage(trainerList.Write());
     }
 
-    void Trainer::TeachSpell(Creature const* npc, Player* player, uint32 spellId) const
+    void Trainer::TeachSpell(Creature* npc, Player* player, uint32 spellId) const
     {
         if (!IsTrainerValidForPlayer(player))
             return;
@@ -115,6 +115,9 @@ namespace Trainer
             player->LearnSpell(trainerSpell->SpellId, false);
 
         SendTeachSucceeded(npc, player, spellId);
+
+        if (WorldSession* session = player->GetSession())
+            session->SendTrainerList(npc);
     }
 
     Spell const* Trainer::GetSpell(uint32 spellId) const

--- a/src/server/game/Entities/Creature/Trainer.h
+++ b/src/server/game/Entities/Creature/Trainer.h
@@ -71,7 +71,7 @@ namespace Trainer
         std::vector<Spell> const& GetSpells() const { return _spells; }
         void SendSpells(Creature const* npc, Player const* player, LocaleConstant locale) const;
         bool CanTeachSpell(Player const* player, Spell const* trainerSpell) const;
-        void TeachSpell(Creature const* npc, Player* player, uint32 spellId) const;
+        void TeachSpell(Creature* npc, Player* player, uint32 spellId) const;
 
         Type GetTrainerType() const { return _type; }
         uint32 GetTrainerRequirement() const { return _requirement; }


### PR DESCRIPTION
## Summary
- refresh the trainer window after a purchase so the server recalculates spell states
- adjust Trainer::TeachSpell signature to accept a non-const creature pointer so the session call compiles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f32fd8cfd08327b5ab06a37db58e5e