### PR TITLE
Fix FFA PvP detection for The Maul

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7148,7 +7148,38 @@ void Player::UpdateArea(uint32 newArea)
 
     AreaTableEntry const* area = sAreaTableStore.LookupEntry(newArea);
     bool oldFFAPvPArea = pvpInfo.IsInFFAPvPArea;
-    pvpInfo.IsInFFAPvPArea = area && (area->Flags & AREA_FLAG_ARENA);
+
+    bool isFFAArea = false;
+    // Walk the area hierarchy in case the arena flag is defined on a parent zone.
+    for (AreaTableEntry const* currentArea = area; currentArea;)
+    {
+        if (currentArea->Flags & AREA_FLAG_ARENA)
+        {
+            isFFAArea = true;
+            break;
+        }
+
+        if (!currentArea->ParentAreaID)
+            break;
+
+        currentArea = sAreaTableStore.LookupEntry(currentArea->ParentAreaID);
+    }
+
+    if (!isFFAArea)
+    {
+        static std::array<uint32, 1> const customFFAAreas = { 3217 }; // The Maul (Dire Maul arena)
+
+        for (uint32 customArea : customFFAAreas)
+        {
+            if (newArea == customArea || m_zoneUpdateId == customArea)
+            {
+                isFFAArea = true;
+                break;
+            }
+        }
+    }
+
+    pvpInfo.IsInFFAPvPArea = isFFAArea;
     UpdatePvPState(true);
 
     // check if we were in ffa arena and we left


### PR DESCRIPTION
## Summary
- walk the area hierarchy when evaluating FFA PvP so arenas flagged on parent zones are honored
- force The Maul (area 3217) to count as FFA PvP even if the live area lookup fails

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69140b1ec62083278ffefda6f3a8e7b2)