### PR TITLE
Align AutoBalance scaling with AzerothCore behavior

### DIFF
--- a/src/server/game/AutoBalance/AutoBalanceCreature.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceCreature.cpp
@@ -322,46 +322,115 @@ void ScaleCreature(Creature* creature)
     if (!creatureTemplate)
         return;
 
+    AutoBalanceCreatureInfo& info = GetCreatureInfo(*creature);
+
     uint8 const level = creature->GetLevel();
-    CreatureBaseStats const* baseStats = sObjectMgr->GetCreatureBaseStats(level, creatureTemplate->unit_class);
-    if (!baseStats)
+    uint8 const unmodifiedLevel = info.Initialized ? info.UnmodifiedLevel : level;
+
+    CreatureBaseStats const* originalBaseStats = sObjectMgr->GetCreatureBaseStats(unmodifiedLevel, creatureTemplate->unit_class);
+    if (!originalBaseStats)
         return;
 
-    AutoBalanceCreatureInfo& info = GetCreatureInfo(*creature);
+    CreatureBaseStats const* levelBaseStats = sObjectMgr->GetCreatureBaseStats(level, creatureTemplate->unit_class);
+    if (!levelBaseStats)
+        return;
+
+    CreatureBaseValues originalBaseValues;
+    originalBaseValues.Health = originalBaseStats->GenerateHealth(creatureTemplate);
+    originalBaseValues.Mana = originalBaseStats->GenerateMana(creatureTemplate);
+    originalBaseValues.Armor = originalBaseStats->GenerateArmor(creatureTemplate);
+    float const originalBaseDamage = originalBaseStats->GenerateBaseDamage(creatureTemplate);
+    originalBaseValues.MinDamage = originalBaseDamage;
+    originalBaseValues.MaxDamage = originalBaseDamage * 1.5f;
+    originalBaseValues.AttackPower = static_cast<float>(originalBaseStats->AttackPower);
+    originalBaseValues.RangedAttackPower = static_cast<float>(originalBaseStats->RangedAttackPower);
+
+    CreatureBaseValues levelBaseValues;
+    levelBaseValues.Health = levelBaseStats->GenerateHealth(creatureTemplate);
+    levelBaseValues.Mana = levelBaseStats->GenerateMana(creatureTemplate);
+    levelBaseValues.Armor = levelBaseStats->GenerateArmor(creatureTemplate);
+    float const levelBaseDamage = levelBaseStats->GenerateBaseDamage(creatureTemplate);
+    levelBaseValues.MinDamage = levelBaseDamage;
+    levelBaseValues.MaxDamage = levelBaseDamage * 1.5f;
+    levelBaseValues.AttackPower = static_cast<float>(levelBaseStats->AttackPower);
+    levelBaseValues.RangedAttackPower = static_cast<float>(levelBaseStats->RangedAttackPower);
+
+    auto computeLevelMultiplier = [](float originalValue, float newValue)
+    {
+        if (originalValue <= 0.0f)
+            return 1.0f;
+
+        float multiplier = newValue / originalValue;
+        if (!std::isfinite(multiplier) || multiplier <= 0.0f)
+            return 1.0f;
+
+        return multiplier;
+    };
+
+    float const levelHealthMultiplier = computeLevelMultiplier(static_cast<float>(originalBaseValues.Health), static_cast<float>(levelBaseValues.Health));
+    float const levelManaMultiplier = computeLevelMultiplier(static_cast<float>(originalBaseValues.Mana), static_cast<float>(levelBaseValues.Mana));
+    float const levelArmorMultiplier = computeLevelMultiplier(static_cast<float>(originalBaseValues.Armor), static_cast<float>(levelBaseValues.Armor));
+    float const levelDamageMultiplier = computeLevelMultiplier(originalBaseValues.MinDamage, levelBaseValues.MinDamage);
+    float const levelAttackPowerMultiplier = computeLevelMultiplier(originalBaseValues.AttackPower, levelBaseValues.AttackPower);
+    float const levelRangedAttackPowerMultiplier = computeLevelMultiplier(originalBaseValues.RangedAttackPower, levelBaseValues.RangedAttackPower);
+
+    CreatureMultipliers const baseMultipliers = { healthMultiplier, manaMultiplier, damageMultiplier, armorMultiplier, crowdControlMultiplier };
+    CreatureMultipliers const finalMultipliers =
+    {
+        healthMultiplier * levelHealthMultiplier,
+        manaMultiplier * levelManaMultiplier,
+        damageMultiplier * levelDamageMultiplier,
+        armorMultiplier * levelArmorMultiplier,
+        crowdControlMultiplier
+    };
+
+    auto multipliersDiffer = [](float lhs, float rhs)
+    {
+        return std::fabs(lhs - rhs) > 0.0005f;
+    };
+
+    auto baseValuesDiffer = [](CreatureBaseValues const& lhs, CreatureBaseValues const& rhs)
+    {
+        auto floatsDiffer = [](float l, float r)
+        {
+            return std::fabs(l - r) > 0.0005f;
+        };
+
+        return lhs.Health != rhs.Health || lhs.Mana != rhs.Mana || lhs.Armor != rhs.Armor ||
+            floatsDiffer(lhs.MinDamage, rhs.MinDamage) || floatsDiffer(lhs.MaxDamage, rhs.MaxDamage) ||
+            floatsDiffer(lhs.AttackPower, rhs.AttackPower) || floatsDiffer(lhs.RangedAttackPower, rhs.RangedAttackPower);
+    };
 
     bool const requiresUpdate = !info.Initialized ||
         info.BaseLevel != level ||
         info.TargetPlayerCount != targetPlayers ||
         info.EffectivePlayerCount != effectivePlayers ||
