### PR TITLE
Restore arena replay module implementation

### DIFF
--- a/sql/custom/characters/mod_arena_replay.sql
+++ b/sql/custom/characters/mod_arena_replay.sql
@@ -1,0 +1,22 @@
+-- Arena replay module tables
+
+CREATE TABLE IF NOT EXISTS `character_arena_replays` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `arenaTypeId` INT NULL DEFAULT NULL,
+  `typeId` INT NULL DEFAULT NULL,
+  `contentSize` INT NULL DEFAULT NULL,
+  `contents` LONGBLOB NULL,
+  `mapId` INT NULL DEFAULT NULL,
+  `savedBy` VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT '0',
+  `timestamp` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `character_saved_replays` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `character_id` INT UNSIGNED NOT NULL,
+  `replay_id` INT UNSIGNED NOT NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_character_replay` (`character_id`, `replay_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -604,9 +604,9 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_INS_DESERTER_TRACK, "INSERT INTO battleground_deserters (guid, type, datetime) VALUES (?, ?, NOW())", CONNECTION_ASYNC);
 
     // bg replays
-    PrepareStatement(CHAR_INS_ARENA_REPLAYS, "INSERT INTO character_bg_replays (arenaTypeId, typeId, contentSize, contents, mapId) VALUES (?, ?, ?, ?, ?)", CONNECTION_ASYNC);
-    PrepareStatement(CHAR_SEL_ARENA_REPLAYS, "SELECT id, arenaTypeId, typeId, contentSize, contents, mapId FROM character_bg_replays where id =  ?", CONNECTION_SYNCH);
-    PrepareStatement(CHAR_SEL_LAST_10_ARENA_REPLAYS, "SELECT id, arenaTypeId, typeId, contentSize, contents, mapId FROM character_bg_replays order by id desc limit 10", CONNECTION_SYNCH);
+    PrepareStatement(CHAR_INS_ARENA_REPLAYS, "INSERT INTO character_arena_replays (arenaTypeId, typeId, contentSize, contents, mapId) VALUES (?, ?, ?, ?, ?)", CONNECTION_ASYNC);
+    PrepareStatement(CHAR_SEL_ARENA_REPLAYS, "SELECT id, arenaTypeId, typeId, contentSize, contents, mapId FROM character_arena_replays WHERE id =  ?", CONNECTION_SYNCH);
+    PrepareStatement(CHAR_SEL_LAST_10_ARENA_REPLAYS, "SELECT id, arenaTypeId, typeId, contentSize, contents, mapId FROM character_arena_replays ORDER BY id DESC LIMIT 10", CONNECTION_SYNCH);
 }
 
 CharacterDatabaseConnection::CharacterDatabaseConnection(MySQLConnectionInfo& connInfo) : MySQLConnection(connInfo)

--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -3,36 +3,27 @@
 //
 #include "Player.h"
 #include "Opcodes.h"
-#include "Chat.h"
 #include "Battleground.h"
 #include "BattlegroundMgr.h"
 #include "ScriptMgr.h"
-#include "WorldSession.h"
-#include "WorldSocket.h"
-#include "Log.h"
-#include "Map.h"
-#include "ObjectDefines.h"
-#include "ObjectMgr.h"
-#include "GameTime.h"
-#include "Random.h"
-#include <boost/asio.hpp>
-#include <unordered_map>
-#include <unordered_set>
-#include "DatabaseEnv.h"
-#include <ObjectAccessor.h>
-#include "ScriptMgr.h"
-#include "ScriptedCreature.h"
 #include "ScriptedGossip.h"
-#include "GameEventMgr.h"
-#include "Player.h"
+#include "Chat.h"
+#include "World.h"
 #include "WorldSession.h"
-#include <DBCStores.h>
-#include <zlib.h>
+#include "WorldPacket.h"
+#include "DatabaseEnv.h"
+#include "ByteBuffer.h"
+#include <algorithm>
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 
-std::vector<Opcodes> watchList = {
-    SMSG_BATTLEGROUND_PLAYER_JOINED,
-    SMSG_BATTLEGROUND_PLAYER_LEFT,
+
+std::vector<Opcodes> watchList =
+{
         SMSG_NOTIFICATION,
         SMSG_AURA_UPDATE,
         SMSG_WORLD_STATE_UI_TIMER_UPDATE,
@@ -58,6 +49,13 @@ std::vector<Opcodes> watchList = {
         MSG_MOVE_START_TURN_RIGHT,
         SMSG_SPELL_START,
         SMSG_SPELL_GO,
+        CMSG_CAST_SPELL,
+        CMSG_CANCEL_CAST,
+        SMSG_CAST_FAILED,
+        SMSG_SPELL_START,
+        SMSG_SPELL_FAILURE,
+        SMSG_SPELL_DELAYED,
+        SMSG_PLAY_SPELL_IMPACT,
         SMSG_FORCE_RUN_SPEED_CHANGE,
         SMSG_ATTACK_START,
         SMSG_POWER_UPDATE,
@@ -67,9 +65,7 @@ std::vector<Opcodes> watchList = {
         SMSG_SPELLENERGIZELOG,
         SMSG_SPELLNONMELEEDAMAGELOG,
         SMSG_ATTACK_STOP,
-        SMSG_SPELLLOGEXECUTE,
         SMSG_EMOTE,
-        SMSG_SPELL_DELAYED,
         SMSG_AI_REACTION,
         SMSG_PET_NAME_QUERY_RESPONSE,
         SMSG_CANCEL_AUTO_REPEAT,
@@ -78,632 +74,573 @@ std::vector<Opcodes> watchList = {
         SMSG_GAMEOBJECT_QUERY_RESPONSE,
         SMSG_FORCE_SWIM_SPEED_CHANGE,
         SMSG_GAMEOBJECT_DESPAWN_ANIM,
-        SMSG_CANCEL_COMBAT
+        SMSG_CANCEL_COMBAT,
+        SMSG_DISMOUNTRESULT,
+        SMSG_MOUNTRESULT,
+        SMSG_DISMOUNT,
+        CMSG_MOUNTSPECIAL_ANIM,
+        SMSG_MOUNTSPECIAL_ANIM,
+        SMSG_MIRRORIMAGE_DATA,
+        CMSG_MESSAGECHAT,
+        SMSG_MESSAGECHAT
 };
 
+/*
+CMSG_CANCEL_MOUNT_AURA,
+CMSG_ALTER_APPEARANCE
+SMSG_SUMMON_CANCEL
+SMSG_PLAY_SOUND
+SMSG_PLAY_SPELL_VISUAL
+CMSG_ATTACKSWING
+CMSG_ATTACKSTOP*/
 
 struct PacketRecord { uint32 timestamp; WorldPacket packet; };
-struct MatchRecord {
-    BattlegroundTypeId typeId;
-    uint8 arenaTypeId;
-    uint32 mapId;
-    uint32 startTime = 0;
-    ObjectGuid allianceRecorder;
-    ObjectGuid hordeRecorder;
-    std::deque<PacketRecord> packets;
-};
-
-namespace
-{
-    ObjectGuid GenerateAlternateGuid(ObjectGuid guid)
-    {
-        uint64 raw = guid.GetRawValue();
-        uint64 newRaw = raw;
-        for (int i = 0; i < 6; ++i)
-        {
-            uint8 oldByte = (raw >> (i * 8)) & 0xFF;
-            if (oldByte)
-            {
-                uint8 newByte = oldByte;
-                while (newByte == oldByte)
-                    newByte = uint8(urand(1, 255));
-                newRaw &= ~(uint64(0xFF) << (i * 8));
-                newRaw |= uint64(newByte) << (i * 8);
-            }
-        }
-        return ObjectGuid(newRaw);
-    }
-
-    void ReplaceGuid(WorldPacket& packet, ObjectGuid const& oldGuid, ObjectGuid const& newGuid)
-    {
-        if (oldGuid == newGuid || oldGuid.IsEmpty())
-            return;
-
-        bool compressed = packet.GetOpcode() == SMSG_COMPRESSED_UPDATE_OBJECT;
-        ByteBuffer buffer;
-
-        if (compressed)
-        {
-            if (packet.size() < sizeof(uint32))
-                return;
-
-            uint32 size = packet.read<uint32>(0);
-            if (!size)
-                return;
-
-            buffer.resize(size);
-            uLongf realSize = size;
-            if (uncompress(buffer.contents(), &realSize, packet.contents() + sizeof(uint32), packet.size() - sizeof(uint32)) != Z_OK)
-                return;
-            buffer.resize(realSize);
-            TC_LOG_DEBUG("bg.replay", "Decompressed packet opcode {} from {} to {} bytes", GetOpcodeNameForLogging(static_cast<Opcodes>(packet.GetOpcode())), packet.size(), realSize);
-
-        }
-        else
-        {
-            buffer.resize(packet.size());
-            if (packet.size() > 0)
-                memcpy(buffer.contents(), packet.contents(), packet.size());
-        }
-
-        uint64 oldRaw = oldGuid.GetRawValue();
-        uint64 newRaw = newGuid.GetRawValue();
-
-        size_t len = buffer.size();
-        uint8* data = buffer.contents();
-        size_t replaced = 0;
-        for (size_t i = 0; i + sizeof(uint64) <= len; ++i)
-        {
-            uint64 val;
-            memcpy(&val, data + i, sizeof(uint64));
-            if (val == oldRaw)
-            {
-                memcpy(data + i, &newRaw, sizeof(uint64));
-                ++replaced;
-            }
-        }
-
-        ByteBuffer oldPack; oldPack << oldGuid.WriteAsPacked();
-        ByteBuffer newPack; newPack << newGuid.WriteAsPacked();
-        auto oldVec = oldPack.contentsAsVector();
-        auto newVec = newPack.contentsAsVector();
-
-        if (!oldVec.empty())
-        {
-            if (oldVec.size() == newVec.size())
-            {
-                for (size_t i = 0; i + oldVec.size() <= len; ++i)
-                    if (memcmp(data + i, oldVec.data(), oldVec.size()) == 0)
-                        memcpy(data + i, newVec.data(), newVec.size());
-            }
-            else
-            {
-                std::vector<uint8> newData;
-                newData.reserve(len); // approximate
-                for (size_t i = 0; i < len;)
-                {
-                    if (i + oldVec.size() <= len && memcmp(data + i, oldVec.data(), oldVec.size()) == 0)
-                    {
-                        newData.insert(newData.end(), newVec.begin(), newVec.end());
-                        i += oldVec.size();
-                    }
-                    else
-                    {
-                        newData.push_back(data[i]);
-                        ++i;
-                    }
-                }
-                buffer.clear();
-                buffer.append(newData.data(), newData.size());
-                len = buffer.size();
-                data = buffer.contents();
-            }
-        }
-
-        TC_LOG_DEBUG("bg.replay", "ReplaceGuid {} -> {} replaced {} raw occurrences", oldGuid.ToString(), newGuid.ToString(), replaced);
-
-        packet.clear();
-        if (compressed)
-        {
-            uLongf destSize = compressBound(len);
-            packet.resize(destSize + sizeof(uint32));
-            packet.put<uint32>(0, len);
-            if (compress(packet.contents() + sizeof(uint32), &destSize, buffer.contents(), len) != Z_OK)
-                return;
-            packet.resize(destSize + sizeof(uint32));
-            packet.SetOpcode(SMSG_COMPRESSED_UPDATE_OBJECT);
-        }
-        else
-        {
-            packet.append(buffer.contents(), len);
-        }
-    }
-}
+struct MatchRecord { BattlegroundTypeId typeId; uint8 arenaTypeId; uint32 mapId; std::deque<PacketRecord> packets; };
 std::unordered_map<uint32, MatchRecord> records;
 std::unordered_map<uint64, MatchRecord> loadedReplays;
-// Headless spectators used for recording packets per battleground instance
-std::unordered_map<uint32, Player*> replayBots;
-// Helper container to avoid recursive bot creation
-std::unordered_set<uint32> creatingReplayBots;
 
-namespace
+class ArenaReplayServerScript : public ServerScript
 {
-    // Dummy socket used so the headless spectator can receive packets
-    class ReplaySocket : public WorldSocket
-    {
-    public:
-        ReplaySocket() : WorldSocket(Create()) {}
-
-        static tcp::socket Create()
-        {
-            static boost::asio::io_context io;
-            tcp::acceptor acceptor(io, tcp::endpoint(tcp::v4(), 0));
-            tcp::socket server(io);
-            tcp::socket client(io);
-            client.connect(tcp::endpoint(boost::asio::ip::address_v4::loopback(),
-                                         acceptor.local_endpoint().port()));
-            acceptor.accept(server);
-            io.poll();
-            acceptor.close();
-            server.close();
-            return client;
-        }
-
-        void Start() override {}
-        bool Update() override { return true; }
-    };
-
-    Player* CreateReplayBot(Battleground* bg)
-    {
-        if (!bg->FindBgMap())
-            return nullptr;
-        WorldSession* botSession = new WorldSession(0, "ReplayBot", std::make_shared<ReplaySocket>(), SEC_ADMINISTRATOR,
-            2, 0, Minutes(0), LOCALE_enUS, 0, false);
-        Player* bot = new Player(botSession);
-
-        struct ReplayBotCreateInfo : CharacterCreateInfo
-        {
-            ReplayBotCreateInfo()
-            {
-                Name = "ReplayBot";
-                Race = RACE_HUMAN;
-                Class = CLASS_MAGE;
-                Gender = GENDER_MALE;
-            }
-        } createInfo;
-
-        bot->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo);
-        botSession->SetPlayer(bot);
-        bot->GetMotionMaster()->Initialize();
-
-        bot->SetGameMaster(true);
-        bot->SetGMVisible(false);
-        bot->SetIsSpectator(true);
-
-        Position const* pos = bg->GetTeamStartPosition(TEAM_ALLIANCE);
-        bot->Relocate(*pos);
-        bot->SetBattlegroundId(bg->GetInstanceID(), bg->GetTypeID(), PLAYER_MAX_BATTLEGROUND_QUEUES, false, false, TEAM_NEUTRAL);
-        bot->ResetMap();
-        bot->SetMap(bg->GetBgMap());
-        bg->GetBgMap()->AddPlayerToMap(bot);
-        bg->AddSpectator(bot);
-        TC_LOG_DEBUG("bg.replay", "Created replay bot for instance {}", bg->GetInstanceID());
-        return bot;
-    }
-
-    void DestroyReplayBot(Battleground* bg)
-    {
-        auto itr = replayBots.find(bg->GetInstanceID());
-        if (itr == replayBots.end())
-            return;
-        Player* bot = itr->second;
-        WorldSession* session = bot->GetSession();
-        bot->CleanupsBeforeDelete();
-        if (bot->GetMap())
-            bot->GetMap()->RemovePlayerFromMap(bot, true);
-        if (session)
-            session->SetPlayer(nullptr);
-        delete session;
-        replayBots.erase(itr);
-    }
-}
-
-class BGReplayServerScript : public ServerScript {
 public:
-    BGReplayServerScript() : ServerScript("BGReplayServerScript") {}
+    ArenaReplayServerScript() : ServerScript("ArenaReplayServerScript") {}
 
-    void OnPacketSend(WorldSession* session, WorldPacket& packet) override {
-        if (session == nullptr || session->GetPlayer() == nullptr) return;
+
+    bool CanPacketSend(WorldSession* session, WorldPacket& packet) override
+    {
+        if (session == nullptr || session->GetPlayer() == nullptr)
+            return true;
 
         Battleground* bg = session->GetPlayer()->GetBattleground();
 
-        //ignore packet when no bg or casual games
-        if (bg == nullptr || bg->IsReplay()) return;
-        // ignore packets before players have entered the battleground
-        if (bg->GetStatus() <= BattlegroundStatus::STATUS_WAIT_QUEUE) return;
+        if (!bg)
+            return true;
 
+        uint32 replayId = bg->GetReplayID();
 
-        // ensure the record container exists for this battleground instance
-        if (records.find(bg->GetInstanceID()) == records.end())
-            records[bg->GetInstanceID()] = MatchRecord();
+        // ignore packet when no bg or casual games
+        if (replayId > 0)
+            return true;
 
+        // ignore packets until arena started
+        if (bg->GetStatus() != BattlegroundStatus::STATUS_IN_PROGRESS)
+            return true; 
 
-        MatchRecord& record = records[bg->GetInstanceID()];
-
-        BattlegroundMap* map = bg->FindBgMap();
-        if (!map)
-            return; // map hasn't been created yet
-
-        // player hasn't teleported into the battleground instance
-        if (session->GetPlayer()->GetMap() != map)
-            return;
-
-        uint32 instanceId = bg->GetInstanceID();
-        if (!replayBots[instanceId])
+        // record packets from 1 player of each team
+        // iterate just in case a player leaves and used as reference
+        for (auto it : bg->GetPlayers())
         {
-            if (creatingReplayBots.count(instanceId))
-                return;
-
-            creatingReplayBots.insert(instanceId);
-            replayBots[instanceId] = CreateReplayBot(bg);
-            creatingReplayBots.erase(instanceId);
-            return;
-        }
-        if (session->GetPlayer() != replayBots[instanceId])
-            return;
-        //ignore packets not in watch list
-        if (std::find(watchList.begin(), watchList.end(), packet.GetOpcode()) == watchList.end())
-            return;
-
-        TC_LOG_TRACE("bg.replay", "Recording opcode {} size {}", GetOpcodeNameForLogging(static_cast<Opcodes>(packet.GetOpcode())), packet.size());
-
-        if (record.startTime == 0)
-        {
-            record.startTime = GameTime::GetGameTimeMS() - bg->GetStartTime();
-            for (auto const& itr : bg->GetPlayers())
+            if (it.second->GetBgTeamId() == session->GetPlayer()->GetBgTeamId())
             {
-                ObjectGuid guid = itr.first;
-                if (Player* plr = ObjectAccessor::FindPlayer(guid))
-                {
-                    uint32 team = plr->GetBGTeam();
-                    if (team == ALLIANCE && record.allianceRecorder.IsEmpty())
-                        record.allianceRecorder = plr->GetGUID();
-                    else if (team == HORDE && record.hordeRecorder.IsEmpty())
-                        record.hordeRecorder = plr->GetGUID();
-
-                    if (!record.allianceRecorder.IsEmpty() && !record.hordeRecorder.IsEmpty())
-                        break;
-                }
+                if (it.second->GetGUID() != session->GetPlayer()->GetGUID())
+                    return true;
+                else
+                    break;
             }
         }
 
-        uint32 timestamp = GameTime::GetGameTimeMS() - record.startTime;
-        record.typeId = bg->GetTypeID(false);
-        if (record.typeId == BATTLEGROUND_AA)
-        {
-            record.typeId = bg->GetTypeID(true);
-        }
+        // ignore packets not in watch list
+        if (std::find(watchList.begin(), watchList.end(), packet.GetOpcode()) == watchList.end())
+            return true;
+
+        if (records.find(bg->GetInstanceID()) == records.end())
+            records[bg->GetInstanceID()].packets.clear();
+        MatchRecord& record = records[bg->GetInstanceID()];
+
+        uint32 timestamp = bg->GetStartTime();
+        record.typeId = bg->GetBgTypeID();
         record.arenaTypeId = bg->GetArenaType();
         record.mapId = bg->GetMapId();
-
-        //push back packet inside queue of matchId 0
+        // push back packet inside queue of matchId 0
         record.packets.push_back({ timestamp, /* copy */ WorldPacket(packet) });
+        return true;
     }
 };
 
-
-class BGReplayBGScript : public BattlegroundScript {
+class ArenaReplayBGScript : public BattlegroundScript
+{
 public:
-    BGReplayBGScript() : BattlegroundScript("BGReplayBGScript") {}
+    ArenaReplayBGScript() : BattlegroundScript("ArenaReplayBGScript") {}
 
-    void OnBattlegroundEnd(Battleground* bg, uint32 winner) override
+    void OnBattlegroundUpdate(Battleground* bg, uint32 diff) override
     {
-        //save replay when a bg ends
-        if (!bg->IsReplay()) {
-            saveReplay(bg);
-        }
-        DestroyReplayBot(bg);
-        return;
-    }
-
-    void OnBattlegroundUpdate(Battleground* bg, uint32 diff) override {
-
-        if (!bg->IsReplay()) return;
-        int32 startDelayTime = bg->GetStartDelayTime();
-        if (startDelayTime > 5000)
-        {
-            bg->SetStartDelayTime(5000);
-            bg->SetStartTime(bg->GetStartTime() + (startDelayTime - 5000));
-        }
-        if (bg->GetStatus() < BattlegroundStatus::STATUS_WAIT_JOIN) return;
-
-        //retrieve replay data
-        auto it = loadedReplays.find(bg->GetReplayId());
-        if (it == loadedReplays.end()) return;
-        MatchRecord& match = it->second;
-
-        // ensure spectator has finished loading into the battleground
-        Player* spectator = ObjectAccessor::FindPlayerByLowGUID(bg->GetReplayId());
-        if (!spectator || spectator->GetMapId() != bg->GetMapId())
+        uint32 replayId = bg->GetReplayID();
+        if (replayId == 0)
             return;
 
-        // free data once all spectators have left or the replay is finished
-        if (match.packets.empty() || !bg->HaveSpectators()) {
+        int32 startDelayTime = bg->GetStartDelayTime();
+        if (startDelayTime > 1000) // reduces StartTime only when watching Replay
+        {
+            bg->SetStartDelayTime(1000);
+            bg->SetStartTime(bg->GetStartTime() + (startDelayTime - 1000));
+        }
+
+        if (bg->GetStatus() != BattlegroundStatus::STATUS_IN_PROGRESS)
+            return;
+
+        // retrieve arena replay data
+        auto it = loadedReplays.find(replayId);
+        if (it == loadedReplays.end())
+            return;
+        MatchRecord& match = it->second;
+
+        // if replay ends or spectator left > free arena replay data and/or kick player
+        if (match.packets.empty() || bg->GetPlayers().empty())
+        {
             loadedReplays.erase(it);
-            if (bg->HaveSpectators())
-            {
-                uint32 playerGUID = bg->GetReplayId();
-                bg->EndNow();
-                bg->toggleReplay(0);
-                if (Player* player = ObjectAccessor::FindPlayerByLowGUID(playerGUID))
-                    player->LeaveBattleground(bg);
-            }
+
+            if (!bg->GetPlayers().empty())
+                bg->GetPlayers().begin()->second->LeaveBattleground(bg);
             return;
         }
 
         //send replay data to spectator
-        while (!match.packets.empty() && match.packets.front().timestamp <= bg->GetStartTime()) {
-            if (!bg->HaveSpectators())
+        while (!match.packets.empty() && match.packets.front().timestamp <= bg->GetStartTime())
+        {
+            if (bg->GetPlayers().empty())
                 break;
 
-            TC_LOG_TRACE("bg.replay", "Sending opcode {} size {}", GetOpcodeNameForLogging(static_cast<Opcodes>(match.packets.front().packet.GetOpcode())), match.packets.front().packet.size());
-            spectator->GetSession()->SendPacket(&match.packets.front().packet);
+            WorldPacket* myPacket = &match.packets.front().packet;
+            Player* replayer = bg->GetPlayers().begin()->second;
+            Opcodes myOpcode = (Opcodes)myPacket->GetOpcode();
+            replayer->GetSession()->SendPacket(myPacket);
             match.packets.pop_front();
         }
     }
 
-    void saveReplay(Battleground* bg) {
+    void OnBattlegroundEnd(Battleground* bg, TeamId winnerTeamId) override
+    {
+        uint32 replayId = bg->GetReplayID();
+
+        // save replay when a bg ends
+        if (replayId <= 0)
+        {
+            saveReplay(bg);
+            return;
+        }
+    }
+
+    void saveReplay(Battleground* bg)
+    {
         //retrieve replay data
         auto it = records.find(bg->GetInstanceID());
         if (it == records.end()) return;
         MatchRecord& match = it->second;
 
-        if (match.typeId == BATTLEGROUND_TYPE_NONE)
-        {
-            match.typeId = bg->GetTypeID(false);
-            if (match.typeId == BATTLEGROUND_AA)
-                match.typeId = bg->GetTypeID(true);
-        }
-        if (!match.arenaTypeId)
-            match.arenaTypeId = bg->GetArenaType();
-        if (!match.mapId)
-            match.mapId = bg->GetMapId();
-
-
-        if (match.packets.empty())
-        {
-            TC_LOG_DEBUG("bg.replay", "Replay for instance {} contains no packets and will not be saved", bg->GetInstanceID());
-            records.erase(it);
-            return;
-        }
-
-        TC_LOG_INFO("bg.replay", "Saving replay for instance {} with {} packets", bg->GetInstanceID(), match.packets.size());
-
-        // serialize arena replay data
+        /** serialize arena replay data **/
         ByteBuffer buffer;
-        buffer << match.startTime;
-        buffer << match.allianceRecorder;
-        buffer << match.hordeRecorder;
         uint32 headerSize;
         uint32 timestamp;
         for (auto it : match.packets)
         {
-            headerSize = it.packet.size(); // header 4 Bytes packet size
+            headerSize = it.packet.size(); //header 4Bytes packet size
             timestamp = it.timestamp;
 
-            buffer << headerSize; // 4 bytes
-            buffer << timestamp; // 4 bytes
+            buffer << headerSize; //4 bytes
+            buffer << timestamp; //4 bytes
             buffer << it.packet.GetOpcode(); // 2 bytes
             if (headerSize > 0)
                 buffer.append(it.packet.contents(), it.packet.size()); // headerSize bytes
         }
+        /********************************/
+
 
         CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_ARENA_REPLAYS);
-        stmt->setUInt32(0, uint32(match.arenaTypeId));
-        stmt->setUInt32(1, uint32(match.typeId));
-        stmt->setUInt32(2, buffer.size());
-        stmt->setBinary(3, buffer.contentsAsVector());
-        stmt->setUInt32(4, bg->GetMapId());
+        stmt->SetData<uint32>(0, uint32(match.arenaTypeId));
+        stmt->SetData<uint32>(1, uint32(match.typeId));
+        stmt->SetData<uint32>(2, buffer.size());
+        stmt->SetBinary(3, buffer.contentsAsVector());
+        stmt->SetData<uint32>(4, bg->GetMapId());
         CharacterDatabase.Execute(stmt);
+
         records.erase(it);
+
+        
+        uint32 replayfightid = 0;
+        QueryResult qResult = CharacterDatabase.Query("SELECT MAX(`id`) AS max_id FROM `character_arena_replays`");
+        if (qResult)
+        {
+            do
+            {
+                replayfightid = qResult->Fetch()[0].Get<uint32>();
+            } while (qResult->NextRow());
+        }
+        for (const auto& playerPair : bg->GetPlayers())
+        {
+            Player* player = playerPair.second;
+            ChatHandler(player->GetSession()).PSendSysMessage("Replay saved. Match ID: %u", replayfightid + 1);
+        }
     }
 };
-
 
 class ReplayGossip : public CreatureScript
 {
 public:
+
     ReplayGossip() : CreatureScript("ReplayGossip") { }
-    struct replayAI : public ScriptedAI
+
+    
+    bool OnGossipHello(Player* player, Creature* creature) override
     {
-        replayAI(Creature* creature) : ScriptedAI(creature) { }
-        bool OnGossipHello(Player* player) override
+        AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Replay 2v2 Matches", GOSSIP_SENDER_MAIN, 1);
+        AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Replay 3v3 Matches", GOSSIP_SENDER_MAIN, 2);
+        AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Replay 5v5 Matches", GOSSIP_SENDER_MAIN, 3);
+        AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Replay a Match ID", GOSSIP_SENDER_MAIN, 0, "Enter the Match ID", 0, true);
+        AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Favorite Matches", GOSSIP_SENDER_MAIN, 4);
+        SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
+        return true;
+    }
+
+    bool OnGossipSelect(Player* player, Creature* creature, uint32 sender, uint32 action) override
+    {
+        player->PlayerTalkClass->ClearMenus();
+        switch (action)
         {
-            auto matchIds = loadLast10Replays();
-            for (uint32 matchId : matchIds)
-                AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Replay match " + std::to_string(matchId), GOSSIP_SENDER_MAIN, matchId);
-            SendGossipMenuFor(player, 1775757, me->GetGUID());
-            return true;
-        }
+        case 1: // Replay 2v2 Matches
+            player->PlayerTalkClass->SendCloseGossip();
+            ShowLastReplays2v2(player, creature);
+            break;
+        case 2: // Replay 3v3 Matches
+            player->PlayerTalkClass->SendCloseGossip();
+            ShowLastReplays3v3(player, creature);
+            break;
+        case 3: // Replay 5v5 Matches
+            player->PlayerTalkClass->SendCloseGossip();
+            ShowLastReplays5v5(player, creature);
+            break;
+        case 4: // Saved Replays
+            player->PlayerTalkClass->SendCloseGossip();
+            ShowSavedReplays(player, creature);
+            break;
+        case GOSSIP_ACTION_INFO_DEF: // "Back"
+            OnGossipHello(player, creature);
+            break;
 
-        bool OnGossipSelect(Player* player, uint32 /*menuId*/, uint32 gossipListId) override {
-            uint32 replayId = GetGossipActionFor(player, gossipListId);
-            player->PlayerTalkClass->ClearMenus();
-            StartReplay(player, replayId);
+        default:
+            if (action >= GOSSIP_ACTION_INFO_DEF + 10) // Replay selected arenas (intid >= 10)
+            {
+                return replayArenaMatch(player, action - (GOSSIP_ACTION_INFO_DEF + 10));
+                break;
+            }
+        }
+        return true;
+    }
+
+    bool OnGossipSelectCode(Player* player, Creature* creature, uint32 sender, uint32 action, const char* code) override
+    {
+        if (action == 0) // "Replay a Match ID"
+        {
+            if (!code)
+            {
+                return false;
+            }
             CloseGossipMenuFor(player);
-            return true;
-        }
-
-        bool StartReplay(Player* player, uint32 replayId) {
-            auto handler = ChatHandler(player->GetSession());
-
-            if (!loadReplayDataForPlayer(player, replayId))
-                return false;
-
-            if (loadedReplays[player->GetGUID()].packets.empty())
+            uint32 replayId;
+            try
             {
-                handler.PSendSysMessage("Replay data not found.");
-                handler.SetSentErrorMessage(true);
-                return false;
+                replayId = std::stoi(code);
             }
-
-            MatchRecord record = loadedReplays[player->GetGUID()];
-            Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, GetBattlegroundBracketByLevel(record.mapId, 60), record.arenaTypeId, false);
-            if (!bg) {
-                handler.PSendSysMessage("Couldn't create arena map!");
-                handler.SetSentErrorMessage(true);
-                return false;
-            }
-            player->SetIsSpectator(true);
-            bg->toggleReplay(player->GetGUID());
-            player->SetPendingSpectatorForBG(bg->GetInstanceID());
-            bg->StartBattleground();
-
-            BattlegroundTypeId bgTypeId = bg->GetTypeID();
-
-            uint32 queueSlot = 0;
-            WorldPacket data;
-            TeamId teamId = TEAM_NEUTRAL;
-
-            player->SetBattlegroundId(bg->GetInstanceID(), bgTypeId, queueSlot, true, false, TEAM_NEUTRAL);
-            sBattlegroundMgr->SendToBattleground(player, bg->GetInstanceID(), bgTypeId);
-            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_IN_PROGRESS, 0, bg->GetStartTime(), bg->GetArenaType(), teamId);
-            player->GetSession()->SendPacket(&data);
-
-            handler.PSendSysMessage("Replay begins.");
-            return true;
-        }
-
-        bool loadReplayDataForPlayer(Player* p, uint32 matchId) {
-            TC_LOG_INFO("bg.replay", "Loading replay {} for player {} ({})", matchId, p->GetName(), p->GetGUID().ToString());
-            CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_ARENA_REPLAYS);
-            stmt->setUInt32(0, matchId);
-
-            PreparedQueryResult result = CharacterDatabase.Query(stmt);
-            if (!result) {
-                ChatHandler(p->GetSession()).PSendSysMessage("Replay data not found.");
-                return false;
-            }
-
-            Field* fields = result->Fetch();
-            if (!fields) {
-                ChatHandler(p->GetSession()).PSendSysMessage("Replay data not found.");
-                return false;
-            }
-            MatchRecord record;
-            deserializeMatchData(record, fields);
-            TC_LOG_INFO("bg.replay", "Deserialized replay: start {} map {} packets {}", record.startTime, record.mapId, record.packets.size());
-
-            ObjectGuid spectator = p->GetGUID();
-            if (record.allianceRecorder == spectator || record.hordeRecorder == spectator)
+            catch (...)
             {
-                ObjectGuid newGuid = ObjectGuid::Create<HighGuid::Player>(sObjectMgr->GetGenerator<HighGuid::Player>().Generate());
-                TC_LOG_INFO("bg.replay", "Replacing spectator GUID {} with {}", spectator.ToString(), newGuid.ToString());
-                for (PacketRecord& r : record.packets)
-                    ReplaceGuid(r.packet, spectator, newGuid);
-
-                if (record.allianceRecorder == spectator)
-                    record.allianceRecorder = newGuid;
-                if (record.hordeRecorder == spectator)
-                    record.hordeRecorder = newGuid;
+                ChatHandler(player->GetSession()).PSendSysMessage("Invalid Match ID.");
+                return false;
             }
-
-            loadedReplays[p->GetGUID()] = std::move(record);
-            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[p->GetGUID()].packets.size(), p->GetGUID().ToString());
-            return true;
+            return replayArenaMatch(player, replayId);
         }
+        else if (action == 5) // "Add a Favorite Match"
+        {
+            if (!code)
+                return false;
+            CloseGossipMenuFor(player);
+            try
+            {
+                uint32 NumeroDigitado = std::stoi(code);
+                BookmarkMatch(player->GetGUID().GetCounter(), NumeroDigitado);
+                return true;
+            }
+            catch (...)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("Invalid Match ID.");
+                return false;
+            }
+        }
+        return false;
+    }
 
-        std::vector<uint32> loadLast10Replays() {
-            std::vector<uint32> records;
-            CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_LAST_10_ARENA_REPLAYS);
-            PreparedQueryResult result = CharacterDatabase.Query(stmt);
-            if (!result)
-                return records;
 
-            do {
+private:
+
+    void ShowSavedReplays(Player* player, Creature* creature, bool firstPage = true)
+    {
+        AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Bookmark a Match ID", GOSSIP_SENDER_MAIN, 5, "Enter the Match ID", 0, true);
+
+        std::string sortOrder = (firstPage) ? "ASC" : "DESC";
+        QueryResult result = CharacterDatabase.Query("SELECT replay_id FROM character_saved_replays WHERE character_id = " + std::to_string(player->GetGUID().GetCounter()) + " ORDER BY id " + sortOrder + " LIMIT 29");
+        if (!result)
+        {
+            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "No saved replays found.", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
+        }
+        else
+        {
+            const uint32 actionOffset = GOSSIP_ACTION_INFO_DEF + 10;
+            do
+            {
                 Field* fields = result->Fetch();
                 if (!fields)
-                    return records;
+                    break;
 
-                uint32 matchId = fields[0].GetUInt32();
-                records.push_back(matchId);
+                uint32 matchId = fields[0].Get<uint32>();
+                AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Replay match " + std::to_string(matchId), GOSSIP_SENDER_MAIN, actionOffset + matchId);
             } while (result->NextRow());
-
-            return records;
         }
 
-        void deserializeMatchData(MatchRecord& record, Field* fields) {
-            record.arenaTypeId = uint8(fields[1].GetUInt32());
-            record.typeId = BattlegroundTypeId(fields[2].GetUInt32());
-            int size = uint32(fields[3].GetUInt32());
-            std::vector<uint8> data = fields[4].GetBinary();
-            record.mapId = uint32(fields[5].GetUInt32());
-            ByteBuffer buffer;
-            buffer.append(&data[0], data.size());
+        if (firstPage)
+        {
+            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Next Page", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+        }
+        AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Back", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
+        SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
+    }
 
-            buffer >> record.startTime;
-            buffer >> record.allianceRecorder;
-            buffer >> record.hordeRecorder;
+    void ShowLastReplays2v2(Player* player, Creature* creature)
+    {
+        auto matchIds = loadLast10Replays2v2();
 
-            /** deserialize replay binary data **/
-            uint32 packetSize;
-            uint32 packetTimestamp;
-            uint16 opcode;
-            while (buffer.rpos() <= buffer.size() - 1) {
-                buffer >> packetSize;
-                buffer >> packetTimestamp;
-                buffer >> opcode;
+        const uint32 actionOffset = GOSSIP_ACTION_INFO_DEF + 10;
 
-                WorldPacket packet(opcode, packetSize);
-
-                if (packetSize > 0) {
-                    std::vector<uint8> tmp(packetSize, 0);
-                    buffer.read(&tmp[0], packetSize);
-                    packet.append(&tmp[0], packetSize);
-                }
-
-                record.packets.push_back({ packetTimestamp, packet });
-            }
-
-            if (!record.packets.empty())
+        if (matchIds.empty())
+        {
+            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "No replays found for 2v2.", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
+        }
+        else
+        {
+            for (uint32 matchId : matchIds)
             {
-                uint32 const firstTimestamp = record.packets.front().timestamp;
-                if (firstTimestamp)
-                {
-                    for (PacketRecord& packetRecord : record.packets)
-                    {
-                        if (packetRecord.timestamp <= firstTimestamp)
-                            packetRecord.timestamp = 0;
-                        else
-                            packetRecord.timestamp -= firstTimestamp;
-                    }
-                }
+                AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Replay match " + std::to_string(matchId), GOSSIP_SENDER_MAIN, actionOffset + matchId);
             }
         }
-    };
-    CreatureAI* GetAI(Creature* creature) const override
+        AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Back", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
+        SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
+    }
+    void ShowLastReplays3v3(Player* player, Creature* creature)
     {
-        return new replayAI(creature);
+        auto matchIds = loadLast10Replays3v3();
+
+        const uint32 actionOffset = GOSSIP_ACTION_INFO_DEF + 10;
+
+        if (matchIds.empty())
+        {
+            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "No replays found for 3v3.", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
+        }
+        else
+        {
+            for (uint32 matchId : matchIds)
+            {
+                AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Replay match " + std::to_string(matchId), GOSSIP_SENDER_MAIN, actionOffset + matchId);
+            }
+        }
+        AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Back", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
+        SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
+    }
+    void ShowLastReplays5v5(Player* player, Creature* creature)
+    {
+        auto matchIds = loadLast10Replays5v5();
+
+        const uint32 actionOffset = GOSSIP_ACTION_INFO_DEF + 10;
+
+        if (matchIds.empty())
+        {
+            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "No replays found for 5v5.", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
+        }
+        else
+        {
+            for (uint32 matchId : matchIds)
+            {
+                AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Replay match " + std::to_string(matchId), GOSSIP_SENDER_MAIN, actionOffset + matchId);
+            }
+        }
+        AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Back", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
+        SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
+    }
+
+    std::vector<uint32> loadLast10Replays2v2()
+    {
+        std::vector<uint32> records;
+        QueryResult result = CharacterDatabase.Query("SELECT id FROM character_arena_replays WHERE arenaTypeId = 2 ORDER BY id DESC LIMIT 10");
+        if (!result)
+            return records;
+
+        do {
+            Field* fields = result->Fetch();
+            if (!fields)
+                return records;
+
+            uint32 matchId = fields[0].Get<uint32>();
+            records.push_back(matchId);
+        } while (result->NextRow());
+
+        return records;
+    }
+    std::vector<uint32> loadLast10Replays3v3()
+    {
+        std::vector<uint32> records;
+        QueryResult result = CharacterDatabase.Query("SELECT id FROM character_arena_replays WHERE arenaTypeId = 3 ORDER BY id DESC LIMIT 10");
+        if (!result)
+            return records;
+
+        do {
+            Field* fields = result->Fetch();
+            if (!fields)
+                return records;
+
+            uint32 matchId = fields[0].Get<uint32>();
+            records.push_back(matchId);
+        } while (result->NextRow());
+
+        return records;
+    }
+    std::vector<uint32> loadLast10Replays5v5()
+    {
+        std::vector<uint32> records;
+        QueryResult result = CharacterDatabase.Query("SELECT id FROM character_arena_replays WHERE arenaTypeId = 5 ORDER BY id DESC LIMIT 10");
+        if (!result)
+            return records;
+
+        do {
+            Field* fields = result->Fetch();
+            if (!fields)
+                return records;
+
+            uint32 matchId = fields[0].Get<uint32>();
+            records.push_back(matchId);
+        } while (result->NextRow());
+
+        return records;
+    }
+    std::vector<uint32> loadLast10Replays3v3solo()
+    {
+        std::vector<uint32> records;
+        QueryResult result = CharacterDatabase.Query("SELECT id FROM character_arena_replays WHERE arenaTypeId = 4 ORDER BY id DESC LIMIT 10");
+        if (!result)
+            return records;
+
+        do {
+            Field* fields = result->Fetch();
+            if (!fields)
+                return records;
+
+            uint32 matchId = fields[0].Get<uint32>();
+            records.push_back(matchId);
+        } while (result->NextRow());
+
+        return records;
+    }
+
+    void BookmarkMatch(uint64 playerGuid, uint32 code)
+    {
+        QueryResult result = CharacterDatabase.Query("SELECT id FROM character_saved_replays WHERE character_id = " + std::to_string(playerGuid) + " AND replay_id = " + std::to_string(code));
+        if (!result)
+        {
+            std::string query = "INSERT INTO character_saved_replays (character_id, replay_id) VALUES (" + std::to_string(playerGuid) + ", " + std::to_string(code) + ")";
+            CharacterDatabase.Execute(query.c_str());
+        }
+    }
+
+
+    bool replayArenaMatch(Player* player, uint32 replayId)
+    {
+        auto handler = ChatHandler(player->GetSession());
+
+        if (!loadReplayDataForPlayer(player, replayId))
+            return false;
+
+        MatchRecord record = loadedReplays[player->GetGUID().GetCounter()];
+
+        Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, GetBattlegroundBracketByLevel(record.mapId, sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL)), record.arenaTypeId, false);
+        if (!bg)
+        {
+            handler.PSendSysMessage("Couldn't create arena map!");
+            handler.SetSentErrorMessage(true);
+            return false;
+        }
+
+        bg->SetReplayID(player->GetGUID().GetCounter());
+        player->SetPendingSpectatorForBG(bg->GetInstanceID());
+        bg->StartBattleground();
+
+        BattlegroundTypeId bgTypeId = bg->GetBgTypeID();
+
+        TeamId teamId = Player::TeamIdForRace(player->getRace());
+
+        uint32 queueSlot = 0;
+        WorldPacket data;
+
+        player->SetBattlegroundId(bg->GetInstanceID(), bgTypeId, queueSlot, true, false, TEAM_NEUTRAL);
+        player->SetEntryPoint();
+        sBattlegroundMgr->SendToBattleground(player, bg->GetInstanceID(), bgTypeId);
+        sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_IN_PROGRESS, 0, bg->GetStartTime(), bg->GetArenaType(), teamId);
+        player->GetSession()->SendPacket(&data);
+        handler.PSendSysMessage("Replay ID %u begins.", replayId);
+        return true;
+    }
+
+    bool loadReplayDataForPlayer(Player* p, uint32 matchId)
+    {
+        QueryResult result = CharacterDatabase.PQuery("SELECT id, arenaTypeId, typeId, contentSize, contents, mapId FROM character_arena_replays WHERE id = {}", matchId);
+        if (!result)
+        {
+            ChatHandler(p->GetSession()).PSendSysMessage("Replay data not found.");
+            return false;
+        }
+
+        Field* fields = result->Fetch();
+        if (!fields)
+        {
+            ChatHandler(p->GetSession()).PSendSysMessage("Replay data not found.");
+            return false;
+        }
+        MatchRecord record;
+        deserializeMatchData(record, fields);
+
+        loadedReplays[p->GetGUID().GetCounter()] = std::move(record);
+        return true;
+    }
+
+    void deserializeMatchData(MatchRecord& record, Field* fields)
+    {
+        record.arenaTypeId = uint8(fields[1].Get<uint32>());
+        record.typeId = BattlegroundTypeId(fields[2].Get<uint32>());
+        int size = uint32(fields[3].Get<uint32>());
+        std::vector<uint8> data = fields[4].Get<Binary>();
+        record.mapId = uint32(fields[5].Get<uint32>());
+        ByteBuffer buffer;
+        buffer.append(&data[0], data.size());
+
+        /** deserialize replay binary data **/
+        uint32 packetSize;
+        uint32 packetTimestamp;
+        uint16 opcode;
+        while (buffer.rpos() <= buffer.size() - 1)
+        {
+            buffer >> packetSize;
+            buffer >> packetTimestamp;
+            buffer >> opcode;
+
+            WorldPacket packet(opcode, packetSize);
+
+            if (packetSize > 0) {
+                std::vector<uint8> tmp(packetSize, 0);
+                buffer.read(&tmp[0], packetSize);
+                packet.append(&tmp[0], packetSize);
+            }
+
+            record.packets.push_back({ packetTimestamp, packet });
+        }
     }
 };
 
-class BGReplayPlayerScript : public PlayerScript
+void AddArenaReplayScripts()
 {
-public:
-    BGReplayPlayerScript() : PlayerScript("BGReplayPlayerScript") { }
-
-    void OnMapChanged(Player* player) override
-    {
-        if (Battleground* bg = player->GetBattleground())
-            if (bg->IsReplay())
-                if (BattlegroundMap* map = bg->FindBgMap())
-                    map->SetVisibilityRange(MAX_VISIBILITY_DISTANCE);
-    }
-};
-
-void AddBGReplayScripts() {
-    new BGReplayServerScript();
-    new BGReplayBGScript();
+    new ArenaReplayServerScript();
+    new ArenaReplayBGScript();
     new ReplayGossip();
-    new BGReplayPlayerScript();
 }

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -19,8 +19,10 @@
 
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
-#include "BGReplay.cpp"
+
+void AddArenaReplayScripts();
+
 void AddCustomScripts()
 {
-    AddBGReplayScripts();
+    AddArenaReplayScripts();
 }


### PR DESCRIPTION
## Summary
- replace the previous battleground replay script with the upstream arena replay implementation and gossip menu features
- update the custom script loader and character database prepared statements to match the arena replay workflow
- add SQL definitions for the arena replay storage tables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f64bb9aa148327bb7ebbb08bafe808