### PR TITLE
Require ineligible depleted marks for conversion

### DIFF
--- a/sql/custom/world/2024_08_21_00_world_depleted_mark_exchange.sql
+++ b/sql/custom/world/2024_08_21_00_world_depleted_mark_exchange.sql
@@ -13,8 +13,20 @@ DELETE FROM `quest_template_addon` WHERE `ID` = 90050;
 DELETE FROM `quest_template` WHERE `ID` = 90050;
 DELETE FROM `item_template` WHERE `entry` = 91001;
 
--- Teach depleted marks how to convert themselves when used
+-- Teach depleted marks to cast a spell that mirrors the enchanting reagents
+SET @DEPLETED_MARK_SPELL := 91050;
+-- The matching Spell.dbc row should be cloned from spell 13361 with the new tooltip text.
+
 UPDATE `item_template`
-SET `ScriptName` = 'item_depleted_mark_converter',
+SET `ScriptName` = '',
+    `spellid_1` = @DEPLETED_MARK_SPELL,
+    `spelltrigger_1` = 0,
+    `spellcharges_1` = 0,
+    `spellcooldown_1` = 0,
+    `spellcategorycooldown_1` = 0,
     `description` = 'A depleted medal that hums with unstable energy.\n\nUse: Turn three ineligible depleted marks into one suited to your class.'
 WHERE `entry` BETWEEN 20559 AND 20575;
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = @DEPLETED_MARK_SPELL;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(@DEPLETED_MARK_SPELL, 'spell_depleted_mark_converter');

--- a/sql/custom/world/2024_08_21_00_world_depleted_mark_exchange.sql
+++ b/sql/custom/world/2024_08_21_00_world_depleted_mark_exchange.sql
@@ -1,0 +1,20 @@
+-- Allow depleted marks of honor to stack up to 200, matching restored marks
+UPDATE `item_template` SET `stackable` = 200 WHERE `entry` BETWEEN 20559 AND 20575;
+
+-- Retire the voucher-based exchange quest and its supporting data
+DELETE FROM `creature_queststarter` WHERE `quest` = 90050;
+DELETE FROM `creature_questender` WHERE `quest` = 90050;
+DELETE FROM `creature` WHERE `id` = 91000 OR `guid` = 910000;
+DELETE FROM `creature_template` WHERE `entry` = 91000;
+DELETE FROM `quest_offer_reward` WHERE `ID` = 90050;
+DELETE FROM `quest_request_items` WHERE `ID` = 90050;
+DELETE FROM `quest_details` WHERE `ID` = 90050;
+DELETE FROM `quest_template_addon` WHERE `ID` = 90050;
+DELETE FROM `quest_template` WHERE `ID` = 90050;
+DELETE FROM `item_template` WHERE `entry` = 91001;
+
+-- Teach depleted marks how to convert themselves when used
+UPDATE `item_template`
+SET `ScriptName` = 'item_depleted_mark_converter',
+    `description` = 'A depleted medal that hums with unstable energy.\n\nUse: Turn three ineligible depleted marks into one suited to your class.'
+WHERE `entry` BETWEEN 20559 AND 20575;

--- a/sql/custom/world/2024_08_21_00_world_depleted_mark_exchange.sql
+++ b/sql/custom/world/2024_08_21_00_world_depleted_mark_exchange.sql
@@ -13,9 +13,8 @@ DELETE FROM `quest_template_addon` WHERE `ID` = 90050;
 DELETE FROM `quest_template` WHERE `ID` = 90050;
 DELETE FROM `item_template` WHERE `entry` = 91001;
 
--- Teach depleted marks to cast a spell that mirrors the enchanting reagents
 SET @DEPLETED_MARK_SPELL := 91050;
--- The matching Spell.dbc row should be cloned from spell 13361 with the new tooltip text.
+-- The matching Spell.dbc row is cloned below from spell 13361 with the new tooltip text.
 
 UPDATE `item_template`
 SET `ScriptName` = '',
