### PR TITLE
Align ScriptMgr player hook names with AzerothCore

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2544,7 +2544,7 @@ void Player::GiveXP(uint32 xp, Unit* victim, float group_rate)
 
     uint8 level = GetLevel();
 
-    sScriptMgr->OnGivePlayerXP(this, xp, victim);
+    sScriptMgr->OnGiveXP(this, xp, victim);
 
     // XP to money conversion processed in Player::RewardQuest
     if (IsMaxLevel())
@@ -2673,7 +2673,7 @@ void Player::GiveLevel(uint8 level)
 
     SendQuestGiverStatusMultiple();
 
-    sScriptMgr->OnPlayerLevelChanged(this, oldLevel);
+    sScriptMgr->OnLevelChanged(this, oldLevel);
 }
 
 bool Player::IsMaxLevel() const

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1884,7 +1884,7 @@ void ScriptMgr::OnPlayerKilledByCreature(Creature* killer, Player* killed)
     FOREACH_SCRIPT(PlayerScript)->OnPlayerKilledByCreature(killer, killed);
 }
 
-void ScriptMgr::OnPlayerLevelChanged(Player* player, uint8 oldLevel)
+void ScriptMgr::OnLevelChanged(Player* player, uint8 oldLevel)
 {
     FOREACH_SCRIPT(PlayerScript)->OnLevelChanged(player, oldLevel);
 }
@@ -1924,7 +1924,7 @@ void ScriptMgr::OnPlayerLeaveCombat(Player* player)
     FOREACH_SCRIPT(PlayerScript)->OnPlayerLeaveCombat(player);
 }
 
-void ScriptMgr::OnGivePlayerXP(Player* player, uint32& amount, Unit* victim)
+void ScriptMgr::OnGiveXP(Player* player, uint32& amount, Unit* victim)
 {
     FOREACH_SCRIPT(PlayerScript)->OnGiveXP(player, amount, victim);
 }

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -1092,7 +1092,7 @@ class TC_GAME_API ScriptMgr
         void OnPVPKill(Player* killer, Player* killed);
         void OnCreatureKill(Player* killer, Creature* killed);
         void OnPlayerKilledByCreature(Creature* killer, Player* killed);
-        void OnPlayerLevelChanged(Player* player, uint8 oldLevel);
+        void OnLevelChanged(Player* player, uint8 oldLevel);
         void OnPlayerFreeTalentPointsChanged(Player* player, uint32 newPoints);
         void OnPlayerTalentsReset(Player* player, bool noCost);
         void OnPlayerMoneyChanged(Player* player, int32& amount);
@@ -1100,7 +1100,7 @@ class TC_GAME_API ScriptMgr
         void OnBeforeLootMoney(Player* player, Loot* loot);
         void OnPlayerEnterCombat(Player* player);
         void OnPlayerLeaveCombat(Player* player);
-        void OnGivePlayerXP(Player* player, uint32& amount, Unit* victim);
+        void OnGiveXP(Player* player, uint32& amount, Unit* victim);
         void OnPlayerReputationChange(Player* player, uint32 factionID, int32& standing, bool incremental);
         void OnPlayerDuelRequest(Player* target, Player* challenger);
         void OnPlayerDuelStart(Player* player1, Player* player2);

--- a/src/server/scripts/Commands/cs_reset.cpp
+++ b/src/server/scripts/Commands/cs_reset.cpp
@@ -157,7 +157,7 @@ public:
         if (Pet* pet = target->GetPet())
             pet->SynchronizeLevelWithOwner();
 
-        sScriptMgr->OnPlayerLevelChanged(target, oldLevel);
+        sScriptMgr->OnLevelChanged(target, oldLevel);
 
         return true;
     }


### PR DESCRIPTION
## Summary
- rename the ScriptMgr forwarding helpers for player level and XP hooks to match the PlayerScript method names
- update all call sites so modules receive the expected OnLevelChanged and OnGiveXP callbacks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f910eddf008327b32f5481bbe47cca