### PR TITLE
Report Nature's Grasp miss reasons

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -34,13 +34,16 @@
 #include "Player.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
+#include "SmartEnum.h"
 #include "Spell.h"
 #include "SpellHistory.h"
 #include "SpellMgr.h"
+#include "StringFormat.h"
 #include "ThreatManager.h"
 #include "Unit.h"
 #include "Util.h"
 #include "Vehicle.h"
+#include "World.h"
 #include "WorldPacket.h"
 #include <numeric>
 
@@ -5709,7 +5712,19 @@ void AuraEffect::HandleProcTriggerSpellAuraProc(AuraApplication* aurApp, ProcEve
     if (SpellInfo const* triggeredSpellInfo = sSpellMgr->GetSpellInfo(triggerSpellId))
     {
         TC_LOG_DEBUG("spells.aura.effect", "AuraEffect::HandleProcTriggerSpellAuraProc: Triggering spell {} from aura {} proc", triggeredSpellInfo->Id, GetId());
-        triggerCaster->CastSpell(triggerTarget, triggeredSpellInfo->Id, this);
+        SpellCastResult const castResult = triggerCaster->CastSpell(triggerTarget, triggeredSpellInfo->Id, this);
+
+        if (castResult != SPELL_CAST_OK && IsNaturesGraspAura(GetId()))
+        {
+            if (Player* playerCaster = triggerCaster->ToPlayer())
+                if (WorldSession* session = playerCaster->GetSession())
+                    if (session->GetSecurity() > SEC_PLAYER)
+                    {
+                        EnumText const reasonText = EnumUtils::ToString(castResult);
+                        std::string const message = Trinity::StringFormat("Nature's Grasp failed: {}", reasonText.Title);
+                        sWorld->SendServerMessage(SERVER_MSG_STRING, message, playerCaster);
+                    }
+        }
     }
     else
         TC_LOG_ERROR("spells.aura.effect.nospell","AuraEffect::HandleProcTriggerSpellAuraProc: Spell {} has non-existent spell {} in EffectTriggered[{}] and is therefore not triggered.", GetId(), triggerSpellId, GetEffIndex());

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -45,6 +45,7 @@
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
+#include "StringFormat.h"
 #include "SpellAuraEffects.h"
 #include "SpellHistory.h"
 #include "SpellInfo.h"
@@ -79,6 +80,56 @@ namespace
             return false;
 
         return true;
+    }
+
+    char const* GetNaturesGraspMissReason(SpellMissInfo missInfo)
+    {
+        switch (missInfo)
+        {
+            case SPELL_MISS_MISS: return "missed";
+            case SPELL_MISS_RESIST: return "was resisted";
+            case SPELL_MISS_DODGE: return "was dodged";
+            case SPELL_MISS_PARRY: return "was parried";
+            case SPELL_MISS_BLOCK: return "was blocked";
+            case SPELL_MISS_EVADE: return "evaded";
+            case SPELL_MISS_IMMUNE:
+            case SPELL_MISS_IMMUNE2: return "was immune";
+            case SPELL_MISS_DEFLECT: return "was deflected";
+            case SPELL_MISS_ABSORB: return "was absorbed";
+            case SPELL_MISS_REFLECT: return "was reflected";
+            case SPELL_MISS_INTERRUPT: return "was interrupted";
+            default:
+                break;
+        }
+
+        return nullptr;
+    }
+
+    void ReportNaturesGraspMiss(Spell* spell, SpellMissInfo missInfo, Unit* target)
+    {
+        if (missInfo == SPELL_MISS_NONE || !target)
+            return;
+
+        if (!spell->m_triggeredByAuraSpell || !IsNaturesGraspAura(spell->m_triggeredByAuraSpell->Id))
+            return;
+
+        Player* playerCaster = spell->m_caster->ToPlayer();
+        if (!playerCaster)
+            return;
+
+        WorldSession* session = playerCaster->GetSession();
+        if (!session || session->GetSecurity() <= SEC_PLAYER)
+            return;
+
+        if (char const* reason = GetNaturesGraspMissReason(missInfo))
+        {
+            std::string targetName = target->GetName();
+            if (targetName.empty())
+                targetName = "target";
+
+            std::string const message = Trinity::StringFormat("Nature's Grasp failed on {}: {}", targetName, reason);
+            sWorld->SendServerMessage(SERVER_MSG_STRING, message, playerCaster);
+        }
     }
 }
 
@@ -2360,6 +2411,13 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
             unit->SetInCombatWith(spell->m_originalCaster);
     }
 
+    bool reportedNaturesGraspFailure = false;
+    if (MissCondition != SPELL_MISS_NONE)
+    {
+        ReportNaturesGraspMiss(spell, MissCondition, unit);
+        reportedNaturesGraspFailure = true;
+    }
+
     spell->CallScriptBeforeHitHandlers(MissCondition);
 
     _enablePVP = false; // need to check PvP state before spell effects, but act on it afterwards
@@ -2373,6 +2431,12 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
         SpellMissInfo missInfo = spell->PreprocessSpellHit(_spellHitTarget, ScaleAura, *this);
         if (missInfo != SPELL_MISS_NONE)
         {
+            if (!reportedNaturesGraspFailure)
+            {
+                ReportNaturesGraspMiss(spell, missInfo, unit);
+                reportedNaturesGraspFailure = true;
+            }
+
             if (missInfo != SPELL_MISS_MISS)
                 spell->m_caster->SendSpellMiss(unit, spell->m_spellInfo->Id, missInfo);
             spell->m_damage = 0;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -32,6 +32,24 @@
 #include "SpellAuraDefines.h"
 #include "SpellInfo.h"
 
+bool IsNaturesGraspAura(uint32 spellId)
+{
+    switch (spellId)
+    {
+        case 16689:
+        case 16810:
+        case 16811:
+        case 16812:
+        case 16813:
+        case 17329:
+        case 27009:
+        case 53312:
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool IsPrimaryProfessionSkill(uint32 skill)
 {
     SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -735,6 +735,9 @@ class TC_GAME_API SpellMgr
     friend class UnitTestDataLoader;
 };
 
+
+bool IsNaturesGraspAura(uint32 spellId);
+
 #define sSpellMgr SpellMgr::instance()
 
 #endif


### PR DESCRIPTION
## Summary
- add a shared helper so Nature's Grasp ranks can be identified anywhere in spell code
- teach the spell hit pipeline to report miss/resist/immune reasons for Nature's Grasp procs and send the details via server message to privileged druids

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d9e56fa08327ad3c693be4f80815)