### PR TITLE
Ensure attacking a totem keeps combat active

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8889,11 +8889,11 @@ void Unit::AtTargetAttacked(Unit* target, bool canInitialAggro)
     if (!target->IsEngaged() && !canInitialAggro)
         return;
     target->EngageWithTarget(this);
-    //pet attacked doesn't trigger combat
-    /*
-    if (Unit* targetOwner = target->GetCharmerOrOwner())
-        targetOwner->EngageWithTarget(this);
-    */
+
+    // Totems should always pull their owner into combat when attacked
+    if (target->IsTotem())
+        if (Unit* targetOwner = target->GetCharmerOrOwner())
+            targetOwner->EngageWithTarget(this);
 
     //Patch 3.0.8: All player spells which cause a creature to become aggressive to you will now also immediately cause the creature to be tapped.
     if (Creature* creature = target->ToCreature())


### PR DESCRIPTION
## Summary
- ensure that attacking a totem explicitly pulls its owner into combat so that destroying it no longer drops the attacker out of combat

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917f284db448327862b73c769365331)