### PR TITLE
Trim lower PvP titles based on known ranks

### DIFF
--- a/src/server/scripts/Custom/mod_pvp_titles.cpp
+++ b/src/server/scripts/Custom/mod_pvp_titles.cpp
@@ -291,6 +291,35 @@ void RemoveTitlesBelowRank(Player* player, uint8 highestRank)
     }
 }
 
+uint8 GetHighestKnownRank(Player const* player)
+{
+    for (int8 rank = MAX_RANK - 1; rank >= static_cast<int8>(RANK_ONE); --rank)
+    {
+        bool hasRank = false;
+        ForEachRankTitle(static_cast<uint8>(rank), [player, &hasRank](size_t /*teamIndex*/, CharTitlesEntry const* titleEntry, char const* /*titleName*/)
+        {
+            if (hasRank)
+                return;
+
+            if (player->HasTitle(titleEntry))
+                hasRank = true;
+        });
+
+        if (hasRank)
+            return static_cast<uint8>(rank);
+    }
+
+    return MAX_RANK;
+}
+
+void RemoveTitlesBelowHighestKnownRank(Player* player)
+{
+    uint8 const highestKnownRank = GetHighestKnownRank(player);
+
+    if (highestKnownRank < MAX_RANK)
+        RemoveTitlesBelowRank(player, highestKnownRank);
+}
+
 class PvPTitlesPlayerScript : public PlayerScript
 {
 public:
@@ -312,6 +341,9 @@ public:
 
         if (sConfigMgr->GetBoolDefault("PvPTitles.AwardTitlesOnLogin", false))
             AwardEarnedTitles(player);
+
+        if (sConfigMgr->GetBoolDefault("PvPTitles.RemoveLowerTitles", false))
+            RemoveTitlesBelowHighestKnownRank(player);
     }
 
     void OnPVPKill(Player* killer, Player* killed) override
@@ -332,7 +364,6 @@ private:
     {
         uint32 const kills = player->GetUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS);
         RankThresholdArray const thresholds = GetConfiguredKillThresholds();
-        uint8 const highestEligibleRank = GetHighestEligibleRank(kills, thresholds);
         bool const removeLower = sConfigMgr->GetBoolDefault("PvPTitles.RemoveLowerTitles", false);
 
         for (uint8 rank = RANK_ONE; rank < MAX_RANK; ++rank)
@@ -366,8 +397,8 @@ private:
             }
         }
 
-        if (removeLower && highestEligibleRank < MAX_RANK)
-            RemoveTitlesBelowRank(player, highestEligibleRank);
+        if (removeLower)
+            RemoveTitlesBelowHighestKnownRank(player);
     }
 
     void CleanUpTitles(int32 mode, Player* player)
@@ -376,7 +407,6 @@ private:
 
         RankThresholdArray const thresholds = GetConfiguredKillThresholds();
         bool const removeLower = sConfigMgr->GetBoolDefault("PvPTitles.RemoveLowerTitles", false);
-        uint8 const highestEligibleRank = GetHighestEligibleRank(kills, thresholds);
 
         for (uint8 rank = RANK_ONE; rank < MAX_RANK; ++rank)
         {
@@ -398,8 +428,8 @@ private:
             });
         }
 
-        if (removeLower && highestEligibleRank < MAX_RANK)
-            RemoveTitlesBelowRank(player, highestEligibleRank);
+        if (removeLower)
+            RemoveTitlesBelowHighestKnownRank(player);
     }
 };
 } // namespace


### PR DESCRIPTION
## Summary
- replace the login cleanup helper so it determines which PvP titles to remove based on the highest rank the player currently knows rather than on kill counts
- reuse the new helper everywhere `RemoveLowerTitles` applies so characters always lose obsolete lower ranks after any award or cleanup pass

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691714eb86e08327ab2c3a69b410a8e7)