### PR TITLE
Allow traps to trigger while owner is incapacitated

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -773,7 +773,10 @@ void GameObject::Update(uint32 diff)
                     else if (Unit* target = ObjectAccessor::GetUnit(*this, m_lootStateUnitGUID))
                     {
                         // Some traps do not have a spell but should be triggered
-                        CastSpellExtraArgs args;
+                        // Trap spells should still activate even if their owner is in a state
+                        // that normally prevents casting (for example Feign Death).  Ignore
+                        // caster aura checks so trap triggers are not cancelled by owner state.
+                        CastSpellExtraArgs args(TRIGGERED_IGNORE_CASTER_AURAS);
                         args.SetOriginalCaster(GetOwnerGUID());
                         if (goInfo->trap.spellId)
                         {


### PR DESCRIPTION
## Summary
- ensure trap gameobjects cast their spells with the `TRIGGERED_IGNORE_CASTER_AURAS` flag so they no longer inherit their owner's casting restrictions
- document why the flag is applied so future maintainers understand the interaction with effects such as Feign Death

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e37c30388327aa0970b499e0a860)