### PR TITLE
Fix Spirit Walk Ghost Wolf cooldown handling

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -36,6 +36,7 @@
 #include "Unit.h"
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <unordered_map>
 #include "SharedDefines.h"
 
@@ -62,6 +63,7 @@ enum ShamanSpells
     SPELL_SHAMAN_ITEM_LIGHTNING_SHIELD          = 23552,
     SPELL_SHAMAN_ITEM_LIGHTNING_SHIELD_DAMAGE   = 27635,
     SPELL_SHAMAN_ITEM_MANA_SURGE                = 23571,
+    SPELL_SHAMAN_GHOST_WOLF                     = 2645,
     SPELL_SHAMAN_LIGHTNING_SHIELD_DEFENSIVE_AURA = 81459,
     SPELL_SHAMAN_LAVA_FLOWS_R1                  = 51480,
     SPELL_SHAMAN_LAVA_FLOWS_TRIGGERED_R1        = 64694,
@@ -1653,6 +1655,57 @@ class spell_sha_spirit_hunt : public AuraScript
     }
 };
 
+// 81909 - Spirit Walk
+class spell_sha_ghost_wolf_charge : public SpellScript
+{
+    PrepareSpellScript(spell_sha_ghost_wolf_charge);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_SHAMAN_GHOST_WOLF });
+    }
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+        Unit* target = GetHitUnit();
+
+        if (!caster || !target)
+            return;
+
+        caster->RemoveAurasDueToSpell(SPELL_SHAMAN_GHOST_WOLF);
+
+        if (SpellHistory* spellHistory = caster->GetSpellHistory())
+        {
+            spellHistory->AddCooldown(SPELL_SHAMAN_GHOST_WOLF, 0, std::chrono::seconds(6));
+
+            if (SpellInfo const* ghostWolfInfo = sSpellMgr->GetSpellInfo(SPELL_SHAMAN_GHOST_WOLF))
+                spellHistory->SendCooldownEvent(ghostWolfInfo, 0, nullptr, false);
+        }
+
+        if (caster->GetShapeshiftForm() == FORM_GHOSTWOLF)
+            caster->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+
+        if (!target->IsAlive())
+            return;
+
+        caster->resetAttackTimer(BASE_ATTACK);
+        if (caster->haveOffhandWeapon())
+            caster->resetAttackTimer(OFF_ATTACK);
+
+        bool const startedMelee = caster->Attack(target, true);
+        if (!startedMelee && caster->GetVictim() != target)
+            return;
+
+        caster->AttackerStateUpdate(target);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_sha_ghost_wolf_charge::HandleDummy, EFFECT_2, SPELL_EFFECT_DUMMY);
+    }
+};
+
 // -51525 - Static Shock
 class spell_sha_static_shock : public AuraScript
 {
@@ -2677,6 +2730,7 @@ void AddSC_shaman_spell_scripts()
     RegisterSpellScript(spell_sha_shamanistic_rage);
     RegisterSpellScript(spell_sha_stoneclaw_totem);
     RegisterSpellScript(spell_sha_spirit_hunt);
+    RegisterSpellScript(spell_sha_ghost_wolf_charge);
     RegisterSpellScript(spell_sha_static_shock);
     RegisterSpellScript(spell_sha_tidal_force_dummy);
     RegisterSpellScript(spell_sha_thunderstorm);


### PR DESCRIPTION
## Summary
- send the Ghost Wolf cooldown event packet when Spirit Walk's dummy effect fires
- reset the shaman's melee swing timers before forcing the hit to avoid double auto attacks
- keep the forced melee swing while ensuring the Ghost Wolf form is removed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69050e9f2b288327bd805c5def937437