### PR TITLE
Persist honor changes immediately

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7120,13 +7120,14 @@ void Player::ModifyHonorPoints(int32 value, CharacterDatabaseTransaction trans, 
         AddItem(40752, value);
     SetHonorPoints(uint32(newValue));
 
+    CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_HONOR_POINTS);
+    stmt->setUInt32(0, newValue);
+    stmt->setUInt32(1, GetGUID().GetCounter());
+
     if (trans)
-    {
-        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_HONOR_POINTS);
-        stmt->setUInt32(0, newValue);
-        stmt->setUInt32(1, GetGUID().GetCounter());
         trans->Append(stmt);
-    }
+    else
+        CharacterDatabase.Execute(stmt);
 }
 
 void Player::ModifyArenaPoints(int32 value, CharacterDatabaseTransaction trans)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1830,7 +1830,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         uint32 GetHonorPoints() const { return GetUInt32Value(PLAYER_FIELD_HONOR_CURRENCY); }
         uint32 GetMaxHonorPoints() const;
         uint32 GetArenaPoints() const { return GetUInt32Value(PLAYER_FIELD_ARENA_CURRENCY); }
-        void ModifyHonorPoints(int32 value, CharacterDatabaseTransaction trans = CharacterDatabaseTransaction(nullptr), bool applyHonorGainAuras = true);      //! If trans is specified, honor save query will be added to trans
+        void ModifyHonorPoints(int32 value, CharacterDatabaseTransaction trans = CharacterDatabaseTransaction(nullptr), bool applyHonorGainAuras = true);      //! If trans is specified, honor save query will be added to trans, otherwise saved immediately
         void ModifyArenaPoints(int32 value, CharacterDatabaseTransaction trans = CharacterDatabaseTransaction(nullptr));      //! If trans is specified, arena point save query will be added to trans
         uint32 GetMaxPersonalArenaRatingRequirement(uint32 minarenaslot) const;
         void SetHonorPoints(uint32 value);


### PR DESCRIPTION
## Summary
- ensure ModifyHonorPoints always saves updated honor points even when no database transaction is provided
- clarify the comment on ModifyHonorPoints in the header

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919392cb4808327af86451da32d4b4a)