### PR TITLE
Smooth AutoBalance base stats using highest player level

### DIFF
--- a/src/server/game/AutoBalance/AutoBalanceConfig.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceConfig.cpp
@@ -416,6 +416,96 @@ namespace AutoBalance
             return overrides;
         }
 
+        ScalingMethod ParseScalingMethod(char const* option, ScalingMethod defaultValue, bool logEnabled)
+        {
+            std::string raw = sConfigMgr->GetStringDefault(option, defaultValue == ScalingMethod::Dynamic ? "dynamic" : "fixed");
+            std::string lowered = raw;
+            std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+            if (lowered == "dynamic")
+                return ScalingMethod::Dynamic;
+
+            if (lowered == "fixed")
+                return ScalingMethod::Fixed;
+
+            LogMessage(MessageLevel::Warn, logEnabled, "Invalid scaling method '{}' for {}. Expected 'dynamic' or 'fixed'. Using default ({}).",
+                raw, option, defaultValue == ScalingMethod::Dynamic ? "dynamic" : "fixed");
+            return defaultValue;
+        }
+
+        LevelScalingSettings ParseLevelScalingSettings(char const* ceilingOption, char const* floorOption, LevelScalingSettings defaults, bool logEnabled)
+        {
+            LevelScalingSettings settings = defaults;
+
+            int32 ceiling = sConfigMgr->GetIntDefault(ceilingOption, defaults.Ceiling);
+            int32 floor = sConfigMgr->GetIntDefault(floorOption, defaults.Floor);
+
+            if (ceiling < 0)
+            {
+                LogMessage(MessageLevel::Warn, logEnabled, "{} ({}) must be >= 0. Using {} instead.", ceilingOption, ceiling, defaults.Ceiling);
+                ceiling = defaults.Ceiling;
+            }
+
+            if (floor < 0)
+            {
+                LogMessage(MessageLevel::Warn, logEnabled, "{} ({}) must be >= 0. Using {} instead.", floorOption, floor, defaults.Floor);
+                floor = defaults.Floor;
+            }
+
+            settings.Ceiling = static_cast<int8>(ceiling);
+            settings.Floor = static_cast<int8>(floor);
+            return settings;
+        }
+
+        std::unordered_map<uint32, LevelScalingSettings> ParseLevelScalingOverrides(std::string const& value, bool logEnabled)
+        {
+            std::unordered_map<uint32, LevelScalingSettings> overrides;
+
+            for (std::string_view entry : Trinity::Tokenize(value, ',', false))
+            {
+                entry = Trim(entry);
+                if (entry.empty())
+                    continue;
+
+                std::istringstream stream{std::string(entry)};
+                uint32 mapId = 0;
+                if (!(stream >> mapId))
+                {
+                    LogMessage(MessageLevel::Warn, logEnabled, "Ignoring entry '{}' in AutoBalance.LevelScaling.DynamicLevel.PerInstance: missing map id.", entry);
+                    continue;
+                }
+
+                LevelScalingSettings settings{};
+                settings.Floor = -1;
+                settings.Ceiling = -1;
+                settings.SkipHigher = -1;
+                settings.SkipLower = -1;
+
+                auto readNext = [&](int8& field)
+                {
+                    int32 temp = 0;
+                    if (!(stream >> temp))
+                        return false;
+
+                    field = static_cast<int8>(temp);
+                    return true;
+                };
+
+                if (!readNext(settings.SkipHigher))
+                    settings.SkipHigher = -1;
+                if (!readNext(settings.SkipLower))
+                    settings.SkipLower = -1;
+                if (!readNext(settings.Ceiling))
+                    settings.Ceiling = -1;
+                if (!readNext(settings.Floor))
+                    settings.Floor = -1;
+
+                overrides[mapId] = settings;
+            }
+
+            return overrides;
+        }
+
         void Validate(ModuleConfig& config, bool logEnabled)
         {
             if (!config.MinimumPlayers)
@@ -572,6 +662,22 @@ namespace AutoBalance
         newConfig.MinHPModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MinHPModifier", 0.01f));
         newConfig.MinManaModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MinManaModifier", 0.01f));
         newConfig.MinDamageModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.MinDamageModifier", 0.01f));
+
+        newConfig.LevelScalingEnabled = sConfigMgr->GetBoolDefault("AutoBalance.LevelScaling", false);
+        newConfig.LevelScalingMethod = ParseScalingMethod("AutoBalance.LevelScaling.Method", ScalingMethod::Dynamic, logReady);
+        newConfig.LevelScalingSkipHigherLevels = static_cast<int8>(sConfigMgr->GetIntDefault("AutoBalance.LevelScaling.SkipHigherLevels", 0));
+        newConfig.LevelScalingSkipLowerLevels = static_cast<int8>(sConfigMgr->GetIntDefault("AutoBalance.LevelScaling.SkipLowerLevels", 0));
+        newConfig.LevelScalingDungeonSettings = ParseLevelScalingSettings("AutoBalance.LevelScaling.DynamicLevel.Ceiling.Dungeons", "AutoBalance.LevelScaling.DynamicLevel.Floor.Dungeons", newConfig.LevelScalingDungeonSettings, logReady);
+        newConfig.LevelScalingHeroicDungeonSettings = ParseLevelScalingSettings("AutoBalance.LevelScaling.DynamicLevel.Ceiling.HeroicDungeons", "AutoBalance.LevelScaling.DynamicLevel.Floor.HeroicDungeons", newConfig.LevelScalingHeroicDungeonSettings, logReady);
+        newConfig.LevelScalingRaidSettings = ParseLevelScalingSettings("AutoBalance.LevelScaling.DynamicLevel.Ceiling.Raids", "AutoBalance.LevelScaling.DynamicLevel.Floor.Raids", newConfig.LevelScalingRaidSettings, logReady);
+        newConfig.LevelScalingHeroicRaidSettings = ParseLevelScalingSettings("AutoBalance.LevelScaling.DynamicLevel.Ceiling.HeroicRaids", "AutoBalance.LevelScaling.DynamicLevel.Floor.HeroicRaids", newConfig.LevelScalingHeroicRaidSettings, logReady);
+        newConfig.LevelScalingOverridesByInstance = ParseLevelScalingOverrides(sConfigMgr->GetStringDefault("AutoBalance.LevelScaling.DynamicLevel.PerInstance", ""), logReady);
+
+        newConfig.RewardScalingMethod = ParseScalingMethod("AutoBalance.RewardScaling.Method", ScalingMethod::Dynamic, logReady);
+        newConfig.RewardScalingXP = sConfigMgr->GetBoolDefault("AutoBalance.RewardScaling.XP", false);
+        newConfig.RewardScalingXPModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.RewardScaling.XP.Modifier", 1.0f));
+        newConfig.RewardScalingMoney = sConfigMgr->GetBoolDefault("AutoBalance.RewardScaling.Money", false);
+        newConfig.RewardScalingMoneyModifier = static_cast<float>(sConfigMgr->GetFloatDefault("AutoBalance.RewardScaling.Money.Modifier", 1.0f));
 
         auto const defaultInflection = InflectionPointSettings{};
         newConfig.DungeonInflection = ParseInflectionPointSettings("AutoBalance.InflectionPoint", "AutoBalance.InflectionPoint.CurveFloor", "AutoBalance.InflectionPoint.CurveCeiling", "AutoBalance.InflectionPoint.BossModifier", defaultInflection);

--- a/src/server/game/AutoBalance/AutoBalanceConfig.h
+++ b/src/server/game/AutoBalance/AutoBalanceConfig.h
@@ -11,6 +11,20 @@ namespace AutoBalance
 {
     inline constexpr char const* LogFilter = "module.AutoBalance";
 
+    enum class ScalingMethod : uint8
+    {
+        Fixed,
+        Dynamic
+    };
+
+    struct LevelScalingSettings
+    {
+        int8 Floor = 0;
+        int8 Ceiling = 0;
+        int8 SkipHigher = -1;
+        int8 SkipLower = -1;
+    };
+
     enum class InstanceDifficultyToggle : uint8
     {
         Normal5,
@@ -92,6 +106,22 @@ namespace AutoBalance
         float MinHPModifier = 0.01f;
         float MinManaModifier = 0.01f;
         float MinDamageModifier = 0.01f;
+
+        bool LevelScalingEnabled = false;
+        ScalingMethod LevelScalingMethod = ScalingMethod::Dynamic;
+        int8 LevelScalingSkipHigherLevels = 0;
+        int8 LevelScalingSkipLowerLevels = 0;
+        LevelScalingSettings LevelScalingDungeonSettings{5, 1, -1, -1};
+        LevelScalingSettings LevelScalingHeroicDungeonSettings{5, 2, -1, -1};
+        LevelScalingSettings LevelScalingRaidSettings{5, 3, -1, -1};
+        LevelScalingSettings LevelScalingHeroicRaidSettings{5, 3, -1, -1};
+        std::unordered_map<uint32, LevelScalingSettings> LevelScalingOverridesByInstance;
+
+        bool RewardScalingXP = false;
+        bool RewardScalingMoney = false;
+        float RewardScalingXPModifier = 1.0f;
+        float RewardScalingMoneyModifier = 1.0f;
+        ScalingMethod RewardScalingMethod = ScalingMethod::Dynamic;
 
         InflectionPointSettings DungeonInflection;
         InflectionPointSettings DungeonHeroicInflection;

--- a/src/server/game/AutoBalance/AutoBalanceCreature.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceCreature.cpp
@@ -127,6 +127,44 @@ namespace
         return multiplier;
     }
 
+    float GetBaseExpansionValueForLevel(float const (&baseValues)[MAX_EXPANSIONS], uint8 targetLevel)
+    {
+        float const vanilla = baseValues[EXPANSION_CLASSIC];
+        float const burningCrusade = baseValues[EXPANSION_THE_BURNING_CRUSADE];
+        float const wrath = baseValues[EXPANSION_WRATH_OF_THE_LICH_KING];
+
+        if (targetLevel <= 60)
+            return vanilla;
+
+        if (targetLevel < 63)
+        {
+            float const vanillaMultiplier = (63.0f - static_cast<float>(targetLevel)) / 3.0f;
+            float const bcMultiplier = 1.0f - vanillaMultiplier;
+            return vanilla * vanillaMultiplier + burningCrusade * bcMultiplier;
+        }
+
+        if (targetLevel <= 70)
+            return burningCrusade;
+
+        if (targetLevel < 73)
+        {
+            float const bcMultiplier = (73.0f - static_cast<float>(targetLevel)) / 3.0f;
+            float const wrathMultiplier = 1.0f - bcMultiplier;
+            return burningCrusade * bcMultiplier + wrath * wrathMultiplier;
+        }
+
+        return wrath;
+    }
+
+    float GetBaseExpansionValueForLevel(uint32 const (&baseValues)[MAX_EXPANSIONS], uint8 targetLevel)
+    {
+        float converted[MAX_EXPANSIONS];
+        for (uint8 i = 0; i < MAX_EXPANSIONS; ++i)
+            converted[i] = static_cast<float>(baseValues[i]);
+
+        return GetBaseExpansionValueForLevel(converted, targetLevel);
+    }
+
     InflectionPointSettings SelectInflectionSettings(ModuleConfig const& config, Map const* map, uint32 targetPlayers, bool isBoss)
     {
         InflectionPointSettings settings = map->IsRaid()
@@ -294,6 +332,9 @@ void ScaleCreature(Creature* creature)
     uint32 const effectivePlayers = GetEffectivePlayerCount(map);
     uint32 const targetPlayers = GetTargetPlayerCount(map);
     bool const isBoss = IsBossCreature(*creature);
+    uint8 highestPlayerLevel = GetHighestPlayerLevel(map);
+    if (!highestPlayerLevel)
+        highestPlayerLevel = creature->GetLevel();
 
     InflectionPointSettings const inflectionSettings = SelectInflectionSettings(config, map, targetPlayers, isBoss);
     float const baseMultiplier = EvaluateInflectionMultiplier(effectivePlayers, targetPlayers, inflectionSettings);
@@ -322,46 +363,116 @@ void ScaleCreature(Creature* creature)
     if (!creatureTemplate)
         return;
 
+    AutoBalanceCreatureInfo& info = GetCreatureInfo(*creature);
+
     uint8 const level = creature->GetLevel();
-    CreatureBaseStats const* baseStats = sObjectMgr->GetCreatureBaseStats(level, creatureTemplate->unit_class);
-    if (!baseStats)
+    uint8 const unmodifiedLevel = info.Initialized ? info.UnmodifiedLevel : level;
+
+    CreatureBaseStats const* originalBaseStats = sObjectMgr->GetCreatureBaseStats(unmodifiedLevel, creatureTemplate->unit_class);
+    if (!originalBaseStats)
         return;
 
-    AutoBalanceCreatureInfo& info = GetCreatureInfo(*creature);
+    CreatureBaseStats const* levelBaseStats = sObjectMgr->GetCreatureBaseStats(level, creatureTemplate->unit_class);
+    if (!levelBaseStats)
+        return;
+
+    CreatureBaseValues originalBaseValues;
+    originalBaseValues.Health = originalBaseStats->GenerateHealth(creatureTemplate);
+    originalBaseValues.Mana = originalBaseStats->GenerateMana(creatureTemplate);
+    originalBaseValues.Armor = originalBaseStats->GenerateArmor(creatureTemplate);
+    float const originalBaseDamage = originalBaseStats->GenerateBaseDamage(creatureTemplate);
+    originalBaseValues.MinDamage = originalBaseDamage;
+    originalBaseValues.MaxDamage = originalBaseDamage * 1.5f;
+    originalBaseValues.AttackPower = static_cast<float>(originalBaseStats->AttackPower);
+    originalBaseValues.RangedAttackPower = static_cast<float>(originalBaseStats->RangedAttackPower);
+
+    CreatureBaseValues levelBaseValues;
+    float const smoothedBaseHealth = GetBaseExpansionValueForLevel(levelBaseStats->BaseHealth, highestPlayerLevel);
+    levelBaseValues.Health = static_cast<uint32>(std::round(smoothedBaseHealth * creatureTemplate->ModHealth));
+    levelBaseValues.Mana = levelBaseStats->GenerateMana(creatureTemplate);
+    levelBaseValues.Armor = levelBaseStats->GenerateArmor(creatureTemplate);
+    float const levelBaseDamage = GetBaseExpansionValueForLevel(levelBaseStats->BaseDamage, highestPlayerLevel);
+    levelBaseValues.MinDamage = levelBaseDamage;
+    levelBaseValues.MaxDamage = levelBaseDamage * 1.5f;
+    levelBaseValues.AttackPower = static_cast<float>(levelBaseStats->AttackPower);
+    levelBaseValues.RangedAttackPower = static_cast<float>(levelBaseStats->RangedAttackPower);
+
+    auto computeLevelMultiplier = [](float originalValue, float newValue)
+    {
+        if (originalValue <= 0.0f)
+            return 1.0f;
+
+        float multiplier = newValue / originalValue;
+        if (!std::isfinite(multiplier) || multiplier <= 0.0f)
+            return 1.0f;
+
+        return multiplier;
+    };
+
+    float const levelHealthMultiplier = computeLevelMultiplier(static_cast<float>(originalBaseValues.Health), static_cast<float>(levelBaseValues.Health));
+    float const levelManaMultiplier = computeLevelMultiplier(static_cast<float>(originalBaseValues.Mana), static_cast<float>(levelBaseValues.Mana));
+    float const levelArmorMultiplier = computeLevelMultiplier(static_cast<float>(originalBaseValues.Armor), static_cast<float>(levelBaseValues.Armor));
+    float const levelDamageMultiplier = computeLevelMultiplier(originalBaseValues.MinDamage, levelBaseValues.MinDamage);
+    float const levelAttackPowerMultiplier = computeLevelMultiplier(originalBaseValues.AttackPower, levelBaseValues.AttackPower);
+    float const levelRangedAttackPowerMultiplier = computeLevelMultiplier(originalBaseValues.RangedAttackPower, levelBaseValues.RangedAttackPower);
+
+    CreatureMultipliers const baseMultipliers = { healthMultiplier, manaMultiplier, damageMultiplier, armorMultiplier, crowdControlMultiplier };
+    CreatureMultipliers const finalMultipliers =
+    {
+        healthMultiplier * levelHealthMultiplier,
+        manaMultiplier * levelManaMultiplier,
+        damageMultiplier * levelDamageMultiplier,
+        armorMultiplier * levelArmorMultiplier,
+        crowdControlMultiplier
+    };
+
+    auto multipliersDiffer = [](float lhs, float rhs)
+    {
+        return std::fabs(lhs - rhs) > 0.0005f;
+    };
+
+    auto baseValuesDiffer = [](CreatureBaseValues const& lhs, CreatureBaseValues const& rhs)
+    {
+        auto floatsDiffer = [](float l, float r)
+        {
+            return std::fabs(l - r) > 0.0005f;
+        };
+
+        return lhs.Health != rhs.Health || lhs.Mana != rhs.Mana || lhs.Armor != rhs.Armor ||
+            floatsDiffer(lhs.MinDamage, rhs.MinDamage) || floatsDiffer(lhs.MaxDamage, rhs.MaxDamage) ||
+            floatsDiffer(lhs.AttackPower, rhs.AttackPower) || floatsDiffer(lhs.RangedAttackPower, rhs.RangedAttackPower);
+    };
 
     bool const requiresUpdate = !info.Initialized ||
         info.BaseLevel != level ||
         info.TargetPlayerCount != targetPlayers ||
         info.EffectivePlayerCount != effectivePlayers ||
-        std::fabs(info.Multipliers.Health - healthMultiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Mana - manaMultiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Damage - damageMultiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.Armor - armorMultiplier) > 0.0005f ||
-        std::fabs(info.Multipliers.CrowdControlDuration - crowdControlMultiplier) > 0.0005f;
+        multipliersDiffer(info.BaseMultipliers.Health, baseMultipliers.Health) ||
+        multipliersDiffer(info.BaseMultipliers.Mana, baseMultipliers.Mana) ||
+        multipliersDiffer(info.BaseMultipliers.Damage, baseMultipliers.Damage) ||
+        multipliersDiffer(info.BaseMultipliers.Armor, baseMultipliers.Armor) ||
+        multipliersDiffer(info.BaseMultipliers.CrowdControlDuration, baseMultipliers.CrowdControlDuration) ||
+        multipliersDiffer(info.Multipliers.Health, finalMultipliers.Health) ||
+        multipliersDiffer(info.Multipliers.Mana, finalMultipliers.Mana) ||
+        multipliersDiffer(info.Multipliers.Damage, finalMultipliers.Damage) ||
+        multipliersDiffer(info.Multipliers.Armor, finalMultipliers.Armor) ||
+        multipliersDiffer(info.Multipliers.CrowdControlDuration, finalMultipliers.CrowdControlDuration) ||
+        baseValuesDiffer(info.LevelScaledBaseValues, levelBaseValues);
 
     if (!requiresUpdate)
         return;
 
-    info.BaseValues.Health = baseStats->GenerateHealth(creatureTemplate);
-    info.BaseValues.Mana = baseStats->GenerateMana(creatureTemplate);
-    info.BaseValues.Armor = baseStats->GenerateArmor(creatureTemplate);
+    if (!info.Initialized)
+        info.UnmodifiedLevel = unmodifiedLevel;
 
-    float const baseDamage = baseStats->GenerateBaseDamage(creatureTemplate);
-    info.BaseValues.MinDamage = baseDamage;
-    info.BaseValues.MaxDamage = baseDamage * 1.5f;
-    info.BaseValues.AttackPower = static_cast<float>(baseStats->AttackPower);
-    info.BaseValues.RangedAttackPower = static_cast<float>(baseStats->RangedAttackPower);
-
+    info.BaseValues = originalBaseValues;
+    info.LevelScaledBaseValues = levelBaseValues;
     info.BaseLevel = level;
     info.TargetPlayerCount = targetPlayers;
     info.EffectivePlayerCount = effectivePlayers;
+    info.BaseMultipliers = baseMultipliers;
+    info.Multipliers = finalMultipliers;
     info.Initialized = true;
-
-    info.Multipliers.Health = healthMultiplier;
-    info.Multipliers.Mana = manaMultiplier;
-    info.Multipliers.Damage = damageMultiplier;
-    info.Multipliers.Armor = armorMultiplier;
-    info.Multipliers.CrowdControlDuration = crowdControlMultiplier;
 
     uint32 const oldMaxHealth = creature->GetMaxHealth();
     float const healthPct = oldMaxHealth ? std::clamp(static_cast<float>(creature->GetHealth()) / static_cast<float>(oldMaxHealth), 0.0f, 1.0f) : 1.0f;
@@ -398,15 +509,23 @@ void ScaleCreature(Creature* creature)
         creature->SetBaseWeaponDamage(attackType, MAXDAMAGE, scaledMaxDamage);
     }
 
-    creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, BASE_VALUE, info.BaseValues.AttackPower * info.Multipliers.Damage);
-    creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, BASE_VALUE, info.BaseValues.RangedAttackPower * info.Multipliers.Damage);
+    float const attackPowerMultiplier = info.BaseMultipliers.Damage * levelAttackPowerMultiplier;
+    float const rangedAttackPowerMultiplier = info.BaseMultipliers.Damage * levelRangedAttackPowerMultiplier;
+    creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, BASE_VALUE, info.BaseValues.AttackPower * attackPowerMultiplier);
+    creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, BASE_VALUE, info.BaseValues.RangedAttackPower * rangedAttackPowerMultiplier);
 
     creature->UpdateDamagePhysical(BASE_ATTACK);
     creature->UpdateDamagePhysical(OFF_ATTACK);
     creature->UpdateDamagePhysical(RANGED_ATTACK);
 
     if (config.DebugLogging)
