### PR TITLE
Add far visibility refresh when changing maps

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5140,6 +5140,7 @@ void Player::RepopAtGraveyard()
                 map->LoadGrid(GetPositionX(), GetPositionY());
 
                 UpdateObjectVisibility();
+                UpdateVisibilityForPlayer(true);
 
                 if (Creature* spiritGuide = FindNearestCreature(spiritEntry, 30.0f, false))
                 {
@@ -22891,16 +22892,32 @@ void Player::UpdateObjectVisibility(bool forced)
     else
     {
         Unit::UpdateObjectVisibility(true);
-        UpdateVisibilityForPlayer();
+        UpdateVisibilityForPlayer(false);
     }
 }
 
-void Player::UpdateVisibilityForPlayer()
+void Player::UpdateVisibilityForPlayer(bool mapChange)
 {
     // updates visibility of all objects around point of view for current player
     Trinity::VisibleNotifier notifier(*this);
     Cell::VisitAllObjects(m_seer, notifier, GetSightRange());
     notifier.SendToSelf();   // send gathered data
+
+    if (!mapChange)
+        return;
+
+    // When changing maps, force a far visibility pass to preload distant objects
+    float farVisibility = GetSightRange();
+    if (Map* map = GetMap())
+    {
+        float mapVisibility = map->GetVisibilityRange();
+        if (mapVisibility > farVisibility)
+            farVisibility = mapVisibility;
+    }
+
+    Trinity::VisibleNotifier farNotifier(*this);
+    Cell::VisitAllObjects(m_seer, farNotifier, farVisibility, false);
+    farNotifier.SendToSelf();
 }
 
 void Player::SetPhaseMask(uint32 newPhaseMask, bool update)
@@ -23055,7 +23072,7 @@ void Player::SendInitialPacketsBeforeAddToMap()
 
 void Player::SendInitialPacketsAfterAddToMap()
 {
-    UpdateVisibilityForPlayer();
+    UpdateVisibilityForPlayer(true);
 
     // update zone
     uint32 newzone, newarea;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2064,7 +2064,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         void SendInitialVisiblePackets(Unit* target) const;
         void UpdateObjectVisibility(bool forced = true) override;
-        void UpdateVisibilityForPlayer();
+        void UpdateVisibilityForPlayer(bool mapChange);
         void UpdateVisibilityOf(WorldObject* target);
         void UpdateTriggerVisibility();
         void SetPhaseMask(uint32 newPhaseMask, bool update) override;// overwrite Unit::SetPhaseMask

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1118,7 +1118,7 @@ void WorldSession::HandleFarSightOpcode(WorldPacket& recvData)
         _player->SetSeer(_player);
     }
 
-    GetPlayer()->UpdateVisibilityForPlayer();
+    GetPlayer()->UpdateVisibilityForPlayer(false);
 }
 
 void WorldSession::HandleSetTitleOpcode(WorldPacket& recvData)


### PR DESCRIPTION
## Summary
- add a map-change flag to Player::UpdateVisibilityForPlayer and run a far-visibility pass when requested
- refresh visibility immediately after adding the player to a map and after battleground ghost teleports
- ensure farsight updates call the new helper with an explicit map-change flag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6902cd26c6dc8327886f25198626ab08