### PR TITLE
Restrict Stormwind Stockades access to PvPvE queue

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -982,7 +982,10 @@ public:
 
         ObjectGuid const guid = player->GetGUID();
         if (sPvpveDungeonMgr->IsPlayerInPvpveRun(player))
+        {
+            TeleportOutImmediately(player);
             sPvpveDungeonMgr->OnPlayerLeftMap(player);
+        }
 
         ClearPendingState(guid);
     }
@@ -1061,6 +1064,17 @@ private:
             TeleportDestination const destination = GetTeleportLocation(player);
             player->TeleportTo(destination.MapId, destination.X, destination.Y, destination.Z, destination.O);
         }, 1s);
+    }
+
+    void TeleportOutImmediately(Player* player)
+    {
+        if (!player)
+            return;
+
+        ForceRelease(player);
+
+        TeleportDestination const destination = GetTeleportLocation(player);
+        player->TeleportTo(destination.MapId, destination.X, destination.Y, destination.Z, destination.O);
     }
 
     void ClearPendingState(ObjectGuid const& guid)

--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -39,6 +39,12 @@
 namespace StockadesPvPvE
 {
 constexpr uint32 StockadesMapId = 34;
+constexpr uint32 StockadesExteriorMapId = 0;
+
+namespace
+{
+Position const kStockadesExteriorPosition = { -8779.9f, 834.349f, 94.6801f, 0.653013f };
+}
 
 namespace
 {
@@ -136,7 +142,19 @@ public:
                 return;
 
             if (!sPvpveDungeonMgr->IsPlayerInPvpveRun(player))
+            {
+                if (!player->IsGameMaster())
+                {
+                    if (WorldSession* session = player->GetSession())
+                        session->SendNotification("The Stockades are only accessible through the PvPvE queue.");
+
+                    player->TeleportTo(StockadesExteriorMapId, kStockadesExteriorPosition.GetPositionX(),
+                        kStockadesExteriorPosition.GetPositionY(), kStockadesExteriorPosition.GetPositionZ(),
+                        kStockadesExteriorPosition.GetOrientation());
+                }
+
                 return;
+            }
 
             if (PvpveDungeonRun* run = PvpveDungeonMgr::instance()->GetRunForPlayer(player->GetGUID()))
             {


### PR DESCRIPTION
## Summary
- prevent non-queued players from remaining in the Stockades instance by teleporting them back outside with a warning
- ensure players who log out while in a PvPvE run are teleported to their faction destination immediately and removed from the run

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b30a598483279f5f40451bf4c7e2)