### PR TITLE
Improve hidden itemset resurrection handling

### DIFF
--- a/src/server/scripts/Custom/custom_hidden_itemset_bonus.cpp
+++ b/src/server/scripts/Custom/custom_hidden_itemset_bonus.cpp
@@ -240,6 +240,26 @@ void EnsureHiddenBonusSummons(Player* player, HiddenItemsetBonus const& bonus)
     player->CastSpell(player, bonus.spellId, true);
 }
 
+void ResummonHiddenBonusCreatures(Player* player)
+{
+    if (!player)
+        return;
+
+    uint64 guid = player->GetGUID().GetRawValue();
+    auto itr = s_PlayerActiveHiddenItemsets.find(guid);
+    if (itr == s_PlayerActiveHiddenItemsets.end())
+        return;
+
+    for (uint32 itemsetId : itr->second)
+    {
+        auto bonusItr = s_HiddenItemsetBonuses.find(itemsetId);
+        if (bonusItr == s_HiddenItemsetBonuses.end())
+            continue;
+
+        EnsureHiddenBonusSummons(player, bonusItr->second);
+    }
+}
+
 void RecalcHiddenItemsetBonuses(Player* player)
 {
     if (!player)
@@ -365,7 +385,7 @@ public:
 
     void OnPlayerResurrect(Player* player) override
     {
-        RecalcHiddenItemsetBonuses(player);
+        ResummonHiddenBonusCreatures(player);
     }
 };
 


### PR DESCRIPTION
## Summary
- add a helper that resummons hidden itemset pet summons for active bonuses
- change the resurrection hook to only resummon pets instead of recalculating the full hidden bonus state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b12ac84c8327b3a481ca6916c9e9)