### PR TITLE
Fix PvP title re-award spam when lower titles removed

### DIFF
--- a/src/server/scripts/Custom/mod_pvp_titles.cpp
+++ b/src/server/scripts/Custom/mod_pvp_titles.cpp
@@ -366,11 +366,8 @@ private:
         RankThresholdArray const thresholds = GetConfiguredKillThresholds();
         bool const removeLower = sConfigMgr->GetBoolDefault("PvPTitles.RemoveLowerTitles", false);
 
-        for (uint8 rank = RANK_ONE; rank < MAX_RANK; ++rank)
+        auto const AwardRank = [player](uint8 rank)
         {
-            if (kills < thresholds[rank])
-                continue;
-
             std::vector<char const*> newlyAwarded;
             newlyAwarded.reserve(2);
 
@@ -394,6 +391,23 @@ private:
                     else
                         ChatHandler(session).PSendSysMessage("You have earned the titles '%s' and '%s'.", newlyAwarded[0], newlyAwarded[1]);
                 }
+            }
+        };
+
+        if (removeLower)
+        {
+            uint8 const highestRank = GetHighestEligibleRank(kills, thresholds);
+            if (highestRank < MAX_RANK)
+                AwardRank(highestRank);
+        }
+        else
+        {
+            for (uint8 rank = RANK_ONE; rank < MAX_RANK; ++rank)
+            {
+                if (kills < thresholds[rank])
+                    continue;
+
+                AwardRank(rank);
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid re-awarding every PvP rank when `PvPTitles.RemoveLowerTitles` is enabled and instead only grant the highest eligible rank
- reuse the existing award messaging logic through a helper lambda

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691791058b6883279acdc48138b70d3b)