@@ -30,3 +29,17 @@ WHERE `entry` BETWEEN 20559 AND 20575;
 DELETE FROM `spell_script_names` WHERE `spell_id` = @DEPLETED_MARK_SPELL;
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (@DEPLETED_MARK_SPELL, 'spell_depleted_mark_converter');
+
+-- Clone spell 13361 into dbc.spell_lplus so the depleted mark conversion spell has a proper entry
+DROP TEMPORARY TABLE IF EXISTS `tmp_spell_lplus_clone`;
+CREATE TEMPORARY TABLE `tmp_spell_lplus_clone`
+AS SELECT * FROM `dbc`.`spell_lplus` WHERE `Id` = 13361;
+
+UPDATE `tmp_spell_lplus_clone`
+SET `Id` = @DEPLETED_MARK_SPELL;
+
+DELETE FROM `dbc`.`spell_lplus` WHERE `Id` = @DEPLETED_MARK_SPELL;
+INSERT INTO `dbc`.`spell_lplus`
+SELECT * FROM `tmp_spell_lplus_clone`;
+
+DROP TEMPORARY TABLE IF EXISTS `tmp_spell_lplus_clone`;

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -34,6 +34,7 @@
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ReputationMgr.h"
+#include "Miscellaneous/DepletedMarks.h"
 #include "SpellAuras.h"
 #include "TemporarySummon.h"
 #include "Transport.h"
@@ -852,18 +853,9 @@ void Battleground::EndBattleground(uint32 winner)
                 player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_WIN_BG, player->GetMapId());
                 player->ModifyMoney(winner_money);
 
