### PR TITLE
Improve Dire Maul beads aura diagnostics and chest loot

### DIFF
--- a/src/server/scripts/Custom/custom_diremaul_beads.cpp
+++ b/src/server/scripts/Custom/custom_diremaul_beads.cpp
@@ -28,6 +28,7 @@
 #include "QuestDef.h"
 #include "SharedDefines.h"
 #include "SpellAuraEffects.h"
+#include "UpdateFields.h"
 #include "Util.h"
 #include <algorithm>
 #include <cctype>
@@ -41,6 +42,7 @@
 
 namespace DireMaulBeads
 {
+    static constexpr uint32 KalimdorMapId = 1;
     static constexpr uint32 DefaultOgreBeadItemId = 21982;
     static constexpr uint32 DefaultOgreBeadAuraId = 90002;
     static constexpr char const* DefaultAreaIdList = "495,496,498,2557,3217";
@@ -119,7 +121,7 @@ namespace DireMaulBeads
         if (!player)
             return false;
 
-        if (player->GetMapId() != 1)
+        if (player->GetMapId() != KalimdorMapId)
             return false;
 
         if (s_DireMaulAreaIds.empty())
@@ -143,9 +145,15 @@ namespace DireMaulBeads
         if (!auraId)
             return;
 
+        uint32 const mapId = player->GetMapId();
+        uint32 const areaId = player->GetAreaId();
+        uint32 const zoneId = player->GetZoneId();
+
         if (!IsInOutdoorDireMaul(player))
         {
             player->RemoveAura(auraId);
+            TC_LOG_ERROR("scripts", "DireMaulBeads: skipping aura {} for {} - outside configured area (map {}, zone {}, area {})",
+                auraId, player->GetName(), mapId, zoneId, areaId);
             return;
         }
 
@@ -153,6 +161,8 @@ namespace DireMaulBeads
         if (!beadItemId)
         {
             player->RemoveAura(auraId);
+            TC_LOG_ERROR("scripts", "DireMaulBeads: skipping aura {} for {} - bead item id is 0 (map {}, zone {}, area {})",
+                auraId, player->GetName(), mapId, zoneId, areaId);
             return;
         }
 
@@ -160,15 +170,28 @@ namespace DireMaulBeads
         if (!beadCount)
         {
             player->RemoveAura(auraId);
+            TC_LOG_ERROR("scripts", "DireMaulBeads: skipping aura {} for {} - no beads (map {}, zone {}, area {}, item {})",
+                auraId, player->GetName(), mapId, zoneId, areaId, beadItemId);
             return;
         }
 
         uint8 const stacks = beadCount > 255 ? 255 : static_cast<uint8>(beadCount);
 
-        if (Aura* aura = player->GetAura(auraId))
+        Aura* aura = player->GetAura(auraId);
+        if (aura)
             aura->SetStackAmount(stacks);
-        else if (Aura* aura = player->AddAura(auraId, player))
-            aura->SetStackAmount(stacks);
+        else
+            aura = player->AddAura(auraId, player);
+
+        if (!aura)
+        {
+            TC_LOG_ERROR("scripts", "DireMaulBeads: failed to apply aura {} for {} despite {} beads (map {}, zone {}, area {})",
+                auraId, player->GetName(), beadCount, mapId, zoneId, areaId);
+            return;
+        }
+
+        TC_LOG_INFO("scripts", "DireMaulBeads: applied aura {} ({} stacks) for {} (map {}, zone {}, area {})",
+            auraId, stacks, player->GetName(), mapId, zoneId, areaId);
     }
 
     uint32 GetBeadChestGameObjectId()
@@ -204,6 +227,7 @@ namespace DireMaulBeads
         Loot& loot = chest->loot;
         loot.clear();
         loot.loot_type = LOOT_CORPSE;
+        loot.lootOwnerGUID.Clear();
 
         uint32 remaining = beadCount;
         while (remaining && loot.items.size() < MAX_NR_LOOT_ITEMS)
@@ -222,7 +246,11 @@ namespace DireMaulBeads
             remaining -= stack;
         }
 
+        chest->SetLootRecipient(nullptr);
         chest->SetLootState(GO_READY);
+        chest->SetGoState(GO_STATE_READY);
+        chest->ForceValuesUpdateAtIndex(GAMEOBJECT_DYNAMIC);
+        chest->ForceValuesUpdateAtIndex(GAMEOBJECT_FLAGS);
         return chest;
     }
 


### PR DESCRIPTION
## Summary
- escalate the Dire Maul bead aura skip reasons to error-level logging and log successful applications for easier diagnosis
- clear summoned chest ownership so anyone can loot the stored beads and force-update its state so only the victim's beads appear

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69140a628bf48327a334c2b3485fbae5)