### PR TITLE
Fix PvPvE queue lock after leaving Stockades

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -710,6 +710,8 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
     run->PlayerSpawns.erase(guid);
     _playerToRun.erase(runItr);
 
+    _playerToTeam.erase(guid);
+
     EvaluateRunState(*run);
 }
 


### PR DESCRIPTION
## Summary
- clear the PvPvE team membership map when a player leaves the Stockades instance so they can be queued again immediately

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691918f2c32c8327a036703a974f557b)