### PR TITLE
Fix replay spectator battleground map setup

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -658,7 +658,20 @@ public:
                 handler.SetSentErrorMessage(true);
                 return false;
             }
-            bg->SetMapId(record.mapId);
+
+            if (BattlegroundTemplate const* replayTemplate = sBattlegroundMgr->GetBattlegroundTemplateByMapId(record.mapId))
+            {
+                bg->SetMapId(record.mapId);
+                bg->SetTeamStartPosition(TEAM_ALLIANCE, replayTemplate->StartLocation[TEAM_ALLIANCE]);
+                bg->SetTeamStartPosition(TEAM_HORDE, replayTemplate->StartLocation[TEAM_HORDE]);
+            }
+            else
+            {
+                handler.PSendSysMessage("Couldn't locate battleground template for replay map!");
+                handler.SetSentErrorMessage(true);
+                return false;
+            }
+
             player->SetIsSpectator(true);
             bg->toggleReplay(spectatorLowGuid);
             player->SetPendingSpectatorForBG(bg->GetInstanceID());
@@ -668,11 +681,14 @@ public:
 
             uint32 queueSlot = 0;
             WorldPacket data;
-            TeamId teamId = TEAM_NEUTRAL;
+            Team team = player->GetTeam();
+            TeamId teamId = player->GetTeamId();
 
-            player->SetBattlegroundId(bg->GetInstanceID(), bgTypeId, queueSlot, true, false, TEAM_NEUTRAL);
+            player->SetBGTeam(team);
+
+            player->SetBattlegroundId(bg->GetInstanceID(), bgTypeId, queueSlot, true, false, teamId);
             sBattlegroundMgr->SendToBattleground(player, bg->GetInstanceID(), bgTypeId);
-            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_IN_PROGRESS, 0, bg->GetStartTime(), bg->GetArenaType(), teamId);
+            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_IN_PROGRESS, 0, bg->GetStartTime(), bg->GetArenaType(), team);
             player->GetSession()->SendPacket(&data);
 
             handler.PSendSysMessage("Replay begins.");

--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -91,7 +91,21 @@ struct MatchRecord {
     ObjectGuid allianceRecorder;
     ObjectGuid hordeRecorder;
     std::deque<PacketRecord> packets;
+    std::unordered_map<uint64, uint64> guidRemaps;
 };
+
+namespace
+{
+    constexpr uint32 ReplayFormatMagic = 0x42475250; // 'BGRP'
+
+    bool IsAlternateGuidUsed(MatchRecord const& record, uint64 alternateRaw)
+    {
+        for (auto const& pair : record.guidRemaps)
+            if (pair.second == alternateRaw)
+                return true;
+        return false;
+    }
+}
 
 namespace
 {
@@ -220,7 +234,7 @@ namespace
     }
 }
 std::unordered_map<uint32, MatchRecord> records;
-std::unordered_map<uint64, MatchRecord> loadedReplays;
+std::unordered_map<uint32, MatchRecord> loadedReplays;
 // Headless spectators used for recording packets per battleground instance
 std::unordered_map<uint32, Player*> replayBots;
 // Helper container to avoid recursive bot creation
@@ -365,6 +379,21 @@ public:
                 ObjectGuid guid = itr.first;
                 if (Player* plr = ObjectAccessor::FindPlayer(guid))
                 {
+                    if (!plr->IsSpectator())
+                    {
+                        uint64 rawGuid = guid.GetRawValue();
+                        if (record.guidRemaps.find(rawGuid) == record.guidRemaps.end())
+                        {
+                            ObjectGuid alternate;
+                            do
+                            {
+                                alternate = GenerateAlternateGuid(guid);
+                            } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                            record.guidRemaps[rawGuid] = alternate.GetRawValue();
+                        }
+                    }
+
                     uint32 team = plr->GetBGTeam();
                     if (team == ALLIANCE && record.allianceRecorder.IsEmpty())
                         record.allianceRecorder = plr->GetGUID();
@@ -373,6 +402,29 @@ public:
 
                     if (!record.allianceRecorder.IsEmpty() && !record.hordeRecorder.IsEmpty())
                         break;
+                }
+            }
+        }
+        else
+        {
+            for (auto const& itr : bg->GetPlayers())
+            {
+                ObjectGuid guid = itr.first;
+                if (record.guidRemaps.find(guid.GetRawValue()) != record.guidRemaps.end())
+                    continue;
+
+                if (Player* plr = ObjectAccessor::FindPlayer(guid))
+                {
+                    if (plr->IsSpectator())
+                        continue;
+
+                    ObjectGuid alternate;
+                    do
+                    {
+                        alternate = GenerateAlternateGuid(guid);
+                    } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                    record.guidRemaps[guid.GetRawValue()] = alternate.GetRawValue();
                 }
             }
         }
@@ -481,9 +533,17 @@ public:
 
         // serialize arena replay data
         ByteBuffer buffer;
+        buffer << ReplayFormatMagic;
+        buffer << uint16(1);
         buffer << match.startTime;
         buffer << match.allianceRecorder;
         buffer << match.hordeRecorder;
+        buffer << uint32(match.guidRemaps.size());
+        for (auto const& [originalRaw, mappedRaw] : match.guidRemaps)
+        {
+            buffer << ObjectGuid(originalRaw);
+            buffer << ObjectGuid(mappedRaw);
+        }
         uint32 headerSize;
         uint32 timestamp;
         for (auto it : match.packets)
@@ -540,14 +600,15 @@ public:
             if (!loadReplayDataForPlayer(player, replayId))
                 return false;
 
