### PR TITLE
Ensure trap miss feedback reaches targets

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2620,6 +2620,9 @@ SpellMissInfo WorldObject::SpellHitResult(Unit* victim, SpellInfo const* spellIn
 
 void WorldObject::SendSpellMiss(Unit* target, uint32 spellID, SpellMissInfo missInfo)
 {
+    if (!target)
+        return;
+
     WorldPacket data(SMSG_SPELLLOGMISS, (4 + 8 + 1 + 4 + 8 + 1));
     data << uint32(spellID);
     data << uint64(GetGUID());
@@ -2629,7 +2632,27 @@ void WorldObject::SendSpellMiss(Unit* target, uint32 spellID, SpellMissInfo miss
     data << uint64(target->GetGUID());                      // target GUID
     data << uint8(missInfo);
     // end loop
-    SendMessageToSet(&data, true);
+
+    if (IsInWorld())
+    {
+        SendMessageToSet(&data, true);
+        return;
+    }
+
+    if (GameObject const* gameObjectCaster = ToGameObject())
+    {
+        if (gameObjectCaster->GetGoType() == GAMEOBJECT_TYPE_TRAP)
+        {
+            // Traps despawn the moment they trigger, so they might no longer be in the world when miss feedback is sent.
+            // In that case broadcast the result around the target so players nearby still get the feedback text.
+            target->SendMessageToSet(&data, true);
+            return;
+        }
+    }
+
+    // If we reach this point we are no longer in world (for example destroyed spell caster).
+    // Fallback to broadcasting the packet around the target so it still receives the feedback text.
+    target->SendMessageToSet(&data, true);
 }
 
 FactionTemplateEntry const* WorldObject::GetFactionTemplateEntry() const


### PR DESCRIPTION
## Summary
- ensure we bail out gracefully if no miss target is supplied
- when trap gameobjects have already despawned, relay spell miss packets via the victim so nearby players still receive the feedback
- fall back to broadcasting via the victim for other destroyed casters as well so the floating text is not lost

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916eef7a87083278af140c73851f41f)