### PR TITLE
Fix PvPvE requeue after leaving runs

### DIFF
--- a/sql/updates/custom/2024_04_04_00_pvpve_dungeon.sql
+++ b/sql/updates/custom/2024_04_04_00_pvpve_dungeon.sql
@@ -16,13 +16,11 @@ CREATE TABLE IF NOT EXISTS `pvpve_dungeon_template` (
 CREATE TABLE IF NOT EXISTS `pvpve_dungeon_spawn` (
   `TemplateId` INT UNSIGNED NOT NULL,
   `SpawnIndex` TINYINT UNSIGNED NOT NULL,
-  `CreatureEntry` INT UNSIGNED NOT NULL,
   `MapId` SMALLINT UNSIGNED NOT NULL DEFAULT 0,
   `PositionX` FLOAT NOT NULL DEFAULT 0,
   `PositionY` FLOAT NOT NULL DEFAULT 0,
   `PositionZ` FLOAT NOT NULL DEFAULT 0,
   `Orientation` FLOAT NOT NULL DEFAULT 0,
-  `RespawnSeconds` INT UNSIGNED NOT NULL DEFAULT 30,
   PRIMARY KEY (`TemplateId`, `SpawnIndex`),
   CONSTRAINT `FK_pvpve_dungeon_spawn_template` FOREIGN KEY (`TemplateId`) REFERENCES `pvpve_dungeon_template` (`Id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -41,16 +39,17 @@ ON DUPLICATE KEY UPDATE
   `MaxPlayersPerTeam` = VALUES(`MaxPlayersPerTeam`),
   `MaxRuntimeSecs` = VALUES(`MaxRuntimeSecs`);
 
-INSERT INTO `pvpve_dungeon_spawn` (`TemplateId`, `SpawnIndex`, `CreatureEntry`, `MapId`, `PositionX`, `PositionY`, `PositionZ`, `Orientation`, `RespawnSeconds`)
+INSERT INTO `pvpve_dungeon_spawn` (`TemplateId`, `SpawnIndex`, `MapId`, `PositionX`, `PositionY`, `PositionZ`, `Orientation`)
 VALUES
-  (1, 0, 1706, 34, 48.825, -7.284, -20.216, 5.78, 30),
-  (1, 1, 1707, 34, 73.594, -10.873, -20.219, 4.60, 30),
-  (1, 2, 1708, 34, 96.325, -12.443, -20.219, 3.10, 30)
+  -- Center staging area in the entry hall
+  (1, 0, 34, 52.573, -0.411, -20.213, 4.69),
+  -- South cell block (left wing)
+  (1, 1, 34, 90.944, -33.215, -20.219, 1.57),
+  -- North cell block (right wing)
+  (1, 2, 34, 90.944, 33.215, -20.219, 4.71)
 ON DUPLICATE KEY UPDATE
-  `CreatureEntry` = VALUES(`CreatureEntry`),
   `MapId` = VALUES(`MapId`),
   `PositionX` = VALUES(`PositionX`),
   `PositionY` = VALUES(`PositionY`),
   `PositionZ` = VALUES(`PositionZ`),
-  `Orientation` = VALUES(`Orientation`),
-  `RespawnSeconds` = VALUES(`RespawnSeconds`);
+  `Orientation` = VALUES(`Orientation`);

--- a/sql/updates/custom/2024_06_01_00_pvpve_dungeon_duo_team_size.sql
+++ b/sql/updates/custom/2024_06_01_00_pvpve_dungeon_duo_team_size.sql
@@ -1,0 +1,5 @@
+-- Align Stockades PvPvE template with 2-player queue requirements
+UPDATE `pvpve_dungeon_template`
+SET `MinPlayersPerTeam` = 2,
+    `MaxPlayersPerTeam` = 2
+WHERE `Id` = 1;

--- a/sql/updates/custom/2024_06_03_00_pvpve_spawn_rework.sql
+++ b/sql/updates/custom/2024_06_03_00_pvpve_spawn_rework.sql
@@ -1,0 +1,55 @@
+-- Align PvPvE spawn points with dedicated player positions
+SET @currentDb := DATABASE();
+
+-- Drop legacy CreatureEntry column if it exists
+SET @hasCreatureEntry := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = @currentDb
+      AND TABLE_NAME = 'pvpve_dungeon_spawn'
+      AND COLUMN_NAME = 'CreatureEntry');
+SET @dropCreatureSql := IF(@hasCreatureEntry > 0,
+    'ALTER TABLE `pvpve_dungeon_spawn` DROP COLUMN `CreatureEntry`',
+    'DO 0');
+PREPARE stmt FROM @dropCreatureSql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Drop legacy RespawnSeconds column if it exists
+SET @hasRespawn := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = @currentDb
+      AND TABLE_NAME = 'pvpve_dungeon_spawn'
+      AND COLUMN_NAME = 'RespawnSeconds');
+SET @dropRespawnSql := IF(@hasRespawn > 0,
+    'ALTER TABLE `pvpve_dungeon_spawn` DROP COLUMN `RespawnSeconds`',
+    'DO 0');
+PREPARE stmt FROM @dropRespawnSql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Reposition the Stockades PvPvE spawn points into clear areas
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 52.573,
+    `PositionY` = -0.411,
+    `PositionZ` = -20.213,
+    `Orientation` = 4.69
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 0;
+
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 90.944,
+    `PositionY` = -33.215,
+    `PositionZ` = -20.219,
+    `Orientation` = 1.57
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 1;
+
+UPDATE `pvpve_dungeon_spawn`
+SET `MapId` = 34,
+    `PositionX` = 90.944,
+    `PositionY` = 33.215,
+    `PositionZ` = -20.219,
+    `Orientation` = 4.71
+WHERE `TemplateId` = 1 AND `SpawnIndex` = 2;

--- a/sql/updates/custom/2024_06_05_00_pvpve_dungeon_allow_solo.sql
+++ b/sql/updates/custom/2024_06_05_00_pvpve_dungeon_allow_solo.sql
@@ -1,0 +1,5 @@
+-- Allow Stockades PvPvE template to accept solo entries for testing
+UPDATE `pvpve_dungeon_template`
+SET `MinPlayersPerTeam` = 1,
+    `MaxPlayersPerTeam` = 2
+WHERE `Id` = 1;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -344,6 +344,7 @@ Player::Player(WorldSession* session) : Unit(true)
 
     m_HomebindTimer = 0;
     m_InstanceValid = true;
+    m_InstanceValidityOverride = false;
     m_dungeonDifficulty = DUNGEON_DIFFICULTY_NORMAL;
     m_raidDifficulty = RAID_DIFFICULTY_10MAN_NORMAL;
     m_raidMapDifficulty = RAID_DIFFICULTY_10MAN_NORMAL;
@@ -19377,6 +19378,14 @@ void Player::SendSavedInstances()
     }
 }
 
+void Player::SetInstanceValidityOverride(bool enabled)
+{
+    m_InstanceValidityOverride = enabled;
+
+    if (enabled)
+        m_InstanceValid = true;
+}
+
 bool Player::Satisfy(AccessRequirement const* ar, uint32 target_map, bool report)
 {
     if (!IsGameMaster() && ar)
@@ -19464,6 +19473,9 @@ bool Player::CheckInstanceValidity(bool /*isLogin*/)
 {
     // game masters' instances are always valid
     if (IsGameMaster())
+        return true;
+
+    if (HasInstanceValidityOverride())
         return true;
 
     // non-instances are always valid

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2107,6 +2107,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         uint32 m_HomebindTimer;
         bool m_InstanceValid;
+        bool m_InstanceValidityOverride;
         // permanent binds and solo binds by difficulty
         BoundInstancesMap m_boundInstances[MAX_DIFFICULTY];
         InstancePlayerBind* GetBoundInstance(uint32 mapid, Difficulty difficulty, bool withExpired = false);
@@ -2120,6 +2121,8 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         bool HasPendingBind() const { return _pendingBindId > 0; }
         void SendRaidInfo();
         void SendSavedInstances();
+        void SetInstanceValidityOverride(bool enabled);
+        bool HasInstanceValidityOverride() const { return m_InstanceValidityOverride; }
         bool Satisfy(AccessRequirement const* ar, uint32 target_map, bool report = false);
         bool CheckInstanceValidity(bool /*isLogin*/);
         bool CheckInstanceCount(uint32 instanceId) const;

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -19,18 +19,19 @@
 
 #include "Duration.h"
 #include "DatabaseEnv.h"
-#include "Group.h"
-#include "GroupMgr.h"
+#include "InstanceSaveMgr.h"
 #include "InstanceScript.h"
 #include "Log.h"
 #include "MapInstanced.h"
 #include "MapManager.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "Random.h"
 #include "ScriptMgr.h"
 
 #include <algorithm>
 #include <ctime>
+#include <set>
 #include <string>
 
 namespace
@@ -42,7 +43,7 @@ char const* const kSpawnQuery = "SELECT TemplateId, SpawnIndex, PositionX, Posit
     "FROM pvpve_dungeon_spawn ORDER BY TemplateId, SpawnIndex";
 
 constexpr uint32 kPvpveFfaAuraSpellId = 0;
-constexpr uint32 kPvpveFfaPlayerFlag = PLAYER_FLAGS_UNK7;
+constexpr UnitPVPStateFlags kPvpveFfaPvpFlag = UNIT_BYTE2_FLAG_FFA_PVP;
 }
 
 DungeonTemplate const* PvpveDungeonMgr::GetDungeonTemplate(uint32 templateId) const
@@ -90,6 +91,11 @@ void PvpveDungeonMgr::OnPlayerEnteredInstance(Player* player, PvpveDungeonInstan
         run->InstanceMap = player->GetMap();
 
     run->InstanceScript = instanceScript;
+
+    // Allow PvPvE participants to remain inside the dungeon without being
+    // ejected for not being in the instance owner’s party.
+    player->m_InstanceValid = true;
+    player->SetInstanceValidityOverride(true);
 }
 
 PvpveDungeonMgr* PvpveDungeonMgr::Instance()
@@ -435,7 +441,16 @@ void PvpveDungeonMgr::AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& qu
         return;
     }
 
-    uint8 spawnIndex = PickSpawnIndex(run.TemplateId);
+    uint32 const runInstanceId = run.InstanceId ? run.InstanceId : (run.InstanceMap ? run.InstanceMap->GetInstanceId() : 0u);
+    InstanceSave* instanceSave = nullptr;
+    if (runInstanceId)
+    {
+        instanceSave = sInstanceSaveMgr->GetInstanceSave(runInstanceId);
+        if (!instanceSave)
+            TC_LOG_WARN("server.custom", "PvpveDungeonMgr: run {} is tracking instance {} but no InstanceSave exists yet.", run.Id, runInstanceId);
+    }
+
+    uint8 spawnIndex = PickSpawnIndex(run);
     auto spawnItr = std::find_if(spawnList->begin(), spawnList->end(), [spawnIndex](SpawnPoint const& spawn)
     {
         return spawn.Index == spawnIndex;
@@ -455,53 +470,6 @@ void PvpveDungeonMgr::AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& qu
     team.CreatedTime = std::time(nullptr);
     team.Ready = queued.Ready;
 
-    Group* group = nullptr;
-    if (!run.GroupGuid.IsEmpty())
-        group = sGroupMgr->GetGroupByGUID(run.GroupGuid.GetCounter());
-
-    Player* leader = nullptr;
-    for (ObjectGuid const& guid : team.Members)
-    {
-        leader = ObjectAccessor::FindPlayer(guid);
-        if (leader)
-            break;
-    }
-
-    if (!leader)
-    {
-        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: unable to find an online leader for team {} in run {}.", team.Id, run.Id);
-        return;
-    }
-
-    if (!group)
-    {
-        group = new Group();
-        if (!group->Create(leader))
-        {
-            TC_LOG_ERROR("server.custom", "PvpveDungeonMgr: failed to create raid group for run {} (team {}).", run.Id, team.Id);
-            delete group;
-            return;
-        }
-
-        group->ConvertToRaid();
-        sGroupMgr->AddGroup(group);
-        run.GroupGuid = group->GetGUID();
-    }
-    else if (!group->isRaidGroup())
-        group->ConvertToRaid();
-
-    auto addToRaid = [group, runId = run.Id](Player* player) -> bool
-    {
-        if (group->IsMember(player->GetGUID()))
-            return true;
-
-        if (group->AddMember(player))
-            return true;
-
-        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: failed to add player {} to raid for run {}.", player->GetGUID().ToString(), runId);
-        return false;
-    };
-
     for (ObjectGuid const& memberGuid : team.Members)
     {
         Player* player = ObjectAccessor::FindPlayer(memberGuid);
@@ -511,8 +479,9 @@ void PvpveDungeonMgr::AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& qu
             continue;
         }
 
-        if (!addToRaid(player))
-            continue;
+        player->SetInstanceValidityOverride(true);
+        if (instanceSave)
+            player->BindToInstance(instanceSave, false);
 
         if (!player->TeleportTo(dungeonTemplate->MapId, spawnItr->X, spawnItr->Y, spawnItr->Z, spawnItr->O))
             TC_LOG_WARN("server.custom", "PvpveDungeonMgr: teleport failed for player {} joining run {}.", memberGuid.ToString(), run.Id);
@@ -563,10 +532,30 @@ PvpveDungeonRun* PvpveDungeonMgr::GetRunForPlayer(ObjectGuid const& guid)
     return GetRun(itr->second);
 }
 
-uint8 PvpveDungeonMgr::PickSpawnIndex(uint32 templateId)
+uint8 PvpveDungeonMgr::PickSpawnIndex(PvpveDungeonRun const& run)
 {
-    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: TODO pick spawn index for template {}.", templateId);
-    return 0;
+    auto spawnList = GetSpawnPoints(run.TemplateId);
+    if (!spawnList || spawnList->empty())
+        return 0;
+
+    std::set<uint8> usedIndices;
+    for (uint64 teamId : run.Teams)
+    {
+        if (PvpveTeam* team = GetTeam(teamId))
+            usedIndices.insert(team->SpawnIndex);
+    }
+
+    for (SpawnPoint const& spawn : *spawnList)
+    {
+        if (!usedIndices.count(spawn.Index))
+            return spawn.Index;
+    }
+
+    uint32 randomIdx = urand(0, spawnList->size() - 1);
+    uint8 fallback = (*spawnList)[randomIdx].Index;
+    TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: reusing spawn index {} for template {} due to exhausted slots.",
+        uint32(fallback), run.TemplateId);
+    return fallback;
 }
 
 void PvpveDungeonMgr::OnInstanceCreated(uint32 templateId, uint64 runId, uint32 instanceId)
@@ -648,14 +637,7 @@ void PvpveDungeonMgr::EvaluateRunState(PvpveDungeonRun& run)
             ++activeTeams;
     }
 
-    bool shouldFinish = false;
-    if (run.Teams.size() > 1 && activeTeams <= 1)
-        shouldFinish = true;
-    else if (run.Teams.size() == 1 && activeTeams == 0)
-        shouldFinish = true;
-
-    if (shouldFinish)
-        FinishRun(run);
+    // Runs now finish when the instance boss is defeated; elimination merely tracks team status.
 }
 
 void PvpveDungeonMgr::OnPlayerEliminated(Player* player)
@@ -702,6 +684,9 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
     if (!IsPlayerInPvpveRun(player))
         return;
 
+    ClearPvpveFfaState(player);
+    player->SetInstanceValidityOverride(false);
+
     ObjectGuid const guid = player->GetGUID();
     auto runItr = _playerToRun.find(guid);
     if (runItr == _playerToRun.end())
@@ -723,12 +708,48 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
         run->Players.erase(playerListItr);
 
     run->PlayerSpawns.erase(guid);
+    _playerToTeam.erase(guid);
     _playerToRun.erase(runItr);
 
     EvaluateRunState(*run);
 }
 
-void PvpveDungeonMgr::FinishRun(PvpveDungeonRun& run)
+void PvpveDungeonMgr::OnBossDefeated(uint64 runId, ObjectGuid const& creditGuid)
+{
+    PvpveDungeonRun* run = GetRun(runId);
+    if (!run)
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: ignoring boss defeat for unknown run {}.", runId);
+        return;
+    }
+
+    if (run->Finished)
+    {
+        TC_LOG_DEBUG("server.custom", "PvpveDungeonMgr: run {} already finished; boss defeat notification ignored.", runId);
+        return;
+    }
+
+    run->BossDefeated = true;
+
+    uint64 preferredWinner = 0;
+    if (!creditGuid.IsEmpty())
+    {
+        auto teamItr = _playerToTeam.find(creditGuid);
+        if (teamItr != _playerToTeam.end())
+        {
+            if (PvpveTeam* team = GetTeam(teamItr->second))
+            {
+                if (!team->Eliminated)
+                    preferredWinner = team->Id;
+            }
+        }
+    }
+
+    TC_LOG_INFO("server.custom", "PvpveDungeonMgr: boss defeated for run {} (credit team: {}).", runId, preferredWinner);
+    FinishRun(*run, preferredWinner);
+}
+
+void PvpveDungeonMgr::FinishRun(PvpveDungeonRun& run, uint64 preferredWinner)
 {
     if (run.Finished)
         return;
@@ -738,11 +759,25 @@ void PvpveDungeonMgr::FinishRun(PvpveDungeonRun& run)
 
     std::vector<uint64> winningTeams;
     winningTeams.reserve(run.Teams.size());
-    for (uint64 teamId : run.Teams)
+    if (preferredWinner)
     {
-        PvpveTeam* team = GetTeam(teamId);
-        if (team && !team->Eliminated)
-            winningTeams.push_back(teamId);
+        if (PvpveTeam* team = GetTeam(preferredWinner))
+        {
+            if (!team->Eliminated)
+                winningTeams.push_back(preferredWinner);
+        }
+        else
+            preferredWinner = 0;
+    }
+
+    if (winningTeams.empty())
+    {
+        for (uint64 teamId : run.Teams)
+        {
+            PvpveTeam* team = GetTeam(teamId);
+            if (team && !team->Eliminated)
+                winningTeams.push_back(teamId);
+        }
     }
 
     if (winningTeams.empty())
@@ -820,10 +855,17 @@ void PvpveDungeonMgr::CheckRunRuntime(PvpveDungeonRun& run, time_t now)
 
     uint32 const elapsed = uint32(now - run.StartTime);
     if (elapsed < dungeonTemplate->MaxRuntimeSecs)
+    {
+        run.TimeoutWarningSent = false;
         return;
+    }
 
-    TC_LOG_WARN("server.custom", "PvpveDungeonMgr: run {} exceeded max runtime ({}s / {}s). Finishing run.", run.Id, elapsed, dungeonTemplate->MaxRuntimeSecs);
-    FinishRun(run);
+    if (!run.TimeoutWarningSent)
+    {
+        run.TimeoutWarningSent = true;
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: run {} exceeded max runtime ({}s / {}s) but will remain active until the boss is defeated.",
+            run.Id, elapsed, dungeonTemplate->MaxRuntimeSecs);
+    }
 }
 
 uint32 PvpveDungeonMgr::CountActiveRuns() const
@@ -921,6 +963,15 @@ public:
             sPvpveDungeonMgr->OnPlayerLeftMap(player);
             ClearPendingState(guid);
         }
+    }
+
+    void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
+    {
+        if (!player)
+            return;
+
+        if (sPvpveDungeonMgr->IsPlayerInPvpveRun(player))
+            ApplyPvpveFfaState(player);
     }
 
     void OnLogout(Player* player) override
@@ -1053,6 +1104,10 @@ void ApplyPvpveFfaState(Player* player)
     if (!player)
         return;
 
+    player->pvpInfo.IsInFFAPvPArea = true;
+    player->UpdatePvPState();
+    player->SetPvP(true);
+
     if (kPvpveFfaAuraSpellId)
     {
         if (!player->HasAura(kPvpveFfaAuraSpellId))
@@ -1061,8 +1116,8 @@ void ApplyPvpveFfaState(Player* player)
         return;
     }
 
-    if (!player->HasFlag(PLAYER_FLAGS, kPvpveFfaPlayerFlag))
-        player->SetFlag(PLAYER_FLAGS, kPvpveFfaPlayerFlag);
+    if (!player->HasPvpFlag(kPvpveFfaPvpFlag))
+        player->SetPvpFlag(kPvpveFfaPvpFlag);
 }
 
 void ClearPvpveFfaState(Player* player)
@@ -1070,12 +1125,15 @@ void ClearPvpveFfaState(Player* player)
     if (!player)
         return;
 
+    player->pvpInfo.IsInFFAPvPArea = false;
+    player->UpdatePvPState();
+
     if (kPvpveFfaAuraSpellId)
     {
         player->RemoveAura(kPvpveFfaAuraSpellId);
         return;
     }
 
-    if (player->HasFlag(PLAYER_FLAGS, kPvpveFfaPlayerFlag))
-        player->RemoveFlag(PLAYER_FLAGS, kPvpveFfaPlayerFlag);
+    if (player->HasPvpFlag(kPvpveFfaPvpFlag))
+        player->RemovePvpFlag(kPvpveFfaPvpFlag);
 }

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -11,7 +11,6 @@
 
 class Player;
 class Map;
-class Group;
 class Creature;
 class WorldPacket;
 class WorldSession;
@@ -65,12 +64,13 @@ struct PvpveDungeonRun
     Map* InstanceMap = nullptr;
     uint32 InstanceId = 0;
     PvpveDungeonInstance* InstanceScript = nullptr;
-    ObjectGuid GroupGuid;
     time_t CreatedTime = 0;
     time_t StartTime = 0;
     bool Active = false;
     bool Completed = false;
     bool Finished = false;
+    bool BossDefeated = false;
+    bool TimeoutWarningSent = false;
     std::vector<ObjectGuid> Players;
     std::map<ObjectGuid, uint8> PlayerSpawns;
     std::vector<uint64> Teams;
@@ -112,6 +112,7 @@ public:
     void OnPlayerDeath(Player* player);
     void OnInstanceCreated(uint32 templateId, uint64 runId, uint32 instanceId);
     void OnPlayerEnteredInstance(Player* player, PvpveDungeonInstance* instanceScript);
+    void OnBossDefeated(uint64 runId, ObjectGuid const& creditGuid);
     bool IsPlayerInPvpveRun(ObjectGuid const& guid) const;
     bool IsPlayerInPvpveRun(Player const* player) const;
 
@@ -126,14 +127,14 @@ private:
 
     void StartNextRun();
     void AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& queued);
-    uint8 PickSpawnIndex(uint32 templateId);
+    uint8 PickSpawnIndex(PvpveDungeonRun const& run);
     void CleanupRun(uint64 runId);
     void CleanupPlayer(ObjectGuid const& guid);
     void OnPlayerEliminated(Player* player);
     void OnPlayerLeftMap(Player* player);
     void EvaluateRunState(PvpveDungeonRun& run);
     bool TeamHasActiveMembers(PvpveTeam const& team, DungeonTemplate const* dungeonTemplate) const;
-    void FinishRun(PvpveDungeonRun& run);
+    void FinishRun(PvpveDungeonRun& run, uint64 preferredWinner = 0);
     void TrackQueuedMembers(std::vector<ObjectGuid> const& members);
     void UntrackQueuedMembers(std::vector<ObjectGuid> const& members);
     void CheckRunRuntime(PvpveDungeonRun& run, time_t now);

--- a/src/server/scripts/Custom/npc_pvpve_dungeon_queue.cpp
+++ b/src/server/scripts/Custom/npc_pvpve_dungeon_queue.cpp
@@ -34,7 +34,7 @@ constexpr uint32 ACTION_QUEUE = GOSSIP_ACTION_INFO_DEF + 1;
 constexpr uint32 ACTION_CLOSE = GOSSIP_ACTION_INFO_DEF + 2;
 constexpr uint32 STOCKADES_TEMPLATE_ID = 1;
 
-void SendLeaderError(Player* player, char const* text)
+void SendQueueError(Player* player, char const* text)
 {
     if (!player)
         return;
@@ -104,65 +104,90 @@ public:
             if (!player)
                 return;
 
+            DungeonTemplate const* dungeonTemplate = PvpveDungeonMgr::instance()->GetDungeonTemplate(STOCKADES_TEMPLATE_ID);
+            if (!dungeonTemplate || !dungeonTemplate->Enabled)
+            {
+                SendQueueError(player, "The Stockades PvPvE queue is currently unavailable.");
+                return;
+            }
+
             Group* group = player->GetGroup();
+            std::vector<ObjectGuid> memberGuids;
+            memberGuids.reserve(group ? group->GetMembersCount() : 1);
+
             if (!group)
             {
-                SendLeaderError(player, "You must be in a party to queue for the Stockades PvPvE event.");
-                return;
-            }
-
-            if (!group->IsLeader(player->GetGUID()))
-            {
-                SendLeaderError(player, "Only the party leader can queue for the Stockades PvPvE event.");
-                return;
-            }
-
-            if (group->GetMembersCount() != 2)
-            {
-                SendLeaderError(player, "Exactly two party members are required for this queue.");
-                return;
-            }
-
-            std::vector<ObjectGuid> memberGuids;
-            memberGuids.reserve(2);
-
-            for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-            {
-                Player* member = ref->GetSource();
-                if (!member || !member->IsInWorld())
+                if (dungeonTemplate->MinPlayers > 1)
                 {
-                    SendLeaderError(player, "All party members must be online to join the queue.");
+                    SendQueueError(player, "You must be in a party to queue for this event.");
                     return;
                 }
 
-                if (!member->IsAlive())
-                {
-                    SendLeaderError(player, "All party members must be alive to join the queue.");
-                    return;
-                }
-
-                if (member->GetMap() && member->GetMap()->Instanceable())
-                {
-                    SendLeaderError(player, "Party members must leave instances before queueing.");
-                    return;
-                }
-
-                memberGuids.push_back(member->GetGUID());
+                memberGuids.push_back(player->GetGUID());
             }
-
-            if (memberGuids.size() != 2)
+            else
             {
-                SendLeaderError(player, "Unable to determine party members. Please try again.");
-                return;
+                if (!group->IsLeader(player->GetGUID()))
+                {
+                    SendQueueError(player, "Only the party leader can queue for the Stockades PvPvE event.");
+                    return;
+                }
+
+                uint32 const memberCount = group->GetMembersCount();
+                if (dungeonTemplate->MinPlayers && memberCount < dungeonTemplate->MinPlayers)
+                {
+                    SendQueueError(player, "Your party does not meet the minimum size for this event.");
+                    return;
+                }
+
+                if (dungeonTemplate->MaxPlayers && memberCount > dungeonTemplate->MaxPlayers)
+                {
+                    SendQueueError(player, "Your party exceeds the maximum size for this event.");
+                    return;
+                }
+
+                for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+                {
+                    Player* member = ref->GetSource();
+                    if (!member || !member->IsInWorld())
+                    {
+                        SendQueueError(player, "All party members must be online to join the queue.");
+                        return;
+                    }
+
+                    if (!member->IsAlive())
+                    {
+                        SendQueueError(player, "All party members must be alive to join the queue.");
+                        return;
+                    }
+
+                    if (member->GetMap() && member->GetMap()->Instanceable())
+                    {
+                        SendQueueError(player, "Party members must leave instances before queueing.");
+                        return;
+                    }
+
+                    memberGuids.push_back(member->GetGUID());
+                }
+
+                if (memberGuids.size() != memberCount)
+                {
+                    SendQueueError(player, "Unable to determine party members. Please try again.");
+                    return;
+                }
             }
 
             if (!PvpveDungeonMgr::instance()->QueueTeam(STOCKADES_TEMPLATE_ID, memberGuids))
             {
-                SendLeaderError(player, "Failed to join the queue. Please try again shortly.");
+                SendQueueError(player, "Failed to join the queue. Please try again shortly.");
                 return;
             }
 
-            BroadcastToGroup(group, "You have joined the Stockades PvPvE queue!");
+            if (group)
+                BroadcastToGroup(group, "You have joined the Stockades PvPvE queue!");
+            else if (WorldSession* session = player->GetSession())
+                session->SendNotification("You have joined the Stockades PvPvE queue!");
+
             CloseGossipMenuFor(player);
         }
     };

--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -20,6 +20,7 @@
 #include "Configuration/Config.h"
 #include "Duration.h"
 #include "GameObject.h"
+#include "Creature.h"
 #include "Map.h"
 #include "InstanceScript.h"
 #include "Log.h"
@@ -45,6 +46,7 @@ Position const DefaultChestPosition = { 71.879f, -15.478f, -20.215f, 0.0f };
 uint32 s_ChestGameObjectId = 0;
 Seconds s_ChestDespawn = Seconds(DefaultChestDespawnSeconds);
 Position s_ChestPosition = DefaultChestPosition;
+uint32 s_BossCreatureEntry = 0;
 
 void LoadConfig()
 {
@@ -54,13 +56,18 @@ void LoadConfig()
     float const configuredY = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnY", DefaultChestPosition.GetPositionY());
     float const configuredZ = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnZ", DefaultChestPosition.GetPositionZ());
     float const configuredO = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnO", DefaultChestPosition.GetOrientation());
+    int32 const configuredBoss = sConfigMgr->GetIntDefault("StockadesPvPvE.BossCreatureEntry", 0);
 
     s_ChestGameObjectId = configuredEntry > 0 ? uint32(configuredEntry) : 0u;
     s_ChestDespawn = Seconds(configuredDespawn >= 0 ? uint32(configuredDespawn) : DefaultChestDespawnSeconds);
     s_ChestPosition.Relocate(configuredX, configuredY, configuredZ, configuredO);
+    s_BossCreatureEntry = configuredBoss > 0 ? uint32(configuredBoss) : 0u;
 
     if (!s_ChestGameObjectId)
         TC_LOG_WARN("server.custom", "Stockades PvPvE: reward chest entry is 0; chest spawning is disabled.");
+
+    if (!s_BossCreatureEntry)
+        TC_LOG_WARN("server.custom", "Stockades PvPvE: boss creature entry is 0; boss defeat tracking is disabled.");
 }
 
 QuaternionData GetChestRotation()
@@ -82,6 +89,11 @@ void EnsureConfigLoaded()
 uint32 GetChestGameObjectId()
 {
     return s_ChestGameObjectId;
+}
+
+uint32 GetBossCreatureEntry()
+{
+    return s_BossCreatureEntry;
 }
 
 Seconds GetChestDespawnTime()
@@ -125,7 +137,10 @@ public:
                 return;
 
             if (PvpveDungeonRun* run = PvpveDungeonMgr::instance()->GetRunForPlayer(player->GetGUID()))
+            {
+                _pvpveRunId = run->Id;
                 PvpveDungeonMgr::instance()->OnInstanceCreated(run->TemplateId, run->Id, player->GetInstanceId());
+            }
 
             ApplyPvpveFfaState(player);
             sPvpveDungeonMgr->OnPlayerEnteredInstance(player, this);
@@ -149,6 +164,32 @@ public:
             AnnounceVictory(runId, winningTeam);
             SummonRewardChest(runId, winningTeam);
             ClearFfaState(winningTeam);
+            _pvpveRunId = 0;
+        }
+
+        void OnUnitDeath(Unit* unit) override
+        {
+            InstanceScript::OnUnitDeath(unit);
+
+            if (!_pvpveRunId)
+                return;
+
+            if (!unit)
+                return;
+
+            Creature* creature = unit->ToCreature();
+            if (!creature)
+                return;
+
+            uint32 const bossEntry = StockadesPvPvE::GetBossCreatureEntry();
+            if (!bossEntry || creature->GetEntry() != bossEntry)
+                return;
+
+            ObjectGuid creditGuid = ObjectGuid::Empty;
+            if (Player* killer = creature->GetLootRecipient())
+                creditGuid = killer->GetGUID();
+
+            sPvpveDungeonMgr->OnBossDefeated(_pvpveRunId, creditGuid);
         }
 
     private:
@@ -230,6 +271,7 @@ public:
 
         ObjectGuid _rewardChestGuid;
         uint32 _rewardChestRunId = 0;
+        uint64 _pvpveRunId = 0;
     };
 };
 


### PR DESCRIPTION
## Summary
- clear a player's PvPvE team mapping when they leave the dungeon so their GUIDs are no longer treated as actively assigned to a team
- this allows players who finish or abandon a run to requeue without hitting the generic "failed to join" error from the queue NPC

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691753a8ff108327affccb6aeac0d603)