### PR TITLE
Add reload command and packaging updates for AutoBalance

### DIFF
--- a/cmake/InstallConfig.cmake
+++ b/cmake/InstallConfig.cmake
@@ -10,5 +10,10 @@
 
 # Additional module configuration (.conf.dist) files that should be installed
 # alongside the core configuration templates.
-set(TRINITYCORE_MODULE_CONF_DIST
+if(NOT DEFINED TRINITYCORE_MODULE_CONF_DIST)
+  set(TRINITYCORE_MODULE_CONF_DIST "")
+endif()
+
+list(APPEND TRINITYCORE_MODULE_CONF_DIST
   ${CMAKE_SOURCE_DIR}/conf/AutoBalance.conf.dist)
+list(REMOVE_DUPLICATES TRINITYCORE_MODULE_CONF_DIST)

--- a/doc/AutoBalance.md
+++ b/doc/AutoBalance.md
@@ -1,0 +1,19 @@
+# AutoBalance Module (TrinityCore 3.3.5a)
+
+The AutoBalance module scales non-player creatures based on the active party size. TrinityCore integrates the module directly into the core build system and exposes configuration and runtime controls that differ from the upstream project.
+
+## Configuration template
+
+* The template configuration file is installed as `conf/AutoBalance.conf.dist` alongside `worldserver.conf.dist`.  Set `AutoBalance.Conf` in `worldserver.conf` if you want to relocate the runtime configuration file or disable loading entirely. 【F:cmake/InstallConfig.cmake†L1-L8】【F:src/server/worldserver/worldserver.conf.dist†L3109-L3114】
+
+## Reloading configuration at runtime
+
+* After updating `AutoBalance.conf`, run `.reload autobalance` from the console or an authorized GM character.  This triggers an in-game reload without requiring a worldserver restart. 【F:src/server/scripts/Commands/cs_reload.cpp†L24-L39】【F:src/server/game/AutoBalance/AutoBalanceConfig.cpp†L178-L204】
+
+## Logging
+
+* AutoBalance messages use the `module.AutoBalance` log filter. Enable it in `AutoBalance.conf` or `worldserver.conf` if you need verbose diagnostics. 【F:src/server/game/AutoBalance/AutoBalanceConfig.h†L11-L49】
+
+## Source layout
+
+* Core logic lives under `src/server/game/AutoBalance/` and custom script bindings under `src/server/scripts/Custom/AutoBalance/`.  The default script module registers automatically with the TrinityCore script loader. 【F:src/server/game/CMakeLists.txt†L50-L52】【F:src/server/scripts/Custom/custom_script_loader.cpp†L19-L27】

--- a/sql/base/auth_database.sql
+++ b/sql/base/auth_database.sql
@@ -898,6 +898,7 @@ INSERT INTO `rbac_linked_permissions` VALUES
 (196,878),
 (196,879),
 (196,881),
+(196,882),
 (197,232),
 (197,236),
 (197,237),
@@ -1790,7 +1791,8 @@ INSERT INTO `rbac_permissions` VALUES
 (878,'Command: debug questreset'),
 (879,'Command: debug poolstatus'),
 (880,'Command: pdump copy'),
-(881,'Command: reload vehicle_template');
+(881,'Command: reload vehicle_template'),
+(882,'Command: reload autobalance');
 /*!40000 ALTER TABLE `rbac_permissions` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/sql/updates/auth/3.3.5/2024_05_09_00_auth.sql
+++ b/sql/updates/auth/3.3.5/2024_05_09_00_auth.sql
@@ -1,0 +1,4 @@
+DELETE FROM `rbac_linked_permissions` WHERE `id`=196 AND `linkedId`=882;
+DELETE FROM `rbac_permissions` WHERE `id`=882;
+INSERT INTO `rbac_permissions` (`id`, `name`) VALUES (882, 'Command: reload autobalance');
+INSERT INTO `rbac_linked_permissions` (`id`, `linkedId`) VALUES (196, 882);

--- a/src/server/game/Accounts/RBAC.h
+++ b/src/server/game/Accounts/RBAC.h
@@ -493,6 +493,7 @@ enum RBACPermissions
     RBAC_PERM_COMMAND_RELOAD_AREATRIGGER_TELEPORT            = 625,
     RBAC_PERM_COMMAND_RELOAD_AUCTIONS                        = 626,
     RBAC_PERM_COMMAND_RELOAD_AUTOBROADCAST                   = 627,
+    RBAC_PERM_COMMAND_RELOAD_AUTOBALANCE                     = 882,
     // 628 previously used, do not reuse
     RBAC_PERM_COMMAND_RELOAD_CONDITIONS                      = 629,
     RBAC_PERM_COMMAND_RELOAD_CONFIG                          = 630,

--- a/src/server/scripts/Commands/cs_reload.cpp
+++ b/src/server/scripts/Commands/cs_reload.cpp
@@ -24,6 +24,7 @@ EndScriptData */
 
 #include "ScriptMgr.h"
 #include "AccountMgr.h"
+#include "AutoBalance/AutoBalanceConfig.h"
 #include "AchievementMgr.h"
 #include "AuctionHouseMgr.h"
 #include "BattlegroundMgr.h"
@@ -82,6 +83,7 @@ public:
             { "areatrigger_involvedrelation",  rbac::RBAC_PERM_COMMAND_RELOAD_AREATRIGGER_INVOLVEDRELATION,     true,  &HandleReloadQuestAreaTriggersCommand,          "" },
             { "areatrigger_tavern",            rbac::RBAC_PERM_COMMAND_RELOAD_AREATRIGGER_TAVERN,               true,  &HandleReloadAreaTriggerTavernCommand,          "" },
             { "areatrigger_teleport",          rbac::RBAC_PERM_COMMAND_RELOAD_AREATRIGGER_TELEPORT,             true,  &HandleReloadAreaTriggerTeleportCommand,        "" },
+            { "autobalance",                  rbac::RBAC_PERM_COMMAND_RELOAD_AUTOBALANCE,                     true,  &HandleReloadAutoBalanceCommand,               "" },
             { "autobroadcast",                 rbac::RBAC_PERM_COMMAND_RELOAD_AUTOBROADCAST,                    true,  &HandleReloadAutobroadcastCommand,              "" },
             { "battleground_template",         rbac::RBAC_PERM_COMMAND_RELOAD_BATTLEGROUND_TEMPLATE,            true,  &HandleReloadBattlegroundTemplate,              "" },
             { "broadcast_text",                rbac::RBAC_PERM_COMMAND_RELOAD_BROADCAST_TEXT,                   true,  &HandleReloadBroadcastTextCommand,              "" },
@@ -327,6 +329,14 @@ public:
         HandleReloadLocalesQuestOfferRewardCommand(handler, "a");
         HandleReloadLocalesQuestRequestItemsCommand(handler, "a");
         HandleReloadLocalesQuestGreetingCommand(handler, "");
+        return true;
+    }
+
+    static bool HandleReloadAutoBalanceCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        TC_LOG_INFO("misc", "Re-Loading AutoBalance module configuration...");
+        AutoBalance::LoadConfig(true);
+        handler->SendGlobalGMSysMessage("AutoBalance configuration reloaded.");
         return true;
     }
 


### PR DESCRIPTION
## Summary
- add a `.reload autobalance` handler that reuses the module configuration loader
- provision a dedicated RBAC permission and SQL update for the new command
- ensure the AutoBalance configuration template is packaged and document TrinityCore-specific usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc09c2bcb08327a4e6f1c68c688b94