-        std::fabs(info.Multipliers.Health - healthMultiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Mana - manaMultiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Damage - damageMultiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Armor - armorMultiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.CrowdControlDuration - crowdControlMultiplier) > 0.0005f;
+        multipliersDiffer(info.BaseMultipliers.Health, baseMultipliers.Health) ||
+        multipliersDiffer(info.BaseMultipliers.Mana, baseMultipliers.Mana) ||
+        multipliersDiffer(info.BaseMultipliers.Damage, baseMultipliers.Damage) ||
+        multipliersDiffer(info.BaseMultipliers.Armor, baseMultipliers.Armor) ||
+        multipliersDiffer(info.BaseMultipliers.CrowdControlDuration, baseMultipliers.CrowdControlDuration) ||
+        multipliersDiffer(info.Multipliers.Health, finalMultipliers.Health) ||
+        multipliersDiffer(info.Multipliers.Mana, finalMultipliers.Mana) ||
+        multipliersDiffer(info.Multipliers.Damage, finalMultipliers.Damage) ||
+        multipliersDiffer(info.Multipliers.Armor, finalMultipliers.Armor) ||
+        multipliersDiffer(info.Multipliers.CrowdControlDuration, finalMultipliers.CrowdControlDuration) ||
+        baseValuesDiffer(info.LevelScaledBaseValues, levelBaseValues);
 
     if (!requiresUpdate)
         return;
 
-    info.BaseValues.Health = baseStats->GenerateHealth(creatureTemplate);
-    info.BaseValues.Mana = baseStats->GenerateMana(creatureTemplate);
-    info.BaseValues.Armor = baseStats->GenerateArmor(creatureTemplate);
+    if (!info.Initialized)
+        info.UnmodifiedLevel = unmodifiedLevel;
 
