### PR TITLE
Auto-join new characters to world chat

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -18,6 +18,8 @@
 #include "WorldSession.h"
 #include "ArenaTeamMgr.h"
 #include "CalendarMgr.h"
+#include "Channel.h"
+#include "ChannelMgr.h"
 #include "CharacterCache.h"
 #include "CharacterPackets.h"
 #include "Chat.h"
@@ -1025,6 +1027,41 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
                     break;
             }
             repMgr.SendState(nullptr);
+        }
+
+        if (sWorld->getBoolConfig(CONFIG_CHANNEL_AUTOJOIN_WORLD))
+        {
+            std::string const& worldChannelName = sWorld->GetWorldChatChannelName();
+            if (!worldChannelName.empty())
+            {
+                if (ChannelMgr* channelMgr = ChannelMgr::forTeam(pCurrChar->GetTeam()))
+                {
+                    Channel* worldChannel = channelMgr->GetCustomChannel(worldChannelName);
+                    if (!worldChannel)
+                    {
+                        worldChannel = channelMgr->CreateCustomChannel(worldChannelName);
+                        if (!worldChannel)
+                        {
+                            TC_LOG_ERROR("chat.system",
+                                "Unable to create configured world chat channel '{}' for player {} ({}).",
+                                worldChannelName, pCurrChar->GetName(), pCurrChar->GetGUID().ToString());
+                        }
+                    }
+
+                    if (worldChannel)
+                    {
+                        worldChannel->SetOwnership(false);
+                        worldChannel->SetOwner(ObjectGuid::Empty);
+                        worldChannel->SetDirty();
+
+                        if (!worldChannel->IsOn(pCurrChar->GetGUID()))
+                            worldChannel->JoinChannel(pCurrChar);
+                    }
+                }
+                else
+                    TC_LOG_ERROR("chat.system",
+                        "Unable to resolve channel manager for world chat auto-join (team: {}).", pCurrChar->GetTeam());
+            }
         }
     }
 

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -684,6 +684,13 @@ void World::LoadConfigSettings(bool reload)
     m_bool_configs[CONFIG_PRESERVE_CUSTOM_CHANNELS] = sConfigMgr->GetBoolDefault("PreserveCustomChannels", false);
     m_int_configs[CONFIG_PRESERVE_CUSTOM_CHANNEL_DURATION] = sConfigMgr->GetIntDefault("PreserveCustomChannelDuration", 14);
     m_int_configs[CONFIG_PRESERVE_CUSTOM_CHANNEL_INTERVAL] = sConfigMgr->GetIntDefault("PreserveCustomChannelInterval", 5);
+    m_bool_configs[CONFIG_CHANNEL_AUTOJOIN_WORLD] = sConfigMgr->GetBoolDefault("Channel.World.Enable", false);
+    SetWorldChatChannelName(sConfigMgr->GetStringDefault("Channel.World.Name", "World"));
+    if (m_bool_configs[CONFIG_CHANNEL_AUTOJOIN_WORLD] && GetWorldChatChannelName().empty())
+    {
+        TC_LOG_ERROR("server.loading", "Channel.World.Enable is set but Channel.World.Name is empty. Disabling world chat auto-join.");
+        m_bool_configs[CONFIG_CHANNEL_AUTOJOIN_WORLD] = false;
+    }
     m_bool_configs[CONFIG_GRID_UNLOAD] = sConfigMgr->GetBoolDefault("GridUnload", true);
     m_bool_configs[CONFIG_BASEMAP_LOAD_GRIDS] = sConfigMgr->GetBoolDefault("BaseMapLoadAllGrids", false);
     if (m_bool_configs[CONFIG_BASEMAP_LOAD_GRIDS] && m_bool_configs[CONFIG_GRID_UNLOAD])

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -95,6 +95,7 @@ enum WorldBoolConfigs : uint32
     CONFIG_STATS_SAVE_ONLY_ON_LOGOUT,
     CONFIG_ALLOW_TWO_SIDE_INTERACTION_CALENDAR,
     CONFIG_ALLOW_TWO_SIDE_INTERACTION_CHANNEL,
+    CONFIG_CHANNEL_AUTOJOIN_WORLD,
     CONFIG_ALLOW_TWO_SIDE_INTERACTION_GROUP,
     CONFIG_ALLOW_TWO_SIDE_INTERACTION_GUILD,
     CONFIG_ALLOW_TWO_SIDE_INTERACTION_AUCTION,
@@ -647,6 +648,9 @@ class TC_GAME_API World
         /// Get the string for new characters (first login)
         std::string const& GetNewCharString() const { return m_newCharString; }
 
+        void SetWorldChatChannelName(std::string const& name) { m_worldChatChannelName = name; }
+        std::string const& GetWorldChatChannelName() const { return m_worldChatChannelName; }
+
         LocaleConstant GetDefaultDbcLocale() const { return m_defaultDbcLocale; }
 
         /// Get the path where data (dbc, maps) are stored on disk
@@ -833,6 +837,7 @@ class TC_GAME_API World
         uint32 m_MaxPlayerCount;
 
         std::string m_newCharString;
+        std::string m_worldChatChannelName;
 
         float rate_values[MAX_RATES];
         uint32 m_int_configs[INT_CONFIG_VALUE_COUNT];

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -2113,6 +2113,19 @@ PartyLevelReq = 1
 PreserveCustomChannels = 1
 
 #
+#    Channel.World.Enable
+#        Description: Automatically join newly created characters to the configured world chat channel on their first login.
+#        Default:     0 - (Disabled)
+#                     1 - (Enabled)
+#
+#    Channel.World.Name
+#        Description: Name of the world chat channel that new characters join when Channel.World.Enable is enabled.
+#        Default:     "World"
+
+Channel.World.Enable = 0
+Channel.World.Name = "World"
+
+#
 #    PreserveCustomChannelInterval
 #        Description: Interval (in minutes) at which custom channel data is saved to the database
 #        Default:     5 minutes


### PR DESCRIPTION
## Summary
- add configuration options for enabling an automatic world chat channel and selecting its name
- automatically create and join the configured world chat channel for newly created characters while disabling ownership

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913f764f2fc8327a43a31cf1bf8b870)