### PR TITLE
Revert forced combat toggles for Bloodrage and Enrage

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -147,6 +147,11 @@ void CombatManager::Update(uint32 tdiff)
         else
             ++it;
     }
+
+    if (!_pveRefs.empty() || !_pvpRefs.empty())
+        RevalidateCombat();
+
+    UpdateOwnerCombatState();
 }
 
 bool CombatManager::HasPvECombat() const
@@ -159,7 +164,7 @@ bool CombatManager::HasPvECombat() const
 
 bool CombatManager::HasCombat() const
 {
-    return HasPvECombat() || HasPvPCombat() || GetOwner()->HasAura(29131) || GetOwner()->HasAura(5229);
+    return HasPvECombat() || HasPvPCombat() || _forcedCombatRefs != 0;
 }
 
 bool CombatManager::HasPvECombatWithPlayers() const
@@ -188,6 +193,26 @@ Unit* CombatManager::GetAnyTarget() const
         if (!pair.second->IsSuppressedFor(_owner))
             return pair.second->GetOther(_owner);
     return nullptr;
+}
+
+void CombatManager::ModifyForcedCombatState(bool addReference)
+{
+    bool const hadForcedCombat = _forcedCombatRefs != 0;
+
+    if (addReference)
+        ++_forcedCombatRefs;
+    else
+    {
+        if (_forcedCombatRefs == 0)
+            return;
+
+        --_forcedCombatRefs;
+    }
+
+    if (hadForcedCombat == (_forcedCombatRefs != 0))
+        return;
+
+    UpdateOwnerCombatState();
 }
 
 bool CombatManager::SetInCombatWith(Unit* who, bool addSecondUnitSuppressed)

--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -164,7 +164,7 @@ bool CombatManager::HasPvECombat() const
 
 bool CombatManager::HasCombat() const
 {
-    return HasPvECombat() || HasPvPCombat() || _forcedCombatRefs != 0;
+    return HasPvECombat() || HasPvPCombat() || GetOwner()->HasAura(29131) || GetOwner()->HasAura(5229);
 }
 
 bool CombatManager::HasPvECombatWithPlayers() const

--- a/src/server/game/Combat/CombatManager.h
+++ b/src/server/game/Combat/CombatManager.h
@@ -127,6 +127,7 @@ class TC_GAME_API CombatManager
         void EndAllPvPCombat();
         void EndAllCombat() { EndAllPvECombat(); EndAllPvPCombat(); }
         bool UpdateOwnerCombatState() const;
+        void ModifyForcedCombatState(bool addReference);
 
         CombatManager(CombatManager const&) = delete;
         CombatManager& operator=(CombatManager const&) = delete;
@@ -139,7 +140,7 @@ class TC_GAME_API CombatManager
         std::unordered_map<ObjectGuid, CombatReference*> _pveRefs;
         std::unordered_map<ObjectGuid, PvPCombatReference*> _pvpRefs;
 
-        bool m_forcedCombat;
+        uint32 _forcedCombatRefs = 0;
 
     friend struct CombatReference;
     friend struct PvPCombatReference;


### PR DESCRIPTION
## Summary
- revert spell 5229 (Enrage) to only recalculate armor and refresh its damage/defense auras without altering the forced combat counter
- revert spell 29131 (Bloodrage) to simply request a combat state refresh when the aura is applied or removed

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691938562c4883279f083bfbe5589f4a)