### PR TITLE
Fix Warsong Gulch weather reset

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -4774,6 +4774,8 @@ void Map::SendZoneWeather(ZoneDynamicInfo const& zoneDynamicInfo, Player* player
 
                 if (toSet != WEATHER_TYPE_FINE)
                     wz->SetWeather(toSet, 0.9999f); // max intensity so it's visible
+                else
+                    wz->SetWeather(WEATHER_TYPE_FINE, 0.0f);
             }
 
             wz->SendWeatherUpdateToPlayer(player);


### PR DESCRIPTION
## Summary
- ensure the Warsong Gulch weather override can reset the map back to clear conditions instead of leaving the map stuck in heavy weather once precipitation starts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c31158c08327920458b23f4edcb0)