### PR TITLE
Add AutoBalance map custom data tracking

### DIFF
--- a/src/server/game/AutoBalance/AutoBalanceMapData.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceMapData.cpp
@@ -1,0 +1,147 @@
+#include "AutoBalance/AutoBalanceMapData.h"
+#include "AutoBalance/AutoBalanceConfig.h"
+#include "GameTime.h"
+#include "Map.h"
+#include "Player.h"
+#include <algorithm>
+
+namespace AutoBalance
+{
+namespace
+{
+    Map::CustomData::AutoBalanceData& GetMapData(Map* map)
+    {
+        return map->GetCustomData().AutoBalance;
+    }
+
+    Map::CustomData::AutoBalanceData const& GetMapData(Map const* map)
+    {
+        return map->GetCustomData().AutoBalance;
+    }
+
+    uint32 GetMinimumPlayersForMap(Map const* map)
+    {
+        ModuleConfig const& config = GetConfig();
+
+        auto const& overrides = map->IsHeroic() ? config.MinPlayersOverridesHeroic : config.MinPlayersOverridesNormal;
+        uint32 const mapId = map->GetId();
+
+        if (auto const itr = overrides.find(mapId); itr != overrides.end())
+            return itr->second;
+
+        return map->IsHeroic() ? config.MinimumPlayersHeroic : config.MinimumPlayers;
+    }
+
+    void UpdateEffectivePlayerCountInternal(Map* map, uint32 now)
+    {
+        auto& data = GetMapData(map);
+        ModuleConfig const& config = GetConfig();
+
+        data.QueueOffset = config.PlayerCountDifficultyOffset;
+
+        int32 const adjustedPlayerCount = std::max<int32>(0, static_cast<int32>(data.PlayerCount) + data.QueueOffset);
+        uint32 effectivePlayerCount = static_cast<uint32>(adjustedPlayerCount);
+
+        uint32 const minimumPlayers = GetMinimumPlayersForMap(map);
+        if (effectivePlayerCount < minimumPlayers)
+            effectivePlayerCount = minimumPlayers;
+
+        data.EffectivePlayerCount = effectivePlayerCount;
+        data.LastPlayerCountUpdateTimeMS = now;
+    }
+}
+
+void HandleMapCreate(Map* map)
+{
+    if (!map)
+        return;
+
+    auto& data = GetMapData(map);
+    data = Map::CustomData::AutoBalanceData{};
+
+    uint32 const now = GameTime::GetGameTimeMS();
+    UpdateEffectivePlayerCountInternal(map, now);
+    data.LastCombatStateChangeTimeMS = now;
+}
+
+void HandleMapDestroy(Map* map)
+{
+    if (!map)
+        return;
+
+    GetMapData(map) = Map::CustomData::AutoBalanceData{};
+}
+
+void HandlePlayerEnter(Map* map, Player* /*player*/)
+{
+    if (!map)
+        return;
+
+    auto& data = GetMapData(map);
+    uint32 const now = GameTime::GetGameTimeMS();
+
+    ++data.PlayerCount;
+    data.LastPlayerJoinTimeMS = now;
+    UpdateEffectivePlayerCountInternal(map, now);
+}
+
+void HandlePlayerLeave(Map* map, Player* /*player*/)
+{
+    if (!map)
+        return;
+
+    auto& data = GetMapData(map);
+    uint32 const now = GameTime::GetGameTimeMS();
+
+    if (data.PlayerCount)
+        --data.PlayerCount;
+
+    data.LastPlayerLeaveTimeMS = now;
+    UpdateEffectivePlayerCountInternal(map, now);
+}
+
+void HandleCombatStateChange(Map* map, bool locked, Player* /*player*/)
+{
+    if (!map)
+        return;
+
+    auto& data = GetMapData(map);
+    if (data.CombatLocked == locked)
+        return;
+
+    uint32 const now = GameTime::GetGameTimeMS();
+
+    data.CombatLocked = locked;
+    data.CombatStateDirty = true;
+    data.LastCombatStateChangeTimeMS = now;
+
+    if (locked)
+        data.LastCombatStartTimeMS = now;
+    else
+        data.LastCombatEndTimeMS = now;
+}
+
+void RefreshEffectivePlayerCount(Map* map)
+{
+    if (!map)
+        return;
+
+    UpdateEffectivePlayerCountInternal(map, GameTime::GetGameTimeMS());
+}
+
+uint32 GetActivePlayerCount(Map const* map)
+{
+    if (!map)
+        return 0;
+
+    return GetMapData(map).PlayerCount;
+}
+
+uint32 GetEffectivePlayerCount(Map const* map)
+{
+    if (!map)
+        return 0;
+
+    return GetMapData(map).EffectivePlayerCount;
+}
+}

--- a/src/server/game/AutoBalance/AutoBalanceMapData.h
+++ b/src/server/game/AutoBalance/AutoBalanceMapData.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+
+class Map;
+class Player;
+
+namespace AutoBalance
+{
+    void HandleMapCreate(Map* map);
+    void HandleMapDestroy(Map* map);
+    void HandlePlayerEnter(Map* map, Player* player);
+    void HandlePlayerLeave(Map* map, Player* player);
+    void HandleCombatStateChange(Map* map, bool locked, Player* player);
+
+    void RefreshEffectivePlayerCount(Map* map);
+
+    uint32 GetActivePlayerCount(Map const* map);
+    uint32 GetEffectivePlayerCount(Map const* map);
+}

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -323,6 +323,29 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
 {
     friend class MapReference;
     public:
+        struct CustomData
+        {
+            struct AutoBalanceData
+            {
+                uint32 PlayerCount = 0;
+                uint32 EffectivePlayerCount = 0;
+                int32 QueueOffset = 0;
+                uint32 LastPlayerJoinTimeMS = 0;
+                uint32 LastPlayerLeaveTimeMS = 0;
+                uint32 LastPlayerCountUpdateTimeMS = 0;
+                uint32 LastCombatStartTimeMS = 0;
+                uint32 LastCombatEndTimeMS = 0;
+                uint32 LastCombatStateChangeTimeMS = 0;
+                bool CombatLocked = false;
+                bool CombatStateDirty = false;
+            };
+
+            AutoBalanceData AutoBalance;
+        };
+
+        CustomData& GetCustomData() { return _customData; }
+        CustomData const& GetCustomData() const { return _customData; }
+
         Map(uint32 id, time_t, uint32 InstanceId, uint8 SpawnMode, Map* _parent = nullptr);
         virtual ~Map();
 
@@ -760,6 +783,8 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
 
         typedef std::multimap<time_t, ScriptAction> ScriptScheduleMap;
         ScriptScheduleMap m_scriptSchedule;
+
+        CustomData _customData;
 
     public:
         void ProcessRespawns();

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -34,6 +34,7 @@
 #include "WorldSession.h"
 #include "Opcodes.h"
 #include "AutoBalance.h"
+#include "AutoBalance/AutoBalanceMapData.h"
 
 MapManager::MapManager()
     : _nextInstanceId(0), _scheduledScripts(0)
@@ -247,6 +248,7 @@ void MapManager::HandleMapCreated(Map* map)
     if (!AutoBalance::IsEnabled())
         return;
 
+    AutoBalance::HandleMapCreate(map);
     ABScriptMgr::Instance().OnMapCreate(map);
 }
 
@@ -255,6 +257,7 @@ void MapManager::HandleMapDestroyed(Map* map)
     if (!AutoBalance::IsEnabled())
         return;
 
+    AutoBalance::HandleMapDestroy(map);
     ABScriptMgr::Instance().OnMapDestroy(map);
 }
 
@@ -263,6 +266,7 @@ void MapManager::HandlePlayerEnterMap(Map* map, Player* player)
     if (!AutoBalance::IsEnabled())
         return;
 
+    AutoBalance::HandlePlayerEnter(map, player);
     ABScriptMgr::Instance().OnPlayerEnterMap(map, player);
 }
 
@@ -271,6 +275,7 @@ void MapManager::HandlePlayerLeaveMap(Map* map, Player* player)
     if (!AutoBalance::IsEnabled())
         return;
 
+    AutoBalance::HandlePlayerLeave(map, player);
     ABScriptMgr::Instance().OnPlayerLeaveMap(map, player);
 }
 
@@ -279,6 +284,7 @@ void MapManager::HandleInstanceCombatState(Map* map, bool locked, Player* player
     if (!AutoBalance::IsEnabled())
         return;
 
+    AutoBalance::HandleCombatStateChange(map, locked, player);
     ABScriptMgr::Instance().OnCombatStateChanged(map, locked, player);
 }
 


### PR DESCRIPTION
## Summary
- add a Map::CustomData::AutoBalanceData struct to retain per-map player statistics and combat flags
- introduce AutoBalanceMapData helpers to recalculate player counts using config-driven minimums and offsets
- update map lifecycle hooks to keep the custom data in sync as players join/leave or combat state changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa6417b8648327b5651a2f3ac5d2bc