### PR TITLE
Broadcast cooldown events when clearing duel cooldowns

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -768,6 +768,17 @@ void SpellHistory::SendClearCooldowns(std::vector<int32> const& cooldowns) const
     {
         for (int32 spell : cooldowns)
         {
+            if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(uint32(spell)))
+            {
+                if (spellInfo->GetCategory())
+                {
+                    WorldPacket event(SMSG_COOLDOWN_EVENT, 4 + 8);
+                    event << uint32(spell);
+                    event << uint64(_owner->GetGUID());
+                    playerOwner->SendDirectMessage(&event);
+                }
+            }
+
             WorldPacket data(SMSG_CLEAR_COOLDOWN, 4 + 8);
             data << uint32(spell);
             data << uint64(_owner->GetGUID());


### PR DESCRIPTION
## Summary
- send a COOLDOWN_EVENT packet whenever we clear a cooldown so client-side category timers (like Bestial Wrath / PvP trinkets) are reset when duels start or finish

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b9b1dbb483279ceeb7ab16bc58ef)