### PR TITLE
Auto-join world chat channel on login

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5163,6 +5163,8 @@ void Player::CleanupChannels()
 
 void Player::UpdateLocalChannels(uint32 newZone)
 {
+    JoinWorldChannelIfNeeded();
+
     if (GetSession()->PlayerLoading() && !IsBeingTeleportedFar())
         return;                                              // The client handles it automatically after loading, but not after teleporting
 
@@ -5230,6 +5232,44 @@ void Player::UpdateLocalChannels(uint32 newZone)
             cMgr->LeftChannel(removeChannel->GetChannelId(), removeChannel->GetZoneEntry());    // Delete if empty
         }
     }
+}
+
+void Player::JoinWorldChannelIfNeeded()
+{
+    if (!sWorld->getBoolConfig(CONFIG_CHANNEL_AUTOJOIN_WORLD))
+        return;
+
+    std::string const& worldChannelName = sWorld->GetWorldChatChannelName();
+    if (worldChannelName.empty())
+        return;
+
+    ChannelMgr* channelMgr = ChannelMgr::forTeam(GetTeam());
+    if (!channelMgr)
+    {
+        TC_LOG_ERROR("chat.system",
+            "Unable to resolve channel manager for world chat auto-join (team: {}).", GetTeam());
+        return;
+    }
+
+    Channel* worldChannel = channelMgr->GetCustomChannel(worldChannelName);
+    if (!worldChannel)
+    {
+        worldChannel = channelMgr->CreateCustomChannel(worldChannelName);
+        if (!worldChannel)
+        {
+            TC_LOG_ERROR("chat.system",
+                "Unable to create configured world chat channel '{}' for player {} ({}).",
+                worldChannelName, GetName(), GetGUID().ToString());
+            return;
+        }
+    }
+
+    worldChannel->SetOwnership(false);
+    worldChannel->SetOwner(ObjectGuid::Empty);
+    worldChannel->SetDirty();
+
+    if (!worldChannel->IsOn(GetGUID()))
+        worldChannel->JoinChannel(this);
 }
 
 void Player::LeaveLFGChannel()

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1753,6 +1753,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void LeftChannel(Channel* c);
         void CleanupChannels();
         void UpdateLocalChannels(uint32 newZone);
+        void JoinWorldChannelIfNeeded();
         void LeaveLFGChannel();
 
         typedef std::list<Channel*> JoinedChannelsList;

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1029,40 +1029,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
             repMgr.SendState(nullptr);
         }
 
-        if (sWorld->getBoolConfig(CONFIG_CHANNEL_AUTOJOIN_WORLD))
-        {
-            std::string const& worldChannelName = sWorld->GetWorldChatChannelName();
-            if (!worldChannelName.empty())
-            {
-                if (ChannelMgr* channelMgr = ChannelMgr::forTeam(pCurrChar->GetTeam()))
-                {
-                    Channel* worldChannel = channelMgr->GetCustomChannel(worldChannelName);
-                    if (!worldChannel)
-                    {
-                        worldChannel = channelMgr->CreateCustomChannel(worldChannelName);
-                        if (!worldChannel)
-                        {
-                            TC_LOG_ERROR("chat.system",
-                                "Unable to create configured world chat channel '{}' for player {} ({}).",
-                                worldChannelName, pCurrChar->GetName(), pCurrChar->GetGUID().ToString());
-                        }
-                    }
-
-                    if (worldChannel)
-                    {
-                        worldChannel->SetOwnership(false);
-                        worldChannel->SetOwner(ObjectGuid::Empty);
-                        worldChannel->SetDirty();
-
-                        if (!worldChannel->IsOn(pCurrChar->GetGUID()))
-                            worldChannel->JoinChannel(pCurrChar);
-                    }
-                }
-                else
-                    TC_LOG_ERROR("chat.system",
-                        "Unable to resolve channel manager for world chat auto-join (team: {}).", pCurrChar->GetTeam());
-            }
-        }
+        pCurrChar->JoinWorldChannelIfNeeded();
     }
 
     // show time before shutdown if shutdown planned.


### PR DESCRIPTION
## Summary
- ensure players attempt to join the configured world chat channel through a reusable helper
- use the helper during local channel updates and on login so the world channel is joined automatically when enabled

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69140ade05fc832782971f8af7451659)