### PR TITLE
Tie PvPvE completion to boss kill events

### DIFF
--- a/sql/updates/custom/2024_04_04_00_pvpve_dungeon.sql
+++ b/sql/updates/custom/2024_04_04_00_pvpve_dungeon.sql
@@ -16,13 +16,11 @@ CREATE TABLE IF NOT EXISTS `pvpve_dungeon_template` (
 CREATE TABLE IF NOT EXISTS `pvpve_dungeon_spawn` (
   `TemplateId` INT UNSIGNED NOT NULL,
   `SpawnIndex` TINYINT UNSIGNED NOT NULL,
-  `CreatureEntry` INT UNSIGNED NOT NULL,
   `MapId` SMALLINT UNSIGNED NOT NULL DEFAULT 0,
   `PositionX` FLOAT NOT NULL DEFAULT 0,
   `PositionY` FLOAT NOT NULL DEFAULT 0,
   `PositionZ` FLOAT NOT NULL DEFAULT 0,
   `Orientation` FLOAT NOT NULL DEFAULT 0,
-  `RespawnSeconds` INT UNSIGNED NOT NULL DEFAULT 30,
   PRIMARY KEY (`TemplateId`, `SpawnIndex`),
   CONSTRAINT `FK_pvpve_dungeon_spawn_template` FOREIGN KEY (`TemplateId`) REFERENCES `pvpve_dungeon_template` (`Id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -41,16 +39,17 @@ ON DUPLICATE KEY UPDATE
   `MaxPlayersPerTeam` = VALUES(`MaxPlayersPerTeam`),
   `MaxRuntimeSecs` = VALUES(`MaxRuntimeSecs`);
 
-INSERT INTO `pvpve_dungeon_spawn` (`TemplateId`, `SpawnIndex`, `CreatureEntry`, `MapId`, `PositionX`, `PositionY`, `PositionZ`, `Orientation`, `RespawnSeconds`)
+INSERT INTO `pvpve_dungeon_spawn` (`TemplateId`, `SpawnIndex`, `MapId`, `PositionX`, `PositionY`, `PositionZ`, `Orientation`)
 VALUES
-  (1, 0, 1706, 34, 48.825, -7.284, -20.216, 5.78, 30),
-  (1, 1, 1707, 34, 73.594, -10.873, -20.219, 4.60, 30),
-  (1, 2, 1708, 34, 96.325, -12.443, -20.219, 3.10, 30)
+  -- Center staging area in the entry hall
+  (1, 0, 34, 52.573, -0.411, -20.213, 4.69),
+  -- South cell block (left wing)
+  (1, 1, 34, 90.944, -33.215, -20.219, 1.57),
+  -- North cell block (right wing)
+  (1, 2, 34, 90.944, 33.215, -20.219, 4.71)
 ON DUPLICATE KEY UPDATE
-  `CreatureEntry` = VALUES(`CreatureEntry`),
   `MapId` = VALUES(`MapId`),
   `PositionX` = VALUES(`PositionX`),
   `PositionY` = VALUES(`PositionY`),
   `PositionZ` = VALUES(`PositionZ`),
-  `Orientation` = VALUES(`Orientation`),
-  `RespawnSeconds` = VALUES(`RespawnSeconds`);
+  `Orientation` = VALUES(`Orientation`);

--- a/sql/updates/custom/2024_06_01_00_pvpve_dungeon_duo_team_size.sql
+++ b/sql/updates/custom/2024_06_01_00_pvpve_dungeon_duo_team_size.sql
@@ -1,0 +1,5 @@
+-- Align Stockades PvPvE template with 2-player queue requirements
+UPDATE `pvpve_dungeon_template`
+SET `MinPlayersPerTeam` = 2,
+    `MaxPlayersPerTeam` = 2
+WHERE `Id` = 1;

--- a/sql/updates/custom/2024_06_03_00_pvpve_spawn_rework.sql
+++ b/sql/updates/custom/2024_06_03_00_pvpve_spawn_rework.sql
@@ -1,0 +1,55 @@
+-- Align PvPvE spawn points with dedicated player positions
+SET @currentDb := DATABASE();
+
+-- Drop legacy CreatureEntry column if it exists
+SET @hasCreatureEntry := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = @currentDb
+      AND TABLE_NAME = 'pvpve_dungeon_spawn'
+      AND COLUMN_NAME = 'CreatureEntry');
+SET @dropCreatureSql := IF(@hasCreatureEntry > 0,
+    'ALTER TABLE `pvpve_dungeon_spawn` DROP COLUMN `CreatureEntry`',
+    'DO 0');
+PREPARE stmt FROM @dropCreatureSql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Drop legacy RespawnSeconds column if it exists
+SET @hasRespawn := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = @currentDb
+      AND TABLE_NAME = 'pvpve_dungeon_spawn'
+      AND COLUMN_NAME = 'RespawnSeconds');
+SET @dropRespawnSql := IF(@hasRespawn > 0,
+    'ALTER TABLE `pvpve_dungeon_spawn` DROP COLUMN `RespawnSeconds`',
+    'DO 0');
+PREPARE stmt FROM @dropRespawnSql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Reposition the Stockades PvPvE spawn points into clear areas
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 52.573,
+    `PositionY` = -0.411,
+    `PositionZ` = -20.213,
+    `Orientation` = 4.69
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 0;
+
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 90.944,
+    `PositionY` = -33.215,
+    `PositionZ` = -20.219,
+    `Orientation` = 1.57
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 1;
+
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 90.944,
+    `PositionY` = 33.215,
+    `PositionZ` = -20.219,
+    `Orientation` = 4.71
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 2;

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -27,10 +27,12 @@
 #include "MapManager.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "Random.h"
 #include "ScriptMgr.h"
 
 #include <algorithm>
 #include <ctime>
+#include <set>
 #include <string>
 
 namespace
@@ -435,7 +437,7 @@ void PvpveDungeonMgr::AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& qu
         return;
     }
 
-    uint8 spawnIndex = PickSpawnIndex(run.TemplateId);
+    uint8 spawnIndex = PickSpawnIndex(run);
     auto spawnItr = std::find_if(spawnList->begin(), spawnList->end(), [spawnIndex](SpawnPoint const& spawn)
     {
         return spawn.Index == spawnIndex;
@@ -563,10 +565,30 @@ PvpveDungeonRun* PvpveDungeonMgr::GetRunForPlayer(ObjectGuid const& guid)
     return GetRun(itr->second);
 }
 
-uint8 PvpveDungeonMgr::PickSpawnIndex(uint32 templateId)
+uint8 PvpveDungeonMgr::PickSpawnIndex(PvpveDungeonRun const& run)
 {
-    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO pick spawn index for template {}.", templateId);
-    return 0;
+    auto spawnList = GetSpawnPoints(run.TemplateId);
+    if (!spawnList || spawnList->empty())
+        return 0;
+
+    std::set<uint8> usedIndices;
+    for (uint64 teamId : run.Teams)
+    {
+        if (PvpveTeam* team = GetTeam(teamId))
+            usedIndices.insert(team->SpawnIndex);
+    }
+
+    for (SpawnPoint const& spawn : *spawnList)
+    {
+        if (!usedIndices.count(spawn.Index))
+            return spawn.Index;
+    }
+
+    uint32 randomIdx = urand(0, spawnList->size() - 1);
+    uint8 fallback = (*spawnList)[randomIdx].Index;
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: reusing spawn index {} for template {} due to exhausted slots.",
+        uint32(fallback), run.TemplateId);
+    return fallback;
 }
 
 void PvpveDungeonMgr::OnInstanceCreated(uint32 templateId, uint64 runId, uint32 instanceId)
@@ -648,14 +670,7 @@ void PvpveDungeonMgr::EvaluateRunState(PvpveDungeonRun& run)
             ++activeTeams;
     }
 
-    bool shouldFinish = false;
-    if (run.Teams.size() > 1 && activeTeams <= 1)
-        shouldFinish = true;
-    else if (run.Teams.size() == 1 && activeTeams == 0)
-        shouldFinish = true;
-
-    if (shouldFinish)
-        FinishRun(run);
+    // Runs now finish when the instance boss is defeated; elimination merely tracks team status.
 }
 
 void PvpveDungeonMgr::OnPlayerEliminated(Player* player)
@@ -728,7 +743,42 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
     EvaluateRunState(*run);
 }
 
-void PvpveDungeonMgr::FinishRun(PvpveDungeonRun& run)
+void PvpveDungeonMgr::OnBossDefeated(uint64 runId, ObjectGuid const& creditGuid)
+{
+    PvpveDungeonRun* run = GetRun(runId);
+    if (!run)
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: ignoring boss defeat for unknown run {}.", runId);
+        return;
+    }
+
+    if (run->Finished)
+    {
+        TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: run {} already finished; boss defeat notification ignored.", runId);
+        return;
+    }
+
+    run->BossDefeated = true;
+
+    uint64 preferredWinner = 0;
+    if (!creditGuid.IsEmpty())
+    {
+        auto teamItr = _playerToTeam.find(creditGuid);
+        if (teamItr != _playerToTeam.end())
+        {
+            if (PvpveTeam* team = GetTeam(teamItr->second))
+            {
+                if (!team->Eliminated)
+                    preferredWinner = team->Id;
+            }
+        }
+    }
+
+    TC_LOG_INFO("server.custom", "PvpveDungeonMgr: boss defeated for run {} (credit team: {}).", runId, preferredWinner);
+    FinishRun(*run, preferredWinner);
+}
+
+void PvpveDungeonMgr::FinishRun(PvpveDungeonRun& run, uint64 preferredWinner)
 {
     if (run.Finished)
         return;
@@ -738,11 +788,25 @@ void PvpveDungeonMgr::FinishRun(PvpveDungeonRun& run)
 
     std::vector<uint64> winningTeams;
     winningTeams.reserve(run.Teams.size());
-    for (uint64 teamId : run.Teams)
+    if (preferredWinner)
     {
-        PvpveTeam* team = GetTeam(teamId);
-        if (team && !team->Eliminated)
-            winningTeams.push_back(teamId);
+        if (PvpveTeam* team = GetTeam(preferredWinner))
+        {
+            if (!team->Eliminated)
+                winningTeams.push_back(preferredWinner);
+        }
+        else
+            preferredWinner = 0;
+    }
+
+    if (winningTeams.empty())
+    {
+        for (uint64 teamId : run.Teams)
+        {
+            PvpveTeam* team = GetTeam(teamId);
+            if (team && !team->Eliminated)
+                winningTeams.push_back(teamId);
+        }
     }
 
     if (winningTeams.empty())
@@ -820,10 +884,17 @@ void PvpveDungeonMgr::CheckRunRuntime(PvpveDungeonRun& run, time_t now)
 
     uint32 const elapsed = uint32(now - run.StartTime);
     if (elapsed < dungeonTemplate->MaxRuntimeSecs)
+    {
+        run.TimeoutWarningSent = false;
         return;
+    }
 
-    TC_LOG_WARN("server.custom", "PvpveDungeonMgr: run {} exceeded max runtime ({}s / {}s). Finishing run.", run.Id, elapsed, dungeonTemplate->MaxRuntimeSecs);
-    FinishRun(run);
+    if (!run.TimeoutWarningSent)
+    {
+        run.TimeoutWarningSent = true;
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: run {} exceeded max runtime ({}s / {}s) but will remain active until the boss is defeated.",
+            run.Id, elapsed, dungeonTemplate->MaxRuntimeSecs);
+    }
 }
 
 uint32 PvpveDungeonMgr::CountActiveRuns() const

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -71,6 +71,8 @@ struct PvpveDungeonRun
     bool Active = false;
     bool Completed = false;
     bool Finished = false;
+    bool BossDefeated = false;
+    bool TimeoutWarningSent = false;
     std::vector<ObjectGuid> Players;
     std::map<ObjectGuid, uint8> PlayerSpawns;
     std::vector<uint64> Teams;
@@ -112,6 +114,7 @@ public:
     void OnPlayerDeath(Player* player);
     void OnInstanceCreated(uint32 templateId, uint64 runId, uint32 instanceId);
     void OnPlayerEnteredInstance(Player* player, PvpveDungeonInstance* instanceScript);
+    void OnBossDefeated(uint64 runId, ObjectGuid const& creditGuid);
     bool IsPlayerInPvpveRun(ObjectGuid const& guid) const;
     bool IsPlayerInPvpveRun(Player const* player) const;
 
@@ -126,14 +129,14 @@ private:
 
     void StartNextRun();
     void AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& queued);
-    uint8 PickSpawnIndex(uint32 templateId);
+    uint8 PickSpawnIndex(PvpveDungeonRun const& run);
     void CleanupRun(uint64 runId);
     void CleanupPlayer(ObjectGuid const& guid);
     void OnPlayerEliminated(Player* player);
     void OnPlayerLeftMap(Player* player);
     void EvaluateRunState(PvpveDungeonRun& run);
     bool TeamHasActiveMembers(PvpveTeam const& team, DungeonTemplate const* dungeonTemplate) const;
-    void FinishRun(PvpveDungeonRun& run);
+    void FinishRun(PvpveDungeonRun& run, uint64 preferredWinner = 0);
     void TrackQueuedMembers(std::vector<ObjectGuid> const& members);
     void UntrackQueuedMembers(std::vector<ObjectGuid> const& members);
     void CheckRunRuntime(PvpveDungeonRun& run, time_t now);

--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -20,6 +20,7 @@
 #include "Configuration/Config.h"
 #include "Duration.h"
 #include "GameObject.h"
+#include "Creature.h"
 #include "Map.h"
 #include "InstanceScript.h"
 #include "Log.h"
@@ -45,6 +46,7 @@ Position const DefaultChestPosition = { 71.879f, -15.478f, -20.215f, 0.0f };
 uint32 s_ChestGameObjectId = 0;
 Seconds s_ChestDespawn = Seconds(DefaultChestDespawnSeconds);
 Position s_ChestPosition = DefaultChestPosition;
+uint32 s_BossCreatureEntry = 0;
 
 void LoadConfig()
 {
@@ -54,13 +56,18 @@ void LoadConfig()
     float const configuredY = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnY", DefaultChestPosition.GetPositionY());
     float const configuredZ = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnZ", DefaultChestPosition.GetPositionZ());
     float const configuredO = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnO", DefaultChestPosition.GetOrientation());
+    int32 const configuredBoss = sConfigMgr->GetIntDefault("StockadesPvPvE.BossCreatureEntry", 0);
 
     s_ChestGameObjectId = configuredEntry > 0 ? uint32(configuredEntry) : 0u;
     s_ChestDespawn = Seconds(configuredDespawn >= 0 ? uint32(configuredDespawn) : DefaultChestDespawnSeconds);
     s_ChestPosition.Relocate(configuredX, configuredY, configuredZ, configuredO);
+    s_BossCreatureEntry = configuredBoss > 0 ? uint32(configuredBoss) : 0u;
 
     if (!s_ChestGameObjectId)
         TC_LOG_WARN("server.custom", "Stockades PvPvE: reward chest entry is 0; chest spawning is disabled.");
+
+    if (!s_BossCreatureEntry)
+        TC_LOG_WARN("server.custom", "Stockades PvPvE: boss creature entry is 0; boss defeat tracking is disabled.");
 }
 
 QuaternionData GetChestRotation()
@@ -82,6 +89,11 @@ void EnsureConfigLoaded()
 uint32 GetChestGameObjectId()
 {
     return s_ChestGameObjectId;
+}
+
+uint32 GetBossCreatureEntry()
+{
+    return s_BossCreatureEntry;
 }
 
 Seconds GetChestDespawnTime()
@@ -125,7 +137,10 @@ public:
                 return;
 
             if (PvpveDungeonRun* run = PvpveDungeonMgr::instance()->GetRunForPlayer(player->GetGUID()))
+            {
+                _pvpveRunId = run->Id;
                 PvpveDungeonMgr::instance()->OnInstanceCreated(run->TemplateId, run->Id, player->GetInstanceId());
+            }
 
             ApplyPvpveFfaState(player);
             sPvpveDungeonMgr->OnPlayerEnteredInstance(player, this);
@@ -149,6 +164,25 @@ public:
             AnnounceVictory(runId, winningTeam);
             SummonRewardChest(runId, winningTeam);
             ClearFfaState(winningTeam);
+            _pvpveRunId = 0;
+        }
+
+        void OnCreatureKilled(Creature* creature, Player* killer) override
+        {
+            InstanceScript::OnCreatureKilled(creature, killer);
+
+            if (!creature)
+                return;
+
+            uint32 const bossEntry = StockadesPvPvE::GetBossCreatureEntry();
+            if (!bossEntry || creature->GetEntry() != bossEntry)
+                return;
+
+            if (!_pvpveRunId)
+                return;
+
+            ObjectGuid const creditGuid = killer ? killer->GetGUID() : ObjectGuid::Empty;
+            sPvpveDungeonMgr->OnBossDefeated(_pvpveRunId, creditGuid);
         }
 
     private:
@@ -230,6 +264,7 @@ public:
 
         ObjectGuid _rewardChestGuid;
         uint32 _rewardChestRunId = 0;
+        uint64 _pvpveRunId = 0;
     };
 };
 


### PR DESCRIPTION
## Summary
- gate PvPvE dungeon completion on explicit boss defeat notifications instead of automatic elimination, and allow the manager to prefer the killer's team as the winner
- add boss creature configuration to the Stockades PvPvE instance so it can signal the manager when the configured boss dies
- keep runs alive past their max runtime and simply warn while the boss is still alive

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691753a8ff108327affccb6aeac0d603)