### PR TITLE
Handle all Refocus cooldown ranks

### DIFF
--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -37,6 +37,8 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
+#include <array>
+#include <set>
 
 enum GenericData
 {
@@ -3330,16 +3332,76 @@ class spell_item_chicken_cover : public SpellScript
     }
 };
 
-enum Refocus
+namespace Refocus
 {
-    SPELL_AIMED_SHOT    = 19434,
-    SPELL_MULTISHOT     = 2643,
-    SPELL_VOLLEY        = 42243,
-};
+    enum Spells : uint32
+    {
+        SPELL_AIMED_SHOT_R1    = 19434,
+        SPELL_AIMED_SHOT_R2    = 20900,
+        SPELL_AIMED_SHOT_R3    = 20901,
+        SPELL_MULTISHOT_R1     = 2643,
+        SPELL_MULTISHOT_R2     = 14288,
+        SPELL_MULTISHOT_R3     = 14289,
+        SPELL_MULTISHOT_R4     = 14290,
+        SPELL_ARCANE_SHOT_R1   = 3044,
+        SPELL_ARCANE_SHOT_R2   = 14281,
+        SPELL_ARCANE_SHOT_R3   = 14282,
+        SPELL_ARCANE_SHOT_R4   = 14283,
+        SPELL_ARCANE_SHOT_R5   = 14284,
+        SPELL_ARCANE_SHOT_R6   = 14285,
+        SPELL_ARCANE_SHOT_R7   = 14286,
+        SPELL_ARCANE_SHOT_R8   = 14287,
+        SPELL_VOLLEY_R1        = 1510,
+        SPELL_VOLLEY_R2        = 14294,
+        SPELL_VOLLEY_R3        = 14295,
+    };
+
+    static constexpr std::array<uint32, 3> AimedShotRanks =
+    {
+        SPELL_AIMED_SHOT_R1,
+        SPELL_AIMED_SHOT_R2,
+        SPELL_AIMED_SHOT_R3
+    };
+
+    static constexpr std::array<uint32, 4> MultiShotRanks =
+    {
+        SPELL_MULTISHOT_R1,
+        SPELL_MULTISHOT_R2,
+        SPELL_MULTISHOT_R3,
+        SPELL_MULTISHOT_R4
+    };
+
+    static constexpr std::array<uint32, 8> ArcaneShotRanks =
+    {
+        SPELL_ARCANE_SHOT_R1,
+        SPELL_ARCANE_SHOT_R2,
+        SPELL_ARCANE_SHOT_R3,
+        SPELL_ARCANE_SHOT_R4,
+        SPELL_ARCANE_SHOT_R5,
+        SPELL_ARCANE_SHOT_R6,
+        SPELL_ARCANE_SHOT_R7,
+        SPELL_ARCANE_SHOT_R8
+    };
+
+    static constexpr std::array<uint32, 3> VolleyRanks =
+    {
+        SPELL_VOLLEY_R1,
+        SPELL_VOLLEY_R2,
+        SPELL_VOLLEY_R3
+    };
+}
 
 class spell_item_refocus : public SpellScript
 {
     PrepareSpellScript(spell_item_refocus);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo(Refocus::AimedShotRanks)
+            && ValidateSpellInfo(Refocus::MultiShotRanks)
+            && ValidateSpellInfo(Refocus::ArcaneShotRanks)
+            && ValidateSpellInfo(Refocus::VolleyRanks);
+    }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
@@ -3348,14 +3410,38 @@ class spell_item_refocus : public SpellScript
         if (!caster || caster->GetClass() != CLASS_HUNTER)
             return;
 
-        if (caster->GetSpellHistory()->HasCooldown(SPELL_AIMED_SHOT))
-            caster->GetSpellHistory()->ResetCooldown(SPELL_AIMED_SHOT, true);
+        SpellHistory* spellHistory = caster->GetSpellHistory();
+        if (!spellHistory)
+            return;
 
-        if (caster->GetSpellHistory()->HasCooldown(SPELL_MULTISHOT))
-            caster->GetSpellHistory()->ResetCooldown(SPELL_MULTISHOT, true);
+        std::set<uint32> processedCategories;
 
-        if (caster->GetSpellHistory()->HasCooldown(SPELL_VOLLEY))
-            caster->GetSpellHistory()->ResetCooldown(SPELL_VOLLEY, true);
+        auto resetCooldowns = [&](uint32 spellId)
+        {
+            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+            if (!spellInfo)
+                return;
+
+            if (uint32 categoryId = spellInfo->GetCategory())
+            {
+                if (processedCategories.insert(categoryId).second)
+                    spellHistory->ResetCategoryCooldown(categoryId, true);
+            }
+
+            if (spellHistory->HasCooldown(spellId))
+                spellHistory->ResetCooldown(spellId, true);
+        };
+
+        auto resetRanks = [&](auto const& spellIds)
+        {
+            for (uint32 spellId : spellIds)
+                resetCooldowns(spellId);
+        };
+
+        resetRanks(Refocus::AimedShotRanks);
+        resetRanks(Refocus::MultiShotRanks);
+        resetRanks(Refocus::ArcaneShotRanks);
+        resetRanks(Refocus::VolleyRanks);
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- include every classic rank of Aimed Shot, Multi-Shot, Arcane Shot, and Volley in the Refocus cooldown reset logic
- validate all spell ranks during script load and iterate each rank list when clearing cooldowns and categories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906497fad1483278530dafcdf086a31