### PR TITLE
Fix finishing moves ignoring combo point cost

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5397,7 +5397,6 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
         {
             if ((*j)->IsAffectedOnSpell(m_spellInfo))
             {
-                m_needComboPoints = false;
                 if ((*j)->GetMiscValue() == 1)
                 {
                     reqCombat = false;


### PR DESCRIPTION
## Summary
- stop SPELL_AURA_ABILITY_IGNORE_AURASTATE from disabling combo point consumption so finishing moves always clear combo points

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f0c859688327a58e7793a424deac)