### PR TITLE
Ensure pets disengage crowd-controlled targets

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -71,6 +71,7 @@ void PetAI::UpdateAI(uint32 diff)
             me->EnsureVictim()->HasBreakableByDamageCrowdControlAura(me))
         {
             me->InterruptNonMeleeSpells(false);
+            StopAttack();
             return;
         }
 


### PR DESCRIPTION
## Summary
- stop pets from remaining on crowd-controlled targets by triggering their return movement

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69069907513c8327b664c7e2f8a588c6