### PR TITLE
Add PvPvE Stockades instance support

### DIFF
--- a/sql/updates/custom/2024_04_18_00_stockade_pvpve_instance.sql
+++ b/sql/updates/custom/2024_04_18_00_stockade_pvpve_instance.sql
@@ -1,0 +1,2 @@
+-- Ensure the Stockades instance uses the PvPvE-aware script
+UPDATE `instance_template` SET `script`='instance_the_stockade_pvpve' WHERE `map`=34;

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -67,6 +67,31 @@ bool PvpveDungeonMgr::IsPlayerInPvpveRun(Player const* player) const
     return player && IsPlayerInPvpveRun(player->GetGUID());
 }
 
+void PvpveDungeonMgr::OnPlayerEnteredInstance(Player* player, PvpveDungeonInstance* instanceScript)
+{
+    if (!player || !instanceScript)
+        return;
+
+    auto runItr = _playerToRun.find(player->GetGUID());
+    if (runItr == _playerToRun.end())
+        return;
+
+    PvpveDungeonRun* run = GetRun(runItr->second);
+    if (!run)
+        return;
+
+    if (!run->InstanceId)
+    {
+        run->InstanceId = player->GetInstanceId();
+        TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: tracking instance {} for run {}.", run->InstanceId, run->Id);
+    }
+
+    if (!run->InstanceMap)
+        run->InstanceMap = player->GetMap();
+
+    run->InstanceScript = instanceScript;
+}
+
 PvpveDungeonMgr* PvpveDungeonMgr::Instance()
 {
     static PvpveDungeonMgr instance;
@@ -611,8 +636,16 @@ void PvpveDungeonMgr::FinishRun(PvpveDungeonRun& run)
 
         TC_LOG_INFO("server.custom", "PvpveDungeonMgr: run {} finished. Winning teams: {}.", run.Id, winnersList);
     }
+    if (run.InstanceScript)
+    {
+        for (uint64 teamId : winningTeams)
+        {
+            if (PvpveTeam* team = GetTeam(teamId))
+                run.InstanceScript->OnPvpveRunFinished(run.Id, *team);
+        }
+    }
 
-    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO notify instance scripts and distribute rewards for run {}.", run.Id);
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO distribute rewards for run {}.", run.Id);
 }
 
 namespace

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -48,11 +48,20 @@ struct PvpveTeam
     bool Eliminated = false;
 };
 
+class PvpveDungeonInstance
+{
+public:
+    virtual ~PvpveDungeonInstance() = default;
+    virtual void OnPvpveRunFinished(uint32 runId, PvpveTeam const& winningTeam) = 0;
+};
+
 struct PvpveDungeonRun
 {
     uint64 Id = 0;
     uint32 TemplateId = 0;
     Map* InstanceMap = nullptr;
+    uint32 InstanceId = 0;
+    PvpveDungeonInstance* InstanceScript = nullptr;
     ObjectGuid GroupGuid;
     time_t CreatedTime = 0;
     time_t StartTime = 0;
@@ -98,6 +107,7 @@ public:
     void OnPlayerEnterDungeon(Player* player);
     void OnPlayerLeaveDungeon(Player* player);
     void OnPlayerDeath(Player* player);
+    void OnPlayerEnteredInstance(Player* player, PvpveDungeonInstance* instanceScript);
     bool IsPlayerInPvpveRun(ObjectGuid const& guid) const;
     bool IsPlayerInPvpveRun(Player const* player) const;
 

--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -1,0 +1,227 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ScriptMgr.h"
+
+#include "Configuration/Config.h"
+#include "Duration.h"
+#include "GameObject.h"
+#include "InstanceScript.h"
+#include "Log.h"
+#include "ObjectAccessor.h"
+#include "Player.h"
+#include "Position.h"
+#include "QuaternionData.h"
+#include "SharedDefines.h"
+#include "StringFormat.h"
+
+#include "mod_pvpve_dungeon.h"
+
+#include <string>
+
+namespace StockadesPvPvE
+{
+constexpr uint32 StockadesMapId = 34;
+
+namespace
+{
+constexpr uint32 DefaultChestDespawnSeconds = 300;
+Position const DefaultChestPosition = { 71.879f, -15.478f, -20.215f, 0.0f };
+
+uint32 s_ChestGameObjectId = 0;
+Seconds s_ChestDespawn = Seconds(DefaultChestDespawnSeconds);
+Position s_ChestPosition = DefaultChestPosition;
+
+void LoadConfig()
+{
+    int32 const configuredEntry = sConfigMgr->GetIntDefault("StockadesPvPvE.ChestGameObjectId", 0);
+    int32 const configuredDespawn = sConfigMgr->GetIntDefault("StockadesPvPvE.ChestDespawnSeconds", int32(DefaultChestDespawnSeconds));
+    float const configuredX = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnX", DefaultChestPosition.GetPositionX());
+    float const configuredY = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnY", DefaultChestPosition.GetPositionY());
+    float const configuredZ = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnZ", DefaultChestPosition.GetPositionZ());
+    float const configuredO = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnO", DefaultChestPosition.GetOrientation());
+
+    s_ChestGameObjectId = configuredEntry > 0 ? uint32(configuredEntry) : 0u;
+    s_ChestDespawn = Seconds(configuredDespawn >= 0 ? uint32(configuredDespawn) : DefaultChestDespawnSeconds);
+    s_ChestPosition.Relocate(configuredX, configuredY, configuredZ, configuredO);
+
+    if (!s_ChestGameObjectId)
+        TC_LOG_WARN("server.custom", "Stockades PvPvE: reward chest entry is 0; chest spawning is disabled.");
+}
+
+QuaternionData GetChestRotation()
+{
+    return QuaternionData::fromEulerAnglesZYX(s_ChestPosition.GetOrientation(), 0.0f, 0.0f);
+}
+}
+
+void EnsureConfigLoaded()
+{
+    static bool s_ConfigLoaded = false;
+    if (s_ConfigLoaded)
+        return;
+
+    LoadConfig();
+    s_ConfigLoaded = true;
+}
+
+uint32 GetChestGameObjectId()
+{
+    return s_ChestGameObjectId;
+}
+
+Seconds GetChestDespawnTime()
+{
+    return s_ChestDespawn;
+}
+
+Position const& GetChestPosition()
+{
+    return s_ChestPosition;
+}
+
+QuaternionData GetChestQuaternion()
+{
+    return GetChestRotation();
+}
+}
+
+class instance_the_stockade_pvpve : public InstanceMapScript
+{
+public:
+    instance_the_stockade_pvpve() : InstanceMapScript("instance_the_stockade_pvpve", StockadesPvPvE::StockadesMapId) { }
+
+    InstanceScript* GetInstanceScript(InstanceMap* map) const override
+    {
+        return new instance_the_stockade_pvpve_InstanceMapScript(map);
+    }
+
+    struct instance_the_stockade_pvpve_InstanceMapScript : public InstanceScript, public PvpveDungeonInstance
+    {
+        instance_the_stockade_pvpve_InstanceMapScript(InstanceMap* map) : InstanceScript(map) { }
+
+        void OnPlayerEnter(Player* player) override
+        {
+            InstanceScript::OnPlayerEnter(player);
+
+            if (!player)
+                return;
+
+            if (!sPvpveDungeonMgr->IsPlayerInPvpveRun(player))
+                return;
+
+            player->SetPvpFlag(UNIT_BYTE2_FLAG_FFA_PVP);
+            sPvpveDungeonMgr->OnPlayerEnteredInstance(player, this);
+        }
+
+        void OnPlayerLeave(Player* player) override
+        {
+            InstanceScript::OnPlayerLeave(player);
+
+            if (!player)
+                return;
+
+            if (!sPvpveDungeonMgr->IsPlayerInPvpveRun(player))
+                return;
+
+            player->RemovePvpFlag(UNIT_BYTE2_FLAG_FFA_PVP);
+        }
+
+        void OnPvpveRunFinished(uint32 runId, PvpveTeam const& winningTeam) override
+        {
+            AnnounceVictory(runId, winningTeam);
+            SummonRewardChest(runId, winningTeam);
+        }
+
+    private:
+        std::string CollectMemberNames(PvpveTeam const& team) const
+        {
+            std::string result;
+            for (ObjectGuid const& guid : team.Members)
+            {
+                if (Player* player = ObjectAccessor::FindPlayer(guid))
+                {
+                    if (!result.empty())
+                        result += ", ";
+                    result += player->GetName();
+                }
+            }
+
+            return result;
+        }
+
+        void AnnounceVictory(uint32 runId, PvpveTeam const& team)
+        {
+            std::string const memberNames = CollectMemberNames(team);
+            if (!memberNames.empty())
+                DoSendNotifyToInstance(Trinity::StringFormat("Stockades PvPvE run %u complete! Team %llu (%s) is victorious!", runId, team.Id, memberNames.c_str()).c_str());
+            else
+                DoSendNotifyToInstance(Trinity::StringFormat("Stockades PvPvE run %u complete! Team %llu is victorious!", runId, team.Id).c_str());
+        }
+
+        Player* SelectSummoner(PvpveTeam const& team) const
+        {
+            for (ObjectGuid const& guid : team.Members)
+            {
+                if (Player* player = ObjectAccessor::FindPlayer(guid))
+                {
+                    if (player->GetMap() == instance)
+                        return player;
+                }
+            }
+
+            return nullptr;
+        }
+
+        void SummonRewardChest(uint32 runId, PvpveTeam const& team)
+        {
+            uint32 const chestEntry = StockadesPvPvE::GetChestGameObjectId();
+            if (!chestEntry)
+                return;
+
+            if (_rewardChestRunId == runId)
+                return;
+
+            Player* summoner = SelectSummoner(team);
+            if (!summoner)
+            {
+                TC_LOG_WARN("server.custom", "Stockades PvPvE: unable to find a summoner for the reward chest (run {}, team {}).", runId, team.Id);
+                return;
+            }
+
+            if (GameObject* chest = summoner->SummonGameObject(chestEntry, StockadesPvPvE::GetChestPosition(), StockadesPvPvE::GetChestQuaternion(), StockadesPvPvE::GetChestDespawnTime(), GO_SUMMON_TIMED_DESPAWN))
+            {
+                _rewardChestRunId = runId;
+                _rewardChestGuid = chest->GetGUID();
+                TC_LOG_INFO("server.custom", "Stockades PvPvE: spawned reward chest {} for run {} (team {}).", chestEntry, runId, team.Id);
+            }
+            else
+            {
+                TC_LOG_WARN("server.custom", "Stockades PvPvE: failed to summon reward chest {} for run {} (team {}).", chestEntry, runId, team.Id);
+            }
+        }
+
+        ObjectGuid _rewardChestGuid;
+        uint32 _rewardChestRunId = 0;
+    };
+};
+
+void AddSC_instance_the_stockade_pvpve()
+{
+    StockadesPvPvE::EnsureConfigLoaded();
+    new instance_the_stockade_pvpve();
+}

--- a/src/server/scripts/EasternKingdoms/eastern_kingdoms_script_loader.cpp
+++ b/src/server/scripts/EasternKingdoms/eastern_kingdoms_script_loader.cpp
@@ -151,6 +151,7 @@ void AddSC_boss_ironaya();
 void AddSC_uldaman();
 void AddSC_instance_uldaman();
 void AddSC_instance_the_stockade();          //The Stockade
+void AddSC_instance_the_stockade_pvpve();    //The Stockade PvPvE
 void AddSC_boss_akilzon();                   //Zul'Aman
 void AddSC_boss_halazzi();
 void AddSC_boss_hex_lord_malacrass();
@@ -326,6 +327,7 @@ void AddEasternKingdomsScripts()
     AddSC_boss_kiljaeden();
     AddSC_sunwell_plateau();
     AddSC_instance_the_stockade();          //The Stockade
+    AddSC_instance_the_stockade_pvpve();    //The Stockade PvPvE
     AddSC_boss_archaedas();                 //Uldaman
     AddSC_boss_ironaya();
     AddSC_uldaman();

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3204,6 +3204,27 @@ DireMaulBeads.AreaIds = 495,496,498,2557,3217
 DireMaulBeads.ChestGameObjectId = 0
 DireMaulBeads.ChestDespawnSeconds = 300
 
+#    StockadesPvPvE.ChestGameObjectId
+#        Description: GameObject entry to summon when a Stockades PvPvE run finishes.
+#                     Set to 0 to disable automatic chest spawning.
+#        Default:     0
+#
+#    StockadesPvPvE.ChestDespawnSeconds
+#        Description: Lifetime, in seconds, for the Stockades PvPvE reward chest.
+#        Default:     300
+#
+#    StockadesPvPvE.ChestSpawnX / StockadesPvPvE.ChestSpawnY / StockadesPvPvE.ChestSpawnZ
+#    StockadesPvPvE.ChestSpawnO
+#        Description: Coordinates and facing used for the Stockades PvPvE reward chest.
+#        Default:     71.879 / -15.478 / -20.215 / 0.0
+
+StockadesPvPvE.ChestGameObjectId = 0
+StockadesPvPvE.ChestDespawnSeconds = 300
+StockadesPvPvE.ChestSpawnX = 71.879
+StockadesPvPvE.ChestSpawnY = -15.478
+StockadesPvPvE.ChestSpawnZ = -20.215
+StockadesPvPvE.ChestSpawnO = 0.0
+
 #     AllowTrackBothResources
 #        Description: Allows players to track herbs and minerals at the same time (if they have the skills)
 #        Default:     0 - (Do not allow)


### PR DESCRIPTION
## Summary
- add a dedicated Stockades PvPvE InstanceScript that toggles FFA PvP on entry, notifies the PvPvE manager, and spawns a configurable reward chest when a run finishes
- extend the PvPvE dungeon manager so it can associate runs with instance scripts and deliver the victory callback, register the new script, and document/configure the chest options
- update the database to make map 34 use the new script

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177ccfe1cc8327bdbd59ee790a84b4)