### PR TITLE
Make Flare activate instantly

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3642,6 +3642,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->_GetEffect(EFFECT_0).ApplyAuraName = SPELL_AURA_DUMMY;
     });
 
+    // Flare - should explode immediately on the target location (no missile travel time)
+    ApplySpellFix({ 1543 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Speed = 0.0f;
+    });
+
     ApplySpellFix({
         27892, // To Anchor 1
         27928, // To Anchor 1


### PR DESCRIPTION
## Summary
- ensure Flare (spell 1543) detonates immediately by overriding its missile speed to zero so stealthed targets are revealed without a travel delay

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e9fa394083278b3ce62081a7f018)