### PR TITLE
Prevent battleground ghosts from missing resurrection queue

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1357,6 +1357,22 @@ void Battleground::RemovePlayerFromResurrectQueue(ObjectGuid player_guid)
     }
 }
 
+bool Battleground::IsPlayerInResurrectQueue(ObjectGuid player_guid) const
+{
+    for (std::map<ObjectGuid, GuidVector>::const_iterator itr = m_ReviveQueue.begin(); itr != m_ReviveQueue.end(); ++itr)
+    {
+        for (GuidVector::const_iterator itr2 = itr->second.begin(); itr2 != itr->second.end(); ++itr2)
+            if (*itr2 == player_guid)
+                return true;
+    }
+
+    for (GuidVector::const_iterator itr = m_ResurrectQueue.begin(); itr != m_ResurrectQueue.end(); ++itr)
+        if (*itr == player_guid)
+            return true;
+
+    return false;
+}
+
 void Battleground::RelocateDeadPlayers(ObjectGuid guideGuid)
 {
     // Those who are waiting to resurrect at this node are taken to the closest own node's graveyard

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -358,6 +358,7 @@ class TC_GAME_API Battleground
 
         void AddPlayerToResurrectQueue(ObjectGuid npc_guid, ObjectGuid player_guid);
         void RemovePlayerFromResurrectQueue(ObjectGuid player_guid);
+        bool IsPlayerInResurrectQueue(ObjectGuid player_guid) const;
 
         /// Relocate all players in ReviveQueue to the closest graveyard
         void RelocateDeadPlayers(ObjectGuid guideGuid);

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -722,10 +722,14 @@ void BattlegroundMgr::SendToBattleground(Player* player, uint32 instanceId, Batt
 void BattlegroundMgr::SendAreaSpiritHealerQueryOpcode(Player* player, Battleground* bg, ObjectGuid guid)
 {
     WorldPacket data(SMSG_AREA_SPIRIT_HEALER_TIME, 12);
-    uint32 time_ = 30000 - bg->GetLastResurrectTime();      // resurrect every 30 seconds
-    if (time_ == uint32(-1))
-        time_ = 0;
-    data << guid << time_;
+
+    uint32 const interval = bg->GetResurrectionInterval();
+    uint32 timeRemaining = 0;
+
+    if (bg->GetLastResurrectTime() < interval)
+        timeRemaining = interval - bg->GetLastResurrectTime();
+
+    data << guid << timeRemaining;
     player->SendDirectMessage(&data);
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5122,7 +5122,7 @@ void Player::RepopAtGraveyard()
                 if (!bg)
                     return;
 
-                if (HasAura(SPELL_WAITING_FOR_RESURRECT))
+                if (bg->IsPlayerInResurrectQueue(GetGUID()))
                     return;
 
                 uint32 spiritEntry = GetBGTeam() == ALLIANCE ? BG_CREATURE_ENTRY_A_SPIRITGUIDE : BG_CREATURE_ENTRY_H_SPIRITGUIDE;


### PR DESCRIPTION
## Summary
- add a helper to detect whether a battleground player is already queued for resurrection
- rely on the battleground’s queue state instead of the Waiting to Resurrect aura before auto-enlisting ghosts with their spirit guide so they can never get stuck out of the queue

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191dfd634883279bc762ee1134beec)