-        TC_LOG_DEBUG(LogFilter, "AutoBalance::ScaleCreature - entry={} level={} players={}/{} base={:.3f} health={:.3f} mana={:.3f} damage={:.3f} armor={:.3f} cc={:.3f}",
-            creature->GetEntry(), level, effectivePlayers, targetPlayers, baseMultiplier, info.Multipliers.Health, info.Multipliers.Mana, info.Multipliers.Damage, info.Multipliers.Armor, info.Multipliers.CrowdControlDuration);
+        TC_LOG_DEBUG(LogFilter,
+            "AutoBalance::ScaleCreature - entry={} level={} players={}/{} base={:.3f} baseMult(h/m/d/a)={:.3f}/{:.3f}/{:.3f}/{:.3f} "
+            "levelAdj(h/m/d/a)={:.3f}/{:.3f}/{:.3f}/{:.3f} final(h/m/d/a)={:.3f}/{:.3f}/{:.3f}/{:.3f} cc={:.3f}",
+            creature->GetEntry(), level, effectivePlayers, targetPlayers, baseMultiplier,
+            info.BaseMultipliers.Health, info.BaseMultipliers.Mana, info.BaseMultipliers.Damage, info.BaseMultipliers.Armor,
+            levelHealthMultiplier, levelManaMultiplier, levelDamageMultiplier, levelArmorMultiplier,
+            info.Multipliers.Health, info.Multipliers.Mana, info.Multipliers.Damage, info.Multipliers.Armor,
+            info.Multipliers.CrowdControlDuration);
 }
 }

