### PR TITLE
Fix Dire Maul bead chest loot visibility

### DIFF
--- a/src/server/scripts/Custom/custom_diremaul_beads.cpp
+++ b/src/server/scripts/Custom/custom_diremaul_beads.cpp
@@ -238,7 +238,7 @@ namespace DireMaulBeads
             lootItem.itemid = beadItemId;
             lootItem.itemIndex = static_cast<uint32>(loot.items.size());
             lootItem.count = stack;
-            lootItem.freeforall = true;
+            lootItem.freeforall = false;
             lootItem.follow_loot_rules = false;
 
             loot.items.push_back(lootItem);


### PR DESCRIPTION
## Summary
- ensure the custom Dire Maul bead chest populates loot slots that remain visible to players

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141e96444483279d72b0e7108b17e5)