### PR TITLE
Add helpers for PvPvE FFA state

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -39,6 +39,8 @@ char const* const kTemplateQuery = "SELECT Id, MapId, Enabled, MinLevel, MaxLeve
 
 char const* const kSpawnQuery = "SELECT TemplateId, SpawnIndex, PositionX, PositionY, PositionZ, Orientation "
     "FROM pvpve_dungeon_spawn ORDER BY TemplateId, SpawnIndex";
+
+constexpr uint32 kPvpveFfaAuraSpellId = 0;
 }
 
 DungeonTemplate const* PvpveDungeonMgr::GetDungeonTemplate(uint32 templateId) const
@@ -857,4 +859,36 @@ void AddSC_custom_pvpve_dungeon()
     new PvpveDungeonPlayerScript();
     new PvpveDungeonWorldScript();
     AddSC_npc_pvpve_dungeon_queue();
+}
+
+void ApplyPvpveFfaState(Player* player)
+{
+    if (!player)
+        return;
+
+    if (kPvpveFfaAuraSpellId)
+    {
+        if (!player->HasAura(kPvpveFfaAuraSpellId))
+            player->AddAura(kPvpveFfaAuraSpellId, player);
+
+        return;
+    }
+
+    if (!player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_FFA_PVP))
+        player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_FFA_PVP);
+}
+
+void ClearPvpveFfaState(Player* player)
+{
+    if (!player)
+        return;
+
+    if (kPvpveFfaAuraSpellId)
+    {
+        player->RemoveAura(kPvpveFfaAuraSpellId);
+        return;
+    }
+
+    if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_FFA_PVP))
+        player->RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_FFA_PVP);
 }

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -153,4 +153,7 @@ private:
 
 #define sPvpveDungeonMgr PvpveDungeonMgr::Instance()
 
+void ApplyPvpveFfaState(Player* player);
+void ClearPvpveFfaState(Player* player);
+
 #endif // MOD_PVPVE_DUNGEON_H

--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -127,7 +127,7 @@ public:
             if (PvpveDungeonRun* run = PvpveDungeonMgr::instance()->GetRunForPlayer(player->GetGUID()))
                 PvpveDungeonMgr::instance()->OnInstanceCreated(run->TemplateId, run->Id, player->GetInstanceId());
 
-            player->SetPvpFlag(UNIT_BYTE2_FLAG_FFA_PVP);
+            ApplyPvpveFfaState(player);
             sPvpveDungeonMgr->OnPlayerEnteredInstance(player, this);
         }
 
@@ -138,16 +138,17 @@ public:
             if (!player)
                 return;
 
+            ClearPvpveFfaState(player);
+
             if (!sPvpveDungeonMgr->IsPlayerInPvpveRun(player))
                 return;
-
-            player->RemovePvpFlag(UNIT_BYTE2_FLAG_FFA_PVP);
         }
 
         void OnPvpveRunFinished(uint32 runId, PvpveTeam const& winningTeam) override
         {
             AnnounceVictory(runId, winningTeam);
             SummonRewardChest(runId, winningTeam);
+            ClearFfaState(winningTeam);
         }
 
     private:
@@ -215,6 +216,15 @@ public:
             else
             {
                 TC_LOG_WARN("server.custom", "Stockades PvPvE: failed to summon reward chest {} for run {} (team {}).", chestEntry, runId, team.Id);
+            }
+        }
+
+        void ClearFfaState(PvpveTeam const& team)
+        {
+            for (ObjectGuid const& guid : team.Members)
+            {
+                if (Player* player = ObjectAccessor::FindPlayer(guid))
+                    ClearPvpveFfaState(player);
             }
         }
 


### PR DESCRIPTION
## Summary
- add reusable helpers in the PvPvE module to apply or clear the FFA PvP state (or an optional aura)
- update the Stockades PvPvE instance to use the helpers and to clear the PvP state as players leave or once the run finishes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917846d6a9483278a7652f4bfe1668f)