--- a/src/server/game/AutoBalance/AutoBalanceCreature.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceCreature.cpp
@@ -364,8 +364,11 @@ void ScaleCreature(Creature* creature)
         return;
 
     AutoBalanceCreatureInfo& info = GetCreatureInfo(*creature);
+    info.IsBoss = isBoss;
+    info.InstancePlayerCount = effectivePlayers;
 
     uint8 const level = creature->GetLevel();
+    info.SelectedLevel = level;
     uint8 const unmodifiedLevel = info.Initialized ? info.UnmodifiedLevel : level;
 
     CreatureBaseStats const* originalBaseStats = sObjectMgr->GetCreatureBaseStats(unmodifiedLevel, creatureTemplate->unit_class);
@@ -472,6 +475,8 @@ void ScaleCreature(Creature* creature)
     info.EffectivePlayerCount = effectivePlayers;
     info.BaseMultipliers = baseMultipliers;
     info.Multipliers = finalMultipliers;
+    info.XPModifier = 1.0f;
+    info.MoneyModifier = 1.0f;
     info.Initialized = true;
 
     uint32 const oldMaxHealth = creature->GetMaxHealth();
@@ -513,6 +518,46 @@ void ScaleCreature(Creature* creature)
     float const rangedAttackPowerMultiplier = info.BaseMultipliers.Damage * levelRangedAttackPowerMultiplier;
     creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, BASE_VALUE, info.BaseValues.AttackPower * attackPowerMultiplier);
     creature->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, BASE_VALUE, info.BaseValues.RangedAttackPower * rangedAttackPowerMultiplier);
