### PR TITLE
Implement advanced AutoBalance configuration support

### DIFF
--- a/src/server/game/AutoBalance/AutoBalanceConfig.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceConfig.cpp
@@ -133,6 +133,289 @@ namespace AutoBalance
             return overrides;
         }
 
+        Optional<float> ParseOptionalFloat(std::string const& value, char const* option, bool logEnabled)
+        {
+            if (value.empty())
+                return { };
+
+            if (Optional<float> parsed = Trinity::StringTo<float>(value))
+                return parsed;
+
+            LogMessage(MessageLevel::Warn, logEnabled, "Ignoring invalid value '{}' for {}.", value, option);
+            return { };
+        }
+
+        InflectionPointSettings ParseInflectionPointSettings(char const* valueOption, char const* floorOption, char const* ceilingOption, char const* bossOption, InflectionPointSettings defaults)
+        {
+            InflectionPointSettings settings = defaults;
+            settings.Value = sConfigMgr->GetFloatDefault(valueOption, defaults.Value);
+            settings.CurveFloor = sConfigMgr->GetFloatDefault(floorOption, defaults.CurveFloor);
+            settings.CurveCeiling = sConfigMgr->GetFloatDefault(ceilingOption, defaults.CurveCeiling);
+            settings.BossModifier = sConfigMgr->GetFloatDefault(bossOption, defaults.BossModifier);
+            return settings;
+        }
+
+        Optional<InflectionOverride> ParseInflectionOverride(char const* valueOption, char const* floorOption, char const* ceilingOption, char const* bossOption, bool logEnabled)
+        {
+            InflectionOverride override;
+            bool hasAny = false;
+
+            auto parse = [&](char const* option, Optional<float>& field)
+            {
+                if (!option)
+                    return;
+
+                std::string const raw = sConfigMgr->GetStringDefault(option, "");
+                if (Optional<float> parsed = ParseOptionalFloat(raw, option, logEnabled))
+                {
+                    field = *parsed;
+                    hasAny = true;
+                }
+            };
+
+            parse(valueOption, override.Value);
+            parse(floorOption, override.CurveFloor);
+            parse(ceilingOption, override.CurveCeiling);
+            parse(bossOption, override.BossModifier);
+
+            if (!hasAny)
+                return { };
+
+            return override;
+        }
+
+        std::unordered_map<uint32, InflectionOverride> ParseInflectionOverrides(std::string const& value, bool logEnabled, char const* settingName)
+        {
+            std::unordered_map<uint32, InflectionOverride> overrides;
+            for (std::string_view entry : Trinity::Tokenize(value, ',', false))
+            {
+                entry = Trim(entry);
+                if (entry.empty())
+                    continue;
+
+                std::istringstream stream{std::string(entry)};
+                uint32 instanceId = 0;
+                if (!(stream >> instanceId))
+                {
+                    LogMessage(MessageLevel::Warn, logEnabled, "Ignoring entry '{}' in {}: missing instance id.", entry, settingName);
+                    continue;
+                }
+
+                float valueField = 0.0f;
+                bool hasAny = false;
+                InflectionOverride override;
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.Value = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.CurveFloor = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.CurveCeiling = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (!hasAny)
+                {
+                    LogMessage(MessageLevel::Warn, logEnabled, "Ignoring entry '{}' in {}: no override values provided.", entry, settingName);
+                    continue;
+                }
+
+                overrides[instanceId] = override;
+            }
+
+            return overrides;
+        }
+
+        std::unordered_map<uint32, float> ParseInflectionBossOverrides(std::string const& value, bool logEnabled, char const* settingName)
+        {
+            std::unordered_map<uint32, float> overrides;
+            for (std::string_view entry : Trinity::Tokenize(value, ',', false))
+            {
+                entry = Trim(entry);
+                if (entry.empty())
+                    continue;
+
+                std::istringstream stream{std::string(entry)};
+                uint32 instanceId = 0;
+                if (!(stream >> instanceId))
+                {
+                    LogMessage(MessageLevel::Warn, logEnabled, "Ignoring entry '{}' in {}: missing instance id.", entry, settingName);
+                    continue;
+                }
+
+                float multiplier = 0.0f;
+                if (!(stream >> multiplier))
+                {
+                    LogMessage(MessageLevel::Warn, logEnabled, "Ignoring entry '{}' in {}: missing boss multiplier value.", entry, settingName);
+                    continue;
+                }
+
+                if (multiplier <= 0.0f)
+                {
+                    LogMessage(MessageLevel::Warn, logEnabled, "Ignoring entry '{}' in {}: boss multiplier must be > 0.", entry, settingName);
+                    continue;
+                }
+
+                overrides[instanceId] = multiplier;
+            }
+
+            return overrides;
+        }
+
+        StatModifierValues ParseStatModifierValues(char const* prefix, StatModifierValues defaults)
+        {
+            StatModifierValues values = defaults;
+
+            auto read = [&](char const* suffix, float fallback) -> float
+            {
+                std::string option = std::string(prefix) + suffix;
+                return sConfigMgr->GetFloatDefault(option.c_str(), fallback);
+            };
+
+            values.Global = read("Global", defaults.Global);
+            values.Health = read("Health", defaults.Health);
+            values.Mana = read("Mana", defaults.Mana);
+            values.Armor = read("Armor", defaults.Armor);
+            values.Damage = read("Damage", defaults.Damage);
+            values.CrowdControlDuration = read("CCDuration", defaults.CrowdControlDuration);
+
+            return values;
+        }
+
+        Optional<StatModifierOverride> ParseStatModifierOverride(char const* prefix, bool logEnabled)
+        {
+            StatModifierOverride override;
+            bool hasAny = false;
+
+            auto parse = [&](char const* suffix, Optional<float>& field)
+            {
+                std::string option = std::string(prefix) + suffix;
+                std::string const raw = sConfigMgr->GetStringDefault(option.c_str(), "");
+                if (Optional<float> parsed = ParseOptionalFloat(raw, option.c_str(), logEnabled))
+                {
+                    field = *parsed;
+                    hasAny = true;
+                }
+            };
+
+            parse("Global", override.Global);
+            parse("Health", override.Health);
+            parse("Mana", override.Mana);
+            parse("Armor", override.Armor);
+            parse("Damage", override.Damage);
+            parse("CCDuration", override.CrowdControlDuration);
+
+            if (!hasAny)
+                return { };
+
+            return override;
+        }
+
+        std::unordered_map<uint32, StatModifierOverride> ParseStatModifierOverrides(std::string const& value, bool logEnabled, char const* settingName)
+        {
+            std::unordered_map<uint32, StatModifierOverride> overrides;
+            for (std::string_view entry : Trinity::Tokenize(value, ',', false))
+            {
+                entry = Trim(entry);
+                if (entry.empty())
+                    continue;
+
+                std::istringstream stream{std::string(entry)};
+                uint32 id = 0;
+                if (!(stream >> id))
+                {
+                    LogMessage(MessageLevel::Warn, logEnabled, "Ignoring entry '{}' in {}: missing identifier.", entry, settingName);
+                    continue;
+                }
+
+                float valueField = 0.0f;
+                bool hasAny = false;
+                StatModifierOverride override;
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.Global = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.Health = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.Mana = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.Armor = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.Damage = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (stream >> valueField)
+                {
+                    if (valueField != -1.0f)
+                    {
+                        override.CrowdControlDuration = valueField;
+                        hasAny = true;
+                    }
+                }
+
+                if (!hasAny)
+                {
+                    LogMessage(MessageLevel::Warn, logEnabled, "Ignoring entry '{}' in {}: no override values provided.", entry, settingName);
+                    continue;
+                }
+
+                overrides[id] = override;
+            }
+
+            return overrides;
+        }
+
         void Validate(ModuleConfig& config, bool logEnabled)
         {
             if (!config.MinimumPlayers)
@@ -157,6 +440,24 @@ namespace AutoBalance
             {
                 LogMessage(MessageLevel::Warn, logEnabled, "AutoBalance.MaxCCDurationModifier ({:.3f}) must be >= AutoBalance.MinCCDurationModifier ({:.3f}). Using the minimum value instead.", config.MaxCCDurationModifier, config.MinCCDurationModifier);
                 config.MaxCCDurationModifier = config.MinCCDurationModifier;
+            }
+
+            if (config.MinHPModifier < 0.0f)
+            {
+                LogMessage(MessageLevel::Warn, logEnabled, "AutoBalance.MinHPModifier ({:.3f}) must be >= 0. Using 0 instead.", config.MinHPModifier);
+                config.MinHPModifier = 0.0f;
+            }
+
+            if (config.MinManaModifier < 0.0f)
+            {
+                LogMessage(MessageLevel::Warn, logEnabled, "AutoBalance.MinManaModifier ({:.3f}) must be >= 0. Using 0 instead.", config.MinManaModifier);
+                config.MinManaModifier = 0.0f;
+            }
+
+            if (config.MinDamageModifier < 0.0f)
+            {
+                LogMessage(MessageLevel::Warn, logEnabled, "AutoBalance.MinDamageModifier ({:.3f}) must be >= 0. Using 0 instead.", config.MinDamageModifier);
+                config.MinDamageModifier = 0.0f;
             }
         }
     }
