### PR TITLE
Fix honor aura modifier handling for battleground rewards

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -645,7 +645,7 @@ void Battleground::CenturionRewardHonorToTeam(uint32 Honor, uint32 TeamID)
 {
     for (BattlegroundPlayerMap::const_iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
         if (Player* player = _GetPlayerForTeam(TeamID, itr, "CenturionRewardHonorToTeam"))
-            player->RewardHonor(nullptr, 1, Honor);
+            player->ModifyHonorPoints(int32(Honor));
 }
 
 void Battleground::RewardHonorToTeam(uint32 Honor, uint32 TeamID)

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -645,9 +645,7 @@ void Battleground::CenturionRewardHonorToTeam(uint32 Honor, uint32 TeamID)
 {
     for (BattlegroundPlayerMap::const_iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
         if (Player* player = _GetPlayerForTeam(TeamID, itr, "CenturionRewardHonorToTeam"))
-        {
-            player->ModifyHonorPoints(Honor);
-        }
+            player->RewardHonor(nullptr, 1, Honor);
 }
 
 void Battleground::RewardHonorToTeam(uint32 Honor, uint32 TeamID)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6920,7 +6920,7 @@ bool Player::RewardHonor(Unit* victim, uint32 groupsize, int32 honor, bool pvpto
     SendDirectMessage(&data);
 
     // add honor points
-    ModifyHonorPoints(honor);
+    ModifyHonorPoints(honor, CharacterDatabaseTransaction(nullptr), false);
 
     ApplyModUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION, honor, true);
 
@@ -7016,8 +7016,15 @@ void Player::SetArenaPoints(uint32 value)
         AddKnownCurrency(ITEM_ARENA_POINTS_ID);
 }
 
-void Player::ModifyHonorPoints(int32 value, CharacterDatabaseTransaction trans)
+void Player::ModifyHonorPoints(int32 value, CharacterDatabaseTransaction trans, bool applyHonorGainAuras)
 {
+    if (applyHonorGainAuras && value > 0)
+    {
+        float modifiedHonor = static_cast<float>(value);
+        AddPct(modifiedHonor, GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HONOR_GAIN_PCT));
+        value = int32(modifiedHonor);
+    }
+
     int32 newValue = int32(GetHonorPoints()) + value;
     if (newValue < 0)
         newValue = 0;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6896,7 +6896,10 @@ bool Player::RewardHonor(Unit* victim, uint32 groupsize, int32 honor, bool pvpto
     {
         if (groupsize > 1)
             honor_f /= groupsize;
+    }
 
+    if (honor_f > 0.0f)
+    {
         // apply honor multiplier from aura (not stacking-get highest)
         AddPct(honor_f, GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HONOR_GAIN_PCT));
     }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1822,7 +1822,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         uint32 GetHonorPoints() const { return GetUInt32Value(PLAYER_FIELD_HONOR_CURRENCY); }
         uint32 GetMaxHonorPoints() const;
         uint32 GetArenaPoints() const { return GetUInt32Value(PLAYER_FIELD_ARENA_CURRENCY); }
-        void ModifyHonorPoints(int32 value, CharacterDatabaseTransaction trans = CharacterDatabaseTransaction(nullptr));      //! If trans is specified, honor save query will be added to trans
+        void ModifyHonorPoints(int32 value, CharacterDatabaseTransaction trans = CharacterDatabaseTransaction(nullptr), bool applyHonorGainAuras = true);      //! If trans is specified, honor save query will be added to trans
         void ModifyArenaPoints(int32 value, CharacterDatabaseTransaction trans = CharacterDatabaseTransaction(nullptr));      //! If trans is specified, arena point save query will be added to trans
         uint32 GetMaxPersonalArenaRatingRequirement(uint32 minarenaslot) const;
         void SetHonorPoints(uint32 value);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4256,6 +4256,9 @@ void Unit::RemoveArenaAuras()
     RemoveAppliedAuras([](AuraApplication const* aurApp)
     {
         Aura const* aura = aurApp->GetBase();
+        if (aura->GetSpellInfo()->Id == 58553)
+            return false;
+
         return (!aura->GetSpellInfo()->HasAttribute(SPELL_ATTR4_DONT_REMOVE_IN_ARENA)                          // don't remove stances, shadowform, pally/hunter auras
             && !aura->IsPassive()                                                                              // don't remove passive auras
             && (aurApp->IsPositive() || !aura->GetSpellInfo()->HasAttribute(SPELL_ATTR3_DEATH_PERSISTENT))) || // not negative death persistent auras


### PR DESCRIPTION
## Summary
- apply honor gain aura modifiers whenever positive honor is awarded so custom battleground payouts benefit from aura 281
- prevent aura 58553 from being stripped during arena or battleground transitions
- route Centurion battleground honor rewards through `RewardHonor` for consistent bookkeeping

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbba723c8c8327a446503acfae586f