+
+    if (TempSummon* summon = creature->ToTempSummon())
+    {
+        info.IsSummon = true;
+        if (Unit* summoner = summon->GetSummonerUnit())
+        {
+            if (Creature* summonerCreature = summoner->ToCreature())
+            {
+                info.SummonerName = summonerCreature->GetName();
+                info.SummonerLevel = summonerCreature->GetLevel();
+            }
+            else if (Player* summonerPlayer = summoner->ToPlayer())
+            {
+                info.SummonerName = summonerPlayer->GetName();
+                info.SummonerLevel = summonerPlayer->GetLevel();
+            }
+        }
+    }
+    else
+    {
+        info.IsSummon = false;
+        info.SummonerName.clear();
+        info.SummonerLevel = 0;
+        info.IsSummonClone = false;
+    }
+
+    auto computeRewardModifier = [&](bool enabled, float modifier)
+    {
+        if (!enabled)
+            return 1.0f;
+
+        if (config.RewardScalingMethod == ScalingMethod::Fixed)
+            return modifier;
+
+        float avg = (finalMultipliers.Health + finalMultipliers.Damage) / 2.0f;
+        return std::max(0.0f, avg * modifier);
+    };
+
+    info.XPModifier = computeRewardModifier(config.RewardScalingXP, config.RewardScalingXPModifier);
+    info.MoneyModifier = computeRewardModifier(config.RewardScalingMoney, config.RewardScalingMoneyModifier);
 
     creature->UpdateDamagePhysical(BASE_ATTACK);
     creature->UpdateDamagePhysical(OFF_ATTACK);