@@ -268,6 +569,85 @@ namespace AutoBalance
         newConfig.PlayerCountDifficultyOffset = sConfigMgr->GetIntDefault("AutoBalance.playerCountDifficultyOffset", 0);
         newConfig.MinCCDurationModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MinCCDurationModifier", 0.25f));
         newConfig.MaxCCDurationModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MaxCCDurationModifier", 1.0f));
+        newConfig.MinHPModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MinHPModifier", 0.01f));
+        newConfig.MinManaModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MinManaModifier", 0.01f));
+        newConfig.MinDamageModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MinDamageModifier", 0.01f));
+
+        auto const defaultInflection = InflectionPointSettings{};
+        newConfig.DungeonInflection = ParseInflectionPointSettings("AutoBalance.InflectionPoint", "AutoBalance.InflectionPoint.CurveFloor", "AutoBalance.InflectionPoint.CurveCeiling", "AutoBalance.InflectionPoint.BossModifier", defaultInflection);
+        newConfig.DungeonHeroicInflection = ParseInflectionPointSettings("AutoBalance.InflectionPointHeroic", "AutoBalance.InflectionPointHeroic.CurveFloor", "AutoBalance.InflectionPointHeroic.CurveCeiling", "AutoBalance.InflectionPointHeroic.BossModifier", defaultInflection);
+        newConfig.RaidInflection = ParseInflectionPointSettings("AutoBalance.InflectionPointRaid", "AutoBalance.InflectionPointRaid.CurveFloor", "AutoBalance.InflectionPointRaid.CurveCeiling", "AutoBalance.InflectionPointRaid.BossModifier", defaultInflection);
+        newConfig.RaidHeroicInflection = ParseInflectionPointSettings("AutoBalance.InflectionPointRaidHeroic", "AutoBalance.InflectionPointRaidHeroic.CurveFloor", "AutoBalance.InflectionPointRaidHeroic.CurveCeiling", "AutoBalance.InflectionPointRaidHeroic.BossModifier", defaultInflection);
+
+        auto applyRaidInflectionOverride = [&](uint32 size, char const* normalPrefix, char const* heroicPrefix)
+        {
+            std::string normalFloor = std::string(normalPrefix) + ".CurveFloor";
+            std::string normalCeiling = std::string(normalPrefix) + ".CurveCeiling";
+            std::string normalBoss = std::string(normalPrefix) + ".BossModifier";
+
+            if (Optional<InflectionOverride> normal = ParseInflectionOverride(normalPrefix, normalFloor.c_str(), normalCeiling.c_str(), normalBoss.c_str(), logReady))
+                newConfig.RaidInflectionOverrides[size] = *normal;
+
+            if (heroicPrefix)
+            {
+                std::string heroicFloor = std::string(heroicPrefix) + ".CurveFloor";
+                std::string heroicCeiling = std::string(heroicPrefix) + ".CurveCeiling";
+                std::string heroicBoss = std::string(heroicPrefix) + ".BossModifier";
+
+                if (Optional<InflectionOverride> heroic = ParseInflectionOverride(heroicPrefix, heroicFloor.c_str(), heroicCeiling.c_str(), heroicBoss.c_str(), logReady))
+                    newConfig.RaidHeroicInflectionOverrides[size] = *heroic;
+            }
+        };
+
+        applyRaidInflectionOverride(10, "AutoBalance.InflectionPointRaid10M", "AutoBalance.InflectionPointRaid10MHeroic");
+        applyRaidInflectionOverride(15, "AutoBalance.InflectionPointRaid15M", "AutoBalance.InflectionPointRaid15MHeroic");
+        applyRaidInflectionOverride(20, "AutoBalance.InflectionPointRaid20M", "AutoBalance.InflectionPointRaid20MHeroic");
+        applyRaidInflectionOverride(25, "AutoBalance.InflectionPointRaid25M", "AutoBalance.InflectionPointRaid25MHeroic");
+        applyRaidInflectionOverride(40, "AutoBalance.InflectionPointRaid40M", nullptr);
+
+        newConfig.InflectionOverridesByInstance = ParseInflectionOverrides(sConfigMgr->GetStringDefault("AutoBalance.InflectionPoint.PerInstance", ""), logReady, "AutoBalance.InflectionPoint.PerInstance");
+        newConfig.InflectionBossOverridesByInstance = ParseInflectionBossOverrides(sConfigMgr->GetStringDefault("AutoBalance.InflectionPoint.Boss.PerInstance", ""), logReady, "AutoBalance.InflectionPoint.Boss.PerInstance");
+
+        auto const defaultStatModifiers = StatModifierValues{};
+        newConfig.DungeonStatModifiers = ParseStatModifierValues("AutoBalance.StatModifier.", defaultStatModifiers);
+        newConfig.DungeonBossStatModifiers = ParseStatModifierValues("AutoBalance.StatModifier.Boss.", defaultStatModifiers);
+        newConfig.DungeonHeroicStatModifiers = ParseStatModifierValues("AutoBalance.StatModifierHeroic.", defaultStatModifiers);
+        newConfig.DungeonHeroicBossStatModifiers = ParseStatModifierValues("AutoBalance.StatModifierHeroic.Boss.", defaultStatModifiers);
+        newConfig.RaidStatModifiers = ParseStatModifierValues("AutoBalance.StatModifierRaid.", defaultStatModifiers);
+        newConfig.RaidBossStatModifiers = ParseStatModifierValues("AutoBalance.StatModifierRaid.Boss.", defaultStatModifiers);
+        newConfig.RaidHeroicStatModifiers = ParseStatModifierValues("AutoBalance.StatModifierRaidHeroic.", defaultStatModifiers);
+        newConfig.RaidHeroicBossStatModifiers = ParseStatModifierValues("AutoBalance.StatModifierRaidHeroic.Boss.", defaultStatModifiers);
+
+        auto applyRaidStatOverride = [&](uint32 size, char const* normalPrefix, char const* heroicPrefix)
+        {
+            if (Optional<StatModifierOverride> normal = ParseStatModifierOverride(normalPrefix, logReady))
+                newConfig.RaidStatOverridesBySize[size] = *normal;
+
+            std::string normalBossPrefix = std::string(normalPrefix) + "Boss.";
+            if (Optional<StatModifierOverride> bossNormal = ParseStatModifierOverride(normalBossPrefix.c_str(), logReady))
+                newConfig.RaidBossStatOverridesBySize[size] = *bossNormal;
+
+            if (heroicPrefix)
+            {
+                if (Optional<StatModifierOverride> heroic = ParseStatModifierOverride(heroicPrefix, logReady))
+                    newConfig.RaidHeroicStatOverridesBySize[size] = *heroic;
+
+                std::string heroicBossPrefix = std::string(heroicPrefix) + "Boss.";
+                if (Optional<StatModifierOverride> heroicBoss = ParseStatModifierOverride(heroicBossPrefix.c_str(), logReady))
+                    newConfig.RaidHeroicBossStatOverridesBySize[size] = *heroicBoss;
+            }
+        };
+
+        applyRaidStatOverride(10, "AutoBalance.StatModifierRaid10M.", "AutoBalance.StatModifierRaid10MHeroic.");
+        applyRaidStatOverride(15, "AutoBalance.StatModifierRaid15M.", "AutoBalance.StatModifierRaid15MHeroic.");
+        applyRaidStatOverride(20, "AutoBalance.StatModifierRaid20M.", "AutoBalance.StatModifierRaid20MHeroic.");
+        applyRaidStatOverride(25, "AutoBalance.StatModifierRaid25M.", "AutoBalance.StatModifierRaid25MHeroic.");
+        applyRaidStatOverride(40, "AutoBalance.StatModifierRaid40M.", nullptr);
+
+        newConfig.StatModifierOverridesByInstance = ParseStatModifierOverrides(sConfigMgr->GetStringDefault("AutoBalance.StatModifier.PerInstance", ""), logReady, "AutoBalance.StatModifier.PerInstance");
+        newConfig.StatModifierBossOverridesByInstance = ParseStatModifierOverrides(sConfigMgr->GetStringDefault("AutoBalance.StatModifier.Boss.PerInstance", ""), logReady, "AutoBalance.StatModifier.Boss.PerInstance");
+        newConfig.StatModifierOverridesByCreature = ParseStatModifierOverrides(sConfigMgr->GetStringDefault("AutoBalance.StatModifier.PerCreature", ""), logReady, "AutoBalance.StatModifier.PerCreature");
+        newConfig.StatModifierBossOverridesByCreature = ParseStatModifierOverrides(sConfigMgr->GetStringDefault("AutoBalance.StatModifier.Boss.PerCreature", ""), logReady, "AutoBalance.StatModifier.Boss.PerCreature");
 
         Validate(newConfig, logReady);
 