-            if (loadedReplays[player->GetGUID()].packets.empty())
+            uint32 const spectatorLowGuid = player->GetGUID().GetCounter();
+            if (loadedReplays[spectatorLowGuid].packets.empty())
             {
                 handler.PSendSysMessage("Replay data not found.");
                 handler.SetSentErrorMessage(true);
                 return false;
             }
 
-            MatchRecord record = loadedReplays[player->GetGUID()];
+            MatchRecord record = loadedReplays[spectatorLowGuid];
             Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, GetBattlegroundBracketByLevel(record.mapId, 60), record.arenaTypeId, false);
             if (!bg) {
                 handler.PSendSysMessage("Couldn't create arena map!");
@@ -595,7 +656,7 @@ public:
             TC_LOG_INFO("bg.replay", "Deserialized replay: start {} map {} packets {}", record.startTime, record.mapId, record.packets.size());
 
             ObjectGuid spectator = p->GetGUID();
-            if (record.allianceRecorder == spectator || record.hordeRecorder == spectator)
+            if (record.guidRemaps.empty() && (record.allianceRecorder == spectator || record.hordeRecorder == spectator))
             {
                 ObjectGuid newGuid = ObjectGuid::Create<HighGuid::Player>(sObjectMgr->GetGenerator<HighGuid::Player>().Generate());
                 TC_LOG_INFO("bg.replay", "Replacing spectator GUID {} with {}", spectator.ToString(), newGuid.ToString());
@@ -608,8 +669,9 @@ public:
                     record.hordeRecorder = newGuid;
             }
 
-            loadedReplays[p->GetGUID()] = std::move(record);
-            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[p->GetGUID()].packets.size(), p->GetGUID().ToString());
+            uint32 const spectatorLowGuid = p->GetGUID().GetCounter();
+            loadedReplays[spectatorLowGuid] = std::move(record);
+            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[spectatorLowGuid].packets.size(), p->GetGUID().ToString());
             return true;
         }
 
@@ -641,9 +703,36 @@ public:
             ByteBuffer buffer;
             buffer.append(&data[0], data.size());
 
-            buffer >> record.startTime;
+            uint32 maybeMagic;
+            buffer >> maybeMagic;
+
+            uint16 version = 0;
+            if (maybeMagic == ReplayFormatMagic)
+            {
+                buffer >> version;
+                buffer >> record.startTime;
+            }
+            else
+            {
+                record.startTime = maybeMagic;
+            }
+
             buffer >> record.allianceRecorder;
             buffer >> record.hordeRecorder;
+
+            if (version >= 1)
+            {
+                uint32 remapCount;
+                buffer >> remapCount;
+                for (uint32 i = 0; i < remapCount; ++i)
+                {
+                    ObjectGuid original;
+                    ObjectGuid mapped;
+                    buffer >> original;
+                    buffer >> mapped;
+                    record.guidRemaps[original.GetRawValue()] = mapped.GetRawValue();
+                }
+            }
 
             /** deserialize replay binary data **/
             uint32 packetSize;
@@ -677,6 +766,23 @@ public:
                         else
                             packetRecord.timestamp -= firstTimestamp;
                     }
+                }
+            }
+
+            if (!record.guidRemaps.empty())
+            {
+                for (auto const& [originalRaw, mappedRaw] : record.guidRemaps)
+                {
+                    ObjectGuid original(originalRaw);
+                    ObjectGuid mapped(mappedRaw);
+
+                    if (record.allianceRecorder == original)
+                        record.allianceRecorder = mapped;
+                    if (record.hordeRecorder == original)
+                        record.hordeRecorder = mapped;
+
+                    for (PacketRecord& packetRecord : record.packets)
+                        ReplaceGuid(packetRecord.packet, original, mapped);
                 }
             }
         }

--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -11,6 +11,7 @@
 #include "WorldSocket.h"
 #include "Log.h"
 #include "Map.h"
+#include "World.h"
 #include "ObjectDefines.h"
 #include "ObjectMgr.h"
 #include "GameTime.h"
@@ -88,10 +89,25 @@ struct MatchRecord {
     uint8 arenaTypeId;
     uint32 mapId;
     uint32 startTime = 0;
+    BattlegroundBracketId bracketId = BG_BRACKET_ID_FIRST;
     ObjectGuid allianceRecorder;
     ObjectGuid hordeRecorder;
     std::deque<PacketRecord> packets;
+    std::unordered_map<uint64, uint64> guidRemaps;
 };
+
+namespace
+{
+    constexpr uint32 ReplayFormatMagic = 0x42475250; // 'BGRP'
+
+    bool IsAlternateGuidUsed(MatchRecord const& record, uint64 alternateRaw)
+    {
+        for (auto const& pair : record.guidRemaps)
+            if (pair.second == alternateRaw)
+                return true;
+        return false;
+    }
+}
 
 namespace
 {
@@ -112,6 +128,40 @@ namespace
             }
         }
         return ObjectGuid(newRaw);
