### PR TITLE
Decouple PvPvE spawns from mob locations

### DIFF
--- a/sql/updates/custom/2024_04_04_00_pvpve_dungeon.sql
+++ b/sql/updates/custom/2024_04_04_00_pvpve_dungeon.sql
@@ -16,13 +16,11 @@ CREATE TABLE IF NOT EXISTS `pvpve_dungeon_template` (
 CREATE TABLE IF NOT EXISTS `pvpve_dungeon_spawn` (
   `TemplateId` INT UNSIGNED NOT NULL,
   `SpawnIndex` TINYINT UNSIGNED NOT NULL,
-  `CreatureEntry` INT UNSIGNED NOT NULL,
   `MapId` SMALLINT UNSIGNED NOT NULL DEFAULT 0,
   `PositionX` FLOAT NOT NULL DEFAULT 0,
   `PositionY` FLOAT NOT NULL DEFAULT 0,
   `PositionZ` FLOAT NOT NULL DEFAULT 0,
   `Orientation` FLOAT NOT NULL DEFAULT 0,
-  `RespawnSeconds` INT UNSIGNED NOT NULL DEFAULT 30,
   PRIMARY KEY (`TemplateId`, `SpawnIndex`),
   CONSTRAINT `FK_pvpve_dungeon_spawn_template` FOREIGN KEY (`TemplateId`) REFERENCES `pvpve_dungeon_template` (`Id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -41,16 +39,17 @@ ON DUPLICATE KEY UPDATE
   `MaxPlayersPerTeam` = VALUES(`MaxPlayersPerTeam`),
   `MaxRuntimeSecs` = VALUES(`MaxRuntimeSecs`);
 
-INSERT INTO `pvpve_dungeon_spawn` (`TemplateId`, `SpawnIndex`, `CreatureEntry`, `MapId`, `PositionX`, `PositionY`, `PositionZ`, `Orientation`, `RespawnSeconds`)
+INSERT INTO `pvpve_dungeon_spawn` (`TemplateId`, `SpawnIndex`, `MapId`, `PositionX`, `PositionY`, `PositionZ`, `Orientation`)
 VALUES
-  (1, 0, 1706, 34, 48.825, -7.284, -20.216, 5.78, 30),
-  (1, 1, 1707, 34, 73.594, -10.873, -20.219, 4.60, 30),
-  (1, 2, 1708, 34, 96.325, -12.443, -20.219, 3.10, 30)
+  -- Center staging area in the entry hall
+  (1, 0, 34, 52.573, -0.411, -20.213, 4.69),
+  -- South cell block (left wing)
+  (1, 1, 34, 90.944, -33.215, -20.219, 1.57),
+  -- North cell block (right wing)
+  (1, 2, 34, 90.944, 33.215, -20.219, 4.71)
 ON DUPLICATE KEY UPDATE
-  `CreatureEntry` = VALUES(`CreatureEntry`),
   `MapId` = VALUES(`MapId`),
   `PositionX` = VALUES(`PositionX`),
   `PositionY` = VALUES(`PositionY`),
   `PositionZ` = VALUES(`PositionZ`),
-  `Orientation` = VALUES(`Orientation`),
-  `RespawnSeconds` = VALUES(`RespawnSeconds`);
+  `Orientation` = VALUES(`Orientation`);

--- a/sql/updates/custom/2024_06_01_00_pvpve_dungeon_duo_team_size.sql
+++ b/sql/updates/custom/2024_06_01_00_pvpve_dungeon_duo_team_size.sql
@@ -1,0 +1,5 @@
+-- Align Stockades PvPvE template with 2-player queue requirements
+UPDATE `pvpve_dungeon_template`
+SET `MinPlayersPerTeam` = 2,
+    `MaxPlayersPerTeam` = 2
+WHERE `Id` = 1;

--- a/sql/updates/custom/2024_06_03_00_pvpve_spawn_rework.sql
+++ b/sql/updates/custom/2024_06_03_00_pvpve_spawn_rework.sql
@@ -1,0 +1,55 @@
+-- Align PvPvE spawn points with dedicated player positions
+SET @currentDb := DATABASE();
+
+-- Drop legacy CreatureEntry column if it exists
+SET @hasCreatureEntry := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = @currentDb
+      AND TABLE_NAME = 'pvpve_dungeon_spawn'
+      AND COLUMN_NAME = 'CreatureEntry');
+SET @dropCreatureSql := IF(@hasCreatureEntry > 0,
+    'ALTER TABLE `pvpve_dungeon_spawn` DROP COLUMN `CreatureEntry`',
+    'DO 0');
+PREPARE stmt FROM @dropCreatureSql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Drop legacy RespawnSeconds column if it exists
+SET @hasRespawn := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = @currentDb
+      AND TABLE_NAME = 'pvpve_dungeon_spawn'
+      AND COLUMN_NAME = 'RespawnSeconds');
+SET @dropRespawnSql := IF(@hasRespawn > 0,
+    'ALTER TABLE `pvpve_dungeon_spawn` DROP COLUMN `RespawnSeconds`',
+    'DO 0');
+PREPARE stmt FROM @dropRespawnSql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Reposition the Stockades PvPvE spawn points into clear areas
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 52.573,
+    `PositionY` = -0.411,
+    `PositionZ` = -20.213,
+    `Orientation` = 4.69
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 0;
+
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 90.944,
+    `PositionY` = -33.215,
+    `PositionZ` = -20.219,
+    `Orientation` = 1.57
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 1;
+
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 90.944,
+    `PositionY` = 33.215,
+    `PositionZ` = -20.219,
+    `Orientation` = 4.71
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 2;

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -27,10 +27,12 @@
 #include "MapManager.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "Random.h"
 #include "ScriptMgr.h"
 
 #include <algorithm>
 #include <ctime>
+#include <set>
 #include <string>
 
 namespace
@@ -435,7 +437,7 @@ void PvpveDungeonMgr::AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& qu
         return;
     }
 
-    uint8 spawnIndex = PickSpawnIndex(run.TemplateId);
+    uint8 spawnIndex = PickSpawnIndex(run);
     auto spawnItr = std::find_if(spawnList->begin(), spawnList->end(), [spawnIndex](SpawnPoint const& spawn)
     {
         return spawn.Index == spawnIndex;
@@ -563,10 +565,30 @@ PvpveDungeonRun* PvpveDungeonMgr::GetRunForPlayer(ObjectGuid const& guid)
     return GetRun(itr->second);
 }
 
-uint8 PvpveDungeonMgr::PickSpawnIndex(uint32 templateId)
+uint8 PvpveDungeonMgr::PickSpawnIndex(PvpveDungeonRun const& run)
 {
-    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO pick spawn index for template {}.", templateId);
-    return 0;
+    auto spawnList = GetSpawnPoints(run.TemplateId);
+    if (!spawnList || spawnList->empty())
+        return 0;
+
+    std::set<uint8> usedIndices;
+    for (uint64 teamId : run.Teams)
+    {
+        if (PvpveTeam* team = GetTeam(teamId))
+            usedIndices.insert(team->SpawnIndex);
+    }
+
+    for (SpawnPoint const& spawn : *spawnList)
+    {
+        if (!usedIndices.count(spawn.Index))
+            return spawn.Index;
+    }
+
+    uint32 randomIdx = urand(0, spawnList->size() - 1);
+    uint8 fallback = (*spawnList)[randomIdx].Index;
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: reusing spawn index {} for template {} due to exhausted slots.",
+        uint32(fallback), run.TemplateId);
+    return fallback;
 }
 
 void PvpveDungeonMgr::OnInstanceCreated(uint32 templateId, uint64 runId, uint32 instanceId)

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -126,7 +126,7 @@ private:
 
     void StartNextRun();
     void AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& queued);
-    uint8 PickSpawnIndex(uint32 templateId);
+    uint8 PickSpawnIndex(PvpveDungeonRun const& run);
     void CleanupRun(uint64 runId);
     void CleanupPlayer(ObjectGuid const& guid);
     void OnPlayerEliminated(Player* player);


### PR DESCRIPTION
## Summary
- update the base PvPvE spawn schema/data so Stockades teams use bespoke coordinates instead of creature spawns
- add a migration that drops the unused creature columns and reapplies the new spawn locations for existing databases
- make the dungeon manager pick unused spawn indexes per run (with a fallback roll) so teams are spread across the configured slots

## Testing
- not run (SQL / logic change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691753a8ff108327affccb6aeac0d603)