### PR TITLE
Align Refocus cooldown reset with trap handling pattern

### DIFF
--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -37,6 +37,9 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
+#include <array>
+#include <chrono>
+#include <set>
 
 enum GenericData
 {
@@ -3330,16 +3333,97 @@ class spell_item_chicken_cover : public SpellScript
     }
 };
 
-enum Refocus
+namespace Refocus
 {
-    SPELL_AIMED_SHOT    = 19434,
-    SPELL_MULTISHOT     = 2643,
-    SPELL_VOLLEY        = 42243,
-};
+    enum Spells : uint32
+    {
+        SPELL_AIMED_SHOT_R3    = 20901,
+        SPELL_AIMED_SHOT_R2    = 20900,
+        SPELL_AIMED_SHOT_R1    = 19434,
+        SPELL_MULTISHOT_R4     = 14290,
+        SPELL_MULTISHOT_R3     = 14289,
+        SPELL_MULTISHOT_R2     = 14288,
+        SPELL_MULTISHOT_R1     = 2643,
+        SPELL_ARCANE_SHOT_R8   = 14287,
+        SPELL_ARCANE_SHOT_R7   = 14286,
+        SPELL_ARCANE_SHOT_R6   = 14285,
+        SPELL_ARCANE_SHOT_R5   = 14284,
+        SPELL_ARCANE_SHOT_R4   = 14283,
+        SPELL_ARCANE_SHOT_R3   = 14282,
+        SPELL_ARCANE_SHOT_R2   = 14281,
+        SPELL_ARCANE_SHOT_R1   = 3044,
+        SPELL_VOLLEY_R3        = 14295,
+        SPELL_VOLLEY_R2        = 14294,
+        SPELL_VOLLEY_R1        = 1510,
+    };
+
+    static constexpr std::array<uint32, 3> AimedShotRanks =
+    {
+        SPELL_AIMED_SHOT_R3,
+        SPELL_AIMED_SHOT_R2,
+        SPELL_AIMED_SHOT_R1
+    };
+
+    static constexpr std::array<uint32, 4> MultiShotRanks =
+    {
+        SPELL_MULTISHOT_R4,
+        SPELL_MULTISHOT_R3,
+        SPELL_MULTISHOT_R2,
+        SPELL_MULTISHOT_R1
+    };
+
+    static constexpr std::array<uint32, 8> ArcaneShotRanks =
+    {
+        SPELL_ARCANE_SHOT_R8,
+        SPELL_ARCANE_SHOT_R7,
+        SPELL_ARCANE_SHOT_R6,
+        SPELL_ARCANE_SHOT_R5,
+        SPELL_ARCANE_SHOT_R4,
+        SPELL_ARCANE_SHOT_R3,
+        SPELL_ARCANE_SHOT_R2,
+        SPELL_ARCANE_SHOT_R1
+    };
+
+    static constexpr std::array<uint32, 3> VolleyRanks =
+    {
+        SPELL_VOLLEY_R3,
+        SPELL_VOLLEY_R2,
+        SPELL_VOLLEY_R1
+    };
+
+    template <std::size_t N>
+    static void ResetKnownRanks(Player* caster, SpellHistory* spellHistory, std::array<uint32, N> const& spellIds, std::set<uint32>& processedCategories)
+    {
+        for (uint32 const spellId : spellIds)
+        {
+            if (!caster->HasSpell(spellId))
+                continue;
+
+            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+            if (!spellInfo)
+                continue;
+
+            if (uint32 const categoryId = spellInfo->GetCategory())
+                if (processedCategories.insert(categoryId).second)
+                    spellHistory->ResetCategoryCooldown(categoryId, true);
+
+            if (spellHistory->HasCooldown(spellId))
+                spellHistory->ResetCooldown(spellId, true);
+        }
+    }
+}
 
 class spell_item_refocus : public SpellScript
 {
     PrepareSpellScript(spell_item_refocus);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo(Refocus::AimedShotRanks)
+            && ValidateSpellInfo(Refocus::MultiShotRanks)
+            && ValidateSpellInfo(Refocus::ArcaneShotRanks)
+            && ValidateSpellInfo(Refocus::VolleyRanks);
+    }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
@@ -3348,14 +3432,22 @@ class spell_item_refocus : public SpellScript
         if (!caster || caster->GetClass() != CLASS_HUNTER)
             return;
 
-        if (caster->GetSpellHistory()->HasCooldown(SPELL_AIMED_SHOT))
-            caster->GetSpellHistory()->ResetCooldown(SPELL_AIMED_SHOT, true);
+        caster->m_Events.AddEventAtOffset([caster]()
+        {
+            if (!caster)
+                return;
 
-        if (caster->GetSpellHistory()->HasCooldown(SPELL_MULTISHOT))
-            caster->GetSpellHistory()->ResetCooldown(SPELL_MULTISHOT, true);
+            SpellHistory* spellHistory = caster->GetSpellHistory();
+            if (!spellHistory)
+                return;
 
-        if (caster->GetSpellHistory()->HasCooldown(SPELL_VOLLEY))
-            caster->GetSpellHistory()->ResetCooldown(SPELL_VOLLEY, true);
+            std::set<uint32> processedCategories;
+
+            Refocus::ResetKnownRanks(caster, spellHistory, Refocus::AimedShotRanks, processedCategories);
+            Refocus::ResetKnownRanks(caster, spellHistory, Refocus::MultiShotRanks, processedCategories);
+            Refocus::ResetKnownRanks(caster, spellHistory, Refocus::ArcaneShotRanks, processedCategories);
+            Refocus::ResetKnownRanks(caster, spellHistory, Refocus::VolleyRanks, processedCategories);
+        }, std::chrono::milliseconds(1));
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- reorder the Refocus rank lists so the highest rank is checked first and add a helper to process known ranks
- schedule the cooldown reset like the hunter trap script and only reset cooldowns and categories for ranks the player knows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906497fad1483278530dafcdf086a31