--- a/src/server/game/AutoBalance/AutoBalanceCreatureInfo.h
+++ b/src/server/game/AutoBalance/AutoBalanceCreatureInfo.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Define.h"
+#include <string>
 
 namespace AutoBalance
 {
@@ -32,8 +33,18 @@ namespace AutoBalance
         CreatureMultipliers Multipliers;
         uint8 BaseLevel = 0;
         uint8 UnmodifiedLevel = 0;
+        uint8 SelectedLevel = 0;
         uint32 TargetPlayerCount = 0;
         uint32 EffectivePlayerCount = 0;
+        uint32 InstancePlayerCount = 0;
+        float XPModifier = 1.0f;
+        float MoneyModifier = 1.0f;
+        bool IsBoss = false;
+        bool IsSummon = false;
+        bool IsSummonClone = false;
+        bool ActiveForMapStats = true;
+        std::string SummonerName;
+        uint8 SummonerLevel = 0;
         bool Initialized = false;
     };
 }

--- a/src/server/game/AutoBalance/AutoBalanceCreatureInfo.h
+++ b/src/server/game/AutoBalance/AutoBalanceCreatureInfo.h
@@ -27,8 +27,11 @@ namespace AutoBalance
     struct AutoBalanceCreatureInfo
     {
         CreatureBaseValues BaseValues;
+        CreatureBaseValues LevelScaledBaseValues;
+        CreatureMultipliers BaseMultipliers;
         CreatureMultipliers Multipliers;
         uint8 BaseLevel = 0;
+        uint8 UnmodifiedLevel = 0;
         uint32 TargetPlayerCount = 0;
         uint32 EffectivePlayerCount = 0;
         bool Initialized = false;

--- a/src/server/game/AutoBalance/AutoBalanceMapData.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceMapData.cpp
@@ -32,6 +32,27 @@ namespace
         return map->IsHeroic() ? config.MinimumPlayersHeroic : config.MinimumPlayers;
     }
 
