### PR TITLE
Add AutoBalance script scaffolding and map hooks

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -92,6 +92,7 @@ Map::~Map()
 {
     // UnloadAll must be called before deleting the map
 
+    sMapMgr->HandleMapDestroyed(this);
     sScriptMgr->OnDestroyMap(this);
 
     // Delete all waiting spawns, else there will be a memory leak
@@ -304,6 +305,7 @@ i_scriptLock(false), _respawnTimes(std::make_unique<RespawnListContainer>()), _r
     _weatherUpdateTimer.SetInterval(time_t(1 * IN_MILLISECONDS));
 
     sScriptMgr->OnCreateMap(this);
+    sMapMgr->HandleMapCreated(this);
 }
 
 void Map::InitVisibilityDistance()
@@ -615,6 +617,7 @@ bool Map::AddPlayerToMap(Player* player)
         ConvertCorpseToBones(player->GetGUID());
 
     sScriptMgr->OnPlayerEnterMap(this, player);
+    sMapMgr->HandlePlayerEnterMap(this, player);
     return true;
 }
 
@@ -1011,6 +1014,7 @@ void Map::RemovePlayerFromMap(Player* player, bool remove)
     // Before leaving map, update zone/area for stats
     player->UpdateZone(MAP_INVALID_ZONE, 0);
     sScriptMgr->OnPlayerLeaveMap(this, player);
+    sMapMgr->HandlePlayerLeaveMap(this, player);
 
     player->CombatStop();
 
@@ -3860,8 +3864,21 @@ Map::EnterState InstanceMap::CannotEnter(Player* player)
     }
 
     // cannot enter while an encounter is in progress (unless this is a relog, in which case it is permitted)
-    if (!player->IsLoading() && IsRaid() && GetInstanceScript() && GetInstanceScript()->IsEncounterInProgress())
-        return CANNOT_ENTER_ZONE_IN_COMBAT;
+    if (!player->IsLoading() && IsRaid())
+    {
+        if (InstanceScript* instanceScript = GetInstanceScript())
+        {
+            if (instanceScript->IsEncounterInProgress())
+            {
+                sMapMgr->HandleInstanceCombatState(this, true, player);
+                return CANNOT_ENTER_ZONE_IN_COMBAT;
+            }
+
+            sMapMgr->HandleInstanceCombatState(this, false, player);
+        }
+        else
+            sMapMgr->HandleInstanceCombatState(this, false, player);
+    }
 
     // cannot enter if player is permanent saved to a different instance id
     if (InstancePlayerBind* playerBind = player->GetBoundInstance(GetId(), GetDifficulty()))

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -33,6 +33,7 @@
 #include "Player.h"
 #include "WorldSession.h"
 #include "Opcodes.h"
+#include "Custom/AutoBalance/AutoBalance.h"
 
 MapManager::MapManager()
     : _nextInstanceId(0), _scheduledScripts(0)
@@ -239,6 +240,31 @@ bool MapManager::ExistMapAndVMap(uint32 mapid, float x, float y)
     int gy = (MAX_NUMBER_OF_GRIDS - 1) - p.y_coord;
 
     return Map::ExistMap(mapid, gx, gy) && Map::ExistVMap(mapid, gx, gy);
+}
+
+void MapManager::HandleMapCreated(Map* map)
+{
+    ABScriptMgr::Instance().OnMapCreate(map);
+}
+
+void MapManager::HandleMapDestroyed(Map* map)
+{
+    ABScriptMgr::Instance().OnMapDestroy(map);
+}
+
+void MapManager::HandlePlayerEnterMap(Map* map, Player* player)
+{
+    ABScriptMgr::Instance().OnPlayerEnterMap(map, player);
+}
+
+void MapManager::HandlePlayerLeaveMap(Map* map, Player* player)
+{
+    ABScriptMgr::Instance().OnPlayerLeaveMap(map, player);
+}
+
+void MapManager::HandleInstanceCombatState(Map* map, bool locked, Player* player)
+{
+    ABScriptMgr::Instance().OnCombatStateChanged(map, locked, player);
 }
 
 bool MapManager::IsValidMAP(uint32 mapid, bool startUp)

--- a/src/server/game/Maps/MapManager.h
+++ b/src/server/game/Maps/MapManager.h
@@ -27,6 +27,7 @@
 
 class Transport;
 struct TransportCreatureProto;
+class Player;
 
 class TC_GAME_API MapManager
 {
@@ -133,6 +134,12 @@ class TC_GAME_API MapManager
 
         template<typename Worker>
         void DoForAllMapsWithMapId(uint32 mapId, Worker&& worker);
+
+        void HandleMapCreated(Map* map);
+        void HandleMapDestroyed(Map* map);
+        void HandlePlayerEnterMap(Map* map, Player* player);
+        void HandlePlayerLeaveMap(Map* map, Player* player);
+        void HandleInstanceCombatState(Map* map, bool locked, Player* player = nullptr);
 
         void IncreaseScheduledScriptsCount() { ++_scheduledScripts; }
         void DecreaseScheduledScriptCount() { --_scheduledScripts; }

--- a/src/server/scripts/CMakeLists.txt
+++ b/src/server/scripts/CMakeLists.txt
@@ -95,6 +95,11 @@ endif()
 
 GroupSources(${CMAKE_CURRENT_SOURCE_DIR})
 
+set(CUSTOM_AUTOBALANCE_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/Custom/AutoBalance/AutoBalance.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Custom/AutoBalance/AutoBalanceLoader.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Custom/AutoBalance/Message.cpp)
+
 # Configures the scriptloader with the given name and stores the output in the LOADER_OUT variable.
 # It is possible to expose multiple subdirectories from the same scriptloader through passing
 # it to the variable arguments
@@ -146,12 +151,19 @@ foreach(SCRIPT_MODULE ${SCRIPT_MODULE_LIST})
       list(APPEND STATIC_SCRIPT_MODULES ${SCRIPT_MODULE})
       # Add the module content to the whole static module
       CollectSourceFiles(${SCRIPT_MODULE_PATH} PRIVATE_SOURCES)
+      if(${SCRIPT_MODULE} STREQUAL "Custom")
+        list(APPEND PRIVATE_SOURCES ${CUSTOM_AUTOBALANCE_SOURCES})
+      endif()
     endif()
   elseif(${SCRIPT_MODULE_VARIABLE} STREQUAL "dynamic")
     # Generate an own dynamic module which is loadable on runtime
     # Add the module content to the whole static module
     unset(SCRIPT_MODULE_PRIVATE_SOURCES)
     CollectSourceFiles(${SCRIPT_MODULE_PATH} SCRIPT_MODULE_PRIVATE_SOURCES)
+    if(${SCRIPT_MODULE} STREQUAL "Custom")
+      list(APPEND SCRIPT_MODULE_PRIVATE_SOURCES ${CUSTOM_AUTOBALANCE_SOURCES})
+      list(REMOVE_DUPLICATES SCRIPT_MODULE_PRIVATE_SOURCES)
+    endif()
     # Configure the scriptloader
     ConfigureScriptLoader(${SCRIPT_MODULE} SCRIPT_MODULE_PRIVATE_SCRIPTLOADER ON ${SCRIPT_MODULE})
     GetProjectNameOfScriptModule(${SCRIPT_MODULE} SCRIPT_MODULE_PROJECT_NAME)
@@ -199,6 +211,7 @@ foreach(SCRIPT_MODULE ${SCRIPT_MODULE_LIST})
 endforeach()
 
 # Add the dynamic script modules to the worldserver as dependency
+list(REMOVE_DUPLICATES PRIVATE_SOURCES)
 set(WORLDSERVER_DYNAMIC_SCRIPT_MODULES_DEPENDENCIES ${DYNAMIC_SCRIPT_MODULE_PROJECTS} PARENT_SCOPE)
 
 ConfigureScriptLoader("static" SCRIPT_MODULE_PRIVATE_SCRIPTLOADER OFF ${STATIC_SCRIPT_MODULES})

--- a/src/server/scripts/Custom/AutoBalance/AutoBalance.cpp
+++ b/src/server/scripts/Custom/AutoBalance/AutoBalance.cpp
@@ -1,0 +1,82 @@
+#include "Custom/AutoBalance/AutoBalance.h"
+#include "Map.h"
+#include "Player.h"
+#include <algorithm>
+
+ABScriptMgr& ABScriptMgr::Instance()
+{
+    static ABScriptMgr instance;
+    return instance;
+}
+
+void ABScriptMgr::RegisterModuleScript(ABModuleScript* script)
+{
+    if (!script)
+        return;
+
+    auto itr = std::find(_moduleScripts.begin(), _moduleScripts.end(), script);
+    if (itr == _moduleScripts.end())
+        _moduleScripts.push_back(script);
+}
+
+void ABScriptMgr::Dispatch(AutoBalance::Message const& message)
+{
+    for (ABModuleScript* script : _moduleScripts)
+        script->OnMessage(message);
+}
+
+void ABScriptMgr::OnMapCreate(Map* map)
+{
+    if (!map)
+        return;
+
+    _combatStateByMap[map] = false;
+    Dispatch(AutoBalance::Message::MapCreated(map));
+}
+
+void ABScriptMgr::OnMapDestroy(Map* map)
+{
+    if (!map)
+        return;
+
+    _combatStateByMap.erase(map);
+    Dispatch(AutoBalance::Message::MapDestroyed(map));
+}
+
+void ABScriptMgr::OnPlayerEnterMap(Map* map, Player* player)
+{
+    if (!map)
+        return;
+
+    Dispatch(AutoBalance::Message::PlayerEntered(map, player));
+}
+
+void ABScriptMgr::OnPlayerLeaveMap(Map* map, Player* player)
+{
+    if (!map)
+        return;
+
+    Dispatch(AutoBalance::Message::PlayerLeft(map, player));
+}
+
+void ABScriptMgr::OnCombatStateChanged(Map* map, bool locked, Player* player)
+{
+    if (!map)
+        return;
+
+    auto result = _combatStateByMap.emplace(map, locked);
+    if (!result.second && result.first->second == locked)
+        return;
+
+    result.first->second = locked;
+    Dispatch(AutoBalance::Message::CombatState(map, locked, player));
+}
+
+ABModuleScript::ABModuleScript(char const* name) : _name(name)
+{
+    ABScriptMgr::Instance().RegisterModuleScript(this);
+}
+
+void ABModuleScript::OnMessage(AutoBalance::Message const& /*message*/)
+{
+}

--- a/src/server/scripts/Custom/AutoBalance/AutoBalance.h
+++ b/src/server/scripts/Custom/AutoBalance/AutoBalance.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "Custom/AutoBalance/Message.h"
+
+class Map;
+class Player;
+
+class ABModuleScript;
+
+class ABScriptMgr
+{
+public:
+    static ABScriptMgr& Instance();
+
+    void RegisterModuleScript(ABModuleScript* script);
+
+    void OnMapCreate(Map* map);
+    void OnMapDestroy(Map* map);
+    void OnPlayerEnterMap(Map* map, Player* player);
+    void OnPlayerLeaveMap(Map* map, Player* player);
+    void OnCombatStateChanged(Map* map, bool locked, Player* player = nullptr);
+
+private:
+    ABScriptMgr() = default;
+
+    void Dispatch(AutoBalance::Message const& message);
+
+    std::vector<ABModuleScript*> _moduleScripts;
+    std::unordered_map<Map const*, bool> _combatStateByMap;
+};
+
+class ABModuleScript
+{
+public:
+    explicit ABModuleScript(char const* name);
+    virtual ~ABModuleScript() = default;
+
+    virtual void OnMessage(AutoBalance::Message const& message);
+
+    char const* GetName() const { return _name; }
+
+private:
+    char const* _name;
+};

--- a/src/server/scripts/Custom/AutoBalance/AutoBalanceLoader.cpp
+++ b/src/server/scripts/Custom/AutoBalance/AutoBalanceLoader.cpp
@@ -1,0 +1,20 @@
+#include "Custom/AutoBalance/AutoBalance.h"
+
+namespace
+{
+    class DefaultAutoBalanceModule final : public ABModuleScript
+    {
+    public:
+        DefaultAutoBalanceModule()
+            : ABModuleScript("DefaultAutoBalanceModule")
+        {
+        }
+
+        void OnMessage(AutoBalance::Message const& /*message*/) override { }
+    };
+}
+
+void AddAutoBalanceScripts()
+{
+    new DefaultAutoBalanceModule();
+}

--- a/src/server/scripts/Custom/AutoBalance/Message.cpp
+++ b/src/server/scripts/Custom/AutoBalance/Message.cpp
@@ -1,0 +1,31 @@
+#include "Custom/AutoBalance/Message.h"
+#include "Map.h"
+#include "Player.h"
+
+namespace AutoBalance
+{
+    Message Message::MapCreated(Map* map)
+    {
+        return { MessageType::MapCreated, map, nullptr, false };
+    }
+
+    Message Message::MapDestroyed(Map* map)
+    {
+        return { MessageType::MapDestroyed, map, nullptr, false };
+    }
+
+    Message Message::PlayerEntered(Map* map, Player* player)
+    {
+        return { MessageType::PlayerEntered, map, player, false };
+    }
+
+    Message Message::PlayerLeft(Map* map, Player* player)
+    {
+        return { MessageType::PlayerLeft, map, player, false };
+    }
+
+    Message Message::CombatState(Map* map, bool locked, Player* player)
+    {
+        return { MessageType::CombatStateChanged, map, player, locked };
+    }
+}

--- a/src/server/scripts/Custom/AutoBalance/Message.h
+++ b/src/server/scripts/Custom/AutoBalance/Message.h
@@ -1,0 +1,30 @@
+#pragma once
+
+class Map;
+class Player;
+
+namespace AutoBalance
+{
+    enum class MessageType
+    {
+        MapCreated,
+        MapDestroyed,
+        PlayerEntered,
+        PlayerLeft,
+        CombatStateChanged
+    };
+
+    struct Message
+    {
+        MessageType Type;
+        Map* TargetMap;
+        Player* TargetPlayer;
+        bool CombatLocked;
+
+        static Message MapCreated(Map* map);
+        static Message MapDestroyed(Map* map);
+        static Message PlayerEntered(Map* map, Player* player);
+        static Message PlayerLeft(Map* map, Player* player);
+        static Message CombatState(Map* map, bool locked, Player* player);
+    };
+}

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -19,8 +19,10 @@
 
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
+#include "AutoBalance/AutoBalanceLoader.cpp"
 #include "BGReplay.cpp"
 void AddCustomScripts()
 {
+    AddAutoBalanceScripts();
     AddBGReplayScripts();
 }


### PR DESCRIPTION
## Summary
- add an AutoBalance script manager with message dispatch helpers for map events
- register a default AutoBalance module loader and wire it into the custom script loader and build
- forward map lifecycle, player entry/exit, and combat lock state changes to the AutoBalance manager

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f956428e24832798f86419b1531067