+    }
+
+    PvPDifficultyEntry const* GetFirstBracketForMap(uint32 mapId)
+    {
+        PvPDifficultyEntry const* firstEntry = nullptr;
+        for (uint32 i = 0; i < sPvPDifficultyStore.GetNumRows(); ++i)
+        {
+            if (PvPDifficultyEntry const* entry = sPvPDifficultyStore.LookupEntry(i))
+            {
+                if (entry->MapID != static_cast<int32>(mapId))
+                    continue;
+
+                if (!firstEntry || entry->MinLevel < firstEntry->MinLevel)
+                    firstEntry = entry;
+            }
+        }
+
+        return firstEntry;
+    }
+
+    PvPDifficultyEntry const* ResolveReplayBracket(Player const* spectator, MatchRecord const& record)
+    {
+        if (record.bracketId <= BG_BRACKET_ID_LAST)
+            if (PvPDifficultyEntry const* bracket = GetBattlegroundBracketById(record.mapId, record.bracketId))
+                return bracket;
+
+        if (spectator)
+            if (PvPDifficultyEntry const* bracket = GetBattlegroundBracketByLevel(record.mapId, spectator->GetLevel()))
+                return bracket;
+
+        if (PvPDifficultyEntry const* bracket = GetBattlegroundBracketByLevel(record.mapId, sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL)))
+            return bracket;
+
+        return GetFirstBracketForMap(record.mapId);
     }
 
     void ReplaceGuid(WorldPacket& packet, ObjectGuid const& oldGuid, ObjectGuid const& newGuid)
@@ -220,7 +270,7 @@ namespace
     }
 }
 std::unordered_map<uint32, MatchRecord> records;
-std::unordered_map<uint64, MatchRecord> loadedReplays;
+std::unordered_map<uint32, MatchRecord> loadedReplays;
 // Headless spectators used for recording packets per battleground instance
 std::unordered_map<uint32, Player*> replayBots;
 // Helper container to avoid recursive bot creation
@@ -360,11 +410,27 @@ public:
         if (record.startTime == 0)
         {
             record.startTime = GameTime::GetGameTimeMS() - bg->GetStartTime();
+            record.bracketId = bg->GetBracketId();
             for (auto const& itr : bg->GetPlayers())
             {
                 ObjectGuid guid = itr.first;
                 if (Player* plr = ObjectAccessor::FindPlayer(guid))
                 {
+                    if (!plr->IsSpectator())
+                    {
+                        uint64 rawGuid = guid.GetRawValue();
+                        if (record.guidRemaps.find(rawGuid) == record.guidRemaps.end())
+                        {
+                            ObjectGuid alternate;
+                            do
+                            {
+                                alternate = GenerateAlternateGuid(guid);
+                            } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                            record.guidRemaps[rawGuid] = alternate.GetRawValue();
+                        }
+                    }
+
                     uint32 team = plr->GetBGTeam();
                     if (team == ALLIANCE && record.allianceRecorder.IsEmpty())
                         record.allianceRecorder = plr->GetGUID();
@@ -373,6 +439,29 @@ public:
 
                     if (!record.allianceRecorder.IsEmpty() && !record.hordeRecorder.IsEmpty())
                         break;
+                }
+            }
+        }
+        else
+        {
+            for (auto const& itr : bg->GetPlayers())
+            {
+                ObjectGuid guid = itr.first;
+                if (record.guidRemaps.find(guid.GetRawValue()) != record.guidRemaps.end())
+                    continue;
+
+                if (Player* plr = ObjectAccessor::FindPlayer(guid))
+                {
+                    if (plr->IsSpectator())
+                        continue;
+
+                    ObjectGuid alternate;
+                    do
+                    {
+                        alternate = GenerateAlternateGuid(guid);
+                    } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                    record.guidRemaps[guid.GetRawValue()] = alternate.GetRawValue();
                 }
             }
         }
@@ -481,9 +570,18 @@ public:
 
         // serialize arena replay data
         ByteBuffer buffer;
+        buffer << ReplayFormatMagic;
+        buffer << uint16(2);
         buffer << match.startTime;
+        buffer << uint8(match.bracketId);
         buffer << match.allianceRecorder;
         buffer << match.hordeRecorder;
+        buffer << uint32(match.guidRemaps.size());
+        for (auto const& [originalRaw, mappedRaw] : match.guidRemaps)
+        {
+            buffer << ObjectGuid(originalRaw);
+            buffer << ObjectGuid(mappedRaw);
+        }
         uint32 headerSize;
         uint32 timestamp;
         for (auto it : match.packets)
@@ -540,22 +638,32 @@ public:
             if (!loadReplayDataForPlayer(player, replayId))
                 return false;
 
-            if (loadedReplays[player->GetGUID()].packets.empty())
+            uint32 const spectatorLowGuid = player->GetGUID().GetCounter();
+            if (loadedReplays[spectatorLowGuid].packets.empty())
             {
                 handler.PSendSysMessage("Replay data not found.");
                 handler.SetSentErrorMessage(true);
                 return false;
             }
 
-            MatchRecord record = loadedReplays[player->GetGUID()];
-            Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, GetBattlegroundBracketByLevel(record.mapId, 60), record.arenaTypeId, false);
+            MatchRecord record = loadedReplays[spectatorLowGuid];
+            PvPDifficultyEntry const* bracketEntry = ResolveReplayBracket(player, record);
+            if (!bracketEntry)
+            {
+                handler.PSendSysMessage("Couldn't locate a valid bracket for replay map!");
+                handler.SetSentErrorMessage(true);
+                return false;
+            }
+
+            Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, bracketEntry, record.arenaTypeId, false);
             if (!bg) {
                 handler.PSendSysMessage("Couldn't create arena map!");
                 handler.SetSentErrorMessage(true);
                 return false;
             }
+            bg->SetMapId(record.mapId);
             player->SetIsSpectator(true);
-            bg->toggleReplay(player->GetGUID());
+            bg->toggleReplay(spectatorLowGuid);
             player->SetPendingSpectatorForBG(bg->GetInstanceID());
             bg->StartBattleground();
 
