### PR TITLE
Limit vertical displacement for Outmaneuver and Heroic Leap

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -705,7 +705,11 @@ class spell_hun_masters_call : public SpellScript
 
     SpellCastResult DoCheckCast()
     {
-        Guardian* pet = GetCaster()->ToPlayer()->GetGuardianPet();
+        Player* player = GetCaster()->ToPlayer();
+        if (!player)
+            return SPELL_FAILED_DONT_REPORT_ERROR;
+
+        Guardian* pet = player->GetGuardianPet();
         ASSERT(pet); // checked in Spell::CheckCast
 
         if (!pet->IsPet() || !pet->IsAlive())
@@ -1593,7 +1597,11 @@ class spell_hun_outmaneuver : public SpellScript
 
     SpellCastResult DoCheckCast()
     {
-        Guardian* pet = GetCaster()->ToPlayer()->GetGuardianPet();
+        Player* player = GetCaster()->ToPlayer();
+        if (!player)
+            return SPELL_FAILED_DONT_REPORT_ERROR;
+
+        Guardian* pet = player->GetGuardianPet();
         ASSERT(pet); // checked in Spell::CheckCast
 
         if (!pet->IsPet() || !pet->IsAlive())
@@ -1611,6 +1619,11 @@ class spell_hun_outmaneuver : public SpellScript
 
         if (!pet->IsWithinLOSInMap(GetCaster()))
             return SPELL_FAILED_LINE_OF_SIGHT;
+
+        float const playerZ = player->GetPositionZ();
+        float const petZ = pet->GetPositionZ();
+        if (petZ - playerZ > 20.0f || playerZ - petZ > 20.0f)
+            return SPELL_FAILED_NOPATH;
 
         return SPELL_CAST_OK;
     }

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -102,6 +102,9 @@ class spell_warr_leap : public SpellScript
         // The client shows an area as unreachable once the target destination is 4 yards above your position
         WorldLocation const* destination = GetExplTargetDest();
 
+        if (destination && destination->GetPositionZ() - caster->GetPositionZ() > 20.0f)
+            return SPELL_FAILED_NOPATH;
+
         PathGenerator path(caster);
         if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
             return SPELL_FAILED_NOPATH;


### PR DESCRIPTION
## Summary
- add a vertical distance check to Outmaneuver so the swap fails if either participant would teleport more than 20 yards upward
- ensure Heroic Leap fails cast validation when the chosen destination is more than 20 yards above the warrior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916876591d48327a7bd34bb2503f7e7)