### PR TITLE
Add AutoBalance module scaffolding

### DIFF
--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -19,6 +19,7 @@
 #include "Log.h"
 #include "StringConvert.h"
 #include "Util.h"
+#include <boost/filesystem/path.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <algorithm>
 #include <cstdlib>
@@ -166,6 +167,16 @@ bool ConfigMgr::LoadAdditionalFile(std::string file, bool keepOnReload, std::str
         _additonalFiles.emplace_back(std::move(file));
 
     return true;
+}
+
+void ConfigMgr::LoadModulesConfigs()
+{
+    namespace fs = boost::filesystem;
+
+    fs::path moduleConfig = fs::path(_filename).parent_path() / "AutoBalance.conf";
+    std::string error;
+    if (!LoadAdditionalFile(moduleConfig.generic_string(), true, error))
+        TC_LOG_ERROR("server.loading", "Error loading module configuration {}: {}", moduleConfig.generic_string(), error);
 }
 
 std::vector<std::string> ConfigMgr::OverrideWithEnvVariablesIfAny()

--- a/src/common/Configuration/Config.h
+++ b/src/common/Configuration/Config.h
@@ -33,6 +33,7 @@ public:
     /// Method used only for loading main configuration files (authserver.conf and worldserver.conf)
     bool LoadInitial(std::string file, std::vector<std::string> args, std::string& error);
     bool LoadAdditionalFile(std::string file, bool keepOnReload, std::string& error);
+    void LoadModulesConfigs();
 
     /// Overrides configuration with environment variables and returns overridden keys
     std::vector<std::string> OverrideWithEnvVariablesIfAny();

--- a/src/server/scripts/Custom/AutoBalance/AutoBalance.h
+++ b/src/server/scripts/Custom/AutoBalance/AutoBalance.h
@@ -1,0 +1,35 @@
+#ifndef MOD_AUTOBALANCE_H
+#define MOD_AUTOBALANCE_H
+
+enum ScalingMethod
+{
+    AUTOBALANCE_SCALING_FIXED,
+    AUTOBALANCE_SCALING_DYNAMIC
+};
+
+enum BaseValueType
+{
+    AUTOBALANCE_HEALTH,
+    AUTOBALANCE_DAMAGE_HEALING
+};
+
+enum Relevance
+{
+    AUTOBALANCE_RELEVANCE_FALSE,
+    AUTOBALANCE_RELEVANCE_TRUE,
+    AUTOBALANCE_RELEVANCE_UNCHECKED
+};
+
+enum Damage_Healing_Debug_Phase
+{
+    AUTOBALANCE_DAMAGE_HEALING_DEBUG_PHASE_BEFORE,
+    AUTOBALANCE_DAMAGE_HEALING_DEBUG_PHASE_AFTER
+};
+
+struct World_Multipliers
+{
+    float scaled = 1.0f;
+    float unscaled = 1.0f;
+};
+
+#endif // MOD_AUTOBALANCE_H

--- a/src/server/scripts/Custom/AutoBalance/Message.cpp
+++ b/src/server/scripts/Custom/AutoBalance/Message.cpp
@@ -1,0 +1,565 @@
+#include "Message.h"
+
+#include "ItemTemplate.h"
+
+#include <string>
+#include <unordered_map>
+
+const std::unordered_map<LocaleConstant, std::string> AB_WELCOME_TO_PLAYER = {
+    {LOCALE_enUS, "|cffc3dbff [AutoBalance]|r|cffFF8000 Welcome to {} ({}-player {}). There are {} player(s) in this instance. Difficulty set to {} player(s).|r"},
+    {LOCALE_koKR, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} ({}-player {})에 오신 것을 환영합니다. 이 인스턴스에는 {}명의 플레이어가 있습니다. 난이도가 {}명으로 설정되었습니다.|r"},
+    {LOCALE_frFR, "|cffc3dbff [AutoBalance]|r|cffFF8000 Bienvenue dans {} ({} {}). Il y a {} joueur(s) dans cette instance. La difficulté est réglée sur {} joueur(s).|r"},
+    {LOCALE_deDE, "|cffc3dbff [AutoBalance]|r|cffFF8000 Willkommen in {} ({} Spieler {}). Es gibt {} Spieler in dieser Instanz. Schwierigkeit auf {} Spieler eingestellt.|r"},
+    {LOCALE_zhCN, "|cffc3dbff [AutoBalance]|r|cffFF8000 欢迎来到 {}（{}人 {}）。此副本中有 {} 名玩家。难度设置为 {} 名玩家。|r"},
+    {LOCALE_zhTW, "|cffc3dbff [AutoBalance]|r|cffFF8000 歡迎來到 {}（{}人 {}）。此副本中有 {} 名玩家。難度設定為 {} 名玩家。|r"},
+    {LOCALE_esES, "|cffc3dbff [AutoBalance]|r|cffFF8000 Bienvenido a {} ({} jugador {}). Hay {} jugador(es) en esta instancia. La dificultad se establece en {} jugador(es).|r"},
+    {LOCALE_esMX, "|cffc3dbff [AutoBalance]|r|cffFF8000 Bienvenido a {} ({} jugador {}). Hay {} jugador(es) en esta instancia. La dificultad se establece en {} jugador(es).|r"},
+    {LOCALE_ruRU, "|cffc3dbff [AutoBalance]|r|cffFF8000 Добро пожаловать в {} ({} игрок {}). В этом экземпляре {} игроков. Сложность установлена на {} игроков.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_WELCOME_TO_GM = {
+    {LOCALE_enUS, "|cffc3dbff [AutoBalance]|r|cffFF8000 Your GM flag is turned on. AutoBalance will ignore you. Please turn GM off and exit/re-enter the instance if you'd like to be considering for AutoBalancing.|r"},
+    {LOCALE_koKR, "|cffc3dbff [AutoBalance]|r|cffFF8000 GM 플래그가 켜져 있습니다. AutoBalance는 당신을 무시합니다. AutoBalancing을 고려하려면 GM을 끄고 인스턴스를 나가고 다시 들어가십시오.|r"},
+    {LOCALE_frFR, "|cffc3dbff [AutoBalance]|r|cffFF8000 Votre drapeau GM est activé. AutoBalance vous ignorera. Veuillez désactiver GM et sortir/revenir dans l'instance si vous souhaitez être pris en compte pour l'AutoBalancing.|r"},
+    {LOCALE_deDE, "|cffc3dbff [AutoBalance]|r|cffFF8000 Ihre GM-Flagge ist eingeschaltet. AutoBalance wird Sie ignorieren. Bitte schalten Sie GM aus und verlassen Sie das Instanz, wenn Sie für das AutoBalancing berücksichtigt werden möchten.|r"},
+    {LOCALE_zhCN, "|cffc3dbff [AutoBalance]|r|cffFF8000 您的GM模式已打开。AutoBalance将忽略。如果您希望考虑自动平衡，请关闭GM并退出/重新进入副本。|r"},
+    {LOCALE_zhTW, "|cffc3dbff [AutoBalance]|r|cffFF8000 您的GM模式已打開。AutoBalance將忽略。如果您希望考慮自動平衡，請關閉GM並退出/重新進入副本。|r"},
+    {LOCALE_esES, "|cffc3dbff [AutoBalance]|r|cffFF8000 Su bandera de GM está encendida. AutoBalance te ignorará. Por favor, apague GM y salga/vuelva a entrar en la instancia si desea ser considerado para el AutoBalance.|r"},
+    {LOCALE_esMX, "|cffc3dbff [AutoBalance]|r|cffFF8000 Su bandera de GM está encendida. AutoBalance te ignorará. Por favor, apague GM y salga/vuelva a entrar en la instancia si desea ser considerado para el AutoBalance.|r"},
+    {LOCALE_ruRU, "|cffc3dbff [AutoBalance]|r|cffFF8000 Ваш флаг GM включен. AutoBalance будет игнорировать вас. Пожалуйста, отключите GM и выйдите/войдите в экземпляр, если хотите, чтобы вас учитывали при автобалансировке.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ANNOUNCE_NON_GM_ENTERING_INSTANCE = {
+    {LOCALE_enUS, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} enters the instance. There are {} player(s) in this instance. Difficulty set to {} player(s).|r"},
+    {LOCALE_koKR, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}이(가) 인스턴스에 들어왔습니다. 이 인스턴스에는 {}명의 플레이어가 있습니다. 난이도가 {}명으로 설정되었습니다.|r"},
+    {LOCALE_frFR, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} entre dans l'instance. Il y a {} joueur(s) dans cette instance. La difficulté est réglée sur {} joueur(s).|r"},
+    {LOCALE_deDE, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} betritt die Instanz. Es gibt {} Spieler in dieser Instanz. Schwierigkeit auf {} Spieler eingestellt.|r"},
+    {LOCALE_zhCN, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}进入了副本。此副本中有 {} 名玩家。难度设置为 {} 名玩家。|r"},
+    {LOCALE_zhTW, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}進入了副本。此副本中有 {} 名玩家。難度設定為 {} 名玩家。|r"},
+    {LOCALE_esES, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} entra en la instancia. Hay {} jugador(es) en esta instancia. La dificultad se establece en {} jugador(es).|r"},
+    {LOCALE_esMX, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} entra en la instancia. Hay {} jugador(es) en esta instancia. La dificultad se establece en {} jugador(es).|r"},
+    {LOCALE_ruRU, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} входит в экземпляр. В этом экземпляре {} игроков. Сложность установлена на {} игроков.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_LEAVING_INSTANCE_COMBAT = {
+    {LOCALE_enUS, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} left the instance while combat was in progress. Difficulty locked to no less than {} players until combat ends.|r"},
+    {LOCALE_koKR, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}이(가) 전투 중에 인스턴스를 떠났습니다. 전투가 끝날 때까지 난이도가 {}명 미만으로 잠겨 있습니다.|r"},
+    {LOCALE_frFR, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} a quitté l'instance alors que le combat était en cours. La difficulté est verrouillée à pas moins de {} joueur(s) jusqu'à la fin du combat.|r"},
+    {LOCALE_deDE, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} hat die Instanz verlassen, während der Kampf im Gange war. Die Schwierigkeit ist gesperrt, bis der Kampf endet, auf nicht weniger als {} Spieler.|r"},
+    {LOCALE_zhCN, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}在战斗进行中离开了副本。直到战斗结束，难度锁定为不少于 {} 名玩家。|r"},
+    {LOCALE_zhTW, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}在戰鬥進行中離開了副本。直到戰鬥結束，難度鎖定為不少於 {} 名玩家。|r"},
+    {LOCALE_esES, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} salió de la instancia mientras el combate estaba en progreso. La dificultad está bloqueada a no menos de {} jugador(es) hasta que termine el combate.|r"}
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_LEAVING_INSTANCE = {
+    {LOCALE_enUS, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} left the instance. There are {} player(s) in this instance. Difficulty set to {} player(s).|r"},
+    {LOCALE_koKR, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}이(가) 인스턴스를 떠났습니다. 이 인스턴스에는 {}명의 플레이어가 있습니다. 난이도가 {}명으로 설정되었습니다.|r"},
+    {LOCALE_frFR, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} a quitté l'instance. Il y a {} joueur(s) dans cette instance. La difficulté est réglée sur {} joueur(s).|r"},
+    {LOCALE_deDE, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} hat die Instanz verlassen. Es gibt {} Spieler in dieser Instanz. Schwierigkeit auf {} Spieler eingestellt.|r"},
+    {LOCALE_zhCN, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}离开了副本。此副本中有 {} 名玩家。难度设置为 {} 名玩家。|r"},
+    {LOCALE_zhTW, "|cffc3dbff [AutoBalance]|r|cffFF8000 {}離開了副本。此副本中有 {} 名玩家。難度設定為 {} 名玩家。|r"},
+    {LOCALE_esES, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} salió de la instancia. Hay {} jugador(es) en esta instancia. La dificultad se establece en {} jugador(es).|r"},
+    {LOCALE_esMX, "|cffc3dbff [AutoBalance]|r|cffFF8000 {} salió de la instancia. Hay {} jugador(es) en esta instancia. La dificultad se establece en {}"}
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_SET_OFFSET_COMMAND_DESCRIPTION = {
+    {LOCALE_enUS, "Set the player difficulty offset for this instance. Usage: .ab offset <number>.|r"},
+    {LOCALE_koKR, "이 인스턴스의 플레이어 난이도 오프셋을 설정합니다. 사용법: .ab offset <숫자>.|r"},
+    {LOCALE_frFR, "Définissez le décalage de difficulté du joueur pour cette instance. Utilisation : .ab offset <nombre>.|r"},
+    {LOCALE_deDE, "Legen Sie den Spieler-Schwierigkeits-Offset für diese Instanz fest. Verwendung: .ab offset <Nummer>.|r"},
+    {LOCALE_zhCN, "设置此副本的玩家难度。用法：.ab offset <数字>。|r"},
+    {LOCALE_zhTW, "設定此副本的玩家難度。用法：.ab offset <數字>。|r"},
+    {LOCALE_esES, "Establece el desplazamiento de dificultad del jugador para esta instancia. Uso: .ab offset <número>.|r"},
+    {LOCALE_esMX, "Establece el desplazamiento de dificultad del jugador para esta instancia. Uso: .ab offset <número>.|r"},
+    {LOCALE_ruRU, "Устанавливает смещение сложности игрока для этого экземп"}
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_SET_OFFSET_COMMAND_SUCCESS = {
+    {LOCALE_enUS, "Changing Player Difficulty Offset to {}.|r"},
+    {LOCALE_koKR, "플레이어 난이도 오프셋을 {}(으)로 변경합니다.|r"},
+    {LOCALE_frFR, "Modification du décalage de difficulté du joueur à {}.|r"},
+    {LOCALE_deDE, "Spieler-Schwierigkeits-Offset auf {} ändern.|r"},
+    {LOCALE_zhCN, "将玩家难度更改为 {}。|r"},
+    {LOCALE_zhTW, "將玩家難度更改為 {}。|r"},
+    {LOCALE_esES, "Cambiando el desplazamiento de dificultad del jugador a {}.|r"},
+    {LOCALE_esMX, "Cambiando el desplazamiento de dificultad del jugador a {}.|r"},
+    {LOCALE_ruRU, "Изменение смещения сложности игрока на {}.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_SET_OFFSET_COMMAND_ERROR = {
+    {LOCALE_enUS, "Error changing Player Difficulty Offset! Please try again.|r"},
+    {LOCALE_koKR, "플레이어 난이도 오프셋 변경 중 오류가 발생했습니다! 다시 시도하십시오.|r"},
+    {LOCALE_frFR, "Erreur lors de la modification du décalage de difficulté du joueur ! Veuillez réessayer.|r"},
+    {LOCALE_deDE, "Fehler beim Ändern des Spieler-Schwierigkeits-Offsets! Bitte versuchen Sie es erneut.|r"},
+    {LOCALE_zhCN, "更改玩家难度时出错！请重试。|r"},
+    {LOCALE_zhTW, "更改玩家難度時出錯！請重試。|r"},
+    {LOCALE_esES, "¡Error al cambiar el desplazamiento de dificultad del jugador! Por favor, inténtelo de nuevo.|r"},
+    {LOCALE_esMX, "¡Error al cambiar el desplazamiento de dificultad del jugador! Por favor, inténtelo de nuevo.|r"},
+    {LOCALE_ruRU, "Ошибка при изменении смещения сложности игрока! Пожалуйста, попробуйте еще раз.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_GET_OFFSET_COMMAND_SUCCESS = {
+    {LOCALE_enUS, "Current Player Difficulty Offset = {}.|r"},
+    {LOCALE_koKR, "현재 플레이어 난이도 오프셋 = {}.|r"},
+    {LOCALE_frFR, "Décalage de difficulté actuel du joueur = {}.|r"},
+    {LOCALE_deDE, "Aktueller Spieler-Schwierigkeits-Offset = {}.|r"},
+    {LOCALE_zhCN, "当前玩家难度偏移 = {}。|r"},
+    {LOCALE_zhTW, "當前玩家難度偏移 = {}。|r"},
+    {LOCALE_esES, "Desplazamiento de dificultad actual del jugador = {}.|r"},
+    {LOCALE_esMX, "Desplazamiento de dificultad actual del jugador = {}.|r"},
+    {LOCALE_ruRU, "Текущее смещение сложности игрока = {}.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ADJUSTED_PLAYER_COUNT_COMBAT_LOCKED = {
+    {LOCALE_enUS, "Adjusted Player Count: {} (Combat Locked)|r"},
+    {LOCALE_koKR, "조정된 플레이어 수: {} (전투 잠금됨)|r"},
+    {LOCALE_frFR, "Nombre de joueurs ajusté : {} (verrouillé en combat)|r"},
+    {LOCALE_deDE, "Angepasste Spieleranzahl: {} (Kampf gesperrt)|r"},
+    {LOCALE_zhCN, "调整后的玩家数量：{}（战斗锁定）|r"},
+    {LOCALE_zhTW, "調整後的玩家數量：{}（戰鬥鎖定）|r"},
+    {LOCALE_esES, "Cantidad de jugadores ajustada: {} (bloqueada en combate)|r"},
+    {LOCALE_esMX, "Cantidad de jugadores ajustada: {} (bloqueada en combate)|r"},
+    {LOCALE_ruRU, "Количество игроков, отрегулированное: {} (заблокировано в бою)|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ADJUSTED_PLAYER_COUNT_MAP_MINIMUM = {
+    {LOCALE_enUS, "Adjusted Player Count: {} (Map Minimum)|r"},
+    {LOCALE_koKR, "조정된 플레이어 수: {} (지도 최소)|r"},
+    {LOCALE_frFR, "Nombre de joueurs ajusté : {} (minimum de la carte)|r"},
+    {LOCALE_deDE, "Angepasste Spieleranzahl: {} (Kartenminimum)|r"},
+    {LOCALE_zhCN, "调整后的玩家数量：{}（地图最小）|r"},
+    {LOCALE_zhTW, "調整後的玩家數量：{}（地圖最小）|r"},
+    {LOCALE_esES, "Cantidad de jugadores ajustada: {} (mínimo del mapa)|r"},
+    {LOCALE_esMX, "Cantidad de jugadores ajustada: {} (mínimo del mapa)|r"},
+    {LOCALE_ruRU, "Количество игроков, отрегулированное: {} (минимальное для карты)|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ADJUSTED_PLAYER_COUNT_MAP_MINIMUM_DIFFICULTY_OFFSET = {
+    {LOCALE_enUS, "Adjusted Player Count: {} (Map Minimum + Difficulty Offset of {})|r"},
+    {LOCALE_koKR, "조정된 플레이어 수: {} (지도 최소 + {}의 난이도 오프셋)|r"},
+    {LOCALE_frFR, "Nombre de joueurs ajusté : {} (minimum de la carte + décalage de difficulté de {})|r"},
+    {LOCALE_deDE, "Angepasste Spieleranzahl: {} (Kartenminimum + Schwierigkeits-Offset von {})|r"},
+    {LOCALE_zhCN, "调整后的玩家数量：{}（地图最小 + {}的难度修正）|r"},
+    {LOCALE_zhTW, "調整後的玩家數量：{}（地圖最小 + {}的難度修正）|r"},
+    {LOCALE_esES, "Cantidad de jugadores ajustada: {} (mínimo del mapa + desplazamiento de dificultad de {})|r"},
+    {LOCALE_esMX, "Cantidad de jugadores ajustada: {} (mínimo del mapa + desplazamiento de dificultad de {})|r"},
+    {LOCALE_ruRU, "Количество игроков, отрегулированное: {} (минимальное для карты"}
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ADJUSTED_PLAYER_COUNT_DIFFICULTY_OFFSET = {
+    {LOCALE_enUS, "Adjusted Player Count: {} (Difficulty Offset of {})|r"},
+    {LOCALE_koKR, "조정된 플레이어 수: {} ({}의 난이도 오프셋)|r"},
+    {LOCALE_frFR, "Nombre de joueurs ajusté : {} (décalage de difficulté de {})|r"},
+    {LOCALE_deDE, "Angepasste Spieleranzahl: {} (Schwierigkeits-Offset von {})|r"},
+    {LOCALE_zhCN, "调整后的玩家数量：{}（{}的难度修正）|r"},
+    {LOCALE_zhTW, "調整後的玩家數量：{}（{}的難度修正）|r"},
+    {LOCALE_esES, "Cantidad de jugadores ajustada: {} (desplazamiento de dificultad de {})|r"},
+    {LOCALE_esMX, "Cantidad de jugadores ajustada: {} (desplazamiento de dificultad de {})|r"},
+    {LOCALE_ruRU, "Количество игроков, отрегулированное: {} (смещение сложности {})|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ADJUSTED_PLAYER_COUNT = {
+    {LOCALE_enUS, "Adjusted Player Count: {}|r"},
+    {LOCALE_koKR, "조정된 플레이어 수: {}|r"},
+    {LOCALE_frFR, "Nombre de joueurs ajusté : {}|r"},
+    {LOCALE_deDE, "Angepasste Spieleranzahl: {}|r"},
+    {LOCALE_zhCN, "调整后的玩家数量：{}|r"},
+    {LOCALE_zhTW, "調整後的玩家數量：{}|r"},
+    {LOCALE_esES, "Cantidad de jugadores ajustada: {}|r"},
+    {LOCALE_esMX, "Cantidad de jugadores ajustada: {}|r"},
+    {LOCALE_ruRU, "Количество игроков, отрегулированное: {}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_LFG_RANGE = {
+    {LOCALE_enUS, "LFG Range: Lvl {} - {} (Target: Lvl {})|r"},
+    {LOCALE_koKR, "LFG 범위: 레벨 {} - {} (대상: 레벨 {})|r"},
+    {LOCALE_frFR, "Plage LFG : Niveau {} - {} (Cible : Niveau {})|r"},
+    {LOCALE_deDE, "LFG-Bereich: Stufe {} - {} (Ziel: Stufe {})|r"},
+    {LOCALE_zhCN, "LFG范围：等级 {} - {}（目标：等级 {}）|r"},
+    {LOCALE_zhTW, "LFG範圍：等級 {} - {}（目標：等級 {}）|r"},
+    {LOCALE_esES, "Rango de LFG: Nivel {} - {} (Objetivo: Nivel {})|r"},
+    {LOCALE_esMX, "Rango de LFG: Nivel {} - {} (Objetivo: Nivel {})|r"},
+    {LOCALE_ruRU, "Диапазон поиска группы: Ур. {} - {} (Цель: Ур. {})|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_MAP_LEVEL = {
+    {LOCALE_enUS, "Map Level: {}{}|r"},
+    {LOCALE_koKR, "지도 레벨: {}{}|r"},
+    {LOCALE_frFR, "Niveau de la carte : {}{}|r"},
+    {LOCALE_deDE, "Kartenlevel: {}{}|r"},
+    {LOCALE_zhCN, "地图等级：{}{}|r"},
+    {LOCALE_zhTW, "地圖等級：{}{}|r"},
+    {LOCALE_esES, "Nivel del mapa: {}{}|r"},
+    {LOCALE_esMX, "Nivel del mapa: {}{}|r"},
+    {LOCALE_ruRU, "Уровень карты: {}{}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_LEVEL_SCALING_ENABLED = {
+    {LOCALE_enUS, " (Level Scaling Enabled)|r"},
+    {LOCALE_koKR, " (레벨 스케일링 활성화됨)|r"},
+    {LOCALE_frFR, " (Mise à l'échelle des niveaux activée)|r"},
+    {LOCALE_deDE, " (Stufenanpassung aktiviert)|r"},
+    {LOCALE_zhCN, " （启用等级自动平衡）|r"},
+    {LOCALE_zhTW, " （啟用等級縮放平衡）|r"},
+    {LOCALE_esES, " (Escalado de nivel activado)|r"},
+    {LOCALE_esMX, " (Escalado de nivel activado)|r"},
+    {LOCALE_ruRU, " (Масштабирование уровней включено)|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_LEVEL_SCALING_DISABLED = {
+    {LOCALE_enUS, " (Level Scaling Disabled)|r"},
+    {LOCALE_koKR, " (레벨 스케일링 비활성화됨)|r"},
+    {LOCALE_frFR, " (Mise à l'échelle des niveaux désactivée)|r"},
+    {LOCALE_deDE, " (Stufenanpassung deaktiviert)|r"},
+    {LOCALE_zhCN, " （禁用等级自动平衡）|r"},
+    {LOCALE_zhTW, " （停用等級縮放平衡）|r"},
+    {LOCALE_esES, " (Escalado de nivel desactivado)|r"},
+    {LOCALE_esMX, " (Escalado de nivel desactivado)|r"},
+    {LOCALE_ruRU, " (Масштабирование уровней отключено)|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_WORLD_HEALTH_MULTIPLIER = {
+    {LOCALE_enUS, "World health multiplier: {:.3f}|r"},
+    {LOCALE_koKR, "월드 체력 배율: {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de santé mondiale : {:.3f}|r"},
+    {LOCALE_deDE, "Weltgesundheitsmultiplikator: {:.3f}|r"},
+    {LOCALE_zhCN, "全局生命值倍率：{:.3f}|r"},
+    {LOCALE_zhTW, "全局生命值倍增器：{:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de salud mundial: {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de salud mundial: {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель здоровья мира: {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_WORLD_HOSTILE_DAMAGE_HEALING_MULTIPLIER_TO = {
+    {LOCALE_enUS, "World hostile damage and healing multiplier: {:.3f} -> {:.3f}|r"},
+    {LOCALE_koKR, "월드 적 대미지 및 치유 배율: {:.3f} -> {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de dégâts et de soins hostiles mondiaux : {:.3f} -> {:.3f}|r"},
+    {LOCALE_deDE, "Weltweiter feindlicher Schadens- und Heilungs-Multiplikator: {:.3f} -> {:.3f}|r"},
+    {LOCALE_zhCN, "全局伤害和治疗倍率：{:.3f} -> {:.3f}|r"},
+    {LOCALE_zhTW, "全局敵對傷害和治療倍增器：{:.3f} -> {:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de daño y curación hostil mundial: {:.3f} -> {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de daño y curación hostil mundial: {:.3f} -> {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель урона и лечения мира: {:.3f} -> {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_WORLD_HOSTILE_DAMAGE_HEALING_MULTIPLIER = {
+    {LOCALE_enUS, "World hostile damage and healing multiplier: {:.3f}|r"},
+    {LOCALE_koKR, "월드 적 대미지 및 치유 배율: {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de dégâts et de soins hostiles mondiaux : {:.3f}|r"},
+    {LOCALE_deDE, "Weltweiter feindlicher Schadens- und Heilungs-Multiplikator: {:.3f}|r"},
+    {LOCALE_zhCN, "全局伤害和治疗倍率：{:.3f}|r"},
+    {LOCALE_zhTW, "全局敵對傷害和治療倍增器：{:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de daño y curación hostil mundial: {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de daño y curación hostil mundial: {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель урона и лечения мира: {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ORIGINAL_CREATURE_LEVEL_RANGE = {
+    {LOCALE_enUS, "Original Creature Level Range: {} - {} (Avg: {:.2f})|r"},
+    {LOCALE_koKR, "원래 크리쳐 레벨 범위: {} - {} (평균: {:.2f})|r"},
+    {LOCALE_frFR, "Plage de niveaux de créatures d'origine : {} - {} (Moyenne : {:.2f})|r"},
+    {LOCALE_deDE, "Originaler Kreaturenlevelbereich: {} - {} (Durchschnitt: {:.2f})|r"},
+    {LOCALE_zhCN, "原始生物等级范围：{} - {}（平均：{:2.f}）|r"},
+    {LOCALE_zhTW, "原始生物等級範圍：{} - {}（平均：{:2.f}）|r"},
+    {LOCALE_esES, "Rango de niveles de criaturas originales: {} - {} (Promedio: {:.2f})|r"},
+    {LOCALE_esMX, "Rango de niveles de criaturas originales: {} - {} (Promedio: {:.2f})|r"},
+    {LOCALE_ruRU, "Исходный диапазон уровней существ: {} - {} (Среднее: {:.2f})|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ACTIVE_TOTAL_CREATURES_IN_MAP = {
+    {LOCALE_enUS, "Active | Total Creatures in map: {} | {}|r"},
+    {LOCALE_koKR, "활성 | 지도 내 총 크리쳐: {} | {}|r"},
+    {LOCALE_frFR, "Actif | Créatures totales dans la carte : {} | {}|r"},
+    {LOCALE_deDE, "Aktiv | Gesamte Kreaturen in der Karte: {} | {}|r"},
+    {LOCALE_zhCN, "Active | 地图中的总生物： {} | {}|r"},
+    {LOCALE_zhTW, "Active | 地圖中的總生物： {} | {}|r"},
+    {LOCALE_esES, "Activo | Criaturas totales en el mapa: {} | {}|r"},
+    {LOCALE_esMX, "Activo | Criaturas totales en el mapa: {} | {}|r"},
+    {LOCALE_ruRU, "Активные | Всего существ на карте: {} | {}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_COMMAND_ONLY_IN_INSTANCE = {
+    {LOCALE_enUS, "This command can only be used in a dungeon or raid.|r"},
+    {LOCALE_koKR, "이 명령은 던전이나 공격대에서만 사용할 수 있습니다.|r"},
+    {LOCALE_frFR, "Cette commande ne peut être utilisée que dans un donjon ou un raid.|r"},
+    {LOCALE_deDE, "Dieser Befehl kann nur in einem Dungeon oder Schlachtzug verwendet werden.|r"},
+    {LOCALE_zhCN, "此命令只能在地下城或团队副本中使用。|r"},
+    {LOCALE_zhTW, "此命令只能在地城或團隊副本中使用。|r"},
+    {LOCALE_esES, "Este comando solo se puede usar en una mazmorra o banda.|r"},
+    {LOCALE_esMX, "Este comando solo se puede usar en una mazmorra o banda.|r"},
+    {LOCALE_ruRU, "Эту команду можно использовать только в подземелье или рейде.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_TARGET_NO_IN_INSTANCE = {
+    {LOCALE_enUS, "That target is not in an instance.|r"},
+    {LOCALE_koKR, "그 대상은 인스턴스에 있지 않습니다.|r"},
+    {LOCALE_frFR, "Cette cible n'est pas dans une instance.|r"},
+    {LOCALE_deDE, "Dieses Ziel befindet sich nicht in einer Instanz.|r"},
+    {LOCALE_zhCN, "该目标不在副本中。|r"},
+    {LOCALE_zhTW, "該目標不在副本中。|r"},
+    {LOCALE_esES, "Ese objetivo no está en una instancia.|r"},
+    {LOCALE_esMX, "Ese objetivo no está en una instancia.|r"},
+    {LOCALE_ruRU, "Эта цель не находится в подземелье.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ACTIVE_FOR_MAP_STATS = {
+    {LOCALE_enUS, "Active for Map Stats|r"},
+    {LOCALE_koKR, "지도 통계용 활성|r"},
+    {LOCALE_frFR, "Actif pour les statistiques de la carte|r"},
+    {LOCALE_deDE, "Aktiv für Kartenstatistiken|r"},
+    {LOCALE_zhCN, "地图平衡激活|r"},
+    {LOCALE_zhTW, "地圖平衡激活|r"},
+    {LOCALE_esES, "Activo para estadísticas del mapa|r"},
+    {LOCALE_esMX, "Activo para estadísticas del mapa|r"},
+    {LOCALE_ruRU, "Активно для статистики карты|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_IGNORED_FOR_MAP_STATS = {
+    {LOCALE_enUS, "Ignored for Map Stats|r"},
+    {LOCALE_koKR, "지도 통계용 무시됨|r"},
+    {LOCALE_frFR, "Ignoré pour les statistiques de la carte|r"},
+    {LOCALE_deDE, "Ignoriert für Kartenstatistiken|r"},
+    {LOCALE_zhCN, "地图平衡已忽略|r"},
+    {LOCALE_zhTW, "地圖平衡已忽略|r"},
+    {LOCALE_esES, "Ignorado para estadísticas del mapa|r"},
+    {LOCALE_esMX, "Ignorado para estadísticas del mapa|r"},
+    {LOCALE_ruRU, "Игнорируется для статистики карты|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_CREATURE_DIFFICULTY_LEVEL = {
+    {LOCALE_enUS, "Creature difficulty level: {} player(s)|r"},
+    {LOCALE_koKR, "생물 난이도 레벨: {} 플레이어|r"},
+    {LOCALE_frFR, "Niveau de difficulté de la créature : {} joueur(s)|r"},
+    {LOCALE_deDE, "Kreaturschwierigkeitsstufe: {} Spieler|r"},
+    {LOCALE_zhCN, "生物难度等级：{} 玩家|r"},
+    {LOCALE_zhTW, "生物難度等級：{} 玩家|r"},
+    {LOCALE_esES, "Nivel de dificultad de la criatura: {} jugador(es)|r"},
+    {LOCALE_esMX, "Nivel de dificultad de la criatura: {} jugador(es)|r"},
+    {LOCALE_ruRU, "Уровень сложности существа: {} игрок(ов)|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_CLONE_OF_SUMMON = {
+    {LOCALE_enUS, "Clone of {} ({})|r"},
+    {LOCALE_koKR, "{}의 복제 ({})|r"},
+    {LOCALE_frFR, "Clone de {} ({})|r"},
+    {LOCALE_deDE, "Klon von {} ({})|r"},
+    {LOCALE_zhCN, "{}的克隆（{}）|r"},
+    {LOCALE_zhTW, "{}的克隆（{}）|r"},
+    {LOCALE_esES, "Clon de {} ({})|r"},
+    {LOCALE_esMX, "Clon de {} ({})|r"},
+    {LOCALE_ruRU, "Клон {} ({})|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_SUMMON_OF_SUMMON = {
+    {LOCALE_enUS, "Summon of {} ({})|r"},
+    {LOCALE_koKR, "{}의 소환 ({})|r"},
+    {LOCALE_frFR, "Invocation de {} ({})|r"},
+    {LOCALE_deDE, "Beschwörung von {} ({})|r"},
+    {LOCALE_zhCN, "{}的召唤（{}）|r"},
+    {LOCALE_zhTW, "{}的召喚（{}）|r"},
+    {LOCALE_esES, "Invocación de {} ({})|r"},
+    {LOCALE_esMX, "Invocación de {} ({})|r"},
+    {LOCALE_ruRU, "Призыв {} ({})|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_SUMMON_WITHOUT_SUMMONER = {
+    {LOCALE_enUS, "Summon without a summoner.|r"},
+    {LOCALE_koKR, "소환사 없는 소환.|r"},
+    {LOCALE_frFR, "Invocation sans invocateur.|r"},
+    {LOCALE_deDE, "Beschwörung ohne Beschwörer.|r"},
+    {LOCALE_zhCN, "没有召唤者的召唤物。|r"},
+    {LOCALE_zhTW, "沒有召喚者的召喚物。|r"},
+    {LOCALE_esES, "Invocación sin invocador.|r"},
+    {LOCALE_esMX, "Invocación sin invocador.|r"},
+    {LOCALE_ruRU, "Призыв без призывателя.|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_HEALTH_MULTIPLIER_TO = {
+    {LOCALE_enUS, "Health multiplier: {:.3f} -> {:.3f}|r"},
+    {LOCALE_koKR, "체력 배율: {:.3f} -> {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de santé : {:.3f} -> {:.3f}|r"},
+    {LOCALE_deDE, "Gesundheitsmultiplikator: {:.3f} -> {:.3f}|r"},
+    {LOCALE_zhCN, "生命值倍率：{:.3f} -> {:.3f}|r"},
+    {LOCALE_zhTW, "生命值倍增器：{:.3f} -> {:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de salud: {:.3f} -> {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de salud: {:.3f} -> {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель здоровья: {:.3f} -> {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_MANA_MULTIPLIER_TO = {
+    {LOCALE_enUS, "Mana multiplier: {:.3f} -> {:.3f}|r"},
+    {LOCALE_koKR, "마나 배율: {:.3f} -> {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de mana : {:.3f} -> {:.3f}|r"},
+    {LOCALE_deDE, "Manamultiplikator: {:.3f} -> {:.3f}|r"},
+    {LOCALE_zhCN, "法力值倍率：{:.3f} -> {:.3f}|r"},
+    {LOCALE_zhTW, "法力值倍增器：{:.3f} -> {:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de maná: {:.3f} -> {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de maná: {:.3f} -> {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель маны: {:.3f} -> {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ARMOR_MULTIPLIER_TO = {
+    {LOCALE_enUS, "Armor multiplier: {:.3f} -> {:.3f}|r"},
+    {LOCALE_koKR, "방어구 배율: {:.3f} -> {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur d'armure : {:.3f} -> {:.3f}|r"},
+    {LOCALE_deDE, "Rüstungsmultiplikator: {:.3f} -> {:.3f}|r"},
+    {LOCALE_zhCN, "护甲倍率：{:.3f} -> {:.3f}|r"},
+    {LOCALE_zhTW, "護甲倍增器：{:.3f} -> {:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de armadura: {:.3f} -> {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de armadura: {:.3f} -> {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель брони: {:.3f} -> {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_DAMAGE_MULTIPLIER_TO = {
+    {LOCALE_enUS, "Damage multiplier: {:.3f} -> {:.3f}|r"},
+    {LOCALE_koKR, "피해 배율: {:.3f} -> {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de dégâts : {:.3f} -> {:.3f}|r"},
+    {LOCALE_deDE, "Schadensmultiplikator: {:.3f} -> {:.3f}|r"},
+    {LOCALE_zhCN, "伤害倍率：{:.3f} -> {:.3f}|r"},
+    {LOCALE_zhTW, "傷害倍增器：{:.3f} -> {:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de daño: {:.3f} -> {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de daño: {:.3f} -> {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель урона: {:.3f} -> {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_HEALTH_MULTIPLIER = {
+    {LOCALE_enUS, "Health multiplier: {:.3f}|r"},
+    {LOCALE_koKR, "체력 배율: {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de santé : {:.3f}|r"},
+    {LOCALE_deDE, "Gesundheitsmultiplikator: {:.3f}|r"},
+    {LOCALE_zhCN, "生命值倍率：{:.3f}|r"},
+    {LOCALE_zhTW, "生命值倍增器：{:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de salud: {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de salud: {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель здоровья: {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_MANA_MULTIPLIER = {
+    {LOCALE_enUS, "Mana multiplier: {:.3f}|r"},
+    {LOCALE_koKR, "마나 배율: {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de mana : {:.3f}|r"},
+    {LOCALE_deDE, "Manamultiplikator: {:.3f}|r"},
+    {LOCALE_zhCN, "法力值倍率：{:.3f}|r"},
+    {LOCALE_zhTW, "法力值倍增器：{:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de maná: {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de maná: {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель маны: {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_ARMOR_MULTIPLIER = {
+    {LOCALE_enUS, "Armor multiplier: {:.3f}|r"},
+    {LOCALE_koKR, "방어구 배율: {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur d'armure : {:.3f}|r"},
+    {LOCALE_deDE, "Rüstungsmultiplikator: {:.3f}|r"},
+    {LOCALE_zhCN, "护甲倍率：{:.3f}|r"},
+    {LOCALE_zhTW, "護甲倍增器：{:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de armadura: {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de armadura: {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель брони: {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_DAMAGE_MULTIPLIER = {
+    {LOCALE_enUS, "Damage multiplier: {:.3f}|r"},
+    {LOCALE_koKR, "피해 배율: {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de dégâts : {:.3f}|r"},
+    {LOCALE_deDE, "Schadensmultiplikator: {:.3f}|r"},
+    {LOCALE_zhCN, "伤害倍率：{:.3f}|r"},
+    {LOCALE_zhTW, "傷害倍增器：{:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de daño: {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de daño: {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель урона: {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_CC_DURATION_MULTIPLIER = {
+    {LOCALE_enUS, "CC Duration multiplier: {:.3f}|r"},
+    {LOCALE_koKR, "CC 지속시간 배율: {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur de durée de la CC : {:.3f}|r"},
+    {LOCALE_deDE, "CC-Dauer-Multiplikator: {:.3f}|r"},
+    {LOCALE_zhCN, "控制持续时间倍率：{:.3f}|r"},
+    {LOCALE_zhTW, "控制持續時間倍增器：{:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de duración de CC: {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de duración de CC: {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель длительности контроля: {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_XP_MONEY_MULTIPLIER = {
+    {LOCALE_enUS, "XP multiplier: {:.3f}  Money multiplier: {:.3f}|r"},
+    {LOCALE_koKR, "경험치 배율: {:.3f}  돈 배율: {:.3f}|r"},
+    {LOCALE_frFR, "Multiplicateur d'XP : {:.3f}  Multiplicateur d'argent : {:.3f}|r"},
+    {LOCALE_deDE, "XP-Multiplikator: {:.3f}  Geldmultiplikator: {:.3f}|r"},
+    {LOCALE_zhCN, "经验值倍率：{:.3f}  金钱倍率：{:.3f}|r"},
+    {LOCALE_zhTW, "經驗值倍增器：{:.3f}  金錢倍增器：{:.3f}|r"},
+    {LOCALE_esES, "Multiplicador de XP: {:.3f}  Multiplicador de dinero: {:.3f}|r"},
+    {LOCALE_esMX, "Multiplicador de XP: {:.3f}  Multiplicador de dinero: {:.3f}|r"},
+    {LOCALE_ruRU, "Множитель опыта: {:.3f}  Множитель денег: {:.3f}|r"},
+};
+
+const std::unordered_map<LocaleConstant, std::string> AB_LEAVING_INSTANCE_COMBAT_CHANGE = {
+    {LOCALE_enUS, "|cffc3dbff [AutoBalance]|r|cffFF8000 Combat has ended. Difficulty is no longer locked.|r"},
+    {LOCALE_koKR, "|cffc3dbff [AutoBalance]|r|cffFF8000 전투가 종료되었습니다. 난이도가 더 이상 잠겨 있지 않습니다.|r"},
+    {LOCALE_frFR, "|cffc3dbff [AutoBalance]|r|cffFF8000 Le combat est terminé. La difficulté n'est plus verrouillée.|r"},
+    {LOCALE_deDE, "|cffc3dbff [AutoBalance]|r|cffFF8000 Der Kampf ist vorbei. Die Schwierigkeit ist nicht mehr gesperrt.|r"},
+    {LOCALE_zhCN, "|cffc3dbff [AutoBalance]|r|cffFF8000 战斗结束了。难度不再被锁定。|r"},
+    {LOCALE_zhTW, "|cffc3dbff [AutoBalance]|r|cffFF8000 戰鬥已結束。難度不再被鎖定。|r"},
+    {LOCALE_esES, "|cffc3dbff [AutoBalance]|r|cffFF8000 El combate ha terminado. La dificultad ya no está bloqueada.|r"},
+    {LOCALE_esMX, "|cffc3dbff [AutoBalance]|r|cffFF8000 El combate ha terminado. La dificultad ya no está bloqueada.|r"},
+    {LOCALE_ruRU, "|cffc3dbff [AutoBalance]|r|cffFF8000 Бой окончен. Сложность больше не заблокирована.|r"},
+};
+
+std::unordered_map<std::string, const std::unordered_map<LocaleConstant, std::string>*> abTextMaps = {
+    {"welcome_to_player", &AB_WELCOME_TO_PLAYER},
+    {"welcome_to_gm", &AB_WELCOME_TO_GM},
+    {"announce_non_gm_entering_instance", &AB_ANNOUNCE_NON_GM_ENTERING_INSTANCE},
+    {"leaving_instance_combat", &AB_LEAVING_INSTANCE_COMBAT},
+    {"leaving_instance", &AB_LEAVING_INSTANCE},
+    {"set_offset_command_description", &AB_SET_OFFSET_COMMAND_DESCRIPTION},
+    {"set_offset_command_success", &AB_SET_OFFSET_COMMAND_SUCCESS},
+    {"set_offset_command_error", &AB_SET_OFFSET_COMMAND_ERROR},
+    {"get_offset_command_success", &AB_GET_OFFSET_COMMAND_SUCCESS},
+    {"adjusted_player_count_combat_locked", &AB_ADJUSTED_PLAYER_COUNT_COMBAT_LOCKED},
+    {"adjusted_player_count_map_minimum", &AB_ADJUSTED_PLAYER_COUNT_MAP_MINIMUM},
+    {"adjusted_player_count_map_minimum_difficulty_offset", &AB_ADJUSTED_PLAYER_COUNT_MAP_MINIMUM_DIFFICULTY_OFFSET},
+    {"adjusted_player_count_difficulty_offset", &AB_ADJUSTED_PLAYER_COUNT_DIFFICULTY_OFFSET},
+    {"adjusted_player_count", &AB_ADJUSTED_PLAYER_COUNT},
+    {"lfg_range", &AB_LFG_RANGE},
+    {"map_level", &AB_MAP_LEVEL},
+    {"level_scaling_enabled", &AB_LEVEL_SCALING_ENABLED},
+    {"level_scaling_disabled", &AB_LEVEL_SCALING_DISABLED},
+    {"world_health_multiplier", &AB_WORLD_HEALTH_MULTIPLIER},
+    {"world_hostile_damage_healing_multiplier_to", &AB_WORLD_HOSTILE_DAMAGE_HEALING_MULTIPLIER_TO},
+    {"world_hostile_damage_healing_multiplier", &AB_WORLD_HOSTILE_DAMAGE_HEALING_MULTIPLIER},
+    {"original_creature_level_range", &AB_ORIGINAL_CREATURE_LEVEL_RANGE},
+    {"active_total_creatures_in_map", &AB_ACTIVE_TOTAL_CREATURES_IN_MAP},
+    {"ab_command_only_in_instance", &AB_COMMAND_ONLY_IN_INSTANCE},
+    {"target_no_in_instance", &AB_TARGET_NO_IN_INSTANCE},
+    {"active_for_map_stats", &AB_ACTIVE_FOR_MAP_STATS},
+    {"ignored_for_map_stats", &AB_IGNORED_FOR_MAP_STATS},
+    {"creature_difficulty_level", &AB_CREATURE_DIFFICULTY_LEVEL},
+    {"clone_of_summon", &AB_CLONE_OF_SUMMON},
+    {"summon_of_summon", &AB_SUMMON_OF_SUMMON},
+    {"summon_without_summoner", &AB_SUMMON_WITHOUT_SUMMONER},
+    {"health_multiplier_to", &AB_HEALTH_MULTIPLIER_TO},
+    {"mana_multiplier_to", &AB_MANA_MULTIPLIER_TO},
+    {"armor_multiplier_to", &AB_ARMOR_MULTIPLIER_TO},
+    {"damage_multiplier_to", &AB_DAMAGE_MULTIPLIER_TO},
+    {"health_multiplier", &AB_HEALTH_MULTIPLIER},
+    {"mana_multiplier", &AB_MANA_MULTIPLIER},
+    {"armor_multiplier", &AB_ARMOR_MULTIPLIER},
+    {"damage_multiplier", &AB_DAMAGE_MULTIPLIER},
+    {"cc_duration_multiplier", &AB_CC_DURATION_MULTIPLIER},
+    {"xp_money_multiplier", &AB_XP_MONEY_MULTIPLIER},
+    {"leaving_instance_combat_change", &AB_LEAVING_INSTANCE_COMBAT_CHANGE},
+};
+
+std::string ABGetLocaleText(LocaleConstant locale, const std::string& titleType) {
+    auto textMapIt = abTextMaps.find(titleType);
+    if (textMapIt != abTextMaps.end())
+    {
+        const std::unordered_map<LocaleConstant, std::string>* textMap = textMapIt->second;
+        auto it = textMap->find(locale);
+        if (it != textMap->end())
+            return it->second;
+    }
+
+    return "";
+}

--- a/src/server/scripts/Custom/AutoBalance/Message.h
+++ b/src/server/scripts/Custom/AutoBalance/Message.h
@@ -1,0 +1,11 @@
+#ifndef AB_MESSAGE_H
+#define AB_MESSAGE_H
+
+#include "Common.h"
+#include "ItemTemplate.h"
+
+#include <string>
+
+std::string ABGetLocaleText(LocaleConstant locale, std::string const& titleType);
+
+#endif // AB_MESSAGE_H

--- a/src/server/scripts/Custom/AutoBalance/autobalance.cpp
+++ b/src/server/scripts/Custom/AutoBalance/autobalance.cpp
@@ -1,0 +1,5 @@
+#include "ScriptMgr.h"
+
+void AddSC_autobalance()
+{
+}

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -20,7 +20,10 @@
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
 #include "BGReplay.cpp"
+
+void AddSC_autobalance();
 void AddCustomScripts()
 {
     AddBGReplayScripts();
+    AddSC_autobalance();
 }

--- a/src/server/worldserver/CMakeLists.txt
+++ b/src/server/worldserver/CMakeLists.txt
@@ -80,11 +80,13 @@ if(COPY_CONF AND WIN32)
     add_custom_command(TARGET worldserver
       POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/worldserver.conf.dist ${CMAKE_BINARY_DIR}/bin/$(ConfigurationName)/
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/conf/AutoBalance.conf.dist ${CMAKE_BINARY_DIR}/bin/$(ConfigurationName)/
     )
   elseif(MINGW)
     add_custom_command(TARGET worldserver
       POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/worldserver.conf.dist ${CMAKE_BINARY_DIR}/bin/
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/conf/AutoBalance.conf.dist ${CMAKE_BINARY_DIR}/bin/
     )
   endif()
 endif()
@@ -92,12 +94,12 @@ endif()
 if(UNIX)
   install(TARGETS worldserver DESTINATION bin)
   if(COPY_CONF)
-    install(FILES worldserver.conf.dist DESTINATION ${CONF_DIR})
+    install(FILES worldserver.conf.dist conf/AutoBalance.conf.dist DESTINATION ${CONF_DIR})
   endif()
 elseif(WIN32)
   install(TARGETS worldserver DESTINATION "${CMAKE_INSTALL_PREFIX}")
   if(COPY_CONF)
-    install(FILES worldserver.conf.dist DESTINATION "${CMAKE_INSTALL_PREFIX}")
+    install(FILES worldserver.conf.dist conf/AutoBalance.conf.dist DESTINATION "${CMAKE_INSTALL_PREFIX}")
   endif()
 endif()
 

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -195,6 +195,8 @@ extern int main(int argc, char** argv)
         return 1;
     }
 
+    sConfigMgr->LoadModulesConfigs();
+
     std::vector<std::string> overriddenKeys = sConfigMgr->OverrideWithEnvVariablesIfAny();
 
     std::shared_ptr<Trinity::Asio::IoContext> ioContext = std::make_shared<Trinity::Asio::IoContext>();

--- a/src/server/worldserver/conf/AutoBalance.conf.dist
+++ b/src/server/worldserver/conf/AutoBalance.conf.dist
@@ -1,0 +1,963 @@
+[worldserver]
+##########################
+#
+# Logging
+#
+# Add these lines to your worldserver.conf file to enable logging for AutoBalance.
+# Be sure to add them after the `Logger.module=4,Console Server` line.
+#
+# 4 = Info (Default), 5 = Debug
+#
+##########################
+# Logger.module.AutoBalance=4,Console Server
+# Logger.module.AutoBalance_CombatLocking=4,Console Server
+# Logger.module.AutoBalance_DamageHealingCC=4,Console Server
+# Logger.module.AutoBalance_StatGeneration=4,Console Server
+
+##########################
+#
+# Enable / Disable Settings
+#
+##########################
+
+#
+#     AutoBalance.Enable
+#        Enable/Disable all features globally. If this setting is off, all settings after this one do not take effect.
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalance.Enable.Global=1
+
+#
+#     AutoBalance.Enabled.*
+#        Enable/Disable all features for each instance size and difficulty.
+#        If an instance size is set to 0 here, none of the other settings for that instance size will take effect.
+#        Default:     1 (1 = ON, 0 = OFF)
+#
+AutoBalance.Enable.5M=1
+AutoBalance.Enable.10M=1
+AutoBalance.Enable.15M=1
+AutoBalance.Enable.20M=1
+AutoBalance.Enable.25M=1
+AutoBalance.Enable.40M=1
+AutoBalance.Enable.OtherNormal=1
+
+AutoBalance.Enable.5MHeroic=1
+AutoBalance.Enable.10MHeroic=1
+AutoBalance.Enable.25MHeroic=1
+AutoBalance.Enable.OtherHeroic=1
+
+#
+#     AutoBalance.Disable.PerInstance
+#        Disable all features for the given instance IDs. If an instance ID is not specified here, that instance will follow
+#        the `AutoBalance.Enable.*` settings.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID], [InstanceID], [InstanceID], ..."
+#
+#        Example: AutoBalance.Disable.PerInstance="33, 43, 129"
+#
+#        Default: ""
+AutoBalance.Disable.PerInstance = ""
+
+##########################
+#
+# Minimum Players
+#
+##########################
+#
+#     AutoBalance.MinPlayers
+#     AutoBalance.MinPlayers.Heroic
+#        Sets the Minimum Number of players to scale down to for all normal/heroic instances.
+#        If fewer than this number of players enter the instance, scale to the specified value.
+#
+#        NOTE: Player Difficulty Offset is applied AFTER the player count is adjusted for the MinPlayer setting
+#
+#        AutoBalance.MinPlayers affects only normal instances.
+#        AutoBalance.MinPlayers.Heroic affects only heroic instances.
+#
+#        Example: AutoBalance.MinPlayers = 1
+#                 AutoBalance.MinPlayers.Heroic = 5
+#
+#        Default: 1
+AutoBalance.MinPlayers = 1
+AutoBalance.MinPlayers.Heroic = 1
+AutoBalance.MinPlayers.Raid = 1
+AutoBalance.MinPlayers.RaidHeroic = 1
+
+#
+#     AutoBalance.MinPlayers.PerInstance
+#     AutoBalance.MinPlayers.Heroic.PerInstance
+#        Sets the Minimum Number of players to scale down to per-instance ID.
+#        If fewer than this number of players enter the instance, scale to the specified value.
+#
+#        NOTE: Player Difficulty Offset is applied AFTER the player count is adjusted for the MinPlayer setting
+#
+#        AutoBalance.MinPlayers.PerInstance affects only normal instances.
+#        AutoBalance.MinPlayers.Heroic.PerInstance affects only heroic instances.
+#
+#        If a given Instance ID is not specified in this list, the minimum number of players is set by the generic MinPlayers settings.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [MinPlayers], [InstanceID] [MinPlayers], [InstanceID] [MinPlayers], ..."
+#
+#        Example: AutoBalance.MinPlayers.PerInstance="33 2, 43 5, 129 4"
+#                 AutoBalance.MinPlayers.PerInstance="33 5, 43 5, 129 5"
+#
+#        Default: ""
+AutoBalance.MinPlayers.PerInstance = ""
+AutoBalance.MinPlayers.Heroic.PerInstance = ""
+
+##########################
+#
+# Stat Scaling - Inflection Point
+#
+##########################
+
+#     AutoBalance.InflectionPoint* series
+#        InflectionPoint
+#           Changes the inflection point of the Hyperbolic Tangent function that determines the enemy multiplier for a given player count.
+#           This adjusts the shape of the overall curve. A lower value means that difficulty will increase faster as you add players.
+#
+#           This image provies a visual of several InflectionPoint settings and its affect on the enemy stat multipliers.
+#           https://i.imgur.com/x42UnUR.png
+#
+#           Example: If InflectionPointRaid is 0.5, an enemy in a 40-player instance will have half its life with 20 players in the instance
+#                    If InflectionPointRaid is 0.8, an enemy in a 40-player instance will have half its life with 12 players in the instance
+#
+#           Default: 0.5
+#
+#        CurveFloor
+#           When the curve to determine the enemy multiplier is calculated, start the curve at this value.
+#
+#           This allows you to make enemies have higher stats for lower player counts without adversely affecting the stats of
+#           higher player counts. Applied before `AutoBalance.StatModifier*` values.
+#
+#           Value may be negative if needed to achieve your desired curve.
+#
+#           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
+#           https://i.imgur.com/I8S4cwJ.png
+#
+#           Default: 0.0
+#
+#        CurveCeiling
+#           When the curve to determine the enemy multiplier is calculated, end the curve at this value.
+#
+#           This allows you to make enemies have lower stats for higher player counts without adversely affecting the stats of
+#           lower player counts. Applied before `AutoBalance.StatModifier*` values.
+#
+#           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
+#           https://i.imgur.com/I8S4cwJ.png
+#
+#           May be set to higher than 1.0 to increase difficulty of the instance over the stock values:
+#           https://i.imgur.com/DBPxT8E.png
+#
+#           Default: 1.0
+#
+#       BossModifier
+#           InflectionPoint is multiplied by this value for creatures considered dungeon bosses (from dungeons or raids).
+#           It is a multiplier, not a new Inflection Point. Values higher than 1.0 will make enemies easier at lower player
+#           counts while lower than 1.0 will make enemies easier at lower player counts.
+#
+#           To better understand this effect, see the interactive spreadsheet explained below.
+#
+#           Default: 1.0
+#
+#
+#     An interactive spreadsheet is available for you to visually see what effect your settings have on the difficulty curve.
+#
+#     https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy
+#
+#     To use it, copy the sheet to your own Google Drive and edit the values on the left with the yellow background.
+#     The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given dungeon.
+
+### 5-player dungeons
+AutoBalance.InflectionPoint=0.5
+AutoBalance.InflectionPoint.CurveFloor=0.0
+AutoBalance.InflectionPoint.CurveCeiling=1.0
+AutoBalance.InflectionPoint.BossModifier=1.0
+
+### 5-player heroic dungeons
+AutoBalance.InflectionPointHeroic=0.5
+AutoBalance.InflectionPointHeroic.CurveFloor=0.0
+AutoBalance.InflectionPointHeroic.CurveCeiling=1.0
+AutoBalance.InflectionPointHeroic.BossModifier=1.0
+
+### Default for all raids
+AutoBalance.InflectionPointRaid=0.5
+AutoBalance.InflectionPointRaid.CurveFloor=0.0
+AutoBalance.InflectionPointRaid.CurveCeiling=1.0
+AutoBalance.InflectionPointRaid.BossModifier=1.0
+
+### Default for all heroic raids
+AutoBalance.InflectionPointRaidHeroic=0.5
+AutoBalance.InflectionPointRaidHeroic.CurveFloor=0.0
+AutoBalance.InflectionPointRaidHeroic.CurveCeiling=1.0
+AutoBalance.InflectionPointRaidHeroic.BossModifier=1.0
+
+###
+### By default, all instances use the settings configured above. To customize settings for
+### a particular instance size or difficulty, set the variables below. If the variable is
+### blank, the broader settings above will apply.
+###
+
+### 10-player raids
+AutoBalance.InflectionPointRaid10M=
+AutoBalance.InflectionPointRaid10M.CurveFloor=
+AutoBalance.InflectionPointRaid10M.CurveCeiling=
+AutoBalance.InflectionPointRaid10M.BossModifier=
+
+### 10-player heroic raids
+AutoBalance.InflectionPointRaid10MHeroic=
+AutoBalance.InflectionPointRaid10MHeroic.CurveFloor=
+AutoBalance.InflectionPointRaid10MHeroic.CurveCeiling=
+AutoBalance.InflectionPointRaid10MHeroic.BossModifier=
+
+### 15-player raids
+AutoBalance.InflectionPointRaid15M=
+AutoBalance.InflectionPointRaid15M.CurveFloor=
+AutoBalance.InflectionPointRaid15M.CurveCeiling=
+AutoBalance.InflectionPointRaid15M.BossModifier=
+
+### 20-player raids
+AutoBalance.InflectionPointRaid20M=
+AutoBalance.InflectionPointRaid20M.CurveFloor=
+AutoBalance.InflectionPointRaid20M.CurveCeiling=
+AutoBalance.InflectionPointRaid20M.BossModifier=
+
+### 25-player raids
+AutoBalance.InflectionPointRaid25M=
+AutoBalance.InflectionPointRaid25M.CurveFloor=
+AutoBalance.InflectionPointRaid25M.CurveCeiling=
+AutoBalance.InflectionPointRaid25M.BossModifier=
+
+### 25-player heroic raids
+AutoBalance.InflectionPointRaid25MHeroic=
+AutoBalance.InflectionPointRaid25MHeroic.CurveFloor=
+AutoBalance.InflectionPointRaid25MHeroic.CurveCeiling=
+AutoBalance.InflectionPointRaid25MHeroic.BossModifier=
+
+### 40-player raids
+AutoBalance.InflectionPointRaid40M=
+AutoBalance.InflectionPointRaid40M.CurveFloor=
+AutoBalance.InflectionPointRaid40M.CurveCeiling=
+AutoBalance.InflectionPointRaid40M.BossModifier=
+
+#
+#     AutoBalance.InflectionPoint.PerInstance
+#        Sets Inflection Point settings for specific `InstanceID`s.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Specifying a value of `-1` will skip overriding of that value. For instances not listed, the default inflection value for the instance's
+#        difficulty and size will be used. You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#
+#        Format: "[InstanceID] [InflectionPoint] [CurveFloor] [CurveCeiling], [InstanceID] [InflectionPoint] [CurveFloor] [CurveCeiling], ..."
+#
+#        Example: AutoBalance.InflectionPoint.PerInstance="229 0.4 0.0 1.5, 309 -1 0.0 1.1, 48 0.3"
+#
+#        Default: ""
+#
+AutoBalance.InflectionPoint.PerInstance=""
+
+#
+#     AutoBalance.InflectionPoint.Boss.PerInstance
+#        Sets Inflection Point settings for all bosses in specific `InstanceID`s. Note that the first value is "InflectionPointMultiplier", which behaves
+#        identically to the BossModifier setting. The "normal" inflection point is multiplied by this value for bosses. To better understand this effect,
+#        see the interactive spreadsheet.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        For instances not listed, the default inflection value for the instance's difficulty and size will be used. Only one set of values should be specified
+#        per InstanceID.
+#
+#        Format: "[InstanceID] [InflectionPointMultiplier], [InstanceID] [InflectionPointMultiplier], ..."
+#
+#        Example: AutoBalance.InflectionPoint.Boss.PerInstance="229 1.2, 309 1.5, 48 1.25"
+#
+#        Default: ""
+#
+AutoBalance.InflectionPoint.Boss.PerInstance=""
+
+#
+#     AutoBalance.playerCountDifficultyOffset
+#        Offset of players inside an instance. Affects all instance types.
+#        Default:     0
+AutoBalance.playerCountDifficultyOffset=0
+
+##########################
+#
+# Stat Scaling - Stat Modifiers
+#
+##########################
+
+#     AutoBalance.StatModifier* series
+#        The difficulty curve (as defined by the InflectionPoint settings) determines the base multiplier. The base
+#        multiplier is then adjusted (multiplied) by the appropriate StatModifier setting. This allows you to control
+#        the balance of how scaling affects the four adjustable stats: health, mana, armor, and damage.
+#
+#        AutoBalance.StatModifier*.<Stat> -- only affects non-boss creatures
+#        AutoBalance.StatModifier*.Boss.<Stat> -- only affects bosses
+#
+#        To see this in action, change the `StatModifier` value on the spreadsheet:
+#        https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy
+#
+#        To use it, copy the sheet to your own Google Drive and edit the values on the left with the yellow background.
+#        The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given instance.
+#
+#        Global
+#           Multiply the other four settings by this value. Allows you to increase all the stats (health, mana, armor,
+#           damage) with a single adjustment. Both the global value and the stat-specific value are used at the same time.
+#
+#           Example: If "Global" is 0.5, and "Health" is 1.5, the health of the creature will be multiplied by 0.75 of
+#                    its value (after adjusting for the number of players).
+#
+#           Default: 1.0
+#
+#        Health | Mana | Armor | Damage
+#           Adjusts the StatModifier for the appropriate stat. Affected by the Global StatModifier above.
+#
+#           NOTE: "Damage" affects both creature damage and world damage.
+#
+#           Default: 1.0
+#
+#        Boss.Global | Boss.Health | Boss.Mana | Boss.Armor | Boss.Damage
+#           Sets a SEPARATE stat multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures
+#           considered instance bosses (from dungeons or raids).
+#
+#           Default: If not set for a given instance size/type, defaults to the dungeon/raid default values.
+#
+#           To better understand this effect, see the interactive spreadsheet.
+#
+
+### 5-player dungeons
+AutoBalance.StatModifier.Global=1.0
+AutoBalance.StatModifier.Health=1.0
+AutoBalance.StatModifier.Mana=1.0
+AutoBalance.StatModifier.Armor=1.0
+AutoBalance.StatModifier.Damage=1.0
+
+AutoBalance.StatModifier.Boss.Global=1.0
+AutoBalance.StatModifier.Boss.Health=1.0
+AutoBalance.StatModifier.Boss.Mana=1.0
+AutoBalance.StatModifier.Boss.Armor=1.0
+AutoBalance.StatModifier.Boss.Damage=1.0
+
+### 5-player heroic dungeons
+AutoBalance.StatModifierHeroic.Global=1.0
+AutoBalance.StatModifierHeroic.Health=1.0
+AutoBalance.StatModifierHeroic.Mana=1.0
+AutoBalance.StatModifierHeroic.Armor=1.0
+AutoBalance.StatModifierHeroic.Damage=1.0
+
+AutoBalance.StatModifierHeroic.Boss.Global=1.0
+AutoBalance.StatModifierHeroic.Boss.Health=1.0
+AutoBalance.StatModifierHeroic.Boss.Mana=1.0
+AutoBalance.StatModifierHeroic.Boss.Armor=1.0
+AutoBalance.StatModifierHeroic.Boss.Damage=1.0
+
+### Default for all raids
+AutoBalance.StatModifierRaid.Global=1.0
+AutoBalance.StatModifierRaid.Health=1.0
+AutoBalance.StatModifierRaid.Mana=1.0
+AutoBalance.StatModifierRaid.Armor=1.0
+AutoBalance.StatModifierRaid.Damage=1.0
+
+AutoBalance.StatModifierRaid.Boss.Global=1.0
+AutoBalance.StatModifierRaid.Boss.Health=1.0
+AutoBalance.StatModifierRaid.Boss.Mana=1.0
+AutoBalance.StatModifierRaid.Boss.Armor=1.0
+AutoBalance.StatModifierRaid.Boss.Damage=1.0
+
+### Default for all heroic raids
+AutoBalance.StatModifierRaidHeroic.Global=1.0
+AutoBalance.StatModifierRaidHeroic.Health=1.0
+AutoBalance.StatModifierRaidHeroic.Mana=1.0
+AutoBalance.StatModifierRaidHeroic.Armor=1.0
+AutoBalance.StatModifierRaidHeroic.Damage=1.0
+
+AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Health=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Mana=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Armor=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Damage=1.0
+
+###
+### By default, all instances use the settings configured above. To customize settings for
+### a particular instance size or difficulty, set the variables below. If the variable is
+### blank, the broader settings above will apply.
+###
+
+### 10-player raids
+AutoBalance.StatModifierRaid10M.Global=
+AutoBalance.StatModifierRaid10M.Health=
+AutoBalance.StatModifierRaid10M.Mana=
+AutoBalance.StatModifierRaid10M.Armor=
+AutoBalance.StatModifierRaid10M.Damage=
+
+AutoBalance.StatModifierRaid10M.Boss.Global=
+AutoBalance.StatModifierRaid10M.Boss.Health=
+AutoBalance.StatModifierRaid10M.Boss.Mana=
+AutoBalance.StatModifierRaid10M.Boss.Armor=
+AutoBalance.StatModifierRaid10M.Boss.Damage=
+
+### 10-player heroic raids
+AutoBalance.StatModifierRaid10MHeroic.Global=
+AutoBalance.StatModifierRaid10MHeroic.Health=
+AutoBalance.StatModifierRaid10MHeroic.Mana=
+AutoBalance.StatModifierRaid10MHeroic.Armor=
+AutoBalance.StatModifierRaid10MHeroic.Damage=
+
+AutoBalance.StatModifierRaid10MHeroic.Boss.Global=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Health=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Mana=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Armor=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Damage=
+
+### 15-player raids
+AutoBalance.StatModifierRaid15M.Global=
+AutoBalance.StatModifierRaid15M.Health=
+AutoBalance.StatModifierRaid15M.Mana=
+AutoBalance.StatModifierRaid15M.Armor=
+AutoBalance.StatModifierRaid15M.Damage=
+
+AutoBalance.StatModifierRaid15M.Boss.Global=
+AutoBalance.StatModifierRaid15M.Boss.Health=
+AutoBalance.StatModifierRaid15M.Boss.Mana=
+AutoBalance.StatModifierRaid15M.Boss.Armor=
+AutoBalance.StatModifierRaid15M.Boss.Damage=
+
+### 20-player raids
+AutoBalance.StatModifierRaid20M.Global=
+AutoBalance.StatModifierRaid20M.Health=
+AutoBalance.StatModifierRaid20M.Mana=
+AutoBalance.StatModifierRaid20M.Armor=
+AutoBalance.StatModifierRaid20M.Damage=
+
+AutoBalance.StatModifierRaid20M.Boss.Global=
+AutoBalance.StatModifierRaid20M.Boss.Health=
+AutoBalance.StatModifierRaid20M.Boss.Mana=
+AutoBalance.StatModifierRaid20M.Boss.Armor=
+AutoBalance.StatModifierRaid20M.Boss.Damage=
+
+### 25-player raids
+AutoBalance.StatModifierRaid25M.Global=
+AutoBalance.StatModifierRaid25M.Health=
+AutoBalance.StatModifierRaid25M.Mana=
+AutoBalance.StatModifierRaid25M.Armor=
+AutoBalance.StatModifierRaid25M.Damage=
+
+AutoBalance.StatModifierRaid25M.Boss.Global=
+AutoBalance.StatModifierRaid25M.Boss.Health=
+AutoBalance.StatModifierRaid25M.Boss.Mana=
+AutoBalance.StatModifierRaid25M.Boss.Armor=
+AutoBalance.StatModifierRaid25M.Boss.Damage=
+
+### 25-player heroic raids
+AutoBalance.StatModifierRaid25MHeroic.Global=
+AutoBalance.StatModifierRaid25MHeroic.Health=
+AutoBalance.StatModifierRaid25MHeroic.Mana=
+AutoBalance.StatModifierRaid25MHeroic.Armor=
+AutoBalance.StatModifierRaid25MHeroic.Damage=
+
+AutoBalance.StatModifierRaid25MHeroic.Boss.Global=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Health=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Mana=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Armor=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Damage=
+
+### 40-player raids
+AutoBalance.StatModifierRaid40M.Global=
+AutoBalance.StatModifierRaid40M.Health=
+AutoBalance.StatModifierRaid40M.Mana=
+AutoBalance.StatModifierRaid40M.Armor=
+AutoBalance.StatModifierRaid40M.Damage=
+
+AutoBalance.StatModifierRaid40M.Boss.Global=
+AutoBalance.StatModifierRaid40M.Boss.Health=
+AutoBalance.StatModifierRaid40M.Boss.Mana=
+AutoBalance.StatModifierRaid40M.Boss.Armor=
+AutoBalance.StatModifierRaid40M.Boss.Damage=
+
+#     AutoBalance.StatModifier*.CCDuration series
+#        These StatModifier values affect the duration of CC effects used against the players. CC effects are auras with one
+#        or more of these effects:
+#
+#          - SPELL_AURA_MOD_CHARM
+#          - SPELL_AURA_MOD_CONFUSE
+#          - SPELL_AURA_MOD_DISARM
+#          - SPELL_AURA_MOD_FEAR
+#          - SPELL_AURA_MOD_PACIFY
+#          - SPELL_AURA_MOD_POSSESS
+#          - SPELL_AURA_MOD_SILENCE
+#          - SPELL_AURA_MOD_STUN
+#          - SPELL_AURA_MOD_SPEED_SLOW_ALL
+#
+#        CCDuration
+#           Adjusts the duration of CC effects. Not affected by any global settings.
+#
+#           After the InflectionPoint curve determines the base multiplier, it is multiplied by this value to determine the final
+#           CC duration multiplier.
+#
+#           CCDuration IS affected by the InflectionPoint curve!
+#           CCDuration IS NOT affected by StatModifier*.Global values!
+#           CCDuration IS affected by AutoBalance.MinCCDurationModifier and AutoBalance.MaxCCDurationModifier!
+#
+#           Example:
+#               Assume we are using the default InflectionPoint curve (0.5 with 0.0 floor and 1.0 ceiling), and there are 3 players in the instance.
+#               With 3 players, the base multiplier is '0.6843'. Let's say that CCDuration is set to '0.5'.
+#               The final CC Duration multiplier is 0.6843 * 0.5 = 0.34215
+#               For a CC with a programmed duration of 8 seconds, the CC will last 8 * 0.34215 = 2.7372 seconds.
+#
+#           Default: no value
+#               If no value is set for a given instance type and player count, and the generic values that apply to that instance
+#               are also blank, CC duration will be unchanged.
+#
+#        Boss.CCDuration
+#           Sets a SEPARATE CCDuration multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures
+#           considered instance bosses (from dungeons or raids).
+#
+#           Default: no value
+#               If no value is set for a given instance type and player count, and the generic values that apply to that instance
+#               are also blank, CC duration will be unchanged.
+#
+
+### 5-player dungeons
+AutoBalance.StatModifier.CCDuration=
+AutoBalance.StatModifier.Boss.CCDuration=
+
+### 5-player heroic dungeons
+AutoBalance.StatModifierHeroic.CCDuration=
+AutoBalance.StatModifierHeroic.Boss.CCDuration=
+
+### Default for all raids
+AutoBalance.StatModifierRaid.CCDuration=
+AutoBalance.StatModifierRaid.Boss.CCDuration=
+
+### Default for all heroic raids
+AutoBalance.StatModifierRaidHeroic.CCDuration=
+AutoBalance.StatModifierRaidHeroic.Boss.CCDuration=
+
+###
+### Configuring the CCDuration settings above this line will affect all dungeons and raids.
+### To customize settings for a particular instance size, add your value to the settings below.
+###
+
+### 10-player raids
+AutoBalance.StatModifierRaid10M.CCDuration=
+AutoBalance.StatModifierRaid10M.Boss.CCDuration=
+
+### 10-player heroic raids
+AutoBalance.StatModifierRaid10MHeroic.CCDuration=
+AutoBalance.StatModifierRaid10MHeroic.Boss.CCDuration=
+
+### 15-player raids
+AutoBalance.StatModifierRaid15M.CCDuration=
+AutoBalance.StatModifierRaid15M.Boss.CCDuration=
+
+### 20-player raids
+AutoBalance.StatModifierRaid20M.CCDuration=
+AutoBalance.StatModifierRaid20M.Boss.CCDuration=
+
+### 25-player raids
+AutoBalance.StatModifierRaid25M.CCDuration=
+AutoBalance.StatModifierRaid25M.Boss.CCDuration=
+
+### 25-player heroic raids
+AutoBalance.StatModifierRaid25MHeroic.CCDuration=
+AutoBalance.StatModifierRaid25MHeroic.Boss.CCDuration=
+
+### 40-player raids
+AutoBalance.StatModifierRaid40M.CCDuration=
+AutoBalance.StatModifierRaid40M.Boss.CCDuration=
+
+##########################
+#
+# Stat Scaling - Stat Modifier Overrides
+#
+##########################
+# A note on how the stat modifier settings are prioritized. More specific values REPLACE less-specific values.
+# Bosses and non-boss creatures pull from different settings but work in a similar way.
+#
+# Boss example: High Priest Venoxis (boss, CreatureID 14507) in the Zul'Gurub 20-player raid (InstanceID 309):
+#
+#     StatModifierRaid.Boss.Global=     0.7
+#     StatModifierRaid20M.Boss.Global=  0.8
+#     StatModifier.Boss.PerInstance=    "309 0.9"
+#     StatModifier.PerCreature=         "14507 1.0"
+#
+# Settings are applied from top the bottom, with the bottom setting (1.0) being applied to all stats for the boss.
+# Omitting the "PerCreature" setting would cause the per-instance setting for Zul'Gurub bosses (0.9) to be applied instead, and so on.
+#
+# Non-boss example: Molten Giant (non-boss, CreatureID 11658) in the Molten Core 40-player raid (InstanceID 409):
+#
+#     StatModifierRaid.Damage =     2.1
+#     StatModifierRaid40M.Damage =  2.2
+#     StatModifier.PerInstance =    "409 -1 -1 -1 -1 2.3"
+#     StatModifier.PerCreature=     "11658 -1 -1 -1 -1 2.4"
+#
+# Settings are applied from top the bottom, with the bottom setting (2.4) being applied to the creature's damage multiplier.
+# Omitting the "PerCreature" setting would cause the per-instance setting for Molten Core non-boss damage (2.3) to be applied instead, and so on.
+#
+# Keep in mind that you may use "-1" for any specific override stat to allow less-specific settings to come through.
+#
+# In this way you can make your configs as simple or complicated as you like - if you only want to set some generic dungeon and raid modifiers, everything will
+# work as expected. If you want to tune specific creatures to your liking, you can do that too.
+#
+
+#
+#     AutoBalance.StatModifier.PerInstance
+#        Allows setting per-instance stat modifier values. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#
+#        ONLY AFFECTS NON-BOSS CREATURES.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], [InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], ..."
+#
+#        Example: AutoBalance.StatModifier.PerInstance="409 1.0 0.8 0.8 1.0 1.2 1.0, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifier.PerInstance=""
+
+#
+#     AutoBalance.StatModifier.Boss.PerInstance
+#        Allows setting per-instance stat modifier values for bosses only. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#
+#        ONLY AFFECTS BOSSES.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage] [Boss.CCDuration], [InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage] [Boss.CCDuration], ..."
+#
+#        Example: AutoBalance.StatModifier.Boss.PerInstance="409 1.0 0.8 0.8 1.0 1.2 0.8, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifier.Boss.PerInstance=""
+
+#
+#     AutoBalance.StatModifier.Boss.PerCreature
+#        Allows setting per-creature stat modifier values. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per CreatureID.
+#
+#        Format: "[CreatureID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], [CreatureID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], ..."
+#
+#        Example: AutoBalance.StatModifier.Boss.PerInstance="14507 1.0 0.8 0.8 1.0 1.2 0.5, 11372 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifier.PerCreature=""
+
+#
+#     AutoBalance.MinHPModifier
+#        Minimum Modifier setting for Health Modification. An enemy's health will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinHPModifier=0.01
+
+#
+#     AutoBalance.MinManaModifier
+#        Minimum Modifier setting for Mana Modification. An enemy's mana will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinManaModifier=0.01
+
+#
+#     AutoBalance.MinDamageModifier
+#        Minimum Modifier setting for Damage Modification. An enemy's damage will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinDamageModifier=0.01
+
+#
+#     AutoBalance.MinCCDurationModifier
+#        Minimum Modifier setting for Crowd Control Duration. The duration of an enemy's CC will not be multiplied by a value smaller than this.
+#        Default:     0.25
+AutoBalance.MinCCDurationModifier=0.25
+
+#
+#     AutoBalance.MaxCCDurationModifier
+#        Maximum Modifier setting for Crowd Control Duration. The duration of an enemy's CC will not be multiplied by a value greater than this.
+#        Default:     1.0
+AutoBalance.MaxCCDurationModifier=1.0
+
+##########################
+#
+# Misc Settings
+#
+##########################
+
+#
+#     AutoBalance.ForcedIDXX
+#        Sets MobIDs for the group they belong to.
+#        All 5-player creatures should go in AutoBalance.ForcedID5=
+#        All 10-player creatures should go in AutoBalance.ForcedID10=
+#        All X-player creatures should go in AutoBalance.ForcedIDX=
+AutoBalance.ForcedID40=""
+AutoBalance.ForcedID25=""
+AutoBalance.ForcedID20=""
+AutoBalance.ForcedID10=""
+AutoBalance.ForcedID5=""
+AutoBalance.ForcedID2=""
+
+#
+#     AutoBalance.DisabledID
+#        Disable scaling on specific creatures
+#
+AutoBalance.DisabledID=""
+
+##########################
+#
+# Level Scaling
+#
+##########################
+
+#
+#     AutoBalance.LevelScaling
+#        Scale creatures in instances based on the highest-level player.
+#        0 = Disabled
+#        1 = Enabled (only in dungeons/raids)
+#        Default:     1
+AutoBalance.LevelScaling=1
+
+#
+#     AutoBalance.LevelScaling.Method
+#        Selects which method should be used when the level for scaled creatures.
+#
+#           fixed:
+#               Creatures will be scaled to the level of the highest-level player in the group.
+#
+#           dynamic:
+#               Creatures will be scaled to a level based on 1) their original assignments compared to the
+#               highest-level creature in the instance and 2) the highest-level player in the dungeon. This
+#               means that lower-level trash will still be lower level than you, and higher-level bosses
+#               will still be higher-level than you.
+#
+#        Possible values: "fixed" or "dynamic"
+#
+#        Default: "dynamic"
+AutoBalance.LevelScaling.Method="dynamic"
+
+#
+#     AutoBalance.LevelScaling.SkipHigherLevels
+#        If an instance's average creature level is no more than (SkipHigherLevels) levels
+#        above the highest player level, do not scale down.
+#
+#        To disable scaling instance levels DOWN, set this to the max level of your server (likely 80).
+#        To disable this feature entirely and scale all higher-level instances, set this to 0.
+#
+#        Default: 3
+#
+#     AutoBalance.LevelScaling.SkipLowerLevels
+#        If an instance's average creature level is no more than (SkipLowerLevels) levels
+#        below of the Highest player level, do not scale up.
+#
+#        To disable scaling instance levels UP, set this to the max level of your server (likely 80).
+#        To disable this feature entirely and scale all lower-level instances, set this to 0.
+#
+#        Default: 5
+AutoBalance.LevelScaling.SkipHigherLevels = 3
+AutoBalance.LevelScaling.SkipLowerLevels = 5
+
+#
+#     AutoBalance.LevelScaling.DynamicLevel.Ceiling.*
+#        Sets the maximum number of levels creatures scaled in "dynamic" mode can be OVER your highest-level
+#        player. The creature in the dungeon with the highest original level will be set to the highest-level
+#        player's level + this value.
+#
+#        Only takes effect if AutoBalance.LevelScaling.Method = "dynamic"
+#
+#        Default: 1 (Dungeons), 2 (Heroic Dungeons), 3 (Raids), 3 (Heroic Raids)
+#
+#     AutoBalance.LevelScaling.DynamicLevel.Floor.*
+#        Sets the maximum number of levels creatures scaled in "dynamic" mode can be UNDER your highest-level
+#        player. For instances with wide level spreads, ensures that the level differences stay reasonable.
+#
+#        Only takes effect if AutoBalance.LevelScaling.Method = "dynamic"
+#
+#        Default: 5
+AutoBalance.LevelScaling.DynamicLevel.Ceiling.Dungeons = 1
+AutoBalance.LevelScaling.DynamicLevel.Floor.Dungeons = 5
+
+AutoBalance.LevelScaling.DynamicLevel.Ceiling.HeroicDungeons = 2
+AutoBalance.LevelScaling.DynamicLevel.Floor.HeroicDungeons = 5
+
+AutoBalance.LevelScaling.DynamicLevel.Ceiling.Raids = 3
+AutoBalance.LevelScaling.DynamicLevel.Floor.Raids = 5
+
+AutoBalance.LevelScaling.DynamicLevel.Ceiling.HeroicRaids = 3
+AutoBalance.LevelScaling.DynamicLevel.Floor.HeroicRaids = 5
+
+#
+#     AutoBalance.LevelScaling.DynamicLevel.PerInstance
+#        Allows setting per-instance Dynamic Level options. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#        Set to a value of "" to disable the feature.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [SkipHigherLevels] [SkipLowerLevels] [DynamicLevelCeiling] [DynamicLevelFloor], [InstanceID] [SkipHigherLevels] [SkipLowerLevels] [DynamicLevelCeiling] [DynamicLevelFloor], ..."
+#
+#        Example: AutoBalance.StatModifier.PerInstance="409 -1 -1 0 3, 568 3, 43 -1 8"
+#
+#        Default: "229 -1 -1 1, 230 0 0" (Recommended adjustments)
+#
+# 229 - Blackrock Spire
+# 230 - Blackrock Depths
+AutoBalance.LevelScaling.DynamicLevel.PerInstance="229 -1 -1 1, 230 0 0"
+
+#
+#     AutoBalance.LevelScaling.DynamicLevel.DistanceCheck.PerInstance
+#        Some dungeons contain multiple wings that exist in the same InstanceID. These wings may have different level requirements.
+#        You may set this setting per-instance to ensure that only creatures within [WorldUnits] of any player are included in the
+#        instance level calculation. This will improve the accuracy of creature levels in instances that contain multiple wings.
+#
+#        NOTE: If two players in a party enter two different wings of the same InstanceID at the same time, creature levels will be
+#              calculated incorrectly until one of those players leaves the instance.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [WorldUnits]"
+#
+#        Example: AutoBalance.LevelScaling.DynamicLevel.DistanceCheck.PerInstance="189 500, 624 250"
+#
+#        Default: "189 500" (Recommended adjustments)
+#
+# 189 - Scarlet Monastery
+AutoBalance.LevelScaling.DynamicLevel.DistanceCheck.PerInstance="189 500"
+
+#
+#     AutoBalance.LevelScaling.LevelEndGameBoost
+#
+#        NOTICE: This setting is currently not implemented pending a rewrite.
+#                Enabling it here has NO effect.
+#
+#        See: https://github.com/azerothcore/mod-autobalance/issues/156
+#
+#        Old description:
+#        End game creatures have an exponential (not linear) regression
+#        that is not correctly handled by db values. Keep this enabled
+#        to have stats as near possible to the official ones.
+#
+#        Default:     0 (1 = ON, 0 = OFF)
+AutoBalance.LevelScaling.EndGameBoost = 0        # setting to 1 does not do anything
+
+##########################
+#
+# Reward Scaling
+#
+##########################
+
+#
+#     AutoBalance.RewardScaling.Method
+#        Sets which method should be used when scaling down XP and Money in an instance.
+#
+#           fixed:
+#               XP and Money will be divided by the maximum number of players in the group
+#               regardless of scaling settings. Each player will receive the calculated value.
+#
+#           dynamic:
+#               XP and Money will be scaled based on the the health and damage modifiers that are applied to
+#               the creature. Level scaling is taken into account when determining the reward scaling.
+#
+#               If scaling determines that a creature should have an XP scaling multiplier of .65, the creature
+#               will create 65% of the XP you would normally recieve from a creature at the scaled level.
+#
+#               If scaling determines that a creature should have a money scaling multiplier of 1.5, the creature
+#               will create 150% of the money it would have at its original level and scaling.
+#
+#               The XP and money is evenly split amongst all players in the instance.
+#
+#        Possible values: "fixed" or "dynamic"
+#
+#        Default: "dynamic"
+AutoBalance.RewardScaling.Method="dynamic"
+
+#
+#     AutoBalance.RewardScaling.XP
+#        Scale XP based on the `AutoBalance.RewardScaling.Method` selection.
+#
+#        Default: 1 (1 = ON, 0 = OFF)
+#
+#     AutoBalance.RewardScaling.XP.Modifier
+#        Apply a flat modifier to the amount of XP that is rewarded to players.
+#
+#        Only takes effect if `AutoBalance.RewardScaling.XP` is 1.
+#
+#        If `RewardScaling.XP.Modifier` is set to 1.5 and RewardScaling determines that 100xp should be
+#        rewarded to each player, 150xp will be rewarded.
+#
+#        Default: 1.0 (no change)
+AutoBalance.RewardScaling.XP = 1
+AutoBalance.RewardScaling.XP.Modifier = 1.0
+
+#
+#     AutoBalance.RewardScaling.Money
+#        Scale Money drops based on the `AutoBalance.RewardScaling.Method` selection. If set to 0, the full
+#        amount will be rewarded.
+#
+#        Default: 1 (1 = ON, 0 = OFF)
+#
+#     AutoBalance.RewardScaling.Money.Modifier
+#        Apply a flat modifier to the amount of money that is rewarded to players.
+#
+#        Only takes effect if `AutoBalance.RewardScaling.Money` is 1.
+#
+#        If `RewardScaling.Money.Modifier` is set to 1.5 and RewardScaling determines that 1 gold should be
+#        rewarded to each player, 1 gold 50 silver will be rewarded.
+#
+#        Default: 1.0 (no change)
+AutoBalance.RewardScaling.Money = 1
+AutoBalance.RewardScaling.Money.Modifier = 1.0
+
+##########################
+#
+# Messages
+#
+##########################
+
+#
+#     AutoBalance.PlayerChangeNotify
+#        Set Auto Notifications to all players in Instance that player count has changed.
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalance.PlayerChangeNotify=1
+##########################
+#
+# Announcement
+#
+##########################
+
+#
+#     AutoBalanceAnnounce.enable
+#        Announce the module on login if it is enabled
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalanceAnnounce.enable=1
+
+##########################
+#
+# Deprecated Settings
+#
+##########################
+
+# The following variables are deprecated and should not be used in new deployments. Their values should be left blank.
+# They will still be applied to support backwards compatability, but will be removed entirely in a future release.
+# Their entire functionality (and more) has been moved to new settings referenced in this config file.
+#
+AutoBalance.enable=
+AutoBalance.PerDungeonScaling=
+AutoBalance.PerDungeonBossScaling=
+AutoBalance.BossInflectionMult=
+AutoBalance.rate.global=
+AutoBalance.rate.health=
+AutoBalance.rate.mana=
+AutoBalance.rate.armor=
+AutoBalance.rate.damage=
+AutoBalance.DungeonScaleDownXP=
+AutoBalance.DungeonScaleDownMoney=
+AutoBalance.LevelHigherOffset=
+AutoBalance.LevelLowerOffset=
+AutoBalance.PerDungeonPlayerCounts=
+
+# The following variables have been removed entirely and should not be used in a new or existing deployment.
+# Their values should be left blank.
+# Their entire functionality (and more) has been moved to new settings referenced in this config file.
+AutoBalance.DungeonsOnly=
+AutoBalance.levelUseDbValuesWhenExists=

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3367,9 +3367,974 @@ NoGrayAggro.Below = 0
 #
 
 PreventRenameCharacterOnCustomization = 0
+###################################################################################################
+# AUTOBALANCE MODULE
+#
+# The options below originate from conf/AutoBalance.conf.dist. They are copied here so they can be tuned
+# alongside other worldserver settings.
+###################################################################################################
+##########################
+#
+# Logging
+#
+# Add these lines to your worldserver.conf file to enable logging for AutoBalance.
+# Be sure to add them after the `Logger.module=4,Console Server` line.
+#
+# 4 = Info (Default), 5 = Debug
+#
+##########################
+# Logger.module.AutoBalance=4,Console Server
+# Logger.module.AutoBalance_CombatLocking=4,Console Server
+# Logger.module.AutoBalance_DamageHealingCC=4,Console Server
+# Logger.module.AutoBalance_StatGeneration=4,Console Server
+
+##########################
+#
+# Enable / Disable Settings
+#
+##########################
 
 #
-###################################################################################################
+#     AutoBalance.Enable
+#        Enable/Disable all features globally. If this setting is off, all settings after this one do not take effect.
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalance.Enable.Global=1
+
+#
+#     AutoBalance.Enabled.*
+#        Enable/Disable all features for each instance size and difficulty.
+#        If an instance size is set to 0 here, none of the other settings for that instance size will take effect.
+#        Default:     1 (1 = ON, 0 = OFF)
+#
+AutoBalance.Enable.5M=1
+AutoBalance.Enable.10M=1
+AutoBalance.Enable.15M=1
+AutoBalance.Enable.20M=1
+AutoBalance.Enable.25M=1
+AutoBalance.Enable.40M=1
+AutoBalance.Enable.OtherNormal=1
+
+AutoBalance.Enable.5MHeroic=1
+AutoBalance.Enable.10MHeroic=1
+AutoBalance.Enable.25MHeroic=1
+AutoBalance.Enable.OtherHeroic=1
+
+#
+#     AutoBalance.Disable.PerInstance
+#        Disable all features for the given instance IDs. If an instance ID is not specified here, that instance will follow
+#        the `AutoBalance.Enable.*` settings.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID], [InstanceID], [InstanceID], ..."
+#
+#        Example: AutoBalance.Disable.PerInstance="33, 43, 129"
+#
+#        Default: ""
+AutoBalance.Disable.PerInstance = ""
+
+##########################
+#
+# Minimum Players
+#
+##########################
+#
+#     AutoBalance.MinPlayers
+#     AutoBalance.MinPlayers.Heroic
+#        Sets the Minimum Number of players to scale down to for all normal/heroic instances.
+#        If fewer than this number of players enter the instance, scale to the specified value.
+#
+#        NOTE: Player Difficulty Offset is applied AFTER the player count is adjusted for the MinPlayer setting
+#
+#        AutoBalance.MinPlayers affects only normal instances.
+#        AutoBalance.MinPlayers.Heroic affects only heroic instances.
+#
+#        Example: AutoBalance.MinPlayers = 1
+#                 AutoBalance.MinPlayers.Heroic = 5
+#
+#        Default: 1
+AutoBalance.MinPlayers = 1
+AutoBalance.MinPlayers.Heroic = 1
+AutoBalance.MinPlayers.Raid = 1
+AutoBalance.MinPlayers.RaidHeroic = 1
+
+#
+#     AutoBalance.MinPlayers.PerInstance
+#     AutoBalance.MinPlayers.Heroic.PerInstance
+#        Sets the Minimum Number of players to scale down to per-instance ID.
+#        If fewer than this number of players enter the instance, scale to the specified value.
+#
+#        NOTE: Player Difficulty Offset is applied AFTER the player count is adjusted for the MinPlayer setting
+#
+#        AutoBalance.MinPlayers.PerInstance affects only normal instances.
+#        AutoBalance.MinPlayers.Heroic.PerInstance affects only heroic instances.
+#
+#        If a given Instance ID is not specified in this list, the minimum number of players is set by the generic MinPlayers settings.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [MinPlayers], [InstanceID] [MinPlayers], [InstanceID] [MinPlayers], ..."
+#
+#        Example: AutoBalance.MinPlayers.PerInstance="33 2, 43 5, 129 4"
+#                 AutoBalance.MinPlayers.PerInstance="33 5, 43 5, 129 5"
+#
+#        Default: ""
+AutoBalance.MinPlayers.PerInstance = ""
+AutoBalance.MinPlayers.Heroic.PerInstance = ""
+
+##########################
+#
+# Stat Scaling - Inflection Point
+#
+##########################
+
+#     AutoBalance.InflectionPoint* series
+#        InflectionPoint
+#           Changes the inflection point of the Hyperbolic Tangent function that determines the enemy multiplier for a given player count.
+#           This adjusts the shape of the overall curve. A lower value means that difficulty will increase faster as you add players.
+#
+#           This image provies a visual of several InflectionPoint settings and its affect on the enemy stat multipliers.
+#           https://i.imgur.com/x42UnUR.png
+#
+#           Example: If InflectionPointRaid is 0.5, an enemy in a 40-player instance will have half its life with 20 players in the instance
+#                    If InflectionPointRaid is 0.8, an enemy in a 40-player instance will have half its life with 12 players in the instance
+#
+#           Default: 0.5
+#
+#        CurveFloor
+#           When the curve to determine the enemy multiplier is calculated, start the curve at this value.
+#
+#           This allows you to make enemies have higher stats for lower player counts without adversely affecting the stats of
+#           higher player counts. Applied before `AutoBalance.StatModifier*` values.
+#
+#           Value may be negative if needed to achieve your desired curve.
+#
+#           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
+#           https://i.imgur.com/I8S4cwJ.png
+#
+#           Default: 0.0
+#
+#        CurveCeiling
+#           When the curve to determine the enemy multiplier is calculated, end the curve at this value.
+#
+#           This allows you to make enemies have lower stats for higher player counts without adversely affecting the stats of
+#           lower player counts. Applied before `AutoBalance.StatModifier*` values.
+#
+#           To understand how CurveFloor and CurveCeiling affect the multiplier, see this image:
+#           https://i.imgur.com/I8S4cwJ.png
+#
+#           May be set to higher than 1.0 to increase difficulty of the instance over the stock values:
+#           https://i.imgur.com/DBPxT8E.png
+#
+#           Default: 1.0
+#
+#       BossModifier
+#           InflectionPoint is multiplied by this value for creatures considered dungeon bosses (from dungeons or raids).
+#           It is a multiplier, not a new Inflection Point. Values higher than 1.0 will make enemies easier at lower player
+#           counts while lower than 1.0 will make enemies easier at lower player counts.
+#
+#           To better understand this effect, see the interactive spreadsheet explained below.
+#
+#           Default: 1.0
+#
+#
+#     An interactive spreadsheet is available for you to visually see what effect your settings have on the difficulty curve.
+#
+#     https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy
+#
+#     To use it, copy the sheet to your own Google Drive and edit the values on the left with the yellow background.
+#     The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given dungeon.
+
+### 5-player dungeons
+AutoBalance.InflectionPoint=0.5
+AutoBalance.InflectionPoint.CurveFloor=0.0
+AutoBalance.InflectionPoint.CurveCeiling=1.0
+AutoBalance.InflectionPoint.BossModifier=1.0
+
+### 5-player heroic dungeons
+AutoBalance.InflectionPointHeroic=0.5
+AutoBalance.InflectionPointHeroic.CurveFloor=0.0
+AutoBalance.InflectionPointHeroic.CurveCeiling=1.0
+AutoBalance.InflectionPointHeroic.BossModifier=1.0
+
+### Default for all raids
+AutoBalance.InflectionPointRaid=0.5
+AutoBalance.InflectionPointRaid.CurveFloor=0.0
+AutoBalance.InflectionPointRaid.CurveCeiling=1.0
+AutoBalance.InflectionPointRaid.BossModifier=1.0
+
+### Default for all heroic raids
+AutoBalance.InflectionPointRaidHeroic=0.5
+AutoBalance.InflectionPointRaidHeroic.CurveFloor=0.0
+AutoBalance.InflectionPointRaidHeroic.CurveCeiling=1.0
+AutoBalance.InflectionPointRaidHeroic.BossModifier=1.0
+
+###
+### By default, all instances use the settings configured above. To customize settings for
+### a particular instance size or difficulty, set the variables below. If the variable is
+### blank, the broader settings above will apply.
+###
+
+### 10-player raids
+AutoBalance.InflectionPointRaid10M=
+AutoBalance.InflectionPointRaid10M.CurveFloor=
+AutoBalance.InflectionPointRaid10M.CurveCeiling=
+AutoBalance.InflectionPointRaid10M.BossModifier=
+
+### 10-player heroic raids
+AutoBalance.InflectionPointRaid10MHeroic=
+AutoBalance.InflectionPointRaid10MHeroic.CurveFloor=
+AutoBalance.InflectionPointRaid10MHeroic.CurveCeiling=
+AutoBalance.InflectionPointRaid10MHeroic.BossModifier=
+
+### 15-player raids
+AutoBalance.InflectionPointRaid15M=
+AutoBalance.InflectionPointRaid15M.CurveFloor=
+AutoBalance.InflectionPointRaid15M.CurveCeiling=
+AutoBalance.InflectionPointRaid15M.BossModifier=
+
+### 20-player raids
+AutoBalance.InflectionPointRaid20M=
+AutoBalance.InflectionPointRaid20M.CurveFloor=
+AutoBalance.InflectionPointRaid20M.CurveCeiling=
+AutoBalance.InflectionPointRaid20M.BossModifier=
+
+### 25-player raids
+AutoBalance.InflectionPointRaid25M=
+AutoBalance.InflectionPointRaid25M.CurveFloor=
+AutoBalance.InflectionPointRaid25M.CurveCeiling=
+AutoBalance.InflectionPointRaid25M.BossModifier=
+
+### 25-player heroic raids
+AutoBalance.InflectionPointRaid25MHeroic=
+AutoBalance.InflectionPointRaid25MHeroic.CurveFloor=
+AutoBalance.InflectionPointRaid25MHeroic.CurveCeiling=
+AutoBalance.InflectionPointRaid25MHeroic.BossModifier=
+
+### 40-player raids
+AutoBalance.InflectionPointRaid40M=
+AutoBalance.InflectionPointRaid40M.CurveFloor=
+AutoBalance.InflectionPointRaid40M.CurveCeiling=
+AutoBalance.InflectionPointRaid40M.BossModifier=
+
+#
+#     AutoBalance.InflectionPoint.PerInstance
+#        Sets Inflection Point settings for specific `InstanceID`s.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Specifying a value of `-1` will skip overriding of that value. For instances not listed, the default inflection value for the instance's
+#        difficulty and size will be used. You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#
+#        Format: "[InstanceID] [InflectionPoint] [CurveFloor] [CurveCeiling], [InstanceID] [InflectionPoint] [CurveFloor] [CurveCeiling], ..."
+#
+#        Example: AutoBalance.InflectionPoint.PerInstance="229 0.4 0.0 1.5, 309 -1 0.0 1.1, 48 0.3"
+#
+#        Default: ""
+#
+AutoBalance.InflectionPoint.PerInstance=""
+
+#
+#     AutoBalance.InflectionPoint.Boss.PerInstance
+#        Sets Inflection Point settings for all bosses in specific `InstanceID`s. Note that the first value is "InflectionPointMultiplier", which behaves
+#        identically to the BossModifier setting. The "normal" inflection point is multiplied by this value for bosses. To better understand this effect,
+#        see the interactive spreadsheet.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        For instances not listed, the default inflection value for the instance's difficulty and size will be used. Only one set of values should be specified
+#        per InstanceID.
+#
+#        Format: "[InstanceID] [InflectionPointMultiplier], [InstanceID] [InflectionPointMultiplier], ..."
+#
+#        Example: AutoBalance.InflectionPoint.Boss.PerInstance="229 1.2, 309 1.5, 48 1.25"
+#
+#        Default: ""
+#
+AutoBalance.InflectionPoint.Boss.PerInstance=""
+
+#
+#     AutoBalance.playerCountDifficultyOffset
+#        Offset of players inside an instance. Affects all instance types.
+#        Default:     0
+AutoBalance.playerCountDifficultyOffset=0
+
+##########################
+#
+# Stat Scaling - Stat Modifiers
+#
+##########################
+
+#     AutoBalance.StatModifier* series
+#        The difficulty curve (as defined by the InflectionPoint settings) determines the base multiplier. The base
+#        multiplier is then adjusted (multiplied) by the appropriate StatModifier setting. This allows you to control
+#        the balance of how scaling affects the four adjustable stats: health, mana, armor, and damage.
+#
+#        AutoBalance.StatModifier*.<Stat> -- only affects non-boss creatures
+#        AutoBalance.StatModifier*.Boss.<Stat> -- only affects bosses
+#
+#        To see this in action, change the `StatModifier` value on the spreadsheet:
+#        https://docs.google.com/spreadsheets/d/100cmKIJIjCZ-ncWd0K9ykO8KUgwFTcwg4h2nfE_UeCc/copy
+#
+#        To use it, copy the sheet to your own Google Drive and edit the values on the left with the yellow background.
+#        The "Final Multiplier" value is the actual multiplier that will be applied to enemies in a given instance.
+#
+#        Global
+#           Multiply the other four settings by this value. Allows you to increase all the stats (health, mana, armor,
+#           damage) with a single adjustment. Both the global value and the stat-specific value are used at the same time.
+#
+#           Example: If "Global" is 0.5, and "Health" is 1.5, the health of the creature will be multiplied by 0.75 of
+#                    its value (after adjusting for the number of players).
+#
+#           Default: 1.0
+#
+#        Health | Mana | Armor | Damage
+#           Adjusts the StatModifier for the appropriate stat. Affected by the Global StatModifier above.
+#
+#           NOTE: "Damage" affects both creature damage and world damage.
+#
+#           Default: 1.0
+#
+#        Boss.Global | Boss.Health | Boss.Mana | Boss.Armor | Boss.Damage
+#           Sets a SEPARATE stat multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures
+#           considered instance bosses (from dungeons or raids).
+#
+#           Default: If not set for a given instance size/type, defaults to the dungeon/raid default values.
+#
+#           To better understand this effect, see the interactive spreadsheet.
+#
+
+### 5-player dungeons
+AutoBalance.StatModifier.Global=1.0
+AutoBalance.StatModifier.Health=1.0
+AutoBalance.StatModifier.Mana=1.0
+AutoBalance.StatModifier.Armor=1.0
+AutoBalance.StatModifier.Damage=1.0
+
+AutoBalance.StatModifier.Boss.Global=1.0
+AutoBalance.StatModifier.Boss.Health=1.0
+AutoBalance.StatModifier.Boss.Mana=1.0
+AutoBalance.StatModifier.Boss.Armor=1.0
+AutoBalance.StatModifier.Boss.Damage=1.0
+
+### 5-player heroic dungeons
+AutoBalance.StatModifierHeroic.Global=1.0
+AutoBalance.StatModifierHeroic.Health=1.0
+AutoBalance.StatModifierHeroic.Mana=1.0
+AutoBalance.StatModifierHeroic.Armor=1.0
+AutoBalance.StatModifierHeroic.Damage=1.0
+
+AutoBalance.StatModifierHeroic.Boss.Global=1.0
+AutoBalance.StatModifierHeroic.Boss.Health=1.0
+AutoBalance.StatModifierHeroic.Boss.Mana=1.0
+AutoBalance.StatModifierHeroic.Boss.Armor=1.0
+AutoBalance.StatModifierHeroic.Boss.Damage=1.0
+
+### Default for all raids
+AutoBalance.StatModifierRaid.Global=1.0
+AutoBalance.StatModifierRaid.Health=1.0
+AutoBalance.StatModifierRaid.Mana=1.0
+AutoBalance.StatModifierRaid.Armor=1.0
+AutoBalance.StatModifierRaid.Damage=1.0
+
+AutoBalance.StatModifierRaid.Boss.Global=1.0
+AutoBalance.StatModifierRaid.Boss.Health=1.0
+AutoBalance.StatModifierRaid.Boss.Mana=1.0
+AutoBalance.StatModifierRaid.Boss.Armor=1.0
+AutoBalance.StatModifierRaid.Boss.Damage=1.0
+
+### Default for all heroic raids
+AutoBalance.StatModifierRaidHeroic.Global=1.0
+AutoBalance.StatModifierRaidHeroic.Health=1.0
+AutoBalance.StatModifierRaidHeroic.Mana=1.0
+AutoBalance.StatModifierRaidHeroic.Armor=1.0
+AutoBalance.StatModifierRaidHeroic.Damage=1.0
+
+AutoBalance.StatModifierRaidHeroic.Boss.Global=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Health=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Mana=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Armor=1.0
+AutoBalance.StatModifierRaidHeroic.Boss.Damage=1.0
+
+###
+### By default, all instances use the settings configured above. To customize settings for
+### a particular instance size or difficulty, set the variables below. If the variable is
+### blank, the broader settings above will apply.
+###
+
+### 10-player raids
+AutoBalance.StatModifierRaid10M.Global=
+AutoBalance.StatModifierRaid10M.Health=
+AutoBalance.StatModifierRaid10M.Mana=
+AutoBalance.StatModifierRaid10M.Armor=
+AutoBalance.StatModifierRaid10M.Damage=
+
+AutoBalance.StatModifierRaid10M.Boss.Global=
+AutoBalance.StatModifierRaid10M.Boss.Health=
+AutoBalance.StatModifierRaid10M.Boss.Mana=
+AutoBalance.StatModifierRaid10M.Boss.Armor=
+AutoBalance.StatModifierRaid10M.Boss.Damage=
+
+### 10-player heroic raids
+AutoBalance.StatModifierRaid10MHeroic.Global=
+AutoBalance.StatModifierRaid10MHeroic.Health=
+AutoBalance.StatModifierRaid10MHeroic.Mana=
+AutoBalance.StatModifierRaid10MHeroic.Armor=
+AutoBalance.StatModifierRaid10MHeroic.Damage=
+
+AutoBalance.StatModifierRaid10MHeroic.Boss.Global=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Health=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Mana=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Armor=
+AutoBalance.StatModifierRaid10MHeroic.Boss.Damage=
+
+### 15-player raids
+AutoBalance.StatModifierRaid15M.Global=
+AutoBalance.StatModifierRaid15M.Health=
+AutoBalance.StatModifierRaid15M.Mana=
+AutoBalance.StatModifierRaid15M.Armor=
+AutoBalance.StatModifierRaid15M.Damage=
+
+AutoBalance.StatModifierRaid15M.Boss.Global=
+AutoBalance.StatModifierRaid15M.Boss.Health=
+AutoBalance.StatModifierRaid15M.Boss.Mana=
+AutoBalance.StatModifierRaid15M.Boss.Armor=
+AutoBalance.StatModifierRaid15M.Boss.Damage=
+
+### 20-player raids
+AutoBalance.StatModifierRaid20M.Global=
+AutoBalance.StatModifierRaid20M.Health=
+AutoBalance.StatModifierRaid20M.Mana=
+AutoBalance.StatModifierRaid20M.Armor=
+AutoBalance.StatModifierRaid20M.Damage=
+
+AutoBalance.StatModifierRaid20M.Boss.Global=
+AutoBalance.StatModifierRaid20M.Boss.Health=
+AutoBalance.StatModifierRaid20M.Boss.Mana=
+AutoBalance.StatModifierRaid20M.Boss.Armor=
+AutoBalance.StatModifierRaid20M.Boss.Damage=
+
+### 25-player raids
+AutoBalance.StatModifierRaid25M.Global=
+AutoBalance.StatModifierRaid25M.Health=
+AutoBalance.StatModifierRaid25M.Mana=
+AutoBalance.StatModifierRaid25M.Armor=
+AutoBalance.StatModifierRaid25M.Damage=
+
+AutoBalance.StatModifierRaid25M.Boss.Global=
+AutoBalance.StatModifierRaid25M.Boss.Health=
+AutoBalance.StatModifierRaid25M.Boss.Mana=
+AutoBalance.StatModifierRaid25M.Boss.Armor=
+AutoBalance.StatModifierRaid25M.Boss.Damage=
+
+### 25-player heroic raids
+AutoBalance.StatModifierRaid25MHeroic.Global=
+AutoBalance.StatModifierRaid25MHeroic.Health=
+AutoBalance.StatModifierRaid25MHeroic.Mana=
+AutoBalance.StatModifierRaid25MHeroic.Armor=
+AutoBalance.StatModifierRaid25MHeroic.Damage=
+
+AutoBalance.StatModifierRaid25MHeroic.Boss.Global=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Health=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Mana=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Armor=
+AutoBalance.StatModifierRaid25MHeroic.Boss.Damage=
+
+### 40-player raids
+AutoBalance.StatModifierRaid40M.Global=
+AutoBalance.StatModifierRaid40M.Health=
+AutoBalance.StatModifierRaid40M.Mana=
+AutoBalance.StatModifierRaid40M.Armor=
+AutoBalance.StatModifierRaid40M.Damage=
+
+AutoBalance.StatModifierRaid40M.Boss.Global=
+AutoBalance.StatModifierRaid40M.Boss.Health=
+AutoBalance.StatModifierRaid40M.Boss.Mana=
+AutoBalance.StatModifierRaid40M.Boss.Armor=
+AutoBalance.StatModifierRaid40M.Boss.Damage=
+
+#     AutoBalance.StatModifier*.CCDuration series
+#        These StatModifier values affect the duration of CC effects used against the players. CC effects are auras with one
+#        or more of these effects:
+#
+#          - SPELL_AURA_MOD_CHARM
+#          - SPELL_AURA_MOD_CONFUSE
+#          - SPELL_AURA_MOD_DISARM
+#          - SPELL_AURA_MOD_FEAR
+#          - SPELL_AURA_MOD_PACIFY
+#          - SPELL_AURA_MOD_POSSESS
+#          - SPELL_AURA_MOD_SILENCE
+#          - SPELL_AURA_MOD_STUN
+#          - SPELL_AURA_MOD_SPEED_SLOW_ALL
+#
+#        CCDuration
+#           Adjusts the duration of CC effects. Not affected by any global settings.
+#
+#           After the InflectionPoint curve determines the base multiplier, it is multiplied by this value to determine the final
+#           CC duration multiplier.
+#
+#           CCDuration IS affected by the InflectionPoint curve!
+#           CCDuration IS NOT affected by StatModifier*.Global values!
+#           CCDuration IS affected by AutoBalance.MinCCDurationModifier and AutoBalance.MaxCCDurationModifier!
+#
+#           Example:
+#               Assume we are using the default InflectionPoint curve (0.5 with 0.0 floor and 1.0 ceiling), and there are 3 players in the instance.
+#               With 3 players, the base multiplier is '0.6843'. Let's say that CCDuration is set to '0.5'.
+#               The final CC Duration multiplier is 0.6843 * 0.5 = 0.34215
+#               For a CC with a programmed duration of 8 seconds, the CC will last 8 * 0.34215 = 2.7372 seconds.
+#
+#           Default: no value
+#               If no value is set for a given instance type and player count, and the generic values that apply to that instance
+#               are also blank, CC duration will be unchanged.
+#
+#        Boss.CCDuration
+#           Sets a SEPARATE CCDuration multiplier for bosses. Is NOT affected by the non-boss modifiers. Only applies to creatures
+#           considered instance bosses (from dungeons or raids).
+#
+#           Default: no value
+#               If no value is set for a given instance type and player count, and the generic values that apply to that instance
+#               are also blank, CC duration will be unchanged.
+#
+
+### 5-player dungeons
+AutoBalance.StatModifier.CCDuration=
+AutoBalance.StatModifier.Boss.CCDuration=
+
+### 5-player heroic dungeons
+AutoBalance.StatModifierHeroic.CCDuration=
+AutoBalance.StatModifierHeroic.Boss.CCDuration=
+
+### Default for all raids
+AutoBalance.StatModifierRaid.CCDuration=
+AutoBalance.StatModifierRaid.Boss.CCDuration=
+
+### Default for all heroic raids
+AutoBalance.StatModifierRaidHeroic.CCDuration=
+AutoBalance.StatModifierRaidHeroic.Boss.CCDuration=
+
+###
+### Configuring the CCDuration settings above this line will affect all dungeons and raids.
+### To customize settings for a particular instance size, add your value to the settings below.
+###
+
+### 10-player raids
+AutoBalance.StatModifierRaid10M.CCDuration=
+AutoBalance.StatModifierRaid10M.Boss.CCDuration=
+
+### 10-player heroic raids
+AutoBalance.StatModifierRaid10MHeroic.CCDuration=
+AutoBalance.StatModifierRaid10MHeroic.Boss.CCDuration=
+
+### 15-player raids
+AutoBalance.StatModifierRaid15M.CCDuration=
+AutoBalance.StatModifierRaid15M.Boss.CCDuration=
+
+### 20-player raids
+AutoBalance.StatModifierRaid20M.CCDuration=
+AutoBalance.StatModifierRaid20M.Boss.CCDuration=
+
+### 25-player raids
+AutoBalance.StatModifierRaid25M.CCDuration=
+AutoBalance.StatModifierRaid25M.Boss.CCDuration=
+
+### 25-player heroic raids
+AutoBalance.StatModifierRaid25MHeroic.CCDuration=
+AutoBalance.StatModifierRaid25MHeroic.Boss.CCDuration=
+
+### 40-player raids
+AutoBalance.StatModifierRaid40M.CCDuration=
+AutoBalance.StatModifierRaid40M.Boss.CCDuration=
+
+##########################
+#
+# Stat Scaling - Stat Modifier Overrides
+#
+##########################
+# A note on how the stat modifier settings are prioritized. More specific values REPLACE less-specific values.
+# Bosses and non-boss creatures pull from different settings but work in a similar way.
+#
+# Boss example: High Priest Venoxis (boss, CreatureID 14507) in the Zul'Gurub 20-player raid (InstanceID 309):
+#
+#     StatModifierRaid.Boss.Global=     0.7
+#     StatModifierRaid20M.Boss.Global=  0.8
+#     StatModifier.Boss.PerInstance=    "309 0.9"
+#     StatModifier.PerCreature=         "14507 1.0"
+#
+# Settings are applied from top the bottom, with the bottom setting (1.0) being applied to all stats for the boss.
+# Omitting the "PerCreature" setting would cause the per-instance setting for Zul'Gurub bosses (0.9) to be applied instead, and so on.
+#
+# Non-boss example: Molten Giant (non-boss, CreatureID 11658) in the Molten Core 40-player raid (InstanceID 409):
+#
+#     StatModifierRaid.Damage =     2.1
+#     StatModifierRaid40M.Damage =  2.2
+#     StatModifier.PerInstance =    "409 -1 -1 -1 -1 2.3"
+#     StatModifier.PerCreature=     "11658 -1 -1 -1 -1 2.4"
+#
+# Settings are applied from top the bottom, with the bottom setting (2.4) being applied to the creature's damage multiplier.
+# Omitting the "PerCreature" setting would cause the per-instance setting for Molten Core non-boss damage (2.3) to be applied instead, and so on.
+#
+# Keep in mind that you may use "-1" for any specific override stat to allow less-specific settings to come through.
+#
+# In this way you can make your configs as simple or complicated as you like - if you only want to set some generic dungeon and raid modifiers, everything will
+# work as expected. If you want to tune specific creatures to your liking, you can do that too.
+#
+
+#
+#     AutoBalance.StatModifier.PerInstance
+#        Allows setting per-instance stat modifier values. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#
+#        ONLY AFFECTS NON-BOSS CREATURES.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], [InstanceID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], ..."
+#
+#        Example: AutoBalance.StatModifier.PerInstance="409 1.0 0.8 0.8 1.0 1.2 1.0, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifier.PerInstance=""
+
+#
+#     AutoBalance.StatModifier.Boss.PerInstance
+#        Allows setting per-instance stat modifier values for bosses only. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#
+#        ONLY AFFECTS BOSSES.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage] [Boss.CCDuration], [InstanceID] [Boss.Global] [Boss.Health] [Boss.Mana] [Boss.Armor] [Boss.Damage] [Boss.CCDuration], ..."
+#
+#        Example: AutoBalance.StatModifier.Boss.PerInstance="409 1.0 0.8 0.8 1.0 1.2 0.8, 568 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifier.Boss.PerInstance=""
+
+#
+#     AutoBalance.StatModifier.Boss.PerCreature
+#        Allows setting per-creature stat modifier values. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per CreatureID.
+#
+#        Format: "[CreatureID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], [CreatureID] [Global] [Health] [Mana] [Armor] [Damage] [CCDuration], ..."
+#
+#        Example: AutoBalance.StatModifier.Boss.PerInstance="14507 1.0 0.8 0.8 1.0 1.2 0.5, 11372 -1 -1 -1 -1 1.35, 43 -1 1.2 1.2"
+#
+#        Default: Empty string, which disables the feature.
+AutoBalance.StatModifier.PerCreature=""
+
+#
+#     AutoBalance.MinHPModifier
+#        Minimum Modifier setting for Health Modification. An enemy's health will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinHPModifier=0.01
+
+#
+#     AutoBalance.MinManaModifier
+#        Minimum Modifier setting for Mana Modification. An enemy's mana will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinManaModifier=0.01
+
+#
+#     AutoBalance.MinDamageModifier
+#        Minimum Modifier setting for Damage Modification. An enemy's damage will not be multiplied by a value smaller than this.
+#        Default:     0.01
+AutoBalance.MinDamageModifier=0.01
+
+#
+#     AutoBalance.MinCCDurationModifier
+#        Minimum Modifier setting for Crowd Control Duration. The duration of an enemy's CC will not be multiplied by a value smaller than this.
+#        Default:     0.25
+AutoBalance.MinCCDurationModifier=0.25
+
+#
+#     AutoBalance.MaxCCDurationModifier
+#        Maximum Modifier setting for Crowd Control Duration. The duration of an enemy's CC will not be multiplied by a value greater than this.
+#        Default:     1.0
+AutoBalance.MaxCCDurationModifier=1.0
+
+##########################
+#
+# Misc Settings
+#
+##########################
+
+#
+#     AutoBalance.ForcedIDXX
+#        Sets MobIDs for the group they belong to.
+#        All 5-player creatures should go in AutoBalance.ForcedID5=
+#        All 10-player creatures should go in AutoBalance.ForcedID10=
+#        All X-player creatures should go in AutoBalance.ForcedIDX=
+AutoBalance.ForcedID40=""
+AutoBalance.ForcedID25=""
+AutoBalance.ForcedID20=""
+AutoBalance.ForcedID10=""
+AutoBalance.ForcedID5=""
+AutoBalance.ForcedID2=""
+
+#
+#     AutoBalance.DisabledID
+#        Disable scaling on specific creatures
+#
+AutoBalance.DisabledID=""
+
+##########################
+#
+# Level Scaling
+#
+##########################
+
+#
+#     AutoBalance.LevelScaling
+#        Scale creatures in instances based on the highest-level player.
+#        0 = Disabled
+#        1 = Enabled (only in dungeons/raids)
+#        Default:     1
+AutoBalance.LevelScaling=1
+
+#
+#     AutoBalance.LevelScaling.Method
+#        Selects which method should be used when the level for scaled creatures.
+#
+#           fixed:
+#               Creatures will be scaled to the level of the highest-level player in the group.
+#
+#           dynamic:
+#               Creatures will be scaled to a level based on 1) their original assignments compared to the
+#               highest-level creature in the instance and 2) the highest-level player in the dungeon. This
+#               means that lower-level trash will still be lower level than you, and higher-level bosses
+#               will still be higher-level than you.
+#
+#        Possible values: "fixed" or "dynamic"
+#
+#        Default: "dynamic"
+AutoBalance.LevelScaling.Method="dynamic"
+
+#
+#     AutoBalance.LevelScaling.SkipHigherLevels
+#        If an instance's average creature level is no more than (SkipHigherLevels) levels
+#        above the highest player level, do not scale down.
+#
+#        To disable scaling instance levels DOWN, set this to the max level of your server (likely 80).
+#        To disable this feature entirely and scale all higher-level instances, set this to 0.
+#
+#        Default: 3
+#
+#     AutoBalance.LevelScaling.SkipLowerLevels
+#        If an instance's average creature level is no more than (SkipLowerLevels) levels
+#        below of the Highest player level, do not scale up.
+#
+#        To disable scaling instance levels UP, set this to the max level of your server (likely 80).
+#        To disable this feature entirely and scale all lower-level instances, set this to 0.
+#
+#        Default: 5
+AutoBalance.LevelScaling.SkipHigherLevels = 3
+AutoBalance.LevelScaling.SkipLowerLevels = 5
+
+#
+#     AutoBalance.LevelScaling.DynamicLevel.Ceiling.*
+#        Sets the maximum number of levels creatures scaled in "dynamic" mode can be OVER your highest-level
+#        player. The creature in the dungeon with the highest original level will be set to the highest-level
+#        player's level + this value.
+#
+#        Only takes effect if AutoBalance.LevelScaling.Method = "dynamic"
+#
+#        Default: 1 (Dungeons), 2 (Heroic Dungeons), 3 (Raids), 3 (Heroic Raids)
+#
+#     AutoBalance.LevelScaling.DynamicLevel.Floor.*
+#        Sets the maximum number of levels creatures scaled in "dynamic" mode can be UNDER your highest-level
+#        player. For instances with wide level spreads, ensures that the level differences stay reasonable.
+#
+#        Only takes effect if AutoBalance.LevelScaling.Method = "dynamic"
+#
+#        Default: 5
+AutoBalance.LevelScaling.DynamicLevel.Ceiling.Dungeons = 1
+AutoBalance.LevelScaling.DynamicLevel.Floor.Dungeons = 5
+
+AutoBalance.LevelScaling.DynamicLevel.Ceiling.HeroicDungeons = 2
+AutoBalance.LevelScaling.DynamicLevel.Floor.HeroicDungeons = 5
+
+AutoBalance.LevelScaling.DynamicLevel.Ceiling.Raids = 3
+AutoBalance.LevelScaling.DynamicLevel.Floor.Raids = 5
+
+AutoBalance.LevelScaling.DynamicLevel.Ceiling.HeroicRaids = 3
+AutoBalance.LevelScaling.DynamicLevel.Floor.HeroicRaids = 5
+
+#
+#     AutoBalance.LevelScaling.DynamicLevel.PerInstance
+#        Allows setting per-instance Dynamic Level options. Specifying a value of `-1` will skip overriding of that value.
+#        You may omit entries from the end of the string if desired. Only one set of values should be specified per InstanceID.
+#        Set to a value of "" to disable the feature.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [SkipHigherLevels] [SkipLowerLevels] [DynamicLevelCeiling] [DynamicLevelFloor], [InstanceID] [SkipHigherLevels] [SkipLowerLevels] [DynamicLevelCeiling] [DynamicLevelFloor], ..."
+#
+#        Example: AutoBalance.StatModifier.PerInstance="409 -1 -1 0 3, 568 3, 43 -1 8"
+#
+#        Default: "229 -1 -1 1, 230 0 0" (Recommended adjustments)
+#
+# 229 - Blackrock Spire
+# 230 - Blackrock Depths
+AutoBalance.LevelScaling.DynamicLevel.PerInstance="229 -1 -1 1, 230 0 0"
+
+#
+#     AutoBalance.LevelScaling.DynamicLevel.DistanceCheck.PerInstance
+#        Some dungeons contain multiple wings that exist in the same InstanceID. These wings may have different level requirements.
+#        You may set this setting per-instance to ensure that only creatures within [WorldUnits] of any player are included in the
+#        instance level calculation. This will improve the accuracy of creature levels in instances that contain multiple wings.
+#
+#        NOTE: If two players in a party enter two different wings of the same InstanceID at the same time, creature levels will be
+#              calculated incorrectly until one of those players leaves the instance.
+#
+#        Get a list of Instance IDs here: https://wowpedia.fandom.com/wiki/InstanceID#Classic
+#
+#        Format: "[InstanceID] [WorldUnits]"
+#
+#        Example: AutoBalance.LevelScaling.DynamicLevel.DistanceCheck.PerInstance="189 500, 624 250"
+#
+#        Default: "189 500" (Recommended adjustments)
+#
+# 189 - Scarlet Monastery
+AutoBalance.LevelScaling.DynamicLevel.DistanceCheck.PerInstance="189 500"
+
+#
+#     AutoBalance.LevelScaling.LevelEndGameBoost
+#
+#        NOTICE: This setting is currently not implemented pending a rewrite.
+#                Enabling it here has NO effect.
+#
+#        See: https://github.com/azerothcore/mod-autobalance/issues/156
+#
+#        Old description:
+#        End game creatures have an exponential (not linear) regression
+#        that is not correctly handled by db values. Keep this enabled
+#        to have stats as near possible to the official ones.
+#
+#        Default:     0 (1 = ON, 0 = OFF)
+AutoBalance.LevelScaling.EndGameBoost = 0        # setting to 1 does not do anything
+
+##########################
+#
+# Reward Scaling
+#
+##########################
+
+#
+#     AutoBalance.RewardScaling.Method
+#        Sets which method should be used when scaling down XP and Money in an instance.
+#
+#           fixed:
+#               XP and Money will be divided by the maximum number of players in the group
+#               regardless of scaling settings. Each player will receive the calculated value.
+#
+#           dynamic:
+#               XP and Money will be scaled based on the the health and damage modifiers that are applied to
+#               the creature. Level scaling is taken into account when determining the reward scaling.
+#
+#               If scaling determines that a creature should have an XP scaling multiplier of .65, the creature
+#               will create 65% of the XP you would normally recieve from a creature at the scaled level.
+#
+#               If scaling determines that a creature should have a money scaling multiplier of 1.5, the creature
+#               will create 150% of the money it would have at its original level and scaling.
+#
+#               The XP and money is evenly split amongst all players in the instance.
+#
+#        Possible values: "fixed" or "dynamic"
+#
+#        Default: "dynamic"
+AutoBalance.RewardScaling.Method="dynamic"
+
+#
+#     AutoBalance.RewardScaling.XP
+#        Scale XP based on the `AutoBalance.RewardScaling.Method` selection.
+#
+#        Default: 1 (1 = ON, 0 = OFF)
+#
+#     AutoBalance.RewardScaling.XP.Modifier
+#        Apply a flat modifier to the amount of XP that is rewarded to players.
+#
+#        Only takes effect if `AutoBalance.RewardScaling.XP` is 1.
+#
+#        If `RewardScaling.XP.Modifier` is set to 1.5 and RewardScaling determines that 100xp should be
+#        rewarded to each player, 150xp will be rewarded.
+#
+#        Default: 1.0 (no change)
+AutoBalance.RewardScaling.XP = 1
+AutoBalance.RewardScaling.XP.Modifier = 1.0
+
+#
+#     AutoBalance.RewardScaling.Money
+#        Scale Money drops based on the `AutoBalance.RewardScaling.Method` selection. If set to 0, the full
+#        amount will be rewarded.
+#
+#        Default: 1 (1 = ON, 0 = OFF)
+#
+#     AutoBalance.RewardScaling.Money.Modifier
+#        Apply a flat modifier to the amount of money that is rewarded to players.
+#
+#        Only takes effect if `AutoBalance.RewardScaling.Money` is 1.
+#
+#        If `RewardScaling.Money.Modifier` is set to 1.5 and RewardScaling determines that 1 gold should be
+#        rewarded to each player, 1 gold 50 silver will be rewarded.
+#
+#        Default: 1.0 (no change)
+AutoBalance.RewardScaling.Money = 1
+AutoBalance.RewardScaling.Money.Modifier = 1.0
+
+##########################
+#
+# Messages
+#
+##########################
+
+#
+#     AutoBalance.PlayerChangeNotify
+#        Set Auto Notifications to all players in Instance that player count has changed.
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalance.PlayerChangeNotify=1
+##########################
+#
+# Announcement
+#
+##########################
+
+#
+#     AutoBalanceAnnounce.enable
+#        Announce the module on login if it is enabled
+#        Default:     1 (1 = ON, 0 = OFF)
+AutoBalanceAnnounce.enable=1
+
+##########################
+#
+# Deprecated Settings
+#
+##########################
+
+# The following variables are deprecated and should not be used in new deployments. Their values should be left blank.
+# They will still be applied to support backwards compatability, but will be removed entirely in a future release.
+# Their entire functionality (and more) has been moved to new settings referenced in this config file.
+#
+AutoBalance.enable=
+AutoBalance.PerDungeonScaling=
+AutoBalance.PerDungeonBossScaling=
+AutoBalance.BossInflectionMult=
+AutoBalance.rate.global=
+AutoBalance.rate.health=
+AutoBalance.rate.mana=
+AutoBalance.rate.armor=
+AutoBalance.rate.damage=
+AutoBalance.DungeonScaleDownXP=
+AutoBalance.DungeonScaleDownMoney=
+AutoBalance.LevelHigherOffset=
+AutoBalance.LevelLowerOffset=
+AutoBalance.PerDungeonPlayerCounts=
+
+# The following variables have been removed entirely and should not be used in a new or existing deployment.
+# Their values should be left blank.
+# Their entire functionality (and more) has been moved to new settings referenced in this config file.
+AutoBalance.DungeonsOnly=
+AutoBalance.levelUseDbValuesWhenExists=
 
 ###################################################################################################
 # AUCTION HOUSE BOT SETTINGS


### PR DESCRIPTION
## Summary
- add a Custom/AutoBalance script module with the public AutoBalance API and loader registration
- load AutoBalance.conf at startup and document its options in worldserver.conf.dist
- install the AutoBalance configuration template alongside the worldserver config

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9382fd5308327974ee420f40d3bfe