### PR TITLE
Keep owners in combat when minions engage

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -232,7 +232,21 @@ bool CombatManager::SetInCombatWith(Unit* who, bool addSecondUnitSuppressed)
         NotifyAICombat(_owner, who);
     if (needOtherAI)
         NotifyAICombat(who, _owner);
-    return IsInCombatWith(who);
+
+    bool const inCombat = IsInCombatWith(who);
+
+    if (inCombat)
+    {
+        if (Unit* owner = _owner->GetCharmerOrOwner())
+            if (owner != who && !owner->GetCombatManager().IsInCombatWith(who))
+                owner->GetCombatManager().SetInCombatWith(who);
+
+        if (Unit* owner = who->GetCharmerOrOwner())
+            if (owner != _owner && !owner->GetCombatManager().IsInCombatWith(_owner))
+                owner->GetCombatManager().SetInCombatWith(_owner);
+    }
+
+    return inCombat;
 }
 
 bool CombatManager::IsInCombatWith(ObjectGuid const& guid) const


### PR DESCRIPTION
## Summary
- propagate combat relationships from minions to their owners so PvP combat persists when a summoned unit is attacked

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f9563b8b988327b3f30960fd3a93cc