### PR TITLE
Fix Nature's Grasp helper access

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -47,27 +47,6 @@
 #include "WorldPacket.h"
 #include <numeric>
 
-namespace
-{
-bool IsNaturesGraspAura(uint32 spellId)
-{
-    switch (spellId)
-    {
-        case 16689:
-        case 16810:
-        case 16811:
-        case 16812:
-        case 16813:
-        case 17329:
-        case 27009:
-        case 53312:
-            return true;
-        default:
-            return false;
-    }
-}
-}
-
 //
 // EFFECT HANDLER NOTES
 //

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -168,7 +168,6 @@ namespace
             case SPELL_MISS_DEFLECT: return "was deflected";
             case SPELL_MISS_ABSORB: return "was absorbed";
             case SPELL_MISS_REFLECT: return "was reflected";
-            case SPELL_MISS_INTERRUPT: return "was interrupted";
             default:
                 break;
         }
@@ -181,10 +180,11 @@ namespace
         if (missInfo == SPELL_MISS_NONE || !target)
             return;
 
-        if (!spell->m_triggeredByAuraSpell || !IsNaturesGraspAura(spell->m_triggeredByAuraSpell->Id))
+        SpellInfo const* triggeredByAura = spell->GetTriggeredByAuraSpell();
+        if (!triggeredByAura || !IsNaturesGraspAura(triggeredByAura->Id))
             return;
 
-        Player* playerCaster = spell->m_caster->ToPlayer();
+        Player* playerCaster = spell->GetCaster() ? spell->GetCaster()->ToPlayer() : nullptr;
         if (!playerCaster)
             return;
 

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -449,6 +449,7 @@ class TC_GAME_API Spell
         WorldObject* GetCaster() const { return m_caster; }
         Unit* GetOriginalCaster() const { return m_originalCaster; }
         SpellInfo const* GetSpellInfo() const { return m_spellInfo; }
+        SpellInfo const* GetTriggeredByAuraSpell() const { return m_triggeredByAuraSpell; }
         int32 GetPowerCost() const { return m_powerCost; }
 
         bool UpdatePointers();                              // must be used at call Spell code after time delay (non triggered spell cast/update spell call/etc)


### PR DESCRIPTION
## Summary
- remove the duplicate local `IsNaturesGraspAura` declaration so the shared helper from `SpellMgr` is used everywhere
- expose the triggering aura information through a const getter and update the Nature's Grasp miss reporter to use the public API
- drop the reference to the non-existent `SPELL_MISS_INTERRUPT` miss type

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916fdfae1e88327bb3c50637c58dcaf)