+    uint8 ComputeHighestPlayerLevel(Map const* map)
+    {
+        if (!map)
+            return 0;
+
+        uint8 highest = 0;
+        Map::PlayerList const& players = map->GetPlayers();
+        for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+        {
+            if (Player const* player = itr->GetSource())
+            {
+                if (player->IsGameMaster())
+                    continue;
+
+                highest = std::max<uint8>(highest, player->GetLevel());
+            }
+        }
+
+        return highest;
+    }
+
     void UpdateEffectivePlayerCountInternal(Map* map, uint32 now)
     {
         auto& data = GetMapData(map);
@@ -39,14 +60,52 @@ namespace
 
         data.QueueOffset = config.PlayerCountDifficultyOffset;
 
-        int32 const adjustedPlayerCount = std::max<int32>(0, static_cast<int32>(data.PlayerCount) + data.QueueOffset);
-        uint32 effectivePlayerCount = static_cast<uint32>(adjustedPlayerCount);
+        uint32 playerCount = data.PlayerCount;
+        if (map->IsDungeon())
+            playerCount = std::max<uint32>(playerCount, 1u);
+
+        uint32 effectivePlayerCount = playerCount;
+
+        if (map->IsDungeon())
+        {
+            if (data.CombatLocked)
+            {
+                if (playerCount > data.CombatLockMinPlayers)
+                {
+                    data.CombatLockMinPlayers = playerCount;
+                    data.CombatLockTripped = false;
+                }
+                else if (playerCount < data.CombatLockMinPlayers)
+                {
+                    data.CombatLockTripped = true;
+                }
+
+                effectivePlayerCount = std::max(playerCount, data.CombatLockMinPlayers);
+            }
+            else
+            {
+                data.CombatLockMinPlayers = 0;
+                data.CombatLockTripped = false;
+            }
+        }
+        else
+        {
+            data.CombatLockMinPlayers = 0;
+            data.CombatLockTripped = false;
+        }
 
         uint32 const minimumPlayers = GetMinimumPlayersForMap(map);
         if (effectivePlayerCount < minimumPlayers)
             effectivePlayerCount = minimumPlayers;
 
-        data.EffectivePlayerCount = effectivePlayerCount;
+        int32 adjustedPlayerCount = static_cast<int32>(effectivePlayerCount) + data.QueueOffset;
+        if (adjustedPlayerCount < 1)
+            adjustedPlayerCount = 1;
+
+        data.EffectivePlayerCount = static_cast<uint32>(adjustedPlayerCount);
+        uint8 const computedHighest = ComputeHighestPlayerLevel(map);
+        if (computedHighest || data.PlayerCount == 0)
+            data.HighestPlayerLevel = computedHighest;
         data.LastPlayerCountUpdateTimeMS = now;
     }
 }
@@ -72,7 +131,7 @@ void HandleMapDestroy(Map* map)
     GetMapData(map) = Map::CustomData::AutoBalanceData{};
 }
 
-void HandlePlayerEnter(Map* map, Player* /*player*/)
+void HandlePlayerEnter(Map* map, Player* player)
 {
     if (!map)
         return;
@@ -82,6 +141,8 @@ void HandlePlayerEnter(Map* map, Player* /*player*/)
 
     ++data.PlayerCount;
     data.LastPlayerJoinTimeMS = now;
+    if (player && !player->IsGameMaster())
+        data.HighestPlayerLevel = std::max<uint8>(data.HighestPlayerLevel, player->GetLevel());
     UpdateEffectivePlayerCountInternal(map, now);
 }
 
@@ -97,6 +158,7 @@ void HandlePlayerLeave(Map* map, Player* /*player*/)
         --data.PlayerCount;
 
     data.LastPlayerLeaveTimeMS = now;
+    data.HighestPlayerLevel = ComputeHighestPlayerLevel(map);
     UpdateEffectivePlayerCountInternal(map, now);
 }
 
@@ -116,9 +178,26 @@ void HandleCombatStateChange(Map* map, bool locked, Player* /*player*/)
     data.LastCombatStateChangeTimeMS = now;
 
     if (locked)
+    {
         data.LastCombatStartTimeMS = now;
+
+        if (map->IsDungeon())
+        {
+            uint32 const playerCount = std::max<uint32>(data.PlayerCount, 1u);
+            if (playerCount > data.CombatLockMinPlayers)
+                data.CombatLockMinPlayers = playerCount;
+
+            data.CombatLockTripped = false;
+        }
+    }
     else
+    {
         data.LastCombatEndTimeMS = now;
+        data.CombatLockMinPlayers = 0;
+        data.CombatLockTripped = false;
+    }
+
+    UpdateEffectivePlayerCountInternal(map, now);
 }
 
 void RefreshEffectivePlayerCount(Map* map)
@@ -143,5 +222,13 @@ uint32 GetEffectivePlayerCount(Map const* map)
         return 0;
 
     return GetMapData(map).EffectivePlayerCount;
+}
+
+uint8 GetHighestPlayerLevel(Map const* map)
+{
+    if (!map)
+        return 0;
+
+    return GetMapData(map).HighestPlayerLevel;
 }
 }

--- a/src/server/game/AutoBalance/AutoBalanceMapData.h
+++ b/src/server/game/AutoBalance/AutoBalanceMapData.h
@@ -17,4 +17,5 @@ namespace AutoBalance
 
     uint32 GetActivePlayerCount(Map const* map);
     uint32 GetEffectivePlayerCount(Map const* map);
+    uint8 GetHighestPlayerLevel(Map const* map);
 }

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -330,6 +330,8 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
                 uint32 PlayerCount = 0;
                 uint32 EffectivePlayerCount = 0;
                 int32 QueueOffset = 0;
+                uint8 HighestPlayerLevel = 0;
+                uint32 CombatLockMinPlayers = 0;
                 uint32 LastPlayerJoinTimeMS = 0;
                 uint32 LastPlayerLeaveTimeMS = 0;
                 uint32 LastPlayerCountUpdateTimeMS = 0;
@@ -338,6 +340,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
                 uint32 LastCombatStateChangeTimeMS = 0;
                 bool CombatLocked = false;
                 bool CombatStateDirty = false;
+                bool CombatLockTripped = false;
             };
 
             AutoBalanceData AutoBalance;

--- a/src/server/scripts/Custom/AutoBalance/AutoBalanceCommands.cpp
+++ b/src/server/scripts/Custom/AutoBalance/AutoBalanceCommands.cpp
@@ -175,14 +175,22 @@ public:
 
         handler->PSendSysMessage("AutoBalance stats for %s (entry %u):",
             creature->GetName().c_str(), creature->GetEntry());
