### PR TITLE
Fix FFA area detection for nested arenas

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7150,7 +7150,18 @@ void Player::UpdateArea(uint32 newArea)
 
     AreaTableEntry const* area = sAreaTableStore.LookupEntry(newArea);
     bool oldFFAPvPArea = pvpInfo.IsInFFAPvPArea;
-    pvpInfo.IsInFFAPvPArea = area && (area->Flags & AREA_FLAG_ARENA);
+
+    bool isFFAArea = false;
+    for (AreaTableEntry const* currentArea = area; currentArea; currentArea = currentArea->ParentAreaID ? sAreaTableStore.LookupEntry(currentArea->ParentAreaID) : nullptr)
+    {
+        if (currentArea->Flags & AREA_FLAG_ARENA)
+        {
+            isFFAArea = true;
+            break;
+        }
+    }
+
+    pvpInfo.IsInFFAPvPArea = isFFAArea;
     UpdatePvPState(true);
 
     // check if we were in ffa arena and we left


### PR DESCRIPTION
## Summary
- traverse parent area chain when determining whether a player is inside a free-for-all PvP area
- ensure nested FFA arenas properly flag players even if their parent zone lacks the arena flag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914037fffac83279819858d19fba7f5)