### PR TITLE
Prevent Earthbind Totem pulses from causing combat

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -445,7 +445,7 @@ void ThreatManager::AddThreat(Unit* target, float amount, SpellInfo const* spell
     if (spell)
     {
         if (spell->Id == 14309 || spell->Id == 14308 || spell->Id == 3355 || spell->Id == 13810 || spell->Id == 63487 || spell->Id == 67035 || spell->Id == 72216
-            || spell->Id == 19185 || spell->Id == 3600) //freezing/frost traps don't put you in combat
+            || spell->Id == 19185 || spell->Id == 3600 || spell->Id == 6474) //freezing/frost traps and Earthbind Totem don't put you in combat
         {
             return;
         }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2368,7 +2368,7 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
     if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()))
     {
         if(spell->m_spellInfo->Id != 14309 && spell->m_spellInfo->Id != 14308 && spell->m_spellInfo->Id != 3355 && spell->m_spellInfo->Id != 13810 && spell->m_spellInfo->Id != 63487 && spell->m_spellInfo->Id != 67035
-            && spell->m_spellInfo->Id != 72216 && spell->m_spellInfo->Id != 19185 && spell->m_spellInfo->Id != 3600) //freezing/frost traps don't put you in combat
+            && spell->m_spellInfo->Id != 72216 && spell->m_spellInfo->Id != 19185 && spell->m_spellInfo->Id != 3600 && spell->m_spellInfo->Id != 6474) //freezing/frost traps and Earthbind Totem don't put you in combat
             unit->SetInCombatWith(spell->m_originalCaster);
     }
 
@@ -7845,7 +7845,7 @@ void Spell::PreprocessSpellLaunch(TargetInfo& targetInfo)
     // This will only cause combat - the target will engage once the projectile hits (in Spell::TargetInfo::PreprocessTarget)
     if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged())
         && (m_spellInfo->Id != 14309 && m_spellInfo->Id != 14308 && m_spellInfo->Id != 3355 && m_spellInfo->Id != 13810 && m_spellInfo->Id != 63487 && m_spellInfo->Id != 67035 && m_spellInfo->Id != 72216 && m_spellInfo->Id != 19185
-            && m_spellInfo->Id != 3600)) //freezing/frost traps don't put you in combat
+            && m_spellInfo->Id != 3600 && m_spellInfo->Id != 6474)) //freezing/frost traps and Earthbind Totem don't put you in combat
         m_originalCaster->SetInCombatWith(targetUnit, true);
 
     Unit* unit = nullptr;


### PR DESCRIPTION
## Summary
- treat Earthbind Totem's pulse spell like other crowd control effects that should not trigger combat or threat generation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69093490ec48832787977f224e9ed60f