### PR TITLE
Prevent Entangling Roots self-damage breaks

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5670,9 +5670,22 @@ void AuraEffect::HandleModAttackPowerOfArmorAuraTick(Unit* target, Unit* caster)
     target->UpdateAttackPowerAndDamage(true);
 }
 
-//ttopper: breakable roots/fears
 void AuraEffect::HandleBreakableCCAuraProc(AuraApplication* aurApp, ProcEventInfo& eventInfo)
 {
+    static flag96 const EntanglingRootsFamilyMask(0x00000200, 0, 0);
+
+    SpellInfo const* auraInfo = GetSpellInfo();
+    bool const isEntanglingRootsAura = auraInfo && auraInfo->SpellFamilyName == SPELLFAMILY_DRUID
+        && (auraInfo->SpellFamilyFlags & EntanglingRootsFamilyMask);
+
+    if (isEntanglingRootsAura)
+    {
+        if (DamageInfo* damageInfo = eventInfo.GetDamageInfo())
+            if (SpellInfo const* damageSpell = damageInfo->GetSpellInfo())
+                if (damageSpell->Id == auraInfo->Id)
+                    return;
+    }
+
     Unit* caster = aurApp->GetBase()->GetCaster()->ToUnit();
     int32 maxDamage = 1300;
     if (caster)


### PR DESCRIPTION
## Summary
- remove the Entangling Roots-specific guard logic from Unit damage and aura removal handling
- keep Entangling Roots from breaking on its own periodic damage by handling the exception in HandleBreakableCCAuraProc

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c856c480832787e1f0cf64aed568)