### PR TITLE
Fix missing World include in Warsong Gulch battleground

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -26,6 +26,7 @@
 #include "Player.h"
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
+#include "World.h"
 
 // these variables aren't used outside of this file, so declare them only here
 enum BG_WSG_Rewards


### PR DESCRIPTION
## Summary
- include World.h in BattlegroundWS.cpp so the Warsong Gulch logic can access sWorld configuration values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904a037a7248327947de2c8a9643ed3