### PR TITLE
Add missing return when teaching trainer spells

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -129,6 +129,8 @@ namespace Trainer
                     if (Creature* scheduledNpc = ObjectAccessor::GetCreature(*scheduledPlayer, npcGuid))
                         session->SendTrainerList(scheduledNpc);
         }, 0s);
+
+        return true;
     }
 
     Spell const* Trainer::GetSpell(uint32 spellId) const


### PR DESCRIPTION
## Summary
- return true from Trainer::TeachSpell after successfully teaching a spell to avoid undefined behaviour and disconnects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f391e1824c83278acccc76ac017c3f