### PR TITLE
Add PvPvE dungeon world script

### DIFF
--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -27,6 +27,7 @@ void AddSC_custom_zone_group_rules();
 void AddSC_mod_pvp_titles();
 void AddSC_custom_diremaul_beads();
 void AddSC_custom_gurubashi_arena();
+void AddSC_custom_pvpve_dungeon();
 
 void AddCustomScripts()
 {
@@ -37,4 +38,5 @@ void AddCustomScripts()
     AddSC_mod_pvp_titles();
     AddSC_custom_diremaul_beads();
     AddSC_custom_gurubashi_arena();
+    AddSC_custom_pvpve_dungeon();
 }

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -23,6 +23,7 @@
 #include "Log.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "ScriptMgr.h"
 
 #include <algorithm>
 #include <ctime>
@@ -363,4 +364,27 @@ void PvpveDungeonMgr::OnPlayerEliminated(Player* /*player*/)
 void PvpveDungeonMgr::OnPlayerLeftMap(Player* /*player*/)
 {
     TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO handle player leaving map.");
+}
+
+namespace
+{
+struct PvpveDungeonWorldScript : WorldScript
+{
+    PvpveDungeonWorldScript() : WorldScript("pvpve_dungeon_world") { }
+
+    void OnStartup() override
+    {
+        PvpveDungeonMgr::instance()->LoadConfigFromDB();
+    }
+
+    void OnUpdate(uint32 diff) override
+    {
+        PvpveDungeonMgr::instance()->Update(diff);
+    }
+};
+}
+
+void AddSC_custom_pvpve_dungeon()
+{
+    new PvpveDungeonWorldScript();
 }

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -75,6 +75,10 @@ class PvpveDungeonMgr
 {
 public:
     static PvpveDungeonMgr* Instance();
+    static PvpveDungeonMgr* instance()
+    {
+        return Instance();
+    }
 
     void LoadConfigFromDB();
 


### PR DESCRIPTION
## Summary
- add a WorldScript for the PvPvE dungeon manager so it loads database config on startup and ticks every world update
- expose a helper accessor on the manager and register the script through the custom script loader

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176f4aa1f48327a1f8c391ebd1598f)