@@ -595,7 +703,7 @@ public:
             TC_LOG_INFO("bg.replay", "Deserialized replay: start {} map {} packets {}", record.startTime, record.mapId, record.packets.size());
 
             ObjectGuid spectator = p->GetGUID();
-            if (record.allianceRecorder == spectator || record.hordeRecorder == spectator)
+            if (record.guidRemaps.empty() && (record.allianceRecorder == spectator || record.hordeRecorder == spectator))
             {
                 ObjectGuid newGuid = ObjectGuid::Create<HighGuid::Player>(sObjectMgr->GetGenerator<HighGuid::Player>().Generate());
                 TC_LOG_INFO("bg.replay", "Replacing spectator GUID {} with {}", spectator.ToString(), newGuid.ToString());
@@ -606,10 +714,13 @@ public:
                     record.allianceRecorder = newGuid;
                 if (record.hordeRecorder == spectator)
                     record.hordeRecorder = newGuid;
+
+                record.guidRemaps[spectator.GetRawValue()] = newGuid.GetRawValue();
             }
 
-            loadedReplays[p->GetGUID()] = std::move(record);
-            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[p->GetGUID()].packets.size(), p->GetGUID().ToString());
+            uint32 const spectatorLowGuid = p->GetGUID().GetCounter();
+            loadedReplays[spectatorLowGuid] = std::move(record);
+            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[spectatorLowGuid].packets.size(), p->GetGUID().ToString());
             return true;
         }
 
@@ -641,9 +752,44 @@ public:
             ByteBuffer buffer;
             buffer.append(&data[0], data.size());
 
-            buffer >> record.startTime;
+            uint32 maybeMagic;
+            buffer >> maybeMagic;
+
+            uint16 version = 0;
+            if (maybeMagic == ReplayFormatMagic)
+            {
+                buffer >> version;
+                buffer >> record.startTime;
+
+                if (version >= 2)
+                {
+                    uint8 bracketIdValue;
+                    buffer >> bracketIdValue;
+                    if (bracketIdValue <= BG_BRACKET_ID_LAST)
+                        record.bracketId = static_cast<BattlegroundBracketId>(bracketIdValue);
+                }
+            }
+            else
+            {
+                record.startTime = maybeMagic;
+            }
+
             buffer >> record.allianceRecorder;
             buffer >> record.hordeRecorder;
+
+            if (version >= 1)
+            {
+                uint32 remapCount;
+                buffer >> remapCount;
+                for (uint32 i = 0; i < remapCount; ++i)
+                {
+                    ObjectGuid original;
+                    ObjectGuid mapped;
+                    buffer >> original;
+                    buffer >> mapped;
+                    record.guidRemaps[original.GetRawValue()] = mapped.GetRawValue();
+                }
+            }
 
             /** deserialize replay binary data **/
             uint32 packetSize;
@@ -677,6 +823,23 @@ public:
                         else
                             packetRecord.timestamp -= firstTimestamp;
                     }
+                }
+            }
+
+            if (!record.guidRemaps.empty())
+            {
+                for (auto const& [originalRaw, mappedRaw] : record.guidRemaps)
+                {
+                    ObjectGuid original(originalRaw);
+                    ObjectGuid mapped(mappedRaw);
+
+                    if (record.allianceRecorder == original)
+                        record.allianceRecorder = mapped;
+                    if (record.hordeRecorder == original)
+                        record.hordeRecorder = mapped;
+
+                    for (PacketRecord& packetRecord : record.packets)
+                        ReplaceGuid(packetRecord.packet, original, mapped);
                 }
             }
         }

--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -11,6 +11,7 @@
 #include "WorldSocket.h"
 #include "Log.h"
 #include "Map.h"
+#include "World.h"
 #include "ObjectDefines.h"
 #include "ObjectMgr.h"
 #include "GameTime.h"
@@ -88,10 +89,25 @@ struct MatchRecord {
     uint8 arenaTypeId;
     uint32 mapId;
     uint32 startTime = 0;
+    BattlegroundBracketId bracketId = BG_BRACKET_ID_FIRST;
     ObjectGuid allianceRecorder;
     ObjectGuid hordeRecorder;
     std::deque<PacketRecord> packets;
+    std::unordered_map<uint64, uint64> guidRemaps;
 };
+
+namespace
+{
+    constexpr uint32 ReplayFormatMagic = 0x42475250; // 'BGRP'
+
+    bool IsAlternateGuidUsed(MatchRecord const& record, uint64 alternateRaw)
+    {
+        for (auto const& pair : record.guidRemaps)
+            if (pair.second == alternateRaw)
+                return true;
+        return false;
+    }
+}
 
 namespace
 {
@@ -112,6 +128,37 @@ namespace
             }
         }
         return ObjectGuid(newRaw);
