### PR TITLE
Automatically queue battleground ghosts with spirit guides

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -18,6 +18,7 @@
 #include "Battleground.h"
 #include "ArenaScore.h"
 #include "BattlegroundMgr.h"
+#include <limits>
 #include "BattlegroundScore.h"
 #include "ChatTextBuilder.h"
 #include "Creature.h"
@@ -1679,6 +1680,39 @@ bool Battleground::AddSpiritGuide(uint32 type, float x, float y, float z, float 
 bool Battleground::AddSpiritGuide(uint32 type, Position const& pos, TeamId teamId /*= TEAM_NEUTRAL*/)
 {
     return AddSpiritGuide(type, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation(), teamId);
+}
+
+Creature* Battleground::GetClosestSpiritGuide(Position const& position, TeamId teamId) const
+{
+    Map* map = FindBgMap();
+    if (!map)
+        return nullptr;
+
+    Creature* closest = nullptr;
+    float minDistSq = std::numeric_limits<float>::max();
+    uint32 expectedEntry = (teamId == TEAM_HORDE) ? BG_CREATURE_ENTRY_H_SPIRITGUIDE : BG_CREATURE_ENTRY_A_SPIRITGUIDE;
+
+    for (ObjectGuid const& guid : BgCreatures)
+    {
+        if (!guid)
+            continue;
+
+        Creature* creature = map->GetCreature(guid);
+        if (!creature || !creature->IsSpiritGuide())
+            continue;
+
+        if (creature->GetEntry() != expectedEntry)
+            continue;
+
+        float distSq = creature->GetExactDistSq(position);
+        if (distSq < minDistSq)
+        {
+            minDistSq = distSq;
+            closest = creature;
+        }
+    }
+
+    return closest;
 }
 
 void Battleground::SendMessageToAll(uint32 entry, ChatMsg msgType, Player const* source)

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -483,6 +483,7 @@ class TC_GAME_API Battleground
         bool RemoveObjectFromWorld(uint32 type);
         virtual bool AddSpiritGuide(uint32 type, float x, float y, float z, float o, TeamId teamId = TEAM_NEUTRAL);
         bool AddSpiritGuide(uint32 type, Position const& pos, TeamId teamId = TEAM_NEUTRAL);
+        Creature* GetClosestSpiritGuide(Position const& position, TeamId teamId) const;
         int32 GetObjectType(ObjectGuid guid);
 
         void DoorOpen(uint32 type);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5040,7 +5040,8 @@ void Player::RepopAtGraveyard()
     WorldSafeLocsEntry const* ClosestGrave;
 
     // Special handle for battleground maps
-    if (Battleground* bg = GetBattleground())
+    Battleground* bg = GetBattleground();
+    if (bg)
         ClosestGrave = bg->GetClosestGraveyard(this);
     else
     {
@@ -5058,6 +5059,20 @@ void Player::RepopAtGraveyard()
     if (ClosestGrave)
     {
         TeleportTo(ClosestGrave->Continent, ClosestGrave->Loc.X, ClosestGrave->Loc.Y, ClosestGrave->Loc.Z, GetOrientation(), shouldResurrect ? TELE_REVIVE_AT_TELEPORT : 0);
+        if (bg && !shouldResurrect && isDead())
+        {
+            Position gravePos(ClosestGrave->Loc.X, ClosestGrave->Loc.Y, ClosestGrave->Loc.Z);
+            TeamId teamId = GetBGTeam() == ALLIANCE ? TEAM_ALLIANCE : TEAM_HORDE;
+
+            bg->RemovePlayerFromResurrectQueue(GetGUID());
+
+            if (Creature* spiritGuide = bg->GetClosestSpiritGuide(gravePos, teamId))
+            {
+                bg->AddPlayerToResurrectQueue(spiritGuide->GetGUID(), GetGUID());
+                sBattlegroundMgr->SendAreaSpiritHealerQueryOpcode(this, bg, spiritGuide->GetGUID());
+            }
+        }
+
         if (isDead())                                        // not send if alive, because it used in TeleportTo()
         {
             WorldPackets::Misc::DeathReleaseLoc packet;


### PR DESCRIPTION
## Summary
- add a battleground helper to find the closest spirit guide for each team
- automatically queue dead battleground players with the nearest spirit guide on graveyard teleport
- send the area spirit healer timer packet without requiring manual gossip interaction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f37b86eda883278a0df0f9358b9a8a