--- a/src/server/game/AutoBalance/AutoBalanceConfig.h
+++ b/src/server/game/AutoBalance/AutoBalanceConfig.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Define.h"
+#include "Optional.h"
 #include <array>
 #include <cstddef>
 #include <unordered_map>
@@ -26,6 +27,52 @@ namespace AutoBalance
         Count
     };
 
+    struct InflectionPointSettings
+    {
+        float Value = 0.5f;
+        float CurveFloor = 0.0f;
+        float CurveCeiling = 1.0f;
+        float BossModifier = 1.0f;
+    };
+
+    struct InflectionOverride
+    {
+        Optional<float> Value;
+        Optional<float> CurveFloor;
+        Optional<float> CurveCeiling;
+        Optional<float> BossModifier;
+
+        bool HasAny() const
+        {
+            return Value.has_value() || CurveFloor.has_value() || CurveCeiling.has_value() || BossModifier.has_value();
+        }
+    };
+
+    struct StatModifierValues
+    {
+        float Global = 1.0f;
+        float Health = 1.0f;
+        float Mana = 1.0f;
+        float Armor = 1.0f;
+        float Damage = 1.0f;
+        float CrowdControlDuration = 1.0f;
+    };
+
+    struct StatModifierOverride
+    {
+        Optional<float> Global;
+        Optional<float> Health;
+        Optional<float> Mana;
+        Optional<float> Armor;
+        Optional<float> Damage;
+        Optional<float> CrowdControlDuration;
+
+        bool HasAny() const
+        {
+            return Global.has_value() || Health.has_value() || Mana.has_value() || Armor.has_value() || Damage.has_value() || CrowdControlDuration.has_value();
+        }
+    };
+
     struct ModuleConfig
     {
         bool Enabled = true;
@@ -42,6 +89,35 @@ namespace AutoBalance
         int32 PlayerCountDifficultyOffset = 0;
         float MinCCDurationModifier = 0.25f;
         float MaxCCDurationModifier = 1.0f;
+        float MinHPModifier = 0.01f;
+        float MinManaModifier = 0.01f;
+        float MinDamageModifier = 0.01f;
+
+        InflectionPointSettings DungeonInflection;
+        InflectionPointSettings DungeonHeroicInflection;
+        InflectionPointSettings RaidInflection;
+        InflectionPointSettings RaidHeroicInflection;
+        std::unordered_map<uint32, InflectionOverride> RaidInflectionOverrides;
+        std::unordered_map<uint32, InflectionOverride> RaidHeroicInflectionOverrides;
+        std::unordered_map<uint32, InflectionOverride> InflectionOverridesByInstance;
+        std::unordered_map<uint32, float> InflectionBossOverridesByInstance;
+
+        StatModifierValues DungeonStatModifiers;
+        StatModifierValues DungeonBossStatModifiers;
+        StatModifierValues DungeonHeroicStatModifiers;
+        StatModifierValues DungeonHeroicBossStatModifiers;
+        StatModifierValues RaidStatModifiers;
+        StatModifierValues RaidBossStatModifiers;
+        StatModifierValues RaidHeroicStatModifiers;
+        StatModifierValues RaidHeroicBossStatModifiers;
+        std::unordered_map<uint32, StatModifierOverride> RaidStatOverridesBySize;
+        std::unordered_map<uint32, StatModifierOverride> RaidHeroicStatOverridesBySize;
+        std::unordered_map<uint32, StatModifierOverride> RaidBossStatOverridesBySize;
+        std::unordered_map<uint32, StatModifierOverride> RaidHeroicBossStatOverridesBySize;
+        std::unordered_map<uint32, StatModifierOverride> StatModifierOverridesByInstance;
+        std::unordered_map<uint32, StatModifierOverride> StatModifierBossOverridesByInstance;
+        std::unordered_map<uint32, StatModifierOverride> StatModifierOverridesByCreature;
+        std::unordered_map<uint32, StatModifierOverride> StatModifierBossOverridesByCreature;
     };
 
     ModuleConfig const& GetConfig();

--- a/src/server/game/AutoBalance/AutoBalanceCreature.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceCreature.cpp
@@ -6,8 +6,10 @@
 #include "Map.h"
 #include "ObjectMgr.h"
 #include "SharedDefines.h"
+#include "TemporarySummon.h"
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace AutoBalance
 {
@@ -44,7 +46,53 @@ namespace
         return 1;
     }
 
-    float CalculateMultiplier(uint32 effectivePlayers, uint32 targetPlayers)
+    void ApplyInflectionOverride(InflectionPointSettings& settings, InflectionOverride const& override)
+    {
+        if (override.Value)
+            settings.Value = *override.Value;
+        if (override.CurveFloor)
+            settings.CurveFloor = *override.CurveFloor;
+        if (override.CurveCeiling)
+            settings.CurveCeiling = *override.CurveCeiling;
+        if (override.BossModifier)
+            settings.BossModifier = *override.BossModifier;
+    }
+
+    void ApplyStatOverride(StatModifierValues& values, StatModifierOverride const& override)
+    {
+        if (override.Global)
+            values.Global = *override.Global;
+        if (override.Health)
+            values.Health = *override.Health;
+        if (override.Mana)
+            values.Mana = *override.Mana;
+        if (override.Armor)
+            values.Armor = *override.Armor;
+        if (override.Damage)
+            values.Damage = *override.Damage;
+        if (override.CrowdControlDuration)
+            values.CrowdControlDuration = *override.CrowdControlDuration;
+    }
+
+    bool IsBossCreature(Creature const& creature)
+    {
+        if (creature.IsDungeonBoss() || creature.isWorldBoss())
+            return true;
+
+        if (TempSummon const* summon = creature.ToTempSummon())
+        {
+            if (Unit const* summoner = summon->GetSummoner())
+            {
+                Creature const* summonerCreature = summoner->ToCreature();
+                if (summonerCreature && (summonerCreature->IsDungeonBoss() || summonerCreature->isWorldBoss()))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    float EvaluateInflectionMultiplier(uint32 effectivePlayers, uint32 targetPlayers, InflectionPointSettings const& settings)
     {
         if (!effectivePlayers)
             effectivePlayers = 1;
@@ -52,13 +100,96 @@ namespace
         if (!targetPlayers)
             targetPlayers = 1;
 
-        float multiplier = static_cast<float>(effectivePlayers) / static_cast<float>(targetPlayers);
+        float const maxPlayers = static_cast<float>(targetPlayers);
+        float const adjustedPlayers = static_cast<float>(effectivePlayers);
+
+        float diff = (maxPlayers / 5.0f) * 1.5f;
+        if (!std::isfinite(diff) || diff <= 0.0f)
+            diff = 1.0f;
+
+        auto evaluate = [&](float players)
+        {
+            return (std::tanh((players - settings.Value) / diff) + 1.0f) / 2.0f;
+        };
+
+        float curveCeilingAdjustment = 1.0f;
+        {
+            float const numerator = evaluate(maxPlayers);
+            float const denominator = numerator * (settings.CurveCeiling - settings.CurveFloor) + settings.CurveFloor;
+            if (std::fabs(denominator) > std::numeric_limits<float>::epsilon())
+                curveCeilingAdjustment = settings.CurveCeiling / denominator;
+        }
+
+        float multiplier = evaluate(adjustedPlayers) * (settings.CurveCeiling * curveCeilingAdjustment - settings.CurveFloor) + settings.CurveFloor;
         if (!std::isfinite(multiplier) || multiplier <= 0.0f)
             multiplier = 0.01f;
 
         return multiplier;
     }
 
+    InflectionPointSettings SelectInflectionSettings(ModuleConfig const& config, Map const* map, uint32 targetPlayers, bool isBoss)
+    {
+        InflectionPointSettings settings = map->IsRaid()
+            ? (map->IsHeroic() ? config.RaidHeroicInflection : config.RaidInflection)
+            : (map->IsHeroic() ? config.DungeonHeroicInflection : config.DungeonInflection);
+
+        if (map->IsRaid())
+        {
+            auto const& overrides = map->IsHeroic() ? config.RaidHeroicInflectionOverrides : config.RaidInflectionOverrides;
+            if (auto const it = overrides.find(targetPlayers); it != overrides.end())
+                ApplyInflectionOverride(settings, it->second);
+        }
+
+        if (auto const it = config.InflectionOverridesByInstance.find(map->GetId()); it != config.InflectionOverridesByInstance.end())
+            ApplyInflectionOverride(settings, it->second);
+
+        if (isBoss)
+        {
+            float bossMultiplier = settings.BossModifier;
+            if (auto const it = config.InflectionBossOverridesByInstance.find(map->GetId()); it != config.InflectionBossOverridesByInstance.end())
+                bossMultiplier = it->second;
+
+            if (!std::isfinite(bossMultiplier) || bossMultiplier <= 0.0f)
+                bossMultiplier = 1.0f;
+
+            settings.Value *= bossMultiplier;
+            settings.BossModifier = bossMultiplier;
+        }
+
+        return settings;
+    }
+
+    StatModifierValues SelectStatModifiers(ModuleConfig const& config, Map const* map, Creature const& creature, bool isBoss, uint32 targetPlayers)
+    {
+        StatModifierValues values;
+
+        if (map->IsRaid())
+            values = map->IsHeroic() ? (isBoss ? config.RaidHeroicBossStatModifiers : config.RaidHeroicStatModifiers)
+                                     : (isBoss ? config.RaidBossStatModifiers : config.RaidStatModifiers);
+        else
+            values = map->IsHeroic() ? (isBoss ? config.DungeonHeroicBossStatModifiers : config.DungeonHeroicStatModifiers)
+                                     : (isBoss ? config.DungeonBossStatModifiers : config.DungeonStatModifiers);
+
+        if (map->IsRaid())
+        {
+            auto const& overrides = map->IsHeroic()
+                ? (isBoss ? config.RaidHeroicBossStatOverridesBySize : config.RaidHeroicStatOverridesBySize)
+                : (isBoss ? config.RaidBossStatOverridesBySize : config.RaidStatOverridesBySize);
+
+            if (auto const it = overrides.find(targetPlayers); it != overrides.end())
+                ApplyStatOverride(values, it->second);
+        }
+
+        auto const& instanceOverrides = isBoss ? config.StatModifierBossOverridesByInstance : config.StatModifierOverridesByInstance;
+        if (auto const it = instanceOverrides.find(map->GetId()); it != instanceOverrides.end())
+            ApplyStatOverride(values, it->second);
+
+        auto const& creatureOverrides = isBoss ? config.StatModifierBossOverridesByCreature : config.StatModifierOverridesByCreature;
+        if (auto const it = creatureOverrides.find(creature.GetEntry()); it != creatureOverrides.end())
+            ApplyStatOverride(values, it->second);
+
+        return values;
+    }
 }
 
 AutoBalanceCreatureInfo& GetCreatureInfo(Creature& creature)
@@ -162,7 +293,30 @@ void ScaleCreature(Creature* creature)
 
     uint32 const effectivePlayers = GetEffectivePlayerCount(map);
     uint32 const targetPlayers = GetTargetPlayerCount(map);
-    float const multiplier = CalculateMultiplier(effectivePlayers, targetPlayers);
+    bool const isBoss = IsBossCreature(*creature);
+
+    InflectionPointSettings const inflectionSettings = SelectInflectionSettings(config, map, targetPlayers, isBoss);
+    float const baseMultiplier = EvaluateInflectionMultiplier(effectivePlayers, targetPlayers, inflectionSettings);
+    StatModifierValues const statModifiers = SelectStatModifiers(config, map, *creature, isBoss, targetPlayers);
+
+    auto sanitize = [](float value, float fallback)
+    {
+        if (!std::isfinite(value) || value <= 0.0f)
+            return fallback;
+        return value;
+    };
+
+    float healthMultiplier = sanitize(baseMultiplier * statModifiers.Global * statModifiers.Health, config.MinHPModifier);
+    float manaMultiplier = sanitize(baseMultiplier * statModifiers.Global * statModifiers.Mana, config.MinManaModifier);
+    float armorMultiplier = sanitize(baseMultiplier * statModifiers.Global * statModifiers.Armor, 1.0f);
+    float damageMultiplier = sanitize(baseMultiplier * statModifiers.Global * statModifiers.Damage, config.MinDamageModifier);
+    float crowdControlMultiplier = sanitize(baseMultiplier * statModifiers.CrowdControlDuration, 1.0f);
+
+    healthMultiplier = std::max(healthMultiplier, config.MinHPModifier);
+    manaMultiplier = std::max(manaMultiplier, config.MinManaModifier);
+    armorMultiplier = std::max(armorMultiplier, 0.01f);
+    damageMultiplier = std::max(damageMultiplier, config.MinDamageModifier);
+    crowdControlMultiplier = std::clamp(crowdControlMultiplier, config.MinCCDurationModifier, config.MaxCCDurationModifier);
 
     CreatureTemplate const* creatureTemplate = creature->GetCreatureTemplate();
     if (!creatureTemplate)
@@ -179,11 +333,11 @@ void ScaleCreature(Creature* creature)
         info.BaseLevel != level ||
         info.TargetPlayerCount != targetPlayers ||
         info.EffectivePlayerCount != effectivePlayers ||
-        std::fabs(info.Multipliers.Health - multiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Mana - multiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Damage - multiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Armor - multiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.CrowdControlDuration - multiplier) > 0.0005f;
+        std::fabs(info.Multipliers.Health - healthMultiplier) > 0.0005f ||
+        std::fabs(info.Multipliers.Mana - manaMultiplier) > 0.0005f ||
+        std::fabs(info.Multipliers.Damage - damageMultiplier) > 0.0005f ||
+        std::fabs(info.Multipliers.Armor - armorMultiplier) > 0.0005f ||
+        std::fabs(info.Multipliers.CrowdControlDuration - crowdControlMultiplier) > 0.0005f;
 
     if (!requiresUpdate)
         return;
@@ -203,11 +357,11 @@ void ScaleCreature(Creature* creature)
     info.EffectivePlayerCount = effectivePlayers;
     info.Initialized = true;
 
-    info.Multipliers.Health = multiplier;
-    info.Multipliers.Mana = multiplier;
-    info.Multipliers.Damage = multiplier;
-    info.Multipliers.Armor = multiplier;
-    info.Multipliers.CrowdControlDuration = multiplier;
+    info.Multipliers.Health = healthMultiplier;
+    info.Multipliers.Mana = manaMultiplier;
+    info.Multipliers.Damage = damageMultiplier;
+    info.Multipliers.Armor = armorMultiplier;
+    info.Multipliers.CrowdControlDuration = crowdControlMultiplier;
 
     uint32 const oldMaxHealth = creature->GetMaxHealth();
     float const healthPct = oldMaxHealth ? std::clamp(static_cast<float>(creature->GetHealth()) / static_cast<float>(oldMaxHealth), 0.0f, 1.0f) : 1.0f;
@@ -252,7 +406,7 @@ void ScaleCreature(Creature* creature)
     creature->UpdateDamagePhysical(RANGED_ATTACK);
 
     if (config.DebugLogging)
-        TC_LOG_DEBUG(LogFilter, "AutoBalance::ScaleCreature - entry={} level={} players={}/{} multiplier={:.3f}",
-            creature->GetEntry(), level, effectivePlayers, targetPlayers, multiplier);
+        TC_LOG_DEBUG(LogFilter, "AutoBalance::ScaleCreature - entry={} level={} players={}/{} base={:.3f} health={:.3f} mana={:.3f} damage={:.3f} armor={:.3f} cc={:.3f}",
+            creature->GetEntry(), level, effectivePlayers, targetPlayers, baseMultiplier, info.Multipliers.Health, info.Multipliers.Mana, info.Multipliers.Damage, info.Multipliers.Armor, info.Multipliers.CrowdControlDuration);
 }
 }


### PR DESCRIPTION
## Summary
- extend the AutoBalance configuration schema with inflection, stat modifier, and override structures for instance- and raid-specific tuning
- load and validate the new configuration values, including per-instance and per-creature override strings, when refreshing module settings
- compute creature scaling via the configured inflection curves and stat modifiers, with boss detection and detailed debug output

## Testing
- cmake -S . -B build *(fails: missing Boost headers in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf1dbf8348327a5ba2129da392bd4