### PR TITLE
Keep arena team info server-side for all slots

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7152,7 +7152,24 @@ void Player::SetInArenaTeam(uint32 ArenaTeamId, uint8 slot, uint8 type)
 
 void Player::SetArenaTeamInfoField(uint8 slot, ArenaTeamInfoType type, uint32 value)
 {
-    SetUInt32Value(PLAYER_FIELD_ARENA_TEAM_INFO_1_1 + (slot * ARENA_TEAM_END) + type, value);
+    if (slot >= MAX_ARENA_SLOT)
+    {
+        TC_LOG_ERROR("entities.player", "Player::SetArenaTeamInfoField called for invalid slot {}.", slot);
+        return;
+    }
+
+    m_arenaTeamInfo[slot][type] = value;
+
+    if (slot < ClientArenaSlotCount)
+        SetUInt32Value(PLAYER_FIELD_ARENA_TEAM_INFO_1_1 + (slot * ARENA_TEAM_END) + type, value);
+}
+
+uint32 Player::GetArenaTeamInfoField(uint8 slot, ArenaTeamInfoType type) const
+{
+    if (slot >= MAX_ARENA_SLOT)
+        return 0;
+
+    return m_arenaTeamInfo[slot][type];
 }
 
 uint32 Player::GetZoneIdFromDB(ObjectGuid guid)
@@ -17324,7 +17341,9 @@ void Player::_LoadDeclinedNames(PreparedQueryResult result)
 void Player::_LoadArenaTeamInfo(PreparedQueryResult result)
 {
     // arenateamid, played_week, played_season, personal_rating
-    memset((void*)&m_uint32Values[PLAYER_FIELD_ARENA_TEAM_INFO_1_1], 0, sizeof(uint32) * MAX_ARENA_SLOT * ARENA_TEAM_END);
+    memset((void*)&m_uint32Values[PLAYER_FIELD_ARENA_TEAM_INFO_1_1], 0, sizeof(uint32) * ClientArenaSlotCount * ARENA_TEAM_END);
+    for (auto& slotInfo : m_arenaTeamInfo)
+        slotInfo.fill(0);
 
     std::array<uint16, MAX_ARENA_SLOT> personalRatingCache{};
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -30,6 +30,7 @@
 #include "PetDefines.h"
 #include "PlayerTaxi.h"
 #include "QuestDef.h"
+#include <array>
 #include <memory>
 #include <queue>
 #include <unordered_set>
@@ -1596,11 +1597,14 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         static void RemovePetitionsAndSigns(ObjectGuid guid, CharterTypes type);
 
         // Arena Team
+        static constexpr uint8 ClientArenaSlotCount = 3;
+
         void SetInArenaTeam(uint32 ArenaTeamId, uint8 slot, uint8 type);
         void SetArenaTeamInfoField(uint8 slot, ArenaTeamInfoType type, uint32 value);
+        uint32 GetArenaTeamInfoField(uint8 slot, ArenaTeamInfoType type) const;
         static void LeaveAllArenaTeams(ObjectGuid guid);
-        uint32 GetArenaTeamId(uint8 slot) const { return GetUInt32Value(PLAYER_FIELD_ARENA_TEAM_INFO_1_1 + (slot * ARENA_TEAM_END) + ARENA_TEAM_ID); }
-        uint32 GetArenaPersonalRating(uint8 slot) const { return GetUInt32Value(PLAYER_FIELD_ARENA_TEAM_INFO_1_1 + (slot * ARENA_TEAM_END) + ARENA_TEAM_PERSONAL_RATING); }
+        uint32 GetArenaTeamId(uint8 slot) const { return GetArenaTeamInfoField(slot, ARENA_TEAM_ID); }
+        uint32 GetArenaPersonalRating(uint8 slot) const { return GetArenaTeamInfoField(slot, ARENA_TEAM_PERSONAL_RATING); }
         void SetArenaTeamIdInvited(uint32 ArenaTeamId) { m_ArenaTeamIdInvited = ArenaTeamId; }
         uint32 GetArenaTeamIdInvited() const { return m_ArenaTeamIdInvited; }
 
@@ -2396,6 +2400,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         uint32 m_GuildIdInvited;
         uint32 m_ArenaTeamIdInvited;
+        std::array<std::array<uint32, ARENA_TEAM_END>, MAX_ARENA_SLOT> m_arenaTeamInfo{};
 
         PlayerMails m_mail;
         PlayerSpellMap m_spells;


### PR DESCRIPTION
## Summary
- maintain a canonical arena-team info array for every slot on the server so logic no longer needs to read beyond the client-exposed update fields
- only mirror the first three slots into PLAYER_FIELD_ARENA_TEAM_INFO and guard accesses with MAX_ARENA_SLOT when loading or mutating data

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917effc9b5083278e9441763a162642)