### PR TITLE
Fix shaman weapon enchant duration and arena persistence

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3043,7 +3043,7 @@ void Spell::EffectEnchantItemTmp()
         duration = 3600;                                    // 1 hour
     // shaman family enchantments
     else if (m_spellInfo->SpellFamilyName == SPELLFAMILY_SHAMAN)
-        duration = 300;                                    // 5 mins
+        duration = 1800;                                   // 30 mins
     // other cases with this SpellVisual already selected
     else if (m_spellInfo->SpellVisual[0] == 215)
         duration = 1800;                                    // 30 mins

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3729,6 +3729,22 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx5 |= SPELL_ATTR5_START_PERIODIC_AT_APPLY;
     });
 
+    // Shaman weapon imbues - keep them in arenas and battlegrounds
+    ApplySpellFix({
+        8017, 8018, 8019, 10399,                 // Rockbiter Weapon
+        8024, 8027, 8030, 16339, 16341, 16342,
+        25489, 58785, 58789, 58790,              // Flametongue Weapon
+        8033, 8038, 10456, 16355, 16356,
+        25500, 58794, 58795, 58796,              // Frostbrand Weapon
+        8232, 8235, 10486, 16362, 25505,
+        58801, 58803, 58804,                     // Windfury Weapon
+        51730, 51988, 51991, 51992, 51993, 51994 // Earthliving Weapon
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_NOT_SHAPESHIFT;
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_PRESERVE_ENCHANT_IN_ARENA;
+    });
+
     // Flametongue Totem (Aura)
     ApplySpellFix({
         52109, // rank 1


### PR DESCRIPTION
## Summary
- extend shaman temporary weapon enchant durations to 30 minutes
- allow shaman weapon imbues to persist when entering arenas and battlegrounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69066455bc308327899bde5ac983657d