### PR TITLE
Add Stockades PvPvE invasion raid warning

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -29,6 +29,7 @@
 #include "Position.h"
 #include "SharedDefines.h"
 #include "StringFormat.h"
+#include "World.h"
 
 #include "../../Custom/mod_pvpve_dungeon.h"
 
@@ -141,6 +142,10 @@ public:
                 _pvpveRunId = run->Id;
                 PvpveDungeonMgr::instance()->OnInstanceCreated(run->TemplateId, run->Id, player->GetInstanceId());
             }
+
+            sWorld->SendServerMessage(SERVER_MSG_STRING,
+                Trinity::StringFormat("|cffff0000[Stockades PvPvE]|r %s is invading the Stormwind Stockade!",
+                    player->GetName().c_str()));
 
             ApplyPvpveFfaState(player);
             sPvpveDungeonMgr->OnPlayerEnteredInstance(player, this);


### PR DESCRIPTION
## Summary
- announce a global raid-warning style server message whenever a player enters the Stockades PvPvE instance, highlighting that the dungeon is under attack

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919488724388327b46ce37b8a78a30c)