+    }
+
+    PvPDifficultyEntry const* GetFirstBracketForMap(uint32 mapId)
+    {
+        PvPDifficultyEntry const* firstEntry = nullptr;
+        for (uint8 bracketId = BG_BRACKET_ID_FIRST; bracketId <= BG_BRACKET_ID_LAST; ++bracketId)
+        {
+            if (PvPDifficultyEntry const* entry = GetBattlegroundBracketById(mapId, BattlegroundBracketId(bracketId)))
+            {
+                if (!firstEntry || entry->MinLevel < firstEntry->MinLevel)
+                    firstEntry = entry;
+            }
+        }
+
+        return firstEntry;
+    }
+
+    PvPDifficultyEntry const* ResolveReplayBracket(Player const* spectator, MatchRecord const& record)
+    {
+        if (record.bracketId <= BG_BRACKET_ID_LAST)
+            if (PvPDifficultyEntry const* bracket = GetBattlegroundBracketById(record.mapId, record.bracketId))
+                return bracket;
+
+        if (spectator)
+            if (PvPDifficultyEntry const* bracket = GetBattlegroundBracketByLevel(record.mapId, spectator->GetLevel()))
+                return bracket;
+
+        if (PvPDifficultyEntry const* bracket = GetBattlegroundBracketByLevel(record.mapId, sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL)))
+            return bracket;
+
+        return GetFirstBracketForMap(record.mapId);
     }
 
     void ReplaceGuid(WorldPacket& packet, ObjectGuid const& oldGuid, ObjectGuid const& newGuid)
@@ -220,7 +267,7 @@ namespace
     }
 }
 std::unordered_map<uint32, MatchRecord> records;
-std::unordered_map<uint64, MatchRecord> loadedReplays;
+std::unordered_map<uint32, MatchRecord> loadedReplays;
 // Headless spectators used for recording packets per battleground instance
 std::unordered_map<uint32, Player*> replayBots;
 // Helper container to avoid recursive bot creation
@@ -360,11 +407,27 @@ public:
         if (record.startTime == 0)
         {
             record.startTime = GameTime::GetGameTimeMS() - bg->GetStartTime();
+            record.bracketId = bg->GetBracketId();
             for (auto const& itr : bg->GetPlayers())
             {
                 ObjectGuid guid = itr.first;
                 if (Player* plr = ObjectAccessor::FindPlayer(guid))
                 {
+                    if (!plr->IsSpectator())
+                    {
+                        uint64 rawGuid = guid.GetRawValue();
+                        if (record.guidRemaps.find(rawGuid) == record.guidRemaps.end())
+                        {
+                            ObjectGuid alternate;
+                            do
+                            {
+                                alternate = GenerateAlternateGuid(guid);
+                            } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                            record.guidRemaps[rawGuid] = alternate.GetRawValue();
+                        }
+                    }
+
                     uint32 team = plr->GetBGTeam();
                     if (team == ALLIANCE && record.allianceRecorder.IsEmpty())
                         record.allianceRecorder = plr->GetGUID();
@@ -373,6 +436,29 @@ public:
 
                     if (!record.allianceRecorder.IsEmpty() && !record.hordeRecorder.IsEmpty())
                         break;
+                }
+            }
+        }
+        else
+        {
+            for (auto const& itr : bg->GetPlayers())
+            {
+                ObjectGuid guid = itr.first;
+                if (record.guidRemaps.find(guid.GetRawValue()) != record.guidRemaps.end())
+                    continue;
+
+                if (Player* plr = ObjectAccessor::FindPlayer(guid))
+                {
+                    if (plr->IsSpectator())
+                        continue;
+
+                    ObjectGuid alternate;
+                    do
+                    {
+                        alternate = GenerateAlternateGuid(guid);
+                    } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                    record.guidRemaps[guid.GetRawValue()] = alternate.GetRawValue();
                 }
             }
         }
@@ -481,9 +567,18 @@ public:
 
         // serialize arena replay data
         ByteBuffer buffer;
+        buffer << ReplayFormatMagic;
+        buffer << uint16(2);
         buffer << match.startTime;
+        buffer << uint8(match.bracketId);
         buffer << match.allianceRecorder;
         buffer << match.hordeRecorder;
+        buffer << uint32(match.guidRemaps.size());
+        for (auto const& [originalRaw, mappedRaw] : match.guidRemaps)
+        {
+            buffer << ObjectGuid(originalRaw);
+            buffer << ObjectGuid(mappedRaw);
+        }
         uint32 headerSize;
         uint32 timestamp;
         for (auto it : match.packets)
@@ -540,22 +635,32 @@ public:
             if (!loadReplayDataForPlayer(player, replayId))
                 return false;
 
-            if (loadedReplays[player->GetGUID()].packets.empty())
+            uint32 const spectatorLowGuid = player->GetGUID().GetCounter();
+            if (loadedReplays[spectatorLowGuid].packets.empty())
             {
                 handler.PSendSysMessage("Replay data not found.");
                 handler.SetSentErrorMessage(true);
                 return false;
             }
 
-            MatchRecord record = loadedReplays[player->GetGUID()];
-            Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, GetBattlegroundBracketByLevel(record.mapId, 60), record.arenaTypeId, false);
+            MatchRecord record = loadedReplays[spectatorLowGuid];
+            PvPDifficultyEntry const* bracketEntry = ResolveReplayBracket(player, record);
+            if (!bracketEntry)
+            {
+                handler.PSendSysMessage("Couldn't locate a valid bracket for replay map!");
+                handler.SetSentErrorMessage(true);
+                return false;
+            }
+
+            Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, bracketEntry, record.arenaTypeId, false);
             if (!bg) {
                 handler.PSendSysMessage("Couldn't create arena map!");
                 handler.SetSentErrorMessage(true);
                 return false;
             }
+            bg->SetMapId(record.mapId);
             player->SetIsSpectator(true);
-            bg->toggleReplay(player->GetGUID());
+            bg->toggleReplay(spectatorLowGuid);
             player->SetPendingSpectatorForBG(bg->GetInstanceID());
             bg->StartBattleground();
 
@@ -595,7 +700,7 @@ public:
             TC_LOG_INFO("bg.replay", "Deserialized replay: start {} map {} packets {}", record.startTime, record.mapId, record.packets.size());
 
             ObjectGuid spectator = p->GetGUID();
