### PR TITLE
Log heartbeat resist aura removals

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3566,6 +3566,8 @@ void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMo
 
     aura->HandleAuraSpecificMods(aurApp, caster, false, false);
 
+    aura->LogHeartbeatRemoval(this, removeMode);
+
     if (Player* player = ToPlayer())
         if (sConditionMgr->IsSpellUsedInSpellClickConditions(aurApp->GetBase()->GetId()))
             player->UpdateVisibleGameobjectsOrSpellClicks();

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -436,6 +436,7 @@ m_procCooldown(TimePoint::min())
     m_heartbeatResistChance = 0;
     m_heartbeatDurationCap = 0;
     m_heartbeatResistTimer = 0;
+    m_heartbeatResistRoll = 0.0f;
     m_maxDuration = CalcMaxDuration(createInfo.Caster);
     m_duration = m_maxDuration;
     m_procCharges = CalcMaxCharges(createInfo.Caster);
@@ -2082,6 +2083,38 @@ double inverse_of_normal_cdf(const double p, const double mu, const double sigma
     return mu + sigma * val;
 }
 
+void Aura::LogHeartbeatRemoval(Unit* target, AuraRemoveMode removeMode) const
+{
+    if (m_heartbeatResistChance <= 0.0f || !target)
+        return;
+
+    float totalSeconds = m_maxDuration > 0 ? float(m_maxDuration) / IN_MILLISECONDS : 0.0f;
+    float elapsedMilliseconds = float(m_maxDuration - m_duration);
+    if (elapsedMilliseconds < 0.0f)
+        elapsedMilliseconds = 0.0f;
+    float elapsedSeconds = elapsedMilliseconds / IN_MILLISECONDS;
+    float secondsRemaining = std::max(0, m_duration) / float(IN_MILLISECONDS);
+    float effectiveness = totalSeconds > 0.0f ? (elapsedSeconds / totalSeconds) * 100.0f : 0.0f;
+
+    float roll = m_heartbeatResistRoll;
+    if (roll < 0.0f)
+        roll = 0.0f;
+    if (roll > 1.0f)
+        roll = 1.0f;
+
+    TC_LOG_INFO("server.combat",
+        "Heartbeat resist aura '{}' removed from '{}' (mode {}). Duration {:.2f}/{:.2f}s ({:.2f}% effectiveness, {:.2f}s left). Roll {:.2f}/100 (chance {}%).",
+        GetSpellInfo()->SpellName[sWorld->GetDefaultDbcLocale()],
+        target->GetName(),
+        uint32(removeMode),
+        elapsedSeconds,
+        totalSeconds,
+        effectiveness,
+        secondsRemaining,
+        roll * 100.0f,
+        m_heartbeatResistChance);
+}
+
 void Aura::SetHeartbeatResist(uint32 chance, int32 originalDuration, uint32 drLevel, DiminishingGroup drGroup)
 {
     // NOTE: This is an experimental approximation of heartbeat resist mechanics, more research is required
@@ -2105,11 +2138,7 @@ void Aura::SetHeartbeatResist(uint32 chance, int32 originalDuration, uint32 drLe
 
     m_heartbeatDurationCap = inverse_of_normal_cdf(probability, 15160, 4713);
 
-    std::string str = "heartbeat duration " + std::to_string(m_heartbeatDurationCap) + " roll (out of 100): " + std::to_string((int)(probability * 100.f)) + " "
-        + "Spell[" + this->GetSpellInfo()->SpellName[sWorld->GetDefaultDbcLocale()] + "] Unit[" + this->GetUnitOwner()->GetName()
-        + "] DRLevel[" + std::to_string(drLevel) + "] DRGroup[" + std::to_string(drGroup) + "].";
-
-    //sWorld->SendServerMessage(SERVER_MSG_STRING, str.c_str());
+    m_heartbeatResistRoll = probability;
 }
 
 void Aura::UpdateHeartbeatResist(uint32 diff, Unit* target)

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -37,6 +37,8 @@
 #include "Vehicle.h"
 #include "World.h"
 #include "WorldPacket.h"
+#include <iomanip>
+#include <sstream>
 
 AuraCreateInfo::AuraCreateInfo(SpellInfo const* spellInfo, uint8 auraEffMask, WorldObject* owner) :
     _spellInfo(spellInfo), _auraEffectMask(auraEffMask), _owner(owner)
@@ -2088,6 +2090,14 @@ void Aura::LogHeartbeatRemoval(Unit* target, AuraRemoveMode removeMode) const
     if (m_heartbeatResistChance <= 0.0f || !target)
         return;
 
+    Unit* caster = GetCaster();
+    if (!caster)
+        return;
+
+    Player* casterPlayer = caster->ToPlayer();
+    if (!casterPlayer || !casterPlayer->IsGameMaster())
+        return;
+
     float totalSeconds = m_maxDuration > 0 ? float(m_maxDuration) / IN_MILLISECONDS : 0.0f;
     float elapsedMilliseconds = float(m_maxDuration - m_duration);
     if (elapsedMilliseconds < 0.0f)
@@ -2102,17 +2112,15 @@ void Aura::LogHeartbeatRemoval(Unit* target, AuraRemoveMode removeMode) const
     if (roll > 1.0f)
         roll = 1.0f;
 
-    TC_LOG_INFO("server.combat",
-        "Heartbeat resist aura '{}' removed from '{}' (mode {}). Duration {:.2f}/{:.2f}s ({:.2f}% effectiveness, {:.2f}s left). Roll {:.2f}/100 (chance {}%).",
-        GetSpellInfo()->SpellName[sWorld->GetDefaultDbcLocale()],
-        target->GetName(),
-        uint32(removeMode),
-        elapsedSeconds,
-        totalSeconds,
-        effectiveness,
-        secondsRemaining,
-        roll * 100.0f,
-        m_heartbeatResistChance);
+    std::ostringstream message;
+    message.setf(std::ios::fixed, std::ios::floatfield);
+    message << std::setprecision(2)
+        << "Heartbeat resist aura '" << GetSpellInfo()->SpellName[sWorld->GetDefaultDbcLocale()]
+        << "' removed from '" << target->GetName() << "' (mode " << uint32(removeMode) << "). Duration "
+        << elapsedSeconds << "/" << totalSeconds << "s (" << effectiveness << "% effectiveness, "
+        << secondsRemaining << "s left). Roll " << roll * 100.0f << "/100 (chance " << m_heartbeatResistChance << "%).";
+
+    target->Whisper(message.str(), LANG_UNIVERSAL, casterPlayer);
 }
 
 void Aura::SetHeartbeatResist(uint32 chance, int32 originalDuration, uint32 drLevel, DiminishingGroup drGroup)

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -294,9 +294,12 @@ class TC_GAME_API Aura
         AuraEffect* m_effects[MAX_SPELL_EFFECTS];
         ApplicationMap m_applications;
 
+        void LogHeartbeatRemoval(Unit* target, AuraRemoveMode removeMode) const;
+
         float m_heartbeatResistChance = 0;                      // Chance to break this spell due to heartbeat resistance
         int32 m_heartbeatDurationCap;                    // Heartbeat resistance periodic interval
         int32 m_heartbeatResistTimer;                       // Timer for heartbeat resistance
+        float m_heartbeatResistRoll = 0.0f;                  // Cached heartbeat roll (0-1)
 
         bool m_isRemoved:1;
         bool m_isSingleTarget:1;                        // true if it's a single target spell and registered at caster - can change at spell steal for example


### PR DESCRIPTION
## Summary
- add persistent tracking for heartbeat resist rolls
- log heartbeat resist details to the combat log whenever auras end

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d9265f7c8327be849a607088b9b5)