### PR TITLE
Add PvPvE dungeon manager skeleton

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -1,0 +1,251 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mod_pvpve_dungeon.h"
+
+#include "DatabaseEnv.h"
+#include "Log.h"
+
+#include <algorithm>
+#include <ctime>
+
+namespace
+{
+char const* const kTemplateQuery = "SELECT Id, MapId, Enabled, MinLevel, MaxLevel, MaxTeams, MinPlayersPerTeam, MaxPlayersPerTeam "
+    "FROM pvpve_dungeon_template";
+
+char const* const kSpawnQuery = "SELECT TemplateId, SpawnIndex, PositionX, PositionY, PositionZ, Orientation "
+    "FROM pvpve_dungeon_spawn ORDER BY TemplateId, SpawnIndex";
+}
+
+DungeonTemplate const* PvpveDungeonMgr::GetDungeonTemplate(uint32 templateId) const
+{
+    auto itr = _templates.find(templateId);
+    if (itr == _templates.end())
+        return nullptr;
+
+    return &itr->second;
+}
+
+std::vector<SpawnPoint> const* PvpveDungeonMgr::GetSpawnPoints(uint32 templateId) const
+{
+    auto itr = _spawns.find(templateId);
+    if (itr == _spawns.end())
+        return nullptr;
+
+    return &itr->second;
+}
+
+PvpveDungeonMgr* PvpveDungeonMgr::Instance()
+{
+    static PvpveDungeonMgr instance;
+    return &instance;
+}
+
+PvpveDungeonMgr::PvpveDungeonMgr()
+{
+    _nextRunId = 1;
+    _nextTeamId = 1;
+    _queue.clear();
+    _runs.clear();
+    _teams.clear();
+    _playerToRun.clear();
+    _playerToTeam.clear();
+    _templates.clear();
+    _spawns.clear();
+}
+
+void PvpveDungeonMgr::LoadConfigFromDB()
+{
+    _templates.clear();
+    _spawns.clear();
+
+    QueryResult templateResult = WorldDatabase.Query(kTemplateQuery);
+    if (!templateResult)
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: no dungeon templates found in pvpve_dungeon_template.");
+    }
+    else
+    {
+        do
+        {
+            Field* fields = templateResult->Fetch();
+
+            DungeonTemplate entry;
+            entry.Id = fields[0].GetUInt32();
+            entry.MapId = fields[1].GetUInt16();
+            entry.Enabled = fields[2].GetBool();
+            entry.MinLevel = fields[3].GetUInt8();
+            entry.MaxLevel = fields[4].GetUInt8();
+            entry.MaxTeams = std::max<uint8>(1, fields[5].GetUInt8());
+            entry.MinPlayers = fields[6].GetUInt8();
+            entry.MaxPlayers = fields[7].GetUInt8();
+
+            _templates[entry.Id] = entry;
+        }
+        while (templateResult->NextRow());
+
+        TC_LOG_INFO("server.custom", "PvpveDungeonMgr: loaded {} dungeon templates.", _templates.size());
+    }
+
+    QueryResult spawnResult = WorldDatabase.Query(kSpawnQuery);
+    if (!spawnResult)
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: no spawn points found in pvpve_dungeon_spawn.");
+        return;
+    }
+
+    do
+    {
+        Field* fields = spawnResult->Fetch();
+
+        SpawnPoint spawn;
+        spawn.TemplateId = fields[0].GetUInt32();
+        spawn.Index = fields[1].GetUInt8();
+        spawn.X = fields[2].GetFloat();
+        spawn.Y = fields[3].GetFloat();
+        spawn.Z = fields[4].GetFloat();
+        spawn.O = fields[5].GetFloat();
+
+        _spawns[spawn.TemplateId].push_back(spawn);
+    }
+    while (spawnResult->NextRow());
+
+    TC_LOG_INFO("server.custom", "PvpveDungeonMgr: loaded spawn point data for {} templates.", _spawns.size());
+}
+
+void PvpveDungeonMgr::QueueTeam(uint64 teamId)
+{
+    auto teamItr = _teams.find(teamId);
+    if (teamItr == _teams.end())
+    {
+        TC_LOG_ERROR("server.custom", "PvpveDungeonMgr: unable to queue unknown team {}.", teamId);
+        return;
+    }
+
+    QueuedTeam queued;
+    queued.TeamId = teamId;
+    queued.TemplateId = teamItr->second.TemplateId;
+    queued.QueueTime = std::time(nullptr);
+    queued.Ready = teamItr->second.Ready;
+
+    auto [itr, inserted] = _queue.insert_or_assign(teamId, queued);
+    if (inserted)
+        TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: queued team {} for template {}.", teamId, queued.TemplateId);
+    else
+        TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: updated queue entry for team {}.", teamId);
+}
+
+void PvpveDungeonMgr::CancelQueue(uint64 teamId)
+{
+    if (_queue.erase(teamId))
+        TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: removed team {} from the queue.", teamId);
+}
+
+void PvpveDungeonMgr::Update(uint32 /*diff*/)
+{
+    if (_queue.empty())
+        return;
+
+    // TrinityCore executes world updates on a single thread; no explicit locking needed here.
+    std::vector<uint64> queuedIds;
+    queuedIds.reserve(_queue.size());
+    for (auto const& entry : _queue)
+        queuedIds.push_back(entry.first);
+
+    for (uint64 teamId : queuedIds)
+    {
+        auto queueItr = _queue.find(teamId);
+        if (queueItr == _queue.end())
+            continue;
+
+        auto teamItr = _teams.find(teamId);
+        if (teamItr == _teams.end())
+        {
+            TC_LOG_WARN("server.custom", "PvpveDungeonMgr: dropping non-existent team {} from queue.", teamId);
+            _queue.erase(queueItr);
+            continue;
+        }
+
+        DungeonTemplate const* dungeonTemplate = GetDungeonTemplate(teamItr->second.TemplateId);
+        if (!dungeonTemplate || !dungeonTemplate->Enabled)
+        {
+            TC_LOG_WARN("server.custom", "PvpveDungeonMgr: template {} not available for team {}.", teamItr->second.TemplateId, teamId);
+            _queue.erase(queueItr);
+            continue;
+        }
+
+        PvpveDungeonRun* selectedRun = nullptr;
+        for (auto& runPair : _runs)
+        {
+            PvpveDungeonRun& candidate = runPair.second;
+            if (candidate.TemplateId != dungeonTemplate->Id)
+                continue;
+
+            if (candidate.Completed)
+                continue;
+
+            if (candidate.Teams.size() < dungeonTemplate->MaxTeams)
+            {
+                selectedRun = &candidate;
+                break;
+            }
+        }
+
+        if (!selectedRun)
+        {
+            PvpveDungeonRun newRun;
+            newRun.Id = _nextRunId++;
+            newRun.TemplateId = dungeonTemplate->Id;
+            newRun.CreatedTime = std::time(nullptr);
+            auto [runItr, inserted] = _runs.emplace(newRun.Id, std::move(newRun));
+            selectedRun = &runItr->second;
+            if (inserted)
+                TC_LOG_INFO("server.custom", "PvpveDungeonMgr: created new run {} for template {}.", selectedRun->Id, dungeonTemplate->Id);
+        }
+
+        selectedRun->Teams.push_back(teamId);
+        AssignTeamToRun(*selectedRun, teamItr->second);
+        _queue.erase(queueItr);
+    }
+}
+
+void PvpveDungeonMgr::AssignTeamToRun(PvpveDungeonRun& run, PvpveTeam& team)
+{
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO assign team {} to run {}.", team.Id ? team.Id : run.Teams.back(), run.Id);
+}
+
+uint8 PvpveDungeonMgr::PickSpawnIndex(uint32 templateId)
+{
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO pick spawn index for template {}.", templateId);
+    return 0;
+}
+
+void PvpveDungeonMgr::OnInstanceCreated(Map* /*map*/)
+{
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO handle instance creation.");
+}
+
+void PvpveDungeonMgr::OnPlayerEliminated(Player* /*player*/)
+{
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO handle player elimination.");
+}
+
+void PvpveDungeonMgr::OnPlayerLeftMap(Player* /*player*/)
+{
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO handle player leaving map.");
+}

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -19,10 +19,12 @@ struct DungeonTemplate
 {
     uint32 Id = 0;
     uint32 MapId = 0;
-    uint8 Difficulty = 0;
-    uint32 TimeLimit = 0;
-    uint32 MinPlayers = 0;
-    uint32 MaxPlayers = 0;
+    bool Enabled = false;
+    uint8 MinLevel = 1;
+    uint8 MaxLevel = 60;
+    uint8 MaxTeams = 1;
+    uint8 MinPlayers = 0;
+    uint8 MaxPlayers = 0;
 };
 
 struct SpawnPoint
@@ -56,6 +58,7 @@ struct PvpveDungeonRun
     bool Completed = false;
     std::vector<ObjectGuid> Players;
     std::map<ObjectGuid, uint8> PlayerSpawns;
+    std::vector<uint64> Teams;
 };
 
 struct QueuedTeam
@@ -71,8 +74,7 @@ class PvpveDungeonMgr
 public:
     static PvpveDungeonMgr* Instance();
 
-    void LoadDungeonTemplates();
-    void LoadSpawnPoints();
+    void LoadConfigFromDB();
 
     const DungeonTemplate* GetDungeonTemplate(uint32 templateId) const;
     const std::vector<SpawnPoint>* GetSpawnPoints(uint32 templateId) const;
@@ -80,6 +82,7 @@ public:
     uint64 CreateTeam(std::vector<Player*> const& players, uint32 templateId);
     void RemoveTeam(uint64 teamId);
     void QueueTeam(uint64 teamId);
+    void CancelQueue(uint64 teamId);
 
     void Update(uint32 diff);
 
@@ -94,13 +97,16 @@ public:
     void Reset();
 
 private:
-    PvpveDungeonMgr() = default;
+    PvpveDungeonMgr();
 
     void StartNextRun();
-    void AssignPlayersToRun(PvpveDungeonRun& run, PvpveTeam& team);
-    uint8 GetNextSpawnIndex(uint32 templateId);
+    void AssignTeamToRun(PvpveDungeonRun& run, PvpveTeam& team);
+    uint8 PickSpawnIndex(uint32 templateId);
     void CleanupRun(uint64 runId);
     void CleanupPlayer(ObjectGuid const& guid);
+    void OnInstanceCreated(Map* map);
+    void OnPlayerEliminated(Player* player);
+    void OnPlayerLeftMap(Player* player);
 
     using QueueContainer = std::map<uint64, QueuedTeam>;
     using RunContainer = std::map<uint64, PvpveDungeonRun>;


### PR DESCRIPTION
## Summary
- introduce the PvPvE dungeon manager source file and update the header with template/run metadata
- load dungeon templates and spawn points from the custom tables with logging and queue management plumbing
- add skeleton hooks for assigning teams to runs and future gameplay events

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175cd437d4832786041d56643fa58c)