-    float const baseDamage = baseStats->GenerateBaseDamage(creatureTemplate);
-    info.BaseValues.MinDamage = baseDamage;
-    info.BaseValues.MaxDamage = baseDamage * 1.5f;
-    info.BaseValues.AttackPower = static_cast<float>(baseStats->AttackPower);
-    info.BaseValues.RangedAttackPower = static_cast<float>(baseStats->RangedAttackPower);
-
+    info.BaseValues = originalBaseValues;
+    info.LevelScaledBaseValues = levelBaseValues;
     info.BaseLevel = level;
     info.TargetPlayerCount = targetPlayers;
     info.EffectivePlayerCount = effectivePlayers;
+    info.BaseMultipliers = baseMultipliers;
+    info.Multipliers = finalMultipliers;
     info.Initialized = true;
-
-    info.Multipliers.Health = healthMultiplier;
-    info.Multipliers.Mana = manaMultiplier;
-    info.Multipliers.Damage = damageMultiplier;
-    info.Multipliers.Armor = armorMultiplier;
-    info.Multipliers.CrowdControlDuration = crowdControlMultiplier;
 
     uint32 const oldMaxHealth = creature->GetMaxHealth();
     float const healthPct = oldMaxHealth ? std::clamp(static_cast<float>(creature->GetHealth()) / static_cast<float>(oldMaxHealth), 0.0f, 1.0f) : 1.0f;
@@ -398,15 +467,23 @@ void ScaleCreature(Creature* creature)
         creature->SetBaseWeaponDamage(attackType, MAXDAMAGE, scaledMaxDamage);
     }
 
-    creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, BASE_VALUE, info.BaseValues.AttackPower * info.Multipliers.Damage);
-    creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, BASE_VALUE, info.BaseValues.RangedAttackPower * info.Multipliers.Damage);
+    float const attackPowerMultiplier = info.BaseMultipliers.Damage * levelAttackPowerMultiplier;
+    float const rangedAttackPowerMultiplier = info.BaseMultipliers.Damage * levelRangedAttackPowerMultiplier;
+    creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, BASE_VALUE, info.BaseValues.AttackPower * attackPowerMultiplier);
+    creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, BASE_VALUE, info.BaseValues.RangedAttackPower * rangedAttackPowerMultiplier);
 
     creature->UpdateDamagePhysical(BASE_ATTACK);
     creature->UpdateDamagePhysical(OFF_ATTACK);
     creature->UpdateDamagePhysical(RANGED_ATTACK);
 
     if (config.DebugLogging)
-        TC_LOG_DEBUG(LogFilter, "AutoBalance::ScaleCreature - entry={} level={} players={}/{} base={:.3f} health={:.3f} mana={:.3f} damage={:.3f} armor={:.3f} cc={:.3f}",
-            creature->GetEntry(), level, effectivePlayers, targetPlayers, baseMultiplier, info.Multipliers.Health, info.Multipliers.Mana, info.Multipliers.Damage, info.Multipliers.Armor, info.Multipliers.CrowdControlDuration);
+        TC_LOG_DEBUG(LogFilter,
+            "AutoBalance::ScaleCreature - entry={} level={} players={}/{} base={:.3f} baseMult(h/m/d/a)={:.3f}/{:.3f}/{:.3f}/{:.3f} "
+            "levelAdj(h/m/d/a)={:.3f}/{:.3f}/{:.3f}/{:.3f} final(h/m/d/a)={:.3f}/{:.3f}/{:.3f}/{:.3f} cc={:.3f}",
+            creature->GetEntry(), level, effectivePlayers, targetPlayers, baseMultiplier,
+            info.BaseMultipliers.Health, info.BaseMultipliers.Mana, info.BaseMultipliers.Damage, info.BaseMultipliers.Armor,
+            levelHealthMultiplier, levelManaMultiplier, levelDamageMultiplier, levelArmorMultiplier,
+            info.Multipliers.Health, info.Multipliers.Mana, info.Multipliers.Damage, info.Multipliers.Armor,
+            info.Multipliers.CrowdControlDuration);
 }
 }