-                for (int i = 20559; i <= 20575; i++)
-                {
-                    Item* depletedMark = player->GetItemByEntry(i);
-                    if (depletedMark)
-                    {
-                        if (player->CanUseItem(depletedMark->GetTemplate()) == EQUIP_ERR_OK)
-                        {
-                            player->DestroyItem(depletedMark->GetBagSlot(), depletedMark->GetSlot(), true); //remove old one
-                            player->AddItem(20558, 1); //restored mark of honor
-                        }
-                    }
-                }
+                bool canRestoreMark = isArena() || GetTypeID(true) == BATTLEGROUND_WS;
+                if (canRestoreMark && Trinity::Custom::ConsumeDepletedMarks(player, 1))
+                    player->AddItem(Trinity::Custom::ITEM_RESTORED_MARK_OF_HONOR, 1); // restored mark of honor
             }
             else
             {

--- a/src/server/game/Miscellaneous/DepletedMarks.cpp
+++ b/src/server/game/Miscellaneous/DepletedMarks.cpp
@@ -1,0 +1,192 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Miscellaneous/DepletedMarks.h"
+#include "Entities/Player/Player.h"
+#include "ObjectMgr.h"
+#include <algorithm>
+
+namespace Trinity::Custom
+{
+namespace
+{
+bool MaskMatches(uint32 allowedMask, uint32 playerMask)
+{
+    return allowedMask == 0 || allowedMask == uint32(-1) || (allowedMask & playerMask);
+}
+
+uint8 GetSpecificityScore(uint32 allowedMask, uint32 playerMask)
+{
+    if (allowedMask == 0 || allowedMask == uint32(-1))
+        return 0;
+
+    if (allowedMask == playerMask)
+        return 2;
+
+    if (allowedMask & playerMask)
+        return 1;
+
+    return 0;
+}
+
+bool IsTemplateEligibleForPlayer(ItemTemplate const* itemTemplate, uint32 classMask, uint32 raceMask)
+{
+    return MaskMatches(itemTemplate->AllowableClass, classMask) && MaskMatches(itemTemplate->AllowableRace, raceMask);
+}
+}
+
+uint32 GetTotalDepletedMarkCount(Player const* player, bool includeBank)
+{
+    if (!player)
+        return 0;
+
+    uint32 total = 0;
+    for (uint32 entry : DepletedMarkEntries)
+        total += player->GetItemCount(entry, includeBank);
+
+    return total;
+}
+
+bool HasEnoughDepletedMarks(Player const* player, uint32 requiredCount, bool includeBank)
+{
+    return GetTotalDepletedMarkCount(player, includeBank) >= requiredCount;
+}
+
+bool ConsumeDepletedMarks(Player* player, uint32 amount)
+{
+    if (!player || amount == 0)
+        return false;
+
+    if (!HasEnoughDepletedMarks(player, amount, false))
+        return false;
+
+    for (uint32 entry : DepletedMarkEntries)
+    {
+        if (amount == 0)
+            break;
+
+        uint32 available = player->GetItemCount(entry);
+        if (!available)
+            continue;
+
+        uint32 toRemove = std::min(amount, available);
+        player->DestroyItemCount(entry, toRemove, true);
+        amount -= toRemove;
+    }
+
+    return amount == 0;
+}
+
+uint32 GetTotalIneligibleDepletedMarkCount(Player const* player, bool includeBank)
+{
+    if (!player)
+        return 0;
+
+    uint32 const classMask = player->GetClassMask();
+    uint32 const raceMask = player->GetRaceMask();
+
+    uint32 total = 0;
+    for (uint32 entry : DepletedMarkEntries)
+    {
+        ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(entry);
+        if (!itemTemplate)
+            continue;
+
+        if (IsTemplateEligibleForPlayer(itemTemplate, classMask, raceMask))
+            continue;
+
+        total += player->GetItemCount(entry, includeBank);
+    }
+
+    return total;
+}
+
+bool HasEnoughIneligibleDepletedMarks(Player const* player, uint32 requiredCount, bool includeBank)
+{
+    return GetTotalIneligibleDepletedMarkCount(player, includeBank) >= requiredCount;
+}
+
+bool ConsumeIneligibleDepletedMarks(Player* player, uint32 amount)
+{
+    if (!player || amount == 0)
+        return false;
+
+    if (!HasEnoughIneligibleDepletedMarks(player, amount, false))
+        return false;
+
+    uint32 const classMask = player->GetClassMask();
+    uint32 const raceMask = player->GetRaceMask();
+
+    for (uint32 entry : DepletedMarkEntries)
+    {
+        if (amount == 0)
+            break;
+
+        ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(entry);
+        if (!itemTemplate)
+            continue;
+
+        if (IsTemplateEligibleForPlayer(itemTemplate, classMask, raceMask))
+            continue;
+
+        uint32 available = player->GetItemCount(entry);
+        if (!available)
+            continue;
+
+        uint32 toRemove = std::min(amount, available);
+        player->DestroyItemCount(entry, toRemove, true);
+        amount -= toRemove;
+    }
+
+    return amount == 0;
+}
+
+uint32 GetDepletedMarkEntryForPlayer(Player const* player)
+{
+    if (!player)
+        return 0;
+
+    uint32 const classMask = player->GetClassMask();
+    uint32 const raceMask = player->GetRaceMask();
+
+    uint32 bestEntry = 0;
+    uint8 bestScore = 0;
+
+    for (uint32 entry : DepletedMarkEntries)
+    {
+        ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(entry);
+        if (!itemTemplate)
+            continue;
+
+        if (!IsTemplateEligibleForPlayer(itemTemplate, classMask, raceMask))
+            continue;
+
+        uint8 const classScore = GetSpecificityScore(itemTemplate->AllowableClass, classMask);
+        uint8 const raceScore = GetSpecificityScore(itemTemplate->AllowableRace, raceMask);
+        uint8 const score = classScore * 3 + raceScore;
+
+        if (score > bestScore)
+        {
+            bestScore = score;
+            bestEntry = entry;
+        }
+    }
+
+    return bestEntry;
+}
+}
+

--- a/src/server/game/Miscellaneous/DepletedMarks.h
+++ b/src/server/game/Miscellaneous/DepletedMarks.h
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITYCORE_DEPLETED_MARKS_H
+#define TRINITYCORE_DEPLETED_MARKS_H
+
+#include "Define.h"
+#include <array>
+
+class Player;
+
+namespace Trinity::Custom
+{
+    inline constexpr uint32 ITEM_RESTORED_MARK_OF_HONOR = 20558;
+    inline constexpr uint32 DEPLETED_MARK_FIRST_ENTRY    = 20559;
+    inline constexpr uint32 DEPLETED_MARK_LAST_ENTRY     = 20575;
+    inline constexpr uint32 DEPLETED_MARK_CONVERSION_COST = 3;
+
+    inline constexpr std::array<uint32, DEPLETED_MARK_LAST_ENTRY - DEPLETED_MARK_FIRST_ENTRY + 1> DepletedMarkEntries =
+    {
+        20559, 20560, 20561, 20562, 20563, 20564, 20565, 20566, 20567,
+        20568, 20569, 20570, 20571, 20572, 20573, 20574, 20575
+    };
+
+    uint32 GetTotalDepletedMarkCount(Player const* player, bool includeBank = false);
+    bool HasEnoughDepletedMarks(Player const* player, uint32 requiredCount, bool includeBank = false);
+    bool ConsumeDepletedMarks(Player* player, uint32 amount);
+    uint32 GetTotalIneligibleDepletedMarkCount(Player const* player, bool includeBank = false);
+    bool HasEnoughIneligibleDepletedMarks(Player const* player, uint32 requiredCount, bool includeBank = false);
+    bool ConsumeIneligibleDepletedMarks(Player* player, uint32 amount);
+    uint32 GetDepletedMarkEntryForPlayer(Player const* player);
+}
+
+#endif // TRINITYCORE_DEPLETED_MARKS_H
+

--- a/src/server/scripts/Custom/custom_depleted_mark_exchange.cpp
+++ b/src/server/scripts/Custom/custom_depleted_mark_exchange.cpp
@@ -15,55 +15,80 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "ScriptMgr.h"
 #include "Item.h"
 #include "Miscellaneous/DepletedMarks.h"
 #include "Player.h"
+#include "ScriptMgr.h"
+#include "SpellScript.h"
 
-class item_depleted_mark_converter : public ItemScript
+class spell_depleted_mark_converter : public SpellScript
 {
+    PrepareSpellScript(spell_depleted_mark_converter);
+
 public:
-    item_depleted_mark_converter() : ItemScript("item_depleted_mark_converter") { }
+    spell_depleted_mark_converter() = default;
 
-    bool OnUse(Player* player, Item* item, SpellCastTargets const& /*targets*/) override
+    SpellCastResult CheckRequirement()
     {
-        if (!player || !item)
-            return false;
+        Player* player = GetCaster() ? GetCaster()->ToPlayer() : nullptr;
+        if (!player)
+            return SPELL_FAILED_DONT_REPORT;
 
-        uint32 const rewardEntry = Trinity::Custom::GetDepletedMarkEntryForPlayer(player);
-        if (!rewardEntry)
-        {
-            player->SendEquipError(EQUIP_ERR_CANT_DO_RIGHT_NOW, item, nullptr);
-            return false;
-        }
+        _rewardEntry = Trinity::Custom::GetDepletedMarkEntryForPlayer(player);
+        if (!_rewardEntry)
+            return SPELL_FAILED_DONT_REPORT;
 
         if (!Trinity::Custom::HasEnoughIneligibleDepletedMarks(player, Trinity::Custom::DEPLETED_MARK_CONVERSION_COST))
-        {
-            player->SendEquipError(EQUIP_ERR_ITEM_NOT_FOUND, item, nullptr);
-            return false;
-        }
+            return SPELL_FAILED_NOT_ENOUGH_ITEMS;
 
-        ItemPosCountVec dest;
-        if (player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, rewardEntry, 1) != EQUIP_ERR_OK)
-        {
-            player->SendEquipError(EQUIP_ERR_INVENTORY_FULL, nullptr, nullptr, rewardEntry);
-            return false;
-        }
+        _dest.clear();
+        if (player->CanStoreNewItem(NULL_BAG, NULL_SLOT, _dest, _rewardEntry, 1) != EQUIP_ERR_OK)
+            return SPELL_FAILED_TOO_MANY_OF_ITEM;
+
+        return SPELL_CAST_OK;
+    }
+
+    void HandleScript(SpellEffIndex effIndex)
+    {
+        PreventHitDefaultEffect(effIndex);
+
+        Player* player = GetCaster() ? GetCaster()->ToPlayer() : nullptr;
+        if (!player || !_rewardEntry)
+            return;
 
         if (!Trinity::Custom::ConsumeIneligibleDepletedMarks(player, Trinity::Custom::DEPLETED_MARK_CONVERSION_COST))
         {
-            player->SendEquipError(EQUIP_ERR_CANT_DO_RIGHT_NOW, item, nullptr);
-            return false;
+            player->SendEquipError(EQUIP_ERR_CANT_DO_RIGHT_NOW, GetCastItem(), nullptr);
+            return;
         }
 
-        if (Item* newItem = player->StoreNewItem(dest, rewardEntry, true))
+        if (Item* newItem = player->StoreNewItem(_dest, _rewardEntry, true))
             player->SendNewItem(newItem, 1, true, false);
+    }
 
-        return true;
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_depleted_mark_converter::CheckRequirement);
+        OnEffectHitTarget += SpellEffectFn(spell_depleted_mark_converter::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+
+private:
+    ItemPosCountVec _dest;
+    uint32 _rewardEntry = 0;
+};
+
+class spell_depleted_mark_converter_loader : public SpellScriptLoader
+{
+public:
+    spell_depleted_mark_converter_loader() : SpellScriptLoader("spell_depleted_mark_converter") { }
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_depleted_mark_converter();
     }
 };
 
 void AddSC_custom_depleted_mark_exchange()
 {
-    new item_depleted_mark_converter();
+    new spell_depleted_mark_converter_loader();
 }