-            if (record.allianceRecorder == spectator || record.hordeRecorder == spectator)
+            if (record.guidRemaps.empty() && (record.allianceRecorder == spectator || record.hordeRecorder == spectator))
             {
                 ObjectGuid newGuid = ObjectGuid::Create<HighGuid::Player>(sObjectMgr->GetGenerator<HighGuid::Player>().Generate());
                 TC_LOG_INFO("bg.replay", "Replacing spectator GUID {} with {}", spectator.ToString(), newGuid.ToString());
@@ -606,10 +711,13 @@ public:
                     record.allianceRecorder = newGuid;
                 if (record.hordeRecorder == spectator)
                     record.hordeRecorder = newGuid;
+
+                record.guidRemaps[spectator.GetRawValue()] = newGuid.GetRawValue();
             }
 
-            loadedReplays[p->GetGUID()] = std::move(record);
-            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[p->GetGUID()].packets.size(), p->GetGUID().ToString());
+            uint32 const spectatorLowGuid = p->GetGUID().GetCounter();
+            loadedReplays[spectatorLowGuid] = std::move(record);
+            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[spectatorLowGuid].packets.size(), p->GetGUID().ToString());
             return true;
         }
 
@@ -641,9 +749,44 @@ public:
             ByteBuffer buffer;
             buffer.append(&data[0], data.size());
 
-            buffer >> record.startTime;
+            uint32 maybeMagic;
+            buffer >> maybeMagic;
+
+            uint16 version = 0;
+            if (maybeMagic == ReplayFormatMagic)
+            {
+                buffer >> version;
+                buffer >> record.startTime;
+
+                if (version >= 2)
+                {
+                    uint8 bracketIdValue;
+                    buffer >> bracketIdValue;
+                    if (bracketIdValue <= BG_BRACKET_ID_LAST)
+                        record.bracketId = static_cast<BattlegroundBracketId>(bracketIdValue);
+                }
+            }
+            else
+            {
+                record.startTime = maybeMagic;
+            }
+
             buffer >> record.allianceRecorder;
             buffer >> record.hordeRecorder;
+
+            if (version >= 1)
+            {
+                uint32 remapCount;
+                buffer >> remapCount;
+                for (uint32 i = 0; i < remapCount; ++i)
+                {
+                    ObjectGuid original;
+                    ObjectGuid mapped;
+                    buffer >> original;
+                    buffer >> mapped;
+                    record.guidRemaps[original.GetRawValue()] = mapped.GetRawValue();
+                }
+            }
 
             /** deserialize replay binary data **/
             uint32 packetSize;
@@ -677,6 +820,23 @@ public:
                         else
                             packetRecord.timestamp -= firstTimestamp;
                     }
+                }
+            }
+
+            if (!record.guidRemaps.empty())
+            {
+                for (auto const& [originalRaw, mappedRaw] : record.guidRemaps)
+                {
+                    ObjectGuid original(originalRaw);
+                    ObjectGuid mapped(mappedRaw);
+
+                    if (record.allianceRecorder == original)
+                        record.allianceRecorder = mapped;
+                    if (record.hordeRecorder == original)
+                        record.hordeRecorder = mapped;
+
+                    for (PacketRecord& packetRecord : record.packets)
+                        ReplaceGuid(packetRecord.packet, original, mapped);
                 }
             }
         }

--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -91,7 +91,21 @@ struct MatchRecord {
     ObjectGuid allianceRecorder;
     ObjectGuid hordeRecorder;
     std::deque<PacketRecord> packets;
+    std::unordered_map<uint64, uint64> guidRemaps;
 };
+
+namespace
+{
+    constexpr uint32 ReplayFormatMagic = 0x42475250; // 'BGRP'
+
+    bool IsAlternateGuidUsed(MatchRecord const& record, uint64 alternateRaw)
+    {
+        for (auto const& pair : record.guidRemaps)
+            if (pair.second == alternateRaw)
+                return true;
+        return false;
+    }
+}
 
 namespace
 {
@@ -365,6 +379,21 @@ public:
                 ObjectGuid guid = itr.first;
                 if (Player* plr = ObjectAccessor::FindPlayer(guid))
                 {
+                    if (!plr->IsSpectator())
+                    {
+                        uint64 rawGuid = guid.GetRawValue();
+                        if (record.guidRemaps.find(rawGuid) == record.guidRemaps.end())
+                        {
+                            ObjectGuid alternate;
+                            do
+                            {
+                                alternate = GenerateAlternateGuid(guid);
+                            } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                            record.guidRemaps[rawGuid] = alternate.GetRawValue();
+                        }
+                    }
+
                     uint32 team = plr->GetBGTeam();
                     if (team == ALLIANCE && record.allianceRecorder.IsEmpty())
                         record.allianceRecorder = plr->GetGUID();
@@ -373,6 +402,29 @@ public:
 
                     if (!record.allianceRecorder.IsEmpty() && !record.hordeRecorder.IsEmpty())
                         break;
+                }
+            }
+        }
+        else
+        {
+            for (auto const& itr : bg->GetPlayers())
+            {
+                ObjectGuid guid = itr.first;
+                if (record.guidRemaps.find(guid.GetRawValue()) != record.guidRemaps.end())
+                    continue;
+
+                if (Player* plr = ObjectAccessor::FindPlayer(guid))
+                {
+                    if (plr->IsSpectator())
+                        continue;
+
+                    ObjectGuid alternate;
+                    do
+                    {
+                        alternate = GenerateAlternateGuid(guid);
+                    } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                    record.guidRemaps[guid.GetRawValue()] = alternate.GetRawValue();
                 }
             }
         }
