### PR TITLE
Ensure PvP titles clean up on login

### DIFF
--- a/src/server/scripts/Custom/mod_pvp_titles.cpp
+++ b/src/server/scripts/Custom/mod_pvp_titles.cpp
@@ -291,6 +291,19 @@ void RemoveTitlesBelowRank(Player* player, uint8 highestRank)
     }
 }
 
+void RemoveTitlesBelowHighestEligibleRank(Player* player)
+{
+    if (!sConfigMgr->GetBoolDefault("PvPTitles.RemoveLowerTitles", false))
+        return;
+
+    uint32 const kills = player->GetUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS);
+    RankThresholdArray const thresholds = GetConfiguredKillThresholds();
+    uint8 const highestEligibleRank = GetHighestEligibleRank(kills, thresholds);
+
+    if (highestEligibleRank < MAX_RANK)
+        RemoveTitlesBelowRank(player, highestEligibleRank);
+}
+
 class PvPTitlesPlayerScript : public PlayerScript
 {
 public:
@@ -312,6 +325,8 @@ public:
 
         if (sConfigMgr->GetBoolDefault("PvPTitles.AwardTitlesOnLogin", false))
             AwardEarnedTitles(player);
+
+        RemoveTitlesBelowHighestEligibleRank(player);
     }
 
     void OnPVPKill(Player* killer, Player* killed) override


### PR DESCRIPTION
## Summary
- add a helper that trims all ranks below the highest one a character qualifies for when the RemoveLowerTitles option is enabled
- call the helper during player login so characters no longer keep obsolete lower PvP titles even if no cleanup mode is configured

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691714eb86e08327ab2c3a69b410a8e7)