### PR TITLE
Open spirit healer gossip automatically on release

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -18,6 +18,7 @@
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
 #include "Battleground.h"
+#include "Creature.h"
 #include "CellImpl.h"
 #include "CreatureTextMgr.h"
 #include "DBCStores.h"
@@ -34,6 +35,7 @@
 #include "ObjectMgr.h"
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
+#include "GossipDef.h"
 #include <G3D/g3dmath.h>
 
 Battlefield::Battlefield()
@@ -635,6 +637,22 @@ void Battlefield::SendAreaSpiritHealerQueryOpcode(Player* player, ObjectGuid gui
 
     data << guid << time;
     player->SendDirectMessage(&data);
+
+    if (!player->IsAlive())
+    {
+        if (Map* map = player->GetMap())
+        {
+            if (Creature* spiritGuide = map->GetCreature(guid))
+            {
+                if (spiritGuide->IsSpiritGuide())
+                {
+                    player->PlayerTalkClass->ClearMenus();
+                    player->PrepareGossipMenu(spiritGuide, spiritGuide->GetCreatureTemplate()->GossipMenuId, true);
+                    player->SendPreparedGossip(spiritGuide);
+                }
+            }
+        }
+    }
 }
 
 // ----------------------

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -31,6 +31,7 @@
 #include "Common.h"
 #include "Containers.h"
 #include "Chat.h"
+#include "Creature.h"
 #include "DatabaseEnv.h"
 #include "DisableMgr.h"
 #include "Formulas.h"
@@ -46,6 +47,7 @@
 #include "Player.h"
 #include "World.h"
 #include "WorldPacket.h"
+#include "GossipDef.h"
 
 bool BattlegroundTemplate::IsArena() const
 {
@@ -724,6 +726,22 @@ void BattlegroundMgr::SendAreaSpiritHealerQueryOpcode(Player* player, Battlegrou
         time_ = 0;
     data << guid << time_;
     player->SendDirectMessage(&data);
+
+    if (!player->IsAlive())
+    {
+        if (Map* map = player->GetMap())
+        {
+            if (Creature* spiritGuide = map->GetCreature(guid))
+            {
+                if (spiritGuide->IsSpiritGuide())
+                {
+                    player->PlayerTalkClass->ClearMenus();
+                    player->PrepareGossipMenu(spiritGuide, spiritGuide->GetCreatureTemplate()->GossipMenuId, true);
+                    player->SendPreparedGossip(spiritGuide);
+                }
+            }
+        }
+    }
 }
 
 bool BattlegroundMgr::IsArenaType(BattlegroundTypeId bgTypeId)


### PR DESCRIPTION
## Summary
- automatically open the spirit guide gossip dialog when ghosts receive the spirit healer timer in battlegrounds and battlefields
- reuse existing gossip preparation to ensure the resurrection option is displayed without manual interaction
- include GossipDef so the PlayerMenu definition is available when clearing gossip menus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3d834c3f483278b22d277036a8ac0