-        handler->PSendSysMessage(" Level: %u | Target players: %u | Effective players: %u",
-            info->BaseLevel, info->TargetPlayerCount, info->EffectivePlayerCount);
-        handler->PSendSysMessage(" Base Health: %u | Base Mana: %u | Base Armor: %u",
+        handler->PSendSysMessage(" Original level: %u | Current level: %u | Target players: %u | Effective players: %u",
+            info->UnmodifiedLevel, info->BaseLevel, info->TargetPlayerCount, info->EffectivePlayerCount);
+        handler->PSendSysMessage(" Original base -> Health: %u | Mana: %u | Armor: %u",
             info->BaseValues.Health, info->BaseValues.Mana, info->BaseValues.Armor);
-        handler->PSendSysMessage(" Base Damage: %.3f - %.3f | Base AP: %.3f | Base RAP: %.3f",
+        handler->PSendSysMessage(" Original base -> Damage: %.3f - %.3f | AP: %.3f | RAP: %.3f",
             info->BaseValues.MinDamage, info->BaseValues.MaxDamage,
             info->BaseValues.AttackPower, info->BaseValues.RangedAttackPower);
-        handler->PSendSysMessage(" Multipliers -> Health: %.3f | Mana: %.3f | Damage: %.3f | Armor: %.3f | CC: %.3f",
+        handler->PSendSysMessage(" Level-scaled base -> Health: %u | Mana: %u | Armor: %u",
+            info->LevelScaledBaseValues.Health, info->LevelScaledBaseValues.Mana, info->LevelScaledBaseValues.Armor);
+        handler->PSendSysMessage(" Level-scaled base -> Damage: %.3f - %.3f | AP: %.3f | RAP: %.3f",
+            info->LevelScaledBaseValues.MinDamage, info->LevelScaledBaseValues.MaxDamage,
+            info->LevelScaledBaseValues.AttackPower, info->LevelScaledBaseValues.RangedAttackPower);
+        handler->PSendSysMessage(" Base multipliers -> Health: %.3f | Mana: %.3f | Damage: %.3f | Armor: %.3f | CC: %.3f",
+            info->BaseMultipliers.Health, info->BaseMultipliers.Mana, info->BaseMultipliers.Damage,
+            info->BaseMultipliers.Armor, info->BaseMultipliers.CrowdControlDuration);
+        handler->PSendSysMessage(" Final multipliers -> Health: %.3f | Mana: %.3f | Damage: %.3f | Armor: %.3f | CC: %.3f",
             info->Multipliers.Health, info->Multipliers.Mana, info->Multipliers.Damage,
             info->Multipliers.Armor, info->Multipliers.CrowdControlDuration);
 

--- a/src/server/scripts/Custom/AutoBalance/AutoBalanceCommands.cpp
+++ b/src/server/scripts/Custom/AutoBalance/AutoBalanceCommands.cpp
@@ -29,6 +29,7 @@
 #include "Player.h"
 #include "RBAC.h"
 #include "StringFormat.h"
+#include <algorithm>
 #include <string>
 
 using namespace Trinity::ChatCommands;
@@ -88,6 +89,23 @@ namespace
         return map;
     }
 
+    bool IsMapEnabled(Map const* map, AutoBalance::ModuleConfig const& config)
+    {
+        if (!map)
+            return false;
+
+        if (std::find(config.DisabledInstances.begin(), config.DisabledInstances.end(), map->GetId()) != config.DisabledInstances.end())
+            return false;
+
+        if (!map->IsDungeon())
+            return config.EnableWorldMaps;
+
+        if (map->IsRaid())
+            return config.EnableRaids;
+
+        return config.EnableDungeons;
+    }
+
     uint32 CalculateMinimumPlayers(Map const* map, AutoBalance::ModuleConfig const& config)
     {
         if (!map)
@@ -135,19 +153,65 @@ public:
         Map::CustomData::AutoBalanceData const& data = map->GetCustomData().AutoBalance;
         uint32 const now = GameTime::GetGameTimeMS();
 
-        handler->PSendSysMessage("AutoBalance map stats for map %u (instance %u):", mapId, instanceId);
-        handler->PSendSysMessage(" Active players: %u | Effective players: %u | Minimum players: %u",
-            data.PlayerCount, data.EffectivePlayerCount, CalculateMinimumPlayers(map, config));
-        handler->PSendSysMessage(" Global offset: %d | Applied offset: %d",
-            AutoBalance::GetPlayerCountDifficultyOffset(), data.QueueOffset);
-        handler->PSendSysMessage(" Last join: %s | Last leave: %s | Last count update: %s",
+        InstanceMap* instanceMap = map->ToInstanceMap();
+        uint32 const maxPlayers = instanceMap ? instanceMap->GetMaxPlayers() : 0u;
+        bool const heroic = instanceMap ? instanceMap->IsHeroic() : map->IsHeroic();
+        bool const enabled = IsMapEnabled(map, config) && AutoBalance::IsEnabled();
+
+        handler->PSendSysMessage("---");
+        handler->PSendSysMessage("%s (%u-player %s) | ID %u-%u%s",
+            map->GetMapName(),
+            maxPlayers,
+            heroic ? "Heroic" : "Normal",
+            mapId,
+            instanceId,
+            enabled ? "" : " | AutoBalance DISABLED");
+
+        uint32 nonGMPlayers = 0;
+        uint8 lowestLevel = 0;
+        uint8 highestLevel = 0;
+        Map::PlayerList const& players = map->GetPlayers();
+        for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+        {
+            if (Player const* player = itr->GetSource())
+            {
+                if (player->IsGameMaster())
+                    continue;
+
+                ++nonGMPlayers;
+                uint8 level = player->GetLevel();
+                if (!lowestLevel || level < lowestLevel)
+                    lowestLevel = level;
+                if (level > highestLevel)
+                    highestLevel = level;
+            }
+        }
+
+        handler->PSendSysMessage("Players on map: %u (Lvl %u - %u)", nonGMPlayers, lowestLevel, highestLevel);
+
+        uint32 const minimumPlayers = CalculateMinimumPlayers(map, config);
+        if (data.CombatLocked && data.CombatLockTripped)
+            handler->PSendSysMessage("Adjusted player count: %u (combat locked)", data.EffectivePlayerCount);
+        else if (nonGMPlayers < minimumPlayers && data.QueueOffset)
+            handler->PSendSysMessage("Adjusted player count: %u (map minimum + offset %d)", data.EffectivePlayerCount, data.QueueOffset);
+        else if (nonGMPlayers < minimumPlayers)
+            handler->PSendSysMessage("Adjusted player count: %u (map minimum)", data.EffectivePlayerCount);
+        else if (data.QueueOffset)
+            handler->PSendSysMessage("Adjusted player count: %u (offset %d)", data.EffectivePlayerCount, data.QueueOffset);
+        else
+            handler->PSendSysMessage("Adjusted player count: %u", data.EffectivePlayerCount);
+
+        handler->PSendSysMessage("Minimum players: %u | Global offset: %d",
+            minimumPlayers, AutoBalance::GetPlayerCountDifficultyOffset());
+
+        handler->PSendSysMessage("Last join: %s | Last leave: %s | Last count update: %s",
             FormatTimeSince(data.LastPlayerJoinTimeMS, now).c_str(),
             FormatTimeSince(data.LastPlayerLeaveTimeMS, now).c_str(),
             FormatTimeSince(data.LastPlayerCountUpdateTimeMS, now).c_str());
-        handler->PSendSysMessage(" Combat locked: %s | Dirty state: %s",
+        handler->PSendSysMessage("Combat locked: %s | Dirty state: %s",
             data.CombatLocked ? "yes" : "no",
             data.CombatStateDirty ? "yes" : "no");
-        handler->PSendSysMessage(" Last combat start: %s | Last combat end: %s",
+        handler->PSendSysMessage("Last combat start: %s | Last combat end: %s",
             FormatTimeSince(data.LastCombatStartTimeMS, now).c_str(),
             FormatTimeSince(data.LastCombatEndTimeMS, now).c_str());
 
@@ -173,26 +237,44 @@ public:
             return false;
         }
 
-        handler->PSendSysMessage("AutoBalance stats for %s (entry %u):",
-            creature->GetName().c_str(), creature->GetEntry());
-        handler->PSendSysMessage(" Original level: %u | Current level: %u | Target players: %u | Effective players: %u",
-            info->UnmodifiedLevel, info->BaseLevel, info->TargetPlayerCount, info->EffectivePlayerCount);
-        handler->PSendSysMessage(" Original base -> Health: %u | Mana: %u | Armor: %u",
-            info->BaseValues.Health, info->BaseValues.Mana, info->BaseValues.Armor);
-        handler->PSendSysMessage(" Original base -> Damage: %.3f - %.3f | AP: %.3f | RAP: %.3f",
-            info->BaseValues.MinDamage, info->BaseValues.MaxDamage,
-            info->BaseValues.AttackPower, info->BaseValues.RangedAttackPower);
-        handler->PSendSysMessage(" Level-scaled base -> Health: %u | Mana: %u | Armor: %u",
-            info->LevelScaledBaseValues.Health, info->LevelScaledBaseValues.Mana, info->LevelScaledBaseValues.Armor);
-        handler->PSendSysMessage(" Level-scaled base -> Damage: %.3f - %.3f | AP: %.3f | RAP: %.3f",
-            info->LevelScaledBaseValues.MinDamage, info->LevelScaledBaseValues.MaxDamage,
-            info->LevelScaledBaseValues.AttackPower, info->LevelScaledBaseValues.RangedAttackPower);
-        handler->PSendSysMessage(" Base multipliers -> Health: %.3f | Mana: %.3f | Damage: %.3f | Armor: %.3f | CC: %.3f",
-            info->BaseMultipliers.Health, info->BaseMultipliers.Mana, info->BaseMultipliers.Damage,
-            info->BaseMultipliers.Armor, info->BaseMultipliers.CrowdControlDuration);
-        handler->PSendSysMessage(" Final multipliers -> Health: %.3f | Mana: %.3f | Damage: %.3f | Armor: %.3f | CC: %.3f",
-            info->Multipliers.Health, info->Multipliers.Mana, info->Multipliers.Damage,
-            info->Multipliers.Armor, info->Multipliers.CrowdControlDuration);
+        handler->PSendSysMessage("---");
+
+        std::string levelInfo = Trinity::StringFormat("%u", info->UnmodifiedLevel);
+        if (info->SelectedLevel && info->SelectedLevel != info->UnmodifiedLevel)
+            levelInfo += Trinity::StringFormat("->%u", info->SelectedLevel);
+
+        std::string flags;
+        if (info->IsBoss)
+            flags += " | Boss";
+
+        handler->PSendSysMessage("%s (%s%s), %s",
+            creature->GetName().c_str(), levelInfo.c_str(), flags.c_str(),
+            info->ActiveForMapStats ? "active for map stats" : "ignored for map stats");
+
+        handler->PSendSysMessage("Creature difficulty level: %u", info->InstancePlayerCount);
+
+        if (info->IsSummon)
+        {
+            if (!info->SummonerName.empty())
+                handler->PSendSysMessage("Summon of %s (Lvl %u)", info->SummonerName.c_str(), info->SummonerLevel);
+            else
+                handler->PSendSysMessage("Summon without summoner data");
+        }
+
+        auto printMultiplier = [&](char const* label, float baseMultiplier, float finalMultiplier)
+        {
+            if (info->SelectedLevel && info->SelectedLevel != info->UnmodifiedLevel)
+                handler->PSendSysMessage("%s multiplier: %.3f -> %.3f", label, baseMultiplier, finalMultiplier);
+            else
+                handler->PSendSysMessage("%s multiplier: %.3f", label, finalMultiplier);
+        };
+
+        printMultiplier("Health", info->BaseMultipliers.Health, info->Multipliers.Health);
+        printMultiplier("Mana", info->BaseMultipliers.Mana, info->Multipliers.Mana);
+        printMultiplier("Armor", info->BaseMultipliers.Armor, info->Multipliers.Armor);
+        printMultiplier("Damage", info->BaseMultipliers.Damage, info->Multipliers.Damage);
+        handler->PSendSysMessage("CC duration multiplier: %.3f", info->Multipliers.CrowdControlDuration);
+        handler->PSendSysMessage("XP multiplier: %.3f | Money multiplier: %.3f", info->XPModifier, info->MoneyModifier);
 
         return true;
     }


### PR DESCRIPTION
## Summary
- track the highest non-GM player level per map in the AutoBalance custom data
- expose the tracked level so creature scaling can match AzerothCore's expansion smoothing logic
- smooth level-scaled health and damage baselines using the tracked level before applying multipliers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd9cbb74e483279332376c8b7bfd94