### PR TITLE
Refresh AutoBalance state after configuration reload

### DIFF
--- a/src/server/scripts/Commands/cs_reload.cpp
+++ b/src/server/scripts/Commands/cs_reload.cpp
@@ -25,6 +25,7 @@ EndScriptData */
 #include "ScriptMgr.h"
 #include "AccountMgr.h"
 #include "AutoBalance/AutoBalanceConfig.h"
+#include "AutoBalance/AutoBalanceMapData.h"
 #include "AchievementMgr.h"
 #include "AuctionHouseMgr.h"
 #include "BattlegroundMgr.h"
@@ -336,6 +337,10 @@ public:
     {
         TC_LOG_INFO("misc", "Re-Loading AutoBalance module configuration...");
         AutoBalance::LoadConfig(true);
+        sMapMgr->DoForAllMaps([](Map* map)
+        {
+            AutoBalance::RefreshEffectivePlayerCount(map);
+        });
         handler->SendGlobalGMSysMessage("AutoBalance configuration reloaded.");
         return true;
     }


### PR DESCRIPTION
## Summary
- refresh AutoBalance effective player counts across active maps when the module is reloaded
- include the map data helpers needed by the reload command

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fceede4240832782a74b119f1041ef