### PR TITLE
Refresh trainer spell list after teaching spells

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -77,22 +77,22 @@ namespace Trainer
         player->SendDirectMessage(trainerList.Write());
     }
 
-    void Trainer::TeachSpell(Creature const* npc, Player* player, uint32 spellId) const
+    bool Trainer::TeachSpell(Creature const* npc, Player* player, uint32 spellId) const
     {
         if (!IsTrainerValidForPlayer(player))
-            return;
+            return false;
 
         Spell const* trainerSpell = GetSpell(spellId);
         if (!trainerSpell)
         {
             SendTeachFailure(npc, player, spellId, FailReason::Unavailable);
-            return;
+            return false;
         }
 
         if (!CanTeachSpell(player, trainerSpell))
         {
             SendTeachFailure(npc, player, spellId, FailReason::NotEnoughSkill);
-            return;
+            return false;
         }
 
         float reputationDiscount = player->GetReputationPriceDiscount(npc);
@@ -100,7 +100,7 @@ namespace Trainer
         if (!player->HasEnoughMoney(moneyCost))
         {
             SendTeachFailure(npc, player, spellId, FailReason::NotEnoughMoney);
-            return;
+            return false;
         }
 
         player->ModifyMoney(-moneyCost);
@@ -115,6 +115,7 @@ namespace Trainer
             player->LearnSpell(trainerSpell->SpellId, false);
 
         SendTeachSucceeded(npc, player, spellId);
+        return true;
     }
 
     Spell const* Trainer::GetSpell(uint32 spellId) const

--- a/src/server/game/Entities/Creature/Trainer.h
+++ b/src/server/game/Entities/Creature/Trainer.h
@@ -71,7 +71,7 @@ namespace Trainer
         std::vector<Spell> const& GetSpells() const { return _spells; }
         void SendSpells(Creature const* npc, Player const* player, LocaleConstant locale) const;
         bool CanTeachSpell(Player const* player, Spell const* trainerSpell) const;
-        void TeachSpell(Creature const* npc, Player* player, uint32 spellId) const;
+        bool TeachSpell(Creature const* npc, Player* player, uint32 spellId) const;
 
         Type GetTrainerType() const { return _type; }
         uint32 GetTrainerRequirement() const { return _requirement; }

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -138,7 +138,8 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPackets::NPC::TrainerBuySpel
     if (!trainer)
         return;
 
-    trainer->TeachSpell(npc, _player, packet.SpellID);
+    if (trainer->TeachSpell(npc, _player, packet.SpellID))
+        trainer->SendSpells(npc, _player, GetSessionDbLocaleIndex());
 }
 
 void WorldSession::HandleGossipHelloOpcode(WorldPacket& recvData)


### PR DESCRIPTION
## Summary
- have Trainer::TeachSpell report when a purchase succeeds
- resend the trainer spell list after successful purchases so spell availability states stay accurate

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f32fd8cfd08327b5ab06a37db58e5e