### PR TITLE
Allow auto placement when account bank open

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11825,9 +11825,10 @@ InventoryResult Player::CanBankItem(uint8 bag, uint8 slot, ItemPosCountVec& dest
 
     if (AccountBank::IsAccountBankOpen(this))
     {
+        bool const usingAutoPlacement = (bag == NULL_BAG) && (slot == NULL_SLOT);
         bool const targetIsAccountSlot = (bag == INVENTORY_SLOT_BAG_0) && (slot >= BANK_SLOT_ITEM_START) &&
             (slot < BANK_SLOT_ITEM_START + AccountBank::MAX_SLOTS);
-        if (!targetIsAccountSlot)
+        if (!usingAutoPlacement && !targetIsAccountSlot)
             return EQUIP_ERR_ITEM_DOESNT_GO_TO_SLOT;
 
         if (!IsBankPos(pItem->GetBagSlot(), pItem->GetSlot()) && !AccountBank::IsDepositable(pItem))


### PR DESCRIPTION
## Summary
- adjust Player::CanBankItem so right-click/auto-placement requests while the account bank is open are treated as valid destinations
- preserve the slot validation for manual placements to non-account bank slots

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193cb4573c8327970811309d54ef58)