### PR TITLE
Delay trainer list refresh until after spell learning

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -18,9 +18,12 @@
 #include "Trainer.h"
 #include "Creature.h"
 #include "NPCPackets.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
+#include "Duration.h"
+#include "WorldSession.h"
 
 namespace Trainer
 {
@@ -115,6 +118,17 @@ namespace Trainer
             player->LearnSpell(trainerSpell->SpellId, false);
 
         SendTeachSucceeded(npc, player, spellId);
+
+        ObjectGuid const npcGuid = npc->GetGUID();
+        ObjectGuid const playerGuid = player->GetGUID();
+
+        player->m_Events.AddEventAtOffset([npcGuid, playerGuid]()
+        {
+            if (Player* scheduledPlayer = ObjectAccessor::FindPlayer(playerGuid))
+                if (WorldSession* session = scheduledPlayer->GetSession())
+                    if (Creature* scheduledNpc = ObjectAccessor::GetCreature(*scheduledPlayer, npcGuid))
+                        session->SendTrainerList(scheduledNpc);
+        }, 0s);
     }
 
     Spell const* Trainer::GetSpell(uint32 spellId) const


### PR DESCRIPTION
## Summary
- defer sending the refreshed trainer list until the next update tick so the player's newly learned spells are reflected
- restore the Trainer::TeachSpell signature to take a const creature pointer and pull in the helper dependencies needed for the deferred refresh

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f32fd8cfd08327b5ab06a37db58e5e