--- a/src/server/game/AutoBalance/AutoBalanceCreatureInfo.h
+++ b/src/server/game/AutoBalance/AutoBalanceCreatureInfo.h
@@ -27,8 +27,11 @@ namespace AutoBalance
     struct AutoBalanceCreatureInfo
     {
         CreatureBaseValues BaseValues;
+        CreatureBaseValues LevelScaledBaseValues;
+        CreatureMultipliers BaseMultipliers;
         CreatureMultipliers Multipliers;
         uint8 BaseLevel = 0;
+        uint8 UnmodifiedLevel = 0;
         uint32 TargetPlayerCount = 0;
         uint32 EffectivePlayerCount = 0;
         bool Initialized = false;

--- a/src/server/game/AutoBalance/AutoBalanceMapData.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceMapData.cpp
@@ -39,14 +39,49 @@ namespace
 
         data.QueueOffset = config.PlayerCountDifficultyOffset;
 
-        int32 const adjustedPlayerCount = std::max<int32>(0, static_cast<int32>(data.PlayerCount) + data.QueueOffset);
-        uint32 effectivePlayerCount = static_cast<uint32>(adjustedPlayerCount);
+        uint32 playerCount = data.PlayerCount;
+        if (map->IsDungeon())
+            playerCount = std::max<uint32>(playerCount, 1u);
+
+        uint32 effectivePlayerCount = playerCount;
+
+        if (map->IsDungeon())
+        {
+            if (data.CombatLocked)
+            {
+                if (playerCount > data.CombatLockMinPlayers)
+                {
+                    data.CombatLockMinPlayers = playerCount;
+                    data.CombatLockTripped = false;
+                }
+                else if (playerCount < data.CombatLockMinPlayers)
+                {
+                    data.CombatLockTripped = true;
+                }
+
+                effectivePlayerCount = std::max(playerCount, data.CombatLockMinPlayers);
+            }
+            else
+            {
+                data.CombatLockMinPlayers = 0;
+                data.CombatLockTripped = false;
+            }
+        }
+        else
+        {
+            data.CombatLockMinPlayers = 0;
+            data.CombatLockTripped = false;
+        }
 
         uint32 const minimumPlayers = GetMinimumPlayersForMap(map);
         if (effectivePlayerCount < minimumPlayers)
             effectivePlayerCount = minimumPlayers;
 
-        data.EffectivePlayerCount = effectivePlayerCount;
+        int32 adjustedPlayerCount = static_cast<int32>(effectivePlayerCount) + data.QueueOffset;
+        if (adjustedPlayerCount < 1)
+            adjustedPlayerCount = 1;
+
+        data.EffectivePlayerCount = static_cast<uint32>(adjustedPlayerCount);
         data.LastPlayerCountUpdateTimeMS = now;
     }
 }
@@ -116,9 +151,26 @@ void HandleCombatStateChange(Map* map, bool locked, Player* /*player*/)
     data.LastCombatStateChangeTimeMS = now;
 
     if (locked)
+    {
         data.LastCombatStartTimeMS = now;
+
+        if (map->IsDungeon())
+        {
+            uint32 const playerCount = std::max<uint32>(data.PlayerCount, 1u);
+            if (playerCount > data.CombatLockMinPlayers)
+                data.CombatLockMinPlayers = playerCount;
+
+            data.CombatLockTripped = false;
+        }
+    }
     else
+    {
         data.LastCombatEndTimeMS = now;
+        data.CombatLockMinPlayers = 0;
+        data.CombatLockTripped = false;
+    }
+
+    UpdateEffectivePlayerCountInternal(map, now);
 }
 
 void RefreshEffectivePlayerCount(Map* map)

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -330,6 +330,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
                 uint32 PlayerCount = 0;
                 uint32 EffectivePlayerCount = 0;
                 int32 QueueOffset = 0;