--- a/src/server/scripts/Custom/custom_depleted_mark_exchange.cpp
+++ b/src/server/scripts/Custom/custom_depleted_mark_exchange.cpp
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ScriptMgr.h"
+#include "Item.h"
+#include "Miscellaneous/DepletedMarks.h"
+#include "Player.h"
+
+class item_depleted_mark_converter : public ItemScript
+{
+public:
+    item_depleted_mark_converter() : ItemScript("item_depleted_mark_converter") { }
+
+    bool OnUse(Player* player, Item* item, SpellCastTargets const& /*targets*/) override
+    {
+        if (!player || !item)
+            return false;
+
+        uint32 const rewardEntry = Trinity::Custom::GetDepletedMarkEntryForPlayer(player);
+        if (!rewardEntry)
+        {
+            player->SendEquipError(EQUIP_ERR_CANT_DO_RIGHT_NOW, item, nullptr);
+            return false;
+        }
+
+        if (!Trinity::Custom::HasEnoughIneligibleDepletedMarks(player, Trinity::Custom::DEPLETED_MARK_CONVERSION_COST))
+        {
+            player->SendEquipError(EQUIP_ERR_ITEM_NOT_FOUND, item, nullptr);
+            return false;
+        }
+
+        ItemPosCountVec dest;
+        if (player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, rewardEntry, 1) != EQUIP_ERR_OK)
+        {
+            player->SendEquipError(EQUIP_ERR_INVENTORY_FULL, nullptr, nullptr, rewardEntry);
+            return false;
+        }
+
+        if (!Trinity::Custom::ConsumeIneligibleDepletedMarks(player, Trinity::Custom::DEPLETED_MARK_CONVERSION_COST))
+        {
+            player->SendEquipError(EQUIP_ERR_CANT_DO_RIGHT_NOW, item, nullptr);
+            return false;
+        }
+
+        if (Item* newItem = player->StoreNewItem(dest, rewardEntry, true))
+            player->SendNewItem(newItem, 1, true, false);
+
+        return true;
+    }
+};
+
+void AddSC_custom_depleted_mark_exchange()
+{
+    new item_depleted_mark_converter();
+}

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -28,6 +28,7 @@ void AddSC_mod_pvp_titles();
 void AddSC_custom_diremaul_beads();
 void AddSC_custom_gurubashi_arena();
 void AddSC_custom_pvpve_dungeon();
+void AddSC_custom_depleted_mark_exchange();
 
 void AddCustomScripts()
 {
@@ -39,4 +40,5 @@ void AddCustomScripts()
     AddSC_custom_diremaul_beads();
     AddSC_custom_gurubashi_arena();
     AddSC_custom_pvpve_dungeon();
+    AddSC_custom_depleted_mark_exchange();
 }


### PR DESCRIPTION
## Summary
- add helpers that identify ineligible depleted marks, raise the conversion cost constant to three, and reuse the new logic inside the existing helper utilities
- update the depleted mark item script so it removes exactly three ineligible marks before granting the player their class-appropriate mark
- refresh the custom SQL tooltip so the on-use text explains the new three-ineligible requirement

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f551d9d8832791b99ec0b9a5e57f)