@@ -481,9 +533,17 @@ public:
 
         // serialize arena replay data
         ByteBuffer buffer;
+        buffer << ReplayFormatMagic;
+        buffer << uint16(1);
         buffer << match.startTime;
         buffer << match.allianceRecorder;
         buffer << match.hordeRecorder;
+        buffer << uint32(match.guidRemaps.size());
+        for (auto const& [originalRaw, mappedRaw] : match.guidRemaps)
+        {
+            buffer << ObjectGuid(originalRaw);
+            buffer << ObjectGuid(mappedRaw);
+        }
         uint32 headerSize;
         uint32 timestamp;
         for (auto it : match.packets)
@@ -595,7 +655,7 @@ public:
             TC_LOG_INFO("bg.replay", "Deserialized replay: start {} map {} packets {}", record.startTime, record.mapId, record.packets.size());
 
             ObjectGuid spectator = p->GetGUID();
-            if (record.allianceRecorder == spectator || record.hordeRecorder == spectator)
+            if (record.guidRemaps.empty() && (record.allianceRecorder == spectator || record.hordeRecorder == spectator))
             {
                 ObjectGuid newGuid = ObjectGuid::Create<HighGuid::Player>(sObjectMgr->GetGenerator<HighGuid::Player>().Generate());
                 TC_LOG_INFO("bg.replay", "Replacing spectator GUID {} with {}", spectator.ToString(), newGuid.ToString());
@@ -641,9 +701,36 @@ public:
             ByteBuffer buffer;
             buffer.append(&data[0], data.size());
 
-            buffer >> record.startTime;
+            uint32 maybeMagic;
+            buffer >> maybeMagic;
+
+            uint16 version = 0;
+            if (maybeMagic == ReplayFormatMagic)
+            {
+                buffer >> version;
+                buffer >> record.startTime;
+            }
+            else
+            {
+                record.startTime = maybeMagic;
+            }
+
             buffer >> record.allianceRecorder;
             buffer >> record.hordeRecorder;
+
+            if (version >= 1)
+            {
+                uint32 remapCount;
+                buffer >> remapCount;
+                for (uint32 i = 0; i < remapCount; ++i)
+                {
+                    ObjectGuid original;
+                    ObjectGuid mapped;
+                    buffer >> original;
+                    buffer >> mapped;
+                    record.guidRemaps[original.GetRawValue()] = mapped.GetRawValue();
+                }
+            }
 
             /** deserialize replay binary data **/
             uint32 packetSize;
@@ -677,6 +764,23 @@ public:
                         else
                             packetRecord.timestamp -= firstTimestamp;
                     }
+                }
+            }
+
+            if (!record.guidRemaps.empty())
+            {
+                for (auto const& [originalRaw, mappedRaw] : record.guidRemaps)
+                {
+                    ObjectGuid original(originalRaw);
+                    ObjectGuid mapped(mappedRaw);
+
+                    if (record.allianceRecorder == original)
+                        record.allianceRecorder = mapped;
+                    if (record.hordeRecorder == original)
+                        record.hordeRecorder = mapped;
+
+                    for (PacketRecord& packetRecord : record.packets)
+                        ReplaceGuid(packetRecord.packet, original, mapped);
                 }
             }
         }

--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -91,7 +91,21 @@ struct MatchRecord {
     ObjectGuid allianceRecorder;
     ObjectGuid hordeRecorder;
     std::deque<PacketRecord> packets;
+    std::unordered_map<uint64, uint64> guidRemaps;
 };
+
+namespace
+{
+    constexpr uint32 ReplayFormatMagic = 0x42475250; // 'BGRP'
+
+    bool IsAlternateGuidUsed(MatchRecord const& record, uint64 alternateRaw)
+    {
+        for (auto const& pair : record.guidRemaps)
+            if (pair.second == alternateRaw)
+                return true;
+        return false;
+    }
+}
 
 namespace
 {
@@ -220,7 +234,7 @@ namespace
     }
 }
 std::unordered_map<uint32, MatchRecord> records;
-std::unordered_map<uint64, MatchRecord> loadedReplays;
+std::unordered_map<uint32, MatchRecord> loadedReplays;
 // Headless spectators used for recording packets per battleground instance
 std::unordered_map<uint32, Player*> replayBots;
 // Helper container to avoid recursive bot creation
@@ -365,6 +379,21 @@ public:
                 ObjectGuid guid = itr.first;
                 if (Player* plr = ObjectAccessor::FindPlayer(guid))
                 {
+                    if (!plr->IsSpectator())
+                    {
+                        uint64 rawGuid = guid.GetRawValue();
+                        if (record.guidRemaps.find(rawGuid) == record.guidRemaps.end())
+                        {
+                            ObjectGuid alternate;
+                            do
+                            {
+                                alternate = GenerateAlternateGuid(guid);
+                            } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                            record.guidRemaps[rawGuid] = alternate.GetRawValue();
+                        }
+                    }
+
                     uint32 team = plr->GetBGTeam();
                     if (team == ALLIANCE && record.allianceRecorder.IsEmpty())
                         record.allianceRecorder = plr->GetGUID();
@@ -373,6 +402,29 @@ public:
 
                     if (!record.allianceRecorder.IsEmpty() && !record.hordeRecorder.IsEmpty())
                         break;
+                }
+            }
+        }
+        else
+        {
+            for (auto const& itr : bg->GetPlayers())
+            {
+                ObjectGuid guid = itr.first;
+                if (record.guidRemaps.find(guid.GetRawValue()) != record.guidRemaps.end())
+                    continue;
+
+                if (Player* plr = ObjectAccessor::FindPlayer(guid))
+                {
+                    if (plr->IsSpectator())
+                        continue;
+
+                    ObjectGuid alternate;
+                    do
+                    {
+                        alternate = GenerateAlternateGuid(guid);
+                    } while (alternate.IsEmpty() || alternate == guid || IsAlternateGuidUsed(record, alternate.GetRawValue()));
+
+                    record.guidRemaps[guid.GetRawValue()] = alternate.GetRawValue();
                 }
             }
         }
