### PR TITLE
Fix Chromie name declaration

### DIFF
--- a/src/server/scripts/Custom/custom_zone_group_rules.cpp
+++ b/src/server/scripts/Custom/custom_zone_group_rules.cpp
@@ -31,7 +31,7 @@
 namespace
 {
     uint32 constexpr ChromieEntry = 27915;
-    char const* constexpr ChromieName = "Chromie";
+    char const* const ChromieName = "Chromie";
 
     struct ZoneAreaKey
     {


### PR DESCRIPTION
## Summary
- declare ChromieName as a const pointer so it builds on older compilers

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915bcc8fd1c8327b2053714ef4d19c0)