### PR TITLE
Forward trap miss packets to the trap owner

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2620,6 +2620,9 @@ SpellMissInfo WorldObject::SpellHitResult(Unit* victim, SpellInfo const* spellIn
 
 void WorldObject::SendSpellMiss(Unit* target, uint32 spellID, SpellMissInfo missInfo)
 {
+    if (!target)
+        return;
+
     WorldPacket data(SMSG_SPELLLOGMISS, (4 + 8 + 1 + 4 + 8 + 1));
     data << uint32(spellID);
     data << uint64(GetGUID());
@@ -2629,7 +2632,52 @@ void WorldObject::SendSpellMiss(Unit* target, uint32 spellID, SpellMissInfo miss
     data << uint64(target->GetGUID());                      // target GUID
     data << uint8(missInfo);
     // end loop
-    SendMessageToSet(&data, true);
+
+    if (IsInWorld())
+    {
+        SendMessageToSet(&data, true);
+        return;
+    }
+
+    Player* controllingPlayer = nullptr;
+    if (Unit const* unitCaster = ToUnit())
+        controllingPlayer = unitCaster->GetCharmerOrOwnerPlayerOrPlayerItself();
+    else if (GameObject const* gameObjectCaster = ToGameObject())
+    {
+        if (Unit* owner = gameObjectCaster->GetOwner())
+            controllingPlayer = owner->GetCharmerOrOwnerPlayerOrPlayerItself();
+    }
+
+    auto const broadcastViaTarget = [&data, target](Player* extraRecipient)
+    {
+        target->SendMessageToSet(&data, true);
+
+        if (Player* playerTarget = target->ToPlayer())
+        {
+            playerTarget->SendDirectMessage(&data);
+
+            if (extraRecipient == playerTarget)
+                extraRecipient = nullptr;
+        }
+
+        if (extraRecipient)
+            extraRecipient->SendDirectMessage(&data);
+    };
+
+    if (GameObject const* gameObjectCaster = ToGameObject())
+    {
+        if (gameObjectCaster->GetGoType() == GAMEOBJECT_TYPE_TRAP)
+        {
+            // Traps despawn the moment they trigger, so they might no longer be in the world when miss feedback is sent.
+            // In that case broadcast the result around the target so players nearby still get the feedback text.
+            broadcastViaTarget(controllingPlayer);
+            return;
+        }
+    }
+
+    // If we reach this point we are no longer in world (for example destroyed spell caster).
+    // Fallback to broadcasting the packet around the target so it still receives the feedback text.
+    broadcastViaTarget(controllingPlayer);
 }
 
 FactionTemplateEntry const* WorldObject::GetFactionTemplateEntry() const


### PR DESCRIPTION
## Summary
- track the controlling player when a caster is no longer in the world
- ensure miss/resist packets are rebroadcast via the victim and are also sent directly to the controlling player so trap owners still see floating combat text

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916eef7a87083278af140c73851f41f)