### PR TITLE
Fix automatic spirit healer gossip

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -18,6 +18,7 @@
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
 #include "Battleground.h"
+#include "Creature.h"
 #include "CellImpl.h"
 #include "CreatureTextMgr.h"
 #include "DBCStores.h"
@@ -635,6 +636,22 @@ void Battlefield::SendAreaSpiritHealerQueryOpcode(Player* player, ObjectGuid gui
 
     data << guid << time;
     player->SendDirectMessage(&data);
+
+    if (!player->IsAlive())
+    {
+        if (Map* map = player->GetMap())
+        {
+            if (Creature* spiritGuide = map->GetCreature(guid))
+            {
+                if (spiritGuide->IsSpiritGuide())
+                {
+                    player->SetSelection(guid);
+                    player->PrepareGossipMenu(spiritGuide);
+                    player->SendPreparedGossip(spiritGuide);
+                }
+            }
+        }
+    }
 }
 
 // ----------------------

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -31,6 +31,7 @@
 #include "Common.h"
 #include "Containers.h"
 #include "Chat.h"
+#include "Creature.h"
 #include "DatabaseEnv.h"
 #include "DisableMgr.h"
 #include "Formulas.h"
@@ -724,6 +725,22 @@ void BattlegroundMgr::SendAreaSpiritHealerQueryOpcode(Player* player, Battlegrou
         time_ = 0;
     data << guid << time_;
     player->SendDirectMessage(&data);
+
+    if (!player->IsAlive())
+    {
+        if (Map* map = player->GetMap())
+        {
+            if (Creature* spiritGuide = map->GetCreature(guid))
+            {
+                if (spiritGuide->IsSpiritGuide())
+                {
+                    player->SetSelection(guid);
+                    player->PrepareGossipMenu(spiritGuide);
+                    player->SendPreparedGossip(spiritGuide);
+                }
+            }
+        }
+    }
 }
 
 bool BattlegroundMgr::IsArenaType(BattlegroundTypeId bgTypeId)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -292,11 +292,6 @@ Player::Player(WorldSession* session): Unit(true)
         m_bgBattlegroundQueueID[j].invitedToInstance = 0;
     }
 
-    m_bgSpiritGuideDialogGuid.Clear();
-    m_bgSpiritGuideDialogTimer = 0;
-    m_bgSpiritGuideDialogSendsRemaining = 0;
-    m_bgSpiritGuideDialogSearchAttempts = 0;
-
     m_logintime = GameTime::GetGameTime();
     m_Last_tick = m_logintime;
     m_Played_time[PLAYED_TIME_TOTAL] = 0;
@@ -1061,8 +1056,6 @@ void Player::Update(uint32 p_time)
     SetCanDelayTeleport(true);
     Unit::Update(p_time);
     SetCanDelayTeleport(false);
-
-    HandleBattlegroundSpiritGuideDialog(p_time);
 
     time_t now = GameTime::GetGameTime();
 
@@ -1948,79 +1941,8 @@ void Player::ProcessDelayedOperations()
             g->SendUpdateToPlayer(GetGUID());
     }
 
-    if (m_DelayedOperations & DELAYED_BG_SPIRIT_HEALER)
-    {
-        if (m_bgSpiritGuideDialogGuid)
-        {
-            if (Battleground* bg = GetBattleground())
-                sBattlegroundMgr->SendAreaSpiritHealerQueryOpcode(this, bg, m_bgSpiritGuideDialogGuid);
-
-            m_bgSpiritGuideDialogGuid.Clear();
-        }
-    }
-
     //we have executed ALL delayed ops, so clear the flag
     m_DelayedOperations = 0;
-}
-
-void Player::ClearBattlegroundSpiritGuideDialog()
-{
-    m_bgSpiritGuideDialogGuid.Clear();
-    m_bgSpiritGuideDialogTimer = 0;
-    m_bgSpiritGuideDialogSendsRemaining = 0;
-    m_bgSpiritGuideDialogSearchAttempts = 0;
-}
-
-void Player::StartBattlegroundSpiritGuideDialog(ObjectGuid const& spiritGuideGuid)
-{
-    m_bgSpiritGuideDialogGuid = spiritGuideGuid;
-    m_bgSpiritGuideDialogTimer = 0;
-    m_bgSpiritGuideDialogSendsRemaining = 3;
-    m_bgSpiritGuideDialogSearchAttempts = 0;
-}
-
-void Player::HandleBattlegroundSpiritGuideDialog(uint32 diff)
-{
-    if (!m_bgSpiritGuideDialogGuid)
-        return;
-
-    if (!InBattleground() || IsAlive())
-    {
-        ClearBattlegroundSpiritGuideDialog();
-        return;
-    }
-
-    if (m_bgSpiritGuideDialogTimer > diff)
-    {
-        m_bgSpiritGuideDialogTimer -= diff;
-        return;
-    }
-
-    m_bgSpiritGuideDialogTimer = 200;
-
-    if (Map* map = GetMap())
-    {
-        if (Creature* spiritGuide = map->GetCreature(m_bgSpiritGuideDialogGuid))
-        {
-            SetSelection(m_bgSpiritGuideDialogGuid);
-
-            if (Battleground* bg = GetBattleground())
-                sBattlegroundMgr->SendAreaSpiritHealerQueryOpcode(this, bg, m_bgSpiritGuideDialogGuid);
-
-            if (m_bgSpiritGuideDialogSendsRemaining)
-                --m_bgSpiritGuideDialogSendsRemaining;
-
-            if (m_bgSpiritGuideDialogSendsRemaining == 0)
-                ClearBattlegroundSpiritGuideDialog();
-            else
-                m_bgSpiritGuideDialogTimer = 1000;
-
-            return;
-        }
-    }
-
-    if (++m_bgSpiritGuideDialogSearchAttempts >= 25)
-        ClearBattlegroundSpiritGuideDialog();
 }
 
 void Player::AddToWorld()
@@ -5140,7 +5062,6 @@ void Player::RepopAtGraveyard()
         TeleportTo(ClosestGrave->Continent, ClosestGrave->Loc.X, ClosestGrave->Loc.Y, ClosestGrave->Loc.Z, GetOrientation(), shouldResurrect ? TELE_REVIVE_AT_TELEPORT : 0);
         if (bg && !shouldResurrect && isDead())
         {
-            ClearBattlegroundSpiritGuideDialog();
             Position gravePos(ClosestGrave->Loc.X, ClosestGrave->Loc.Y, ClosestGrave->Loc.Z);
             TeamId teamId = GetBGTeam() == ALLIANCE ? TEAM_ALLIANCE : TEAM_HORDE;
 
@@ -5148,8 +5069,10 @@ void Player::RepopAtGraveyard()
 
             if (Creature* spiritGuide = bg->GetClosestSpiritGuide(gravePos, teamId))
             {
-                bg->AddPlayerToResurrectQueue(spiritGuide->GetGUID(), GetGUID());
-                StartBattlegroundSpiritGuideDialog(spiritGuide->GetGUID());
+                ObjectGuid spiritGuideGuid = spiritGuide->GetGUID();
+                bg->AddPlayerToResurrectQueue(spiritGuideGuid, GetGUID());
+                SetSelection(spiritGuideGuid);
+                sBattlegroundMgr->SendAreaSpiritHealerQueryOpcode(this, bg, spiritGuideGuid);
             }
         }
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -752,7 +752,6 @@ enum PlayerDelayedOperations
     DELAYED_BG_MOUNT_RESTORE    = 0x08,                     ///< Flag to restore mount state after teleport from BG
     DELAYED_BG_TAXI_RESTORE     = 0x10,                     ///< Flag to restore taxi state after teleport from BG
     DELAYED_BG_GROUP_RESTORE    = 0x20,                     ///< Flag to restore group state after teleport from BG
-    DELAYED_BG_SPIRIT_HEALER    = 0x40,
     DELAYED_END
 };
 
@@ -2266,11 +2265,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         BgBattlegroundQueueID_Rec m_bgBattlegroundQueueID[PLAYER_MAX_BATTLEGROUND_QUEUES];
         BGData                    m_bgData;
-        ObjectGuid                m_bgSpiritGuideDialogGuid;
-        uint32                    m_bgSpiritGuideDialogTimer;
-        uint8                     m_bgSpiritGuideDialogSendsRemaining;
-        uint8                     m_bgSpiritGuideDialogSearchAttempts;
-
         bool m_IsBGRandomWinner;
 
         /*********************************************************/
@@ -2534,9 +2528,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         bool IsHasDelayedTeleport() const { return m_bHasDelayedTeleport; }
         void SetDelayedTeleportFlag(bool setting) { m_bHasDelayedTeleport = setting; }
         void ScheduleDelayedOperation(uint32 operation) { if (operation < DELAYED_END) m_DelayedOperations |= operation; }
-        void ClearBattlegroundSpiritGuideDialog();
-        void HandleBattlegroundSpiritGuideDialog(uint32 diff);
-        void StartBattlegroundSpiritGuideDialog(ObjectGuid const& spiritGuideGuid);
 
         bool IsInstanceLoginGameMasterException() const;
 


### PR DESCRIPTION
## Summary
- set the player's selection and send the prepared gossip when notifying ghosts of the spirit healer timer in battlegrounds and battlefields
- remove the delayed spirit healer dialog retry code so resurrection dialogs open directly when a player releases at a graveyard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3d834c3f483278b22d277036a8ac0