@@ -481,9 +533,17 @@ public:
 
         // serialize arena replay data
         ByteBuffer buffer;
+        buffer << ReplayFormatMagic;
+        buffer << uint16(1);
         buffer << match.startTime;
         buffer << match.allianceRecorder;
         buffer << match.hordeRecorder;
+        buffer << uint32(match.guidRemaps.size());
+        for (auto const& [originalRaw, mappedRaw] : match.guidRemaps)
+        {
+            buffer << ObjectGuid(originalRaw);
+            buffer << ObjectGuid(mappedRaw);
+        }
         uint32 headerSize;
         uint32 timestamp;
         for (auto it : match.packets)
@@ -540,14 +600,15 @@ public:
             if (!loadReplayDataForPlayer(player, replayId))
                 return false;
 
-            if (loadedReplays[player->GetGUID()].packets.empty())
+            uint32 const spectatorLowGuid = player->GetGUIDLow();
+            if (loadedReplays[spectatorLowGuid].packets.empty())
             {
                 handler.PSendSysMessage("Replay data not found.");
                 handler.SetSentErrorMessage(true);
                 return false;
             }
 
-            MatchRecord record = loadedReplays[player->GetGUID()];
+            MatchRecord record = loadedReplays[spectatorLowGuid];
             Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, GetBattlegroundBracketByLevel(record.mapId, 60), record.arenaTypeId, false);
             if (!bg) {
                 handler.PSendSysMessage("Couldn't create arena map!");
@@ -595,7 +656,7 @@ public:
             TC_LOG_INFO("bg.replay", "Deserialized replay: start {} map {} packets {}", record.startTime, record.mapId, record.packets.size());
 
             ObjectGuid spectator = p->GetGUID();
-            if (record.allianceRecorder == spectator || record.hordeRecorder == spectator)
+            if (record.guidRemaps.empty() && (record.allianceRecorder == spectator || record.hordeRecorder == spectator))
             {
                 ObjectGuid newGuid = ObjectGuid::Create<HighGuid::Player>(sObjectMgr->GetGenerator<HighGuid::Player>().Generate());
                 TC_LOG_INFO("bg.replay", "Replacing spectator GUID {} with {}", spectator.ToString(), newGuid.ToString());
@@ -608,8 +669,9 @@ public:
                     record.hordeRecorder = newGuid;
             }
 
-            loadedReplays[p->GetGUID()] = std::move(record);
-            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[p->GetGUID()].packets.size(), p->GetGUID().ToString());
+            uint32 const spectatorLowGuid = p->GetGUIDLow();
+            loadedReplays[spectatorLowGuid] = std::move(record);
+            TC_LOG_INFO("bg.replay", "Loaded replay {} packets {} for spectator {}", matchId, loadedReplays[spectatorLowGuid].packets.size(), p->GetGUID().ToString());
             return true;
         }
 
@@ -641,9 +703,36 @@ public:
             ByteBuffer buffer;
             buffer.append(&data[0], data.size());
 
-            buffer >> record.startTime;
+            uint32 maybeMagic;
+            buffer >> maybeMagic;
+
+            uint16 version = 0;
+            if (maybeMagic == ReplayFormatMagic)
+            {
+                buffer >> version;
+                buffer >> record.startTime;
+            }
+            else
+            {
+                record.startTime = maybeMagic;
+            }
+
             buffer >> record.allianceRecorder;
             buffer >> record.hordeRecorder;
+
+            if (version >= 1)
+            {
+                uint32 remapCount;
+                buffer >> remapCount;
+                for (uint32 i = 0; i < remapCount; ++i)
+                {
+                    ObjectGuid original;
+                    ObjectGuid mapped;
+                    buffer >> original;
+                    buffer >> mapped;
+                    record.guidRemaps[original.GetRawValue()] = mapped.GetRawValue();
+                }
+            }
 
             /** deserialize replay binary data **/
             uint32 packetSize;
@@ -677,6 +766,23 @@ public:
                         else
                             packetRecord.timestamp -= firstTimestamp;
                     }
+                }
+            }
+
+            if (!record.guidRemaps.empty())
+            {
+                for (auto const& [originalRaw, mappedRaw] : record.guidRemaps)
+                {
+                    ObjectGuid original(originalRaw);
+                    ObjectGuid mapped(mappedRaw);
+
+                    if (record.allianceRecorder == original)
+                        record.allianceRecorder = mapped;
+                    if (record.hordeRecorder == original)
+                        record.hordeRecorder = mapped;
+
+                    for (PacketRecord& packetRecord : record.packets)
+                        ReplaceGuid(packetRecord.packet, original, mapped);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure replay battlegrounds apply the template start positions for the recorded map before teleporting the spectator
- set the spectator's battleground team data and faction when building the status packet so teleport coordinates are valid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7793f61b08327b0c438bc1e2295b7