+                uint32 CombatLockMinPlayers = 0;
                 uint32 LastPlayerJoinTimeMS = 0;
                 uint32 LastPlayerLeaveTimeMS = 0;
                 uint32 LastPlayerCountUpdateTimeMS = 0;
@@ -338,6 +339,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
                 uint32 LastCombatStateChangeTimeMS = 0;
                 bool CombatLocked = false;
                 bool CombatStateDirty = false;
+                bool CombatLockTripped = false;
             };
 
             AutoBalanceData AutoBalance;

--- a/src/server/scripts/Custom/AutoBalance/AutoBalanceCommands.cpp
+++ b/src/server/scripts/Custom/AutoBalance/AutoBalanceCommands.cpp
@@ -175,14 +175,22 @@ public:
 
         handler->PSendSysMessage("AutoBalance stats for %s (entry %u):",
             creature->GetName().c_str(), creature->GetEntry());
-        handler->PSendSysMessage(" Level: %u | Target players: %u | Effective players: %u",
-            info->BaseLevel, info->TargetPlayerCount, info->EffectivePlayerCount);
-        handler->PSendSysMessage(" Base Health: %u | Base Mana: %u | Base Armor: %u",
+        handler->PSendSysMessage(" Original level: %u | Current level: %u | Target players: %u | Effective players: %u",
+            info->UnmodifiedLevel, info->BaseLevel, info->TargetPlayerCount, info->EffectivePlayerCount);
+        handler->PSendSysMessage(" Original base -> Health: %u | Mana: %u | Armor: %u",
             info->BaseValues.Health, info->BaseValues.Mana, info->BaseValues.Armor);
-        handler->PSendSysMessage(" Base Damage: %.3f - %.3f | Base AP: %.3f | Base RAP: %.3f",
+        handler->PSendSysMessage(" Original base -> Damage: %.3f - %.3f | AP: %.3f | RAP: %.3f",
             info->BaseValues.MinDamage, info->BaseValues.MaxDamage,
             info->BaseValues.AttackPower, info->BaseValues.RangedAttackPower);
-        handler->PSendSysMessage(" Multipliers -> Health: %.3f | Mana: %.3f | Damage: %.3f | Armor: %.3f | CC: %.3f",
+        handler->PSendSysMessage(" Level-scaled base -> Health: %u | Mana: %u | Armor: %u",
+            info->LevelScaledBaseValues.Health, info->LevelScaledBaseValues.Mana, info->LevelScaledBaseValues.Armor);
+        handler->PSendSysMessage(" Level-scaled base -> Damage: %.3f - %.3f | AP: %.3f | RAP: %.3f",
+            info->LevelScaledBaseValues.MinDamage, info->LevelScaledBaseValues.MaxDamage,
+            info->LevelScaledBaseValues.AttackPower, info->LevelScaledBaseValues.RangedAttackPower);
+        handler->PSendSysMessage(" Base multipliers -> Health: %.3f | Mana: %.3f | Damage: %.3f | Armor: %.3f | CC: %.3f",
+            info->BaseMultipliers.Health, info->BaseMultipliers.Mana, info->BaseMultipliers.Damage,
+            info->BaseMultipliers.Armor, info->BaseMultipliers.CrowdControlDuration);
+        handler->PSendSysMessage(" Final multipliers -> Health: %.3f | Mana: %.3f | Damage: %.3f | Armor: %.3f | CC: %.3f",
             info->Multipliers.Health, info->Multipliers.Mana, info->Multipliers.Damage,
             info->Multipliers.Armor, info->Multipliers.CrowdControlDuration);
 


### PR DESCRIPTION
## Summary
- preserve combat lock minimums and queue offsets when calculating effective player counts to mirror AzerothCore's combat locking
- store original versus level-adjusted creature baselines and fold level scaling ratios into the health, mana, damage, and armor multipliers
- extend the autobalance creature statistics command to surface the original base stats, level-scaled stats, and both base and final multipliers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd9cbb74e483279332376c8b7bfd94