### PR TITLE
Hide enemy flag minimap state in Warsong Gulch and respect battleground teams

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -220,7 +220,7 @@ void BattlegroundWS::AddPlayer(Player* player)
     if (!isInBattleground)
     {
         BattlegroundWGScore* scoreEntry = new BattlegroundWGScore(player->GetGUID());
-        if (player->GetTeam() == HORDE)
+        if (player->GetBGTeam() == HORDE)
         {
             scoreEntry->BonusHonor = 1;
         }
@@ -285,7 +285,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
     uint32 winner = 0;
 
     player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
-    if (player->GetTeam() == ALLIANCE)
+    if (player->GetBGTeam() == ALLIANCE)
     {
         if (!IsHordeFlagPickedup())
             return;
@@ -325,23 +325,23 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
     }
     uint32 flag_honor = sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP);
 
-    RewardHonorToTeam(flag_honor, player->GetTeam());
+    RewardHonorToTeam(flag_honor, player->GetBGTeam());
 
     SpawnBGObject(BG_WS_OBJECT_H_FLAG, BG_WS_FLAG_RESPAWN_TIME);
     SpawnBGObject(BG_WS_OBJECT_A_FLAG, BG_WS_FLAG_RESPAWN_TIME);
 
-    if (player->GetTeam() == ALLIANCE)
+    if (player->GetBGTeam() == ALLIANCE)
         SendBroadcastText(BG_WS_TEXT_CAPTURED_HORDE_FLAG, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
     else
         SendBroadcastText(BG_WS_TEXT_CAPTURED_ALLIANCE_FLAG, CHAT_MSG_BG_SYSTEM_HORDE, player);
 
-    UpdateFlagState(player->GetTeam(), 1);                  // flag state none
-    UpdateTeamScore(player->GetTeamId());
+    UpdateFlagState(player->GetBGTeam(), 1);                  // flag state none
+    UpdateTeamScore(Battleground::GetTeamIndexByTeamId(player->GetBGTeam()));
     // only flag capture should be updated
     UpdatePlayerScore(player, SCORE_FLAG_CAPTURES, 1);      // +1 flag captures
 
     // update last flag capture to be used if teamscore is equal
-    SetLastFlagCapture(player->GetTeam());
+    SetLastFlagCapture(player->GetBGTeam());
 
     if (GetTeamScore(TEAM_ALLIANCE) == BG_WS_MAX_TEAM_SCORE)
         winner = ALLIANCE;
@@ -362,7 +362,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
     }
     else
     {
-        _flagsTimer[GetTeamIndexByTeamId(player->GetTeam()) ? 0 : 1] = BG_WS_FLAG_RESPAWN_TIME;
+        _flagsTimer[GetTeamIndexByTeamId(player->GetBGTeam()) ? 0 : 1] = BG_WS_FLAG_RESPAWN_TIME;
     }
 }
 void BattlegroundWS::HandleFlagRoomCapturePoint(int32 team)
@@ -379,7 +379,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
     {
         // if not running, do not cast things at the dropper player (prevent spawning the "dropped" flag), neither send unnecessary messages
         // just take off the aura
-        if (player->GetTeam() == ALLIANCE)
+        if (player->GetBGTeam() == ALLIANCE)
         {
             if (!IsHordeFlagPickedup())
                 return;
@@ -406,7 +406,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
 
     bool set = false;
 
-    if (player->GetTeam() == ALLIANCE)
+    if (player->GetBGTeam() == ALLIANCE)
     {
         if (!IsHordeFlagPickedup())
             return;
@@ -444,9 +444,9 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
     if (set)
     {
         //player->CastSpell(player, SPELL_RECENTLY_DROPPED_FLAG, true);
-        UpdateFlagState(player->GetTeam(), 1);
+        UpdateFlagState(player->GetBGTeam(), 1);
 
-        if (player->GetTeam() == ALLIANCE)
+        if (player->GetBGTeam() == ALLIANCE)
         {
             SendBroadcastText(BG_WS_TEXT_HORDE_FLAG_DROPPED, CHAT_MSG_BG_SYSTEM_HORDE, player);
             UpdateWorldState(BG_WS_FLAG_UNK_HORDE, uint32(-1));
@@ -457,7 +457,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             UpdateWorldState(BG_WS_FLAG_UNK_ALLIANCE, uint32(-1));
         }
 
-        _flagsDropTimer[GetTeamIndexByTeamId(player->GetTeam()) ? 0 : 1] = BG_WS_FLAG_DROP_TIME;
+        _flagsDropTimer[GetTeamIndexByTeamId(player->GetBGTeam()) ? 0 : 1] = BG_WS_FLAG_DROP_TIME;
     }
 }
 
@@ -467,7 +467,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
         return;
 
     //alliance flag picked up from base
-    if (player->GetTeam() == HORDE && GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_BASE
+    if (player->GetBGTeam() == HORDE && GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_BASE
         && BgObjects[BG_WS_OBJECT_A_FLAG] == target_obj->GetGUID())
     {
         SendBroadcastText(BG_WS_TEXT_ALLIANCE_FLAG_PICKED_UP, CHAT_MSG_BG_SYSTEM_HORDE, player);
@@ -490,7 +490,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
     }
 
     //horde flag picked up from base
-    if (player->GetTeam() == ALLIANCE && GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_BASE
+    if (player->GetBGTeam() == ALLIANCE && GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_BASE
         && BgObjects[BG_WS_OBJECT_H_FLAG] == target_obj->GetGUID())
     {
         SendBroadcastText(BG_WS_TEXT_HORDE_FLAG_PICKED_UP, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
@@ -516,7 +516,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
     if (GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_GROUND && player->IsWithinDistInMap(target_obj, 10)
         && target_obj->GetGOInfo()->entry == BG_OBJECT_A_FLAG_GROUND_WS_ENTRY)
     {
-        if (player->GetTeam() == ALLIANCE)
+        if (player->GetBGTeam() == ALLIANCE)
         {
             SendBroadcastText(BG_WS_TEXT_ALLIANCE_FLAG_RETURNED, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
             UpdateFlagState(HORDE, BG_WS_FLAG_STATE_WAIT_RESPAWN);
@@ -550,7 +550,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
     if (GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND && player->IsWithinDistInMap(target_obj, 10)
         && target_obj->GetGOInfo()->entry == BG_OBJECT_H_FLAG_GROUND_WS_ENTRY)
     {
-        if (player->GetTeam() == HORDE)
+        if (player->GetBGTeam() == HORDE)
         {
             SendBroadcastText(BG_WS_TEXT_HORDE_FLAG_RETURNED, CHAT_MSG_BG_SYSTEM_HORDE, player);
             UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_WAIT_RESPAWN);
@@ -612,10 +612,15 @@ void BattlegroundWS::RemovePlayer(Player* player, ObjectGuid guid, uint32 /*team
 
 void BattlegroundWS::UpdateFlagState(uint32 team, uint32 value)
 {
-    if (team == ALLIANCE)
-        UpdateWorldState(BG_WS_FLAG_STATE_ALLIANCE, value);
-    else
-        UpdateWorldState(BG_WS_FLAG_STATE_HORDE, value);
+    uint32 const worldStateId = (team == ALLIANCE) ? BG_WS_FLAG_STATE_ALLIANCE : BG_WS_FLAG_STATE_HORDE;
+
+    // Prevent revealing the enemy flag carrier on the minimap by never sending the
+    // "on player" state to clients. The client displays the minimap icon when this
+    // world state is set to BG_WS_FLAG_STATE_ON_PLAYER, so fall back to
+    // BG_WS_FLAG_STATE_WAIT_RESPAWN instead.
+    uint32 const broadcastValue = (value == BG_WS_FLAG_STATE_ON_PLAYER) ? BG_WS_FLAG_STATE_WAIT_RESPAWN : value;
+
+    UpdateWorldState(worldStateId, broadcastValue);
 }
 
 void BattlegroundWS::UpdateTeamScore(uint32 team)
@@ -814,7 +819,7 @@ WorldSafeLocsEntry const* BattlegroundWS::GetClosestGraveyard(Player* player)
     //if a player dies in preparation phase - then the player can't cheat
     //and teleport to the graveyard outside the flagroom
     //and start running around, while the doors are still closed
-    if (player->GetTeam() == ALLIANCE)
+    if (player->GetBGTeam() == ALLIANCE)
     {
         if (GetStatus() == STATUS_IN_PROGRESS)
             return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_MAIN_ALLIANCE);
@@ -860,12 +865,12 @@ void BattlegroundWS::FillInitialWorldStates(WorldPackets::WorldState::InitWorldS
         packet.Worldstates.emplace_back(BG_WS_STATE_TIMER_ACTIVE, 0);
 
     if (_flagState[TEAM_HORDE] == BG_WS_FLAG_STATE_ON_PLAYER)
-        packet.Worldstates.emplace_back(BG_WS_FLAG_STATE_HORDE, 2);
+        packet.Worldstates.emplace_back(BG_WS_FLAG_STATE_HORDE, BG_WS_FLAG_STATE_WAIT_RESPAWN);
     else
         packet.Worldstates.emplace_back(BG_WS_FLAG_STATE_HORDE, 1);
 
     if (_flagState[TEAM_ALLIANCE] == BG_WS_FLAG_STATE_ON_PLAYER)
-        packet.Worldstates.emplace_back(BG_WS_FLAG_STATE_ALLIANCE, 2);
+        packet.Worldstates.emplace_back(BG_WS_FLAG_STATE_ALLIANCE, BG_WS_FLAG_STATE_WAIT_RESPAWN);
     else
         packet.Worldstates.emplace_back(BG_WS_FLAG_STATE_ALLIANCE, 1);
 }
@@ -887,7 +892,7 @@ bool BattlegroundWS::CheckAchievementCriteriaMeet(uint32 criteriaId, Player cons
         case BG_CRITERIA_CHECK_SAVE_THE_DAY:
             if (target)
                 if (Player const* playerTarget = target->ToPlayer())
-                    return GetFlagState(playerTarget->GetTeam()) == BG_WS_FLAG_STATE_ON_BASE;
+                    return GetFlagState(playerTarget->GetBGTeam()) == BG_WS_FLAG_STATE_ON_BASE;
             return false;
     }
 


### PR DESCRIPTION
## Summary
- stop sending the "on player" world state for Warsong Gulch flags so the enemy carrier no longer appears on the minimap
- ensure newly joining players receive the masked world state in their initial data
- base Warsong Gulch flag handling on each player's battleground team so cross-faction participants see the correct flag colors, scoring, and messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f32d5f8c408327a6050ef6eefec256