### PR TITLE
Fix replay spectator teleport team assignment

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -668,9 +668,9 @@ public:
 
             uint32 queueSlot = 0;
             WorldPacket data;
-            TeamId teamId = TEAM_NEUTRAL;
+            TeamId teamId = player->GetTeamId();
 
-            player->SetBattlegroundId(bg->GetInstanceID(), bgTypeId, queueSlot, true, false, TEAM_NEUTRAL);
+            player->SetBattlegroundId(bg->GetInstanceID(), bgTypeId, queueSlot, true, false, teamId);
             sBattlegroundMgr->SendToBattleground(player, bg->GetInstanceID(), bgTypeId);
             sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_IN_PROGRESS, 0, bg->GetStartTime(), bg->GetArenaType(), teamId);
             player->GetSession()->SendPacket(&data);


### PR DESCRIPTION
## Summary
- ensure replay spectators use their own faction team when loading a replay
- prevent battleground teleports from using an invalid neutral team start position

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7793f61b08327b0c438bc1e2295b7