### PR TITLE
Fix namespace usage for Stockades teleport

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -148,9 +148,11 @@ public:
                     if (WorldSession* session = player->GetSession())
                         session->SendNotification("The Stockades are only accessible through the PvPvE queue.");
 
-                    player->TeleportTo(StockadesExteriorMapId, kStockadesExteriorPosition.GetPositionX(),
-                        kStockadesExteriorPosition.GetPositionY(), kStockadesExteriorPosition.GetPositionZ(),
-                        kStockadesExteriorPosition.GetOrientation());
+                    player->TeleportTo(StockadesPvPvE::StockadesExteriorMapId,
+                        StockadesPvPvE::kStockadesExteriorPosition.GetPositionX(),
+                        StockadesPvPvE::kStockadesExteriorPosition.GetPositionY(),
+                        StockadesPvPvE::kStockadesExteriorPosition.GetPositionZ(),
+                        StockadesPvPvE::kStockadesExteriorPosition.GetOrientation());
                 }
 
                 return;


### PR DESCRIPTION
## Summary
- qualify the Stockades exterior map id and teleport position with the StockadesPvPvE namespace so the script builds again

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d56b1a4883278848c74fc4c5a553)