### PR TITLE
Add Stockades PvPvE queue NPC

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -133,6 +133,71 @@ void PvpveDungeonMgr::LoadConfigFromDB()
     TC_LOG_INFO("server.custom", "PvpveDungeonMgr: loaded spawn point data for {} templates.", _spawns.size());
 }
 
+bool PvpveDungeonMgr::QueueTeam(uint32 templateId, std::vector<ObjectGuid> const& memberGuids)
+{
+    if (memberGuids.empty())
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: cannot queue empty team for template {}.", templateId);
+        return false;
+    }
+
+    DungeonTemplate const* dungeonTemplate = GetDungeonTemplate(templateId);
+    if (!dungeonTemplate || !dungeonTemplate->Enabled)
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: template {} is not available for queueing.", templateId);
+        return false;
+    }
+
+    if (dungeonTemplate->MinPlayers && memberGuids.size() < dungeonTemplate->MinPlayers)
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: team has too few members ({}) for template {} (min {}).",
+            memberGuids.size(), templateId, uint32(dungeonTemplate->MinPlayers));
+        return false;
+    }
+
+    if (dungeonTemplate->MaxPlayers && memberGuids.size() > dungeonTemplate->MaxPlayers)
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: team has too many members ({}) for template {} (max {}).",
+            memberGuids.size(), templateId, uint32(dungeonTemplate->MaxPlayers));
+        return false;
+    }
+
+    for (ObjectGuid const& guid : memberGuids)
+    {
+        if (!guid)
+        {
+            TC_LOG_WARN("server.custom", "PvpveDungeonMgr: refusing to queue team for template {} with invalid member GUID.", templateId);
+            return false;
+        }
+
+        if (_playerToTeam.find(guid) != _playerToTeam.end())
+        {
+            TC_LOG_WARN("server.custom", "PvpveDungeonMgr: player {} is already assigned to a PvPvE team.", guid.ToString());
+            return false;
+        }
+    }
+
+    PvpveTeam team;
+    team.Id = _nextTeamId++;
+    team.TemplateId = templateId;
+    team.Members = memberGuids;
+    team.CreatedTime = std::time(nullptr);
+    team.Ready = true;
+
+    auto [teamItr, inserted] = _teams.emplace(team.Id, std::move(team));
+    if (!inserted)
+    {
+        TC_LOG_ERROR("server.custom", "PvpveDungeonMgr: failed to store team {} for template {}.", team.Id, templateId);
+        return false;
+    }
+
+    for (ObjectGuid const& guid : memberGuids)
+        _playerToTeam[guid] = teamItr->first;
+
+    QueueTeam(teamItr->first);
+    return true;
+}
+
 void PvpveDungeonMgr::QueueTeam(uint64 teamId)
 {
     auto teamItr = _teams.find(teamId);
@@ -384,7 +449,10 @@ struct PvpveDungeonWorldScript : WorldScript
 };
 }
 
+void AddSC_npc_pvpve_dungeon_queue();
+
 void AddSC_custom_pvpve_dungeon()
 {
     new PvpveDungeonWorldScript();
+    AddSC_npc_pvpve_dungeon_queue();
 }

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -88,6 +88,7 @@ public:
     uint64 CreateTeam(std::vector<Player*> const& players, uint32 templateId);
     void RemoveTeam(uint64 teamId);
     void QueueTeam(uint64 teamId);
+    bool QueueTeam(uint32 templateId, std::vector<ObjectGuid> const& memberGuids);
     void CancelQueue(uint64 teamId);
 
     void Update(uint32 diff);

--- a/src/server/scripts/Custom/npc_pvpve_dungeon_queue.cpp
+++ b/src/server/scripts/Custom/npc_pvpve_dungeon_queue.cpp
@@ -1,0 +1,165 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Group.h"
+#include "GroupReference.h"
+#include "Player.h"
+#include "ScriptMgr.h"
+#include "WorldSession.h"
+
+#include "mod_pvpve_dungeon.h"
+
+#include <vector>
+
+namespace
+{
+constexpr uint32 ACTION_QUEUE = GOSSIP_ACTION_INFO_DEF + 1;
+constexpr uint32 ACTION_CLOSE = GOSSIP_ACTION_INFO_DEF + 2;
+constexpr uint32 STOCKADES_TEMPLATE_ID = 1;
+
+void SendLeaderError(Player* player, char const* text)
+{
+    if (!player)
+        return;
+
+    player->PlayerTalkClass->SendCloseGossip();
+    if (WorldSession* session = player->GetSession())
+        session->SendNotification("%s", text);
+}
+
+void BroadcastToGroup(Group* group, char const* text)
+{
+    if (!group || !text)
+        return;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        if (Player* member = ref->GetSource())
+            if (WorldSession* session = member->GetSession())
+                session->SendNotification("%s", text);
+}
+}
+
+class npc_pvpve_dungeon_queue : public CreatureScript
+{
+public:
+    npc_pvpve_dungeon_queue() : CreatureScript("npc_pvpve_dungeon_queue") { }
+
+    bool OnGossipHello(Player* player, Creature* creature) override
+    {
+        if (!player || !creature)
+            return false;
+
+        player->PlayerTalkClass->ClearMenus();
+        player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Queue for Stockades PvPvE", GOSSIP_SENDER_MAIN, ACTION_QUEUE);
+        player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Maybe later", GOSSIP_SENDER_MAIN, ACTION_CLOSE);
+        player->SendGossipMenu(player->GetGossipTextId(creature), creature->GetGUID());
+        return true;
+    }
+
+    bool OnGossipSelect(Player* player, Creature* creature, uint32 sender, uint32 action) override
+    {
+        if (sender != GOSSIP_SENDER_MAIN)
+            return false;
+
+        switch (action)
+        {
+            case ACTION_QUEUE:
+                HandleQueue(player);
+                return true;
+            case ACTION_CLOSE:
+                player->PlayerTalkClass->SendCloseGossip();
+                return true;
+            default:
+                break;
+        }
+
+        return false;
+    }
+
+private:
+    void HandleQueue(Player* player)
+    {
+        if (!player)
+            return;
+
+        Group* group = player->GetGroup();
+        if (!group)
+        {
+            SendLeaderError(player, "You must be in a party to queue for the Stockades PvPvE event.");
+            return;
+        }
+
+        if (!group->IsLeader(player->GetGUID()))
+        {
+            SendLeaderError(player, "Only the party leader can queue for the Stockades PvPvE event.");
+            return;
+        }
+
+        if (group->GetMembersCount() != 2)
+        {
+            SendLeaderError(player, "Exactly two party members are required for this queue.");
+            return;
+        }
+
+        std::vector<ObjectGuid> memberGuids;
+        memberGuids.reserve(2);
+
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (!member || !member->IsInWorld())
+            {
+                SendLeaderError(player, "All party members must be online to join the queue.");
+                return;
+            }
+
+            if (!member->IsAlive())
+            {
+                SendLeaderError(player, "All party members must be alive to join the queue.");
+                return;
+            }
+
+            if (member->GetMap() && member->GetMap()->Instanceable())
+            {
+                SendLeaderError(player, "Party members must leave instances before queueing.");
+                return;
+            }
+
+            memberGuids.push_back(member->GetGUID());
+        }
+
+        if (memberGuids.size() != 2)
+        {
+            SendLeaderError(player, "Unable to determine party members. Please try again.");
+            return;
+        }
+
+        if (!PvpveDungeonMgr::instance()->QueueTeam(STOCKADES_TEMPLATE_ID, memberGuids))
+        {
+            SendLeaderError(player, "Failed to join the queue. Please try again shortly.");
+            return;
+        }
+
+        BroadcastToGroup(group, "You have joined the Stockades PvPvE queue!");
+        player->PlayerTalkClass->SendCloseGossip();
+    }
+};
+
+void AddSC_npc_pvpve_dungeon_queue()
+{
+    new npc_pvpve_dungeon_queue();
+}


### PR DESCRIPTION
## Summary
- add a Stockades PvPvE queue NPC that validates party requirements and enqueues teams through the PvPvE dungeon manager
- extend the PvPvE dungeon manager with helper logic to build teams directly from GUIDs and register the new creature script in the custom loader

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917744a23448327959abb043a8e6e6e)