### PR TITLE
Allow battleground item use except scrolls

### DIFF
--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -119,11 +119,14 @@ void WorldSession::HandleUseItemOpcode(WorldPacket& recvPacket)
         return;
     }
 
-    // Disable usage of inventory items while inside battlegrounds (but still allow equipped trinkets)
+    // Keep stat scrolls disabled inside battlegrounds (but still allow other inventory items)
     if (!pUser->IsGameMaster() && pUser->InBattleground() && !pUser->InArena() && !pItem->IsEquipped())
     {
-        pUser->SendEquipError(EQUIP_ERR_CANT_DO_RIGHT_NOW, pItem, nullptr);
-        return;
+        if (proto->Class == ITEM_CLASS_CONSUMABLE && proto->SubClass == ITEM_SUBCLASS_SCROLL)
+        {
+            pUser->SendEquipError(EQUIP_ERR_CANT_DO_RIGHT_NOW, pItem, nullptr);
+            return;
+        }
     }
 
     // only allow conjured consumable, bandage, poisons (all should have the 2^21 item flag set in DB)

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -120,7 +120,7 @@ void WorldSession::HandleUseItemOpcode(WorldPacket& recvPacket)
     }
 
     // Keep stat scrolls disabled inside battlegrounds (but still allow other inventory items)
-    if (!pUser->IsGameMaster() && pUser->InBattleground() && !pUser->InArena() && !pItem->IsEquipped())
+    if (pUser->InBattleground() && !pUser->InArena() && !pItem->IsEquipped())
     {
         if (proto->Class == ITEM_CLASS_CONSUMABLE && proto->SubClass == ITEM_SUBCLASS_SCROLL)
         {


### PR DESCRIPTION
## Summary
- relax the battleground item restriction so inventory items can be used again
- keep consumable scrolls (e.g. agility/intellect scrolls) blocked to maintain the previous limitation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918dd4fbdd08327a493e3876acdc1a4)