### PR TITLE
Scale AutoBalance spell impact and CC duration

### DIFF
--- a/src/server/game/AutoBalance/AutoBalanceConfig.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceConfig.cpp
@@ -146,6 +146,18 @@ namespace AutoBalance
                 LogMessage(MessageLevel::Warn, logEnabled, "AutoBalance.MinPlayers.Heroic is set to 0. Using 1 instead.");
                 config.MinimumPlayersHeroic = 1;
             }
+
+            if (config.MinCCDurationModifier < 0.0f)
+            {
+                LogMessage(MessageLevel::Warn, logEnabled, "AutoBalance.MinCCDurationModifier ({:.3f}) must be >= 0. Using 0 instead.", config.MinCCDurationModifier);
+                config.MinCCDurationModifier = 0.0f;
+            }
+
+            if (config.MaxCCDurationModifier < config.MinCCDurationModifier)
+            {
+                LogMessage(MessageLevel::Warn, logEnabled, "AutoBalance.MaxCCDurationModifier ({:.3f}) must be >= AutoBalance.MinCCDurationModifier ({:.3f}). Using the minimum value instead.", config.MaxCCDurationModifier, config.MinCCDurationModifier);
+                config.MaxCCDurationModifier = config.MinCCDurationModifier;
+            }
         }
     }
 
@@ -244,6 +256,8 @@ namespace AutoBalance
         newConfig.MinPlayersOverridesNormal = ParseMinPlayersOverrides(sConfigMgr->GetStringDefault("AutoBalance.MinPlayers.PerInstance", ""), logReady, "AutoBalance.MinPlayers.PerInstance");
         newConfig.MinPlayersOverridesHeroic = ParseMinPlayersOverrides(sConfigMgr->GetStringDefault("AutoBalance.MinPlayers.Heroic.PerInstance", ""), logReady, "AutoBalance.MinPlayers.Heroic.PerInstance");
         newConfig.PlayerCountDifficultyOffset = sConfigMgr->GetIntDefault("AutoBalance.playerCountDifficultyOffset", 0);
+        newConfig.MinCCDurationModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MinCCDurationModifier", 0.25f));
+        newConfig.MaxCCDurationModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MaxCCDurationModifier", 1.0f));
 
         Validate(newConfig, logReady);
 

--- a/src/server/game/AutoBalance/AutoBalanceConfig.h
+++ b/src/server/game/AutoBalance/AutoBalanceConfig.h
@@ -40,6 +40,8 @@ namespace AutoBalance
         std::unordered_map<uint32, uint32> MinPlayersOverridesNormal;
         std::unordered_map<uint32, uint32> MinPlayersOverridesHeroic;
         int32 PlayerCountDifficultyOffset = 0;
+        float MinCCDurationModifier = 0.25f;
+        float MaxCCDurationModifier = 1.0f;
     };
 
     ModuleConfig const& GetConfig();

--- a/src/server/game/AutoBalance/AutoBalanceCreature.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceCreature.cpp
@@ -71,6 +71,79 @@ AutoBalanceCreatureInfo const& GetCreatureInfo(Creature const& creature)
     return creature.GetCustomData().AutoBalance.CreatureInfo;
 }
 
+AutoBalanceCreatureInfo* TryGetCreatureInfo(Unit* unit)
+{
+    if (!unit)
+        return nullptr;
+
+    Creature* creature = unit->ToCreature();
+    if (!creature)
+        return nullptr;
+
+    AutoBalanceCreatureInfo& info = GetCreatureInfo(*creature);
+    if (!info.Initialized)
+        return nullptr;
+
+    return &info;
+}
+
+AutoBalanceCreatureInfo const* TryGetCreatureInfo(Unit const* unit)
+{
+    if (!unit)
+        return nullptr;
+
+    Creature const* creature = unit->ToCreature();
+    if (!creature)
+        return nullptr;
+
+    AutoBalanceCreatureInfo const& info = GetCreatureInfo(*creature);
+    if (!info.Initialized)
+        return nullptr;
+
+    return &info;
+}
+
+Optional<float> GetDamageHealingMultiplier(Unit const* unit)
+{
+    if (!IsEnabled())
+        return { };
+
+    AutoBalanceCreatureInfo const* info = TryGetCreatureInfo(unit);
+    if (!info)
+        return { };
+
+    float const multiplier = info->Multipliers.Damage;
+    if (!std::isfinite(multiplier) || multiplier <= 0.0f)
+        return { };
+
+    if (std::fabs(multiplier - 1.0f) <= 0.0005f)
+        return { };
+
+    return multiplier;
+}
+
+Optional<float> GetCrowdControlDurationMultiplier(Unit const* unit)
+{
+    if (!IsEnabled())
+        return { };
+
+    AutoBalanceCreatureInfo const* info = TryGetCreatureInfo(unit);
+    if (!info)
+        return { };
+
+    float multiplier = info->Multipliers.CrowdControlDuration;
+    if (!std::isfinite(multiplier) || multiplier <= 0.0f)
+        return { };
+
+    ModuleConfig const& config = GetConfig();
+    multiplier = std::clamp(multiplier, config.MinCCDurationModifier, config.MaxCCDurationModifier);
+
+    if (std::fabs(multiplier - 1.0f) <= 0.0005f)
+        return { };
+
+    return multiplier;
+}
+
 void ScaleCreature(Creature* creature)
 {
     if (!creature)
@@ -109,7 +182,8 @@ void ScaleCreature(Creature* creature)
         std::fabs(info.Multipliers.Health - multiplier) > 0.0005f ||
         std::fabs(info.Multipliers.Mana - multiplier) > 0.0005f ||
         std::fabs(info.Multipliers.Damage - multiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Armor - multiplier) > 0.0005f;
+        std::fabs(info.Multipliers.Armor - multiplier) > 0.0005f ||
+        std::fabs(info.Multipliers.CrowdControlDuration - multiplier) > 0.0005f;
 
     if (!requiresUpdate)
         return;
@@ -133,6 +207,7 @@ void ScaleCreature(Creature* creature)
     info.Multipliers.Mana = multiplier;
     info.Multipliers.Damage = multiplier;
     info.Multipliers.Armor = multiplier;
+    info.Multipliers.CrowdControlDuration = multiplier;
 
     uint32 const oldMaxHealth = creature->GetMaxHealth();
     float const healthPct = oldMaxHealth ? std::clamp(static_cast<float>(creature->GetHealth()) / static_cast<float>(oldMaxHealth), 0.0f, 1.0f) : 1.0f;

--- a/src/server/game/AutoBalance/AutoBalanceCreature.h
+++ b/src/server/game/AutoBalance/AutoBalanceCreature.h
@@ -1,13 +1,21 @@
 #pragma once
 
 #include "AutoBalance/AutoBalanceCreatureInfo.h"
+#include "Optional.h"
 
 class Creature;
+class Unit;
 
 namespace AutoBalance
 {
     AutoBalanceCreatureInfo& GetCreatureInfo(Creature& creature);
     AutoBalanceCreatureInfo const& GetCreatureInfo(Creature const& creature);
+
+    AutoBalanceCreatureInfo* TryGetCreatureInfo(Unit* unit);
+    AutoBalanceCreatureInfo const* TryGetCreatureInfo(Unit const* unit);
+
+    Optional<float> GetDamageHealingMultiplier(Unit const* unit);
+    Optional<float> GetCrowdControlDurationMultiplier(Unit const* unit);
 
     void ScaleCreature(Creature* creature);
 }

--- a/src/server/game/AutoBalance/AutoBalanceCreatureInfo.h
+++ b/src/server/game/AutoBalance/AutoBalanceCreatureInfo.h
@@ -21,6 +21,7 @@ namespace AutoBalance
         float Mana = 1.0f;
         float Damage = 1.0f;
         float Armor = 1.0f;
+        float CrowdControlDuration = 1.0f;
     };
 
     struct AutoBalanceCreatureInfo

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Unit.h"
+#include "AutoBalance/AutoBalanceCreature.h"
 #include "AbstractFollower.h"
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
@@ -80,7 +81,9 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 float baseMoveSpeed[MAX_MOVE_TYPE] =
 {
@@ -6508,12 +6511,25 @@ void Unit::EnergizeBySpell(Unit* victim, SpellInfo const* spellInfo, int32 damag
 
 uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack /*= 1*/) const
 {
-    if (!spellProto || !victim || damagetype == DIRECT_DAMAGE)
-        return pdamage;
+    Optional<float> const damageMultiplier = AutoBalance::GetDamageHealingMultiplier(this);
+    auto const applyModifier = [&](uint32 value) -> uint32
+    {
+        if (!value || !damageMultiplier)
+            return value;
+
+        double const scaled = std::clamp(static_cast<double>(value) * static_cast<double>(*damageMultiplier), 0.0, static_cast<double>(std::numeric_limits<uint32>::max()));
+        return static_cast<uint32>(std::round(scaled));
+    };
+
+    if (!spellProto || !victim)
+        return applyModifier(pdamage);
+
+    if (damagetype == DIRECT_DAMAGE)
+        return applyModifier(pdamage);
 
     // Some spells don't benefit from done mods
     if (spellProto->HasAttribute(SPELL_ATTR3_NO_DONE_BONUS))
-        return pdamage;
+        return applyModifier(pdamage);
 
     // For totems get damage bonus from owner
     if (GetTypeId() == TYPEID_UNIT && IsTotem())
@@ -6617,7 +6633,10 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uin
     {
         // No bonus damage for SPELL_DAMAGE_CLASS_NONE class spells by default
         if (spellProto->DmgClass == SPELL_DAMAGE_CLASS_NONE)
-            return uint32(std::max(pdamage * DoneTotalMod, 0.0f));
+        {
+            uint32 const baseDamage = uint32(std::max(pdamage * DoneTotalMod, 0.0f));
+            return applyModifier(baseDamage);
+        }
     }
 
     // Default calculation
@@ -6643,7 +6662,8 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uin
     if (Player* modOwner = GetSpellModOwner())
         modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, tmpDamage);
 
-    return uint32(std::max(tmpDamage, 0.0f));
+    uint32 const scaledDamage = uint32(std::max(tmpDamage, 0.0f));
+    return applyModifier(scaledDamage);
 }
 
 float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, DamageEffectType damagetype) const
@@ -7386,6 +7406,16 @@ float Unit::SpellCritChanceTaken(Unit const* caster, SpellInfo const* spellInfo,
 
 uint32 Unit::SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, uint32 healamount, DamageEffectType damagetype, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack /*= 1*/) const
 {
+    Optional<float> const healingMultiplier = AutoBalance::GetDamageHealingMultiplier(this);
+    auto const applyModifier = [&](uint32 value) -> uint32
+    {
+        if (!value || !healingMultiplier)
+            return value;
+
+        double const scaled = std::clamp(static_cast<double>(value) * static_cast<double>(*healingMultiplier), 0.0, static_cast<double>(std::numeric_limits<uint32>::max()));
+        return static_cast<uint32>(std::round(scaled));
+    };
+
     // For totems get healing bonus from owner (statue isn't totem in fact)
     if (GetTypeId() == TYPEID_UNIT && IsTotem())
         if (Unit* owner = GetOwner())
@@ -7393,7 +7423,7 @@ uint32 Unit::SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, ui
 
     // No bonus healing for potion spells
     if (spellProto->SpellFamilyName == SPELLFAMILY_POTION)
-        return healamount;
+        return applyModifier(healamount);
 
     float ApCoeffMod = 1.0f;
     int32 DoneTotal = 0;
@@ -7543,7 +7573,8 @@ uint32 Unit::SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, ui
     if (Player* modOwner = GetSpellModOwner())
         modOwner->ApplySpellMod(spellProto->Id, damagetype == DOT ? SPELLMOD_DOT : SPELLMOD_DAMAGE, heal);
 
-    return uint32(std::max(heal, 0.0f));
+    uint32 const scaledHeal = uint32(std::max(heal, 0.0f));
+    return applyModifier(scaledHeal);
 }
 
 float Unit::SpellHealingPctDone(Unit* victim, SpellInfo const* spellProto) const

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Common.h"
+#include "AutoBalance/AutoBalanceCreature.h"
 #include "CellImpl.h"
 #include "Config.h"
 #include "DynamicObject.h"
@@ -37,6 +38,50 @@
 #include "Vehicle.h"
 #include "World.h"
 #include "WorldPacket.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace
+{
+    bool IsCrowdControlAura(AuraType auraType)
+    {
+        switch (auraType)
+        {
+            case SPELL_AURA_MOD_CHARM:
+            case SPELL_AURA_MOD_CONFUSE:
+            case SPELL_AURA_MOD_DISARM:
+            case SPELL_AURA_MOD_FEAR:
+            case SPELL_AURA_MOD_PACIFY:
+            case SPELL_AURA_MOD_POSSESS:
+            case SPELL_AURA_MOD_SILENCE:
+            case SPELL_AURA_MOD_STUN:
+            case SPELL_AURA_MOD_SPEED_SLOW_ALL:
+                return true;
+            default:
+                break;
+        }
+
+        return false;
+    }
+
+    bool SpellHasCrowdControlAura(SpellInfo const* spellInfo)
+    {
+        if (!spellInfo)
+            return false;
+
+        for (SpellEffectInfo const& effect : spellInfo->GetEffects())
+        {
+            if (!effect.IsAura())
+                continue;
+
+            if (IsCrowdControlAura(static_cast<AuraType>(effect.ApplyAuraName)))
+                return true;
+        }
+
+        return false;
+    }
+}
 
 AuraCreateInfo::AuraCreateInfo(SpellInfo const* spellInfo, uint8 auraEffMask, WorldObject* owner) :
     _spellInfo(spellInfo), _auraEffectMask(auraEffMask), _owner(owner)
@@ -889,6 +934,18 @@ int32 Aura::CalcMaxDuration(Unit* caster) const
     // IsPermanent() checks max duration (which we are supposed to calculate here)
     if (maxDuration != -1 && modOwner)
         modOwner->ApplySpellMod(spellInfo->Id, SPELLMOD_DURATION, maxDuration);
+
+    if (maxDuration > 0 && caster && SpellHasCrowdControlAura(spellInfo))
+    {
+        if (Unit const* unitCaster = caster->ToUnit())
+        {
+            if (Optional<float> const ccModifier = AutoBalance::GetCrowdControlDurationMultiplier(unitCaster))
+            {
+                double const scaled = std::clamp(static_cast<double>(maxDuration) * static_cast<double>(*ccModifier), 0.0, static_cast<double>(std::numeric_limits<int32>::max()));
+                maxDuration = static_cast<int32>(std::round(scaled));
+            }
+        }
+    }
 
     return maxDuration;
 }


### PR DESCRIPTION
## Summary
- add helpers to access AutoBalance creature info and compute per-hit spell scaling factors
- apply damage and healing multipliers in Unit spell bonus hooks and clamp CC durations through Aura calculations
- expose CC-duration configuration bounds and store the new multiplier on scaled creatures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb708c6abc8327bf0a470d5f6a57ad