### PR TITLE
Allow moving Starfire casts to persist

### DIFF
--- a/sql/custom/world/.gitignore
+++ b/sql/custom/world/.gitignore
@@ -1,3 +1,5 @@
 *.sql
 !2024_05_04_00_world_arena_4v4.sql
+!2024_07_05_00_world_starfire_walk.sql
+!2024_07_05_01_world_starfire_snare_talent.sql
 !2024_07_12_00_world_gurubashi_hourly_chest.sql

--- a/sql/custom/world/2024_07_05_00_world_starfire_walk.sql
+++ b/sql/custom/world/2024_07_05_00_world_starfire_walk.sql
@@ -1,0 +1,4 @@
+-- Grant Moonkin Form the ability to move while snared during Starfire
+INSERT INTO `spell_custom_attr` (`entry`, `attributes`) VALUES
+(24858, 0x02000000)
+ON DUPLICATE KEY UPDATE `attributes` = `attributes` | 0x02000000;

--- a/sql/custom/world/2024_07_05_01_world_starfire_snare_talent.sql
+++ b/sql/custom/world/2024_07_05_01_world_starfire_snare_talent.sql
@@ -1,0 +1,19 @@
+-- Shift the walk-while-casting Starfire support from Moonkin Form to the five ranks of Starlight Wrath.
+-- Removing the attribute from Moonkin Form ensures the bonus is now talent-gated.
+UPDATE `spell_custom_attr`
+SET `attributes` = `attributes` & ~0x02000000
+WHERE `entry` = 24858
+  AND `attributes` & 0x02000000;
+
+DELETE FROM `spell_custom_attr`
+WHERE `entry` = 24858
+  AND `attributes` = 0;
+
+-- Flag every Starlight Wrath rank with the snare-enabled Starfire casting attribute.
+INSERT INTO `spell_custom_attr` (`entry`, `attributes`) VALUES
+(16814, 0x02000000),
+(16815, 0x02000000),
+(16816, 0x02000000),
+(16817, 0x02000000),
+(16818, 0x02000000)
+ON DUPLICATE KEY UPDATE `attributes` = `attributes` | VALUES(`attributes`);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Unit.h"
+#include <algorithm>
 #include <array>
 #include "AbstractFollower.h"
 #include "Battlefield.h"
@@ -3204,6 +3205,11 @@ bool Unit::IsMovementPreventedByCasting() const
             if (spell->GetSpellInfo()->IsMoveAllowedChannel())
                 return false;
 
+    if (GetStarfireSnareSpeedRate() > 0.0f)
+        if (Spell* spell = m_currentSpells[CURRENT_GENERIC_SPELL])
+            if (spell->GetSpellInfo()->IsStarfire())
+                return false;
+
     // prohibit movement for all other spell casts
     return true;
 }
@@ -4688,6 +4694,43 @@ bool Unit::HasAuraWithMechanic(uint32 mechanicMask) const
     }
 
     return false;
+}
+
+float Unit::GetStarfireSnareSpeedRate() const
+{
+    float bestRate = 0.0f;
+
+    for (AuraApplicationMap::const_iterator iter = m_appliedAuras.begin(); iter != m_appliedAuras.end(); ++iter)
+    {
+        Aura const* aura = iter->second->GetBase();
+        SpellInfo const* spellInfo = aura->GetSpellInfo();
+        if (!spellInfo || !spellInfo->HasAttribute(SPELL_ATTR0_CU_ALLOW_STARFIRE_SNARE_CAST))
+            continue;
+
+        if (float const spellDefinedRate = spellInfo->GetStarfireSnareSpeedRate())
+        {
+            if (spellDefinedRate > bestRate)
+                bestRate = spellDefinedRate;
+
+            continue;
+        }
+
+        for (uint8 effIndex = EFFECT_0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+        {
+            if (AuraEffect const* auraEffect = aura->GetEffect(effIndex))
+            {
+                int32 const amount = auraEffect->GetAmount();
+                if (amount <= 0)
+                    continue;
+
+                float const rate = std::clamp(static_cast<float>(amount) / 100.0f, 0.0f, 1.0f);
+                if (rate > bestRate)
+                    bestRate = rate;
+            }
+        }
+    }
+
+    return bestRate;
 }
 
 bool Unit::HasStrongerAuraWithDR(SpellInfo const* auraSpellInfo, Unit* caster, bool triggered) const

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1419,6 +1419,7 @@ class TC_GAME_API Unit : public WorldObject
         bool HasAuraTypeWithTriggerSpell(AuraType auratype, uint32 triggerSpell) const;
         bool HasNegativeAuraWithInterruptFlag(uint32 flag, ObjectGuid guid = ObjectGuid::Empty) const;
         bool HasAuraWithMechanic(uint32 mechanicMask) const;
+        float GetStarfireSnareSpeedRate() const;
         bool HasStrongerAuraWithDR(SpellInfo const* auraSpellInfo, Unit* caster, bool triggered) const;
 
         AuraEffect* IsScriptOverriden(SpellInfo const* spell, int32 script) const;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -73,12 +73,42 @@ extern SpellEffectHandlerFn SpellEffectHandlers[TOTAL_SPELL_EFFECTS];
 
 namespace
 {
+    constexpr float MinStarfireSnareSpeedRate = 0.01f;
+    constexpr float MaxStarfireSnareSpeedRate = 1.0f;
+    UnitMoveType const StarfireSnareMoveTypes[] = { MOVE_RUN, MOVE_RUN_BACK, MOVE_SWIM, MOVE_SWIM_BACK };
+
     bool IsTrapGameObject(GameObject const* caster)
     {
         if (!caster)
             return false;
 
         return caster->GetGoType() == GAMEOBJECT_TYPE_TRAP;
+    }
+
+    bool ApplyStarfireSnare(Player* player, float requestedSpeedRate)
+    {
+        float const clampedSpeedRate = std::clamp(requestedSpeedRate, MinStarfireSnareSpeedRate, MaxStarfireSnareSpeedRate);
+        if (clampedSpeedRate <= 0.0f)
+            return false;
+
+        bool snared = false;
+
+        for (UnitMoveType moveType : StarfireSnareMoveTypes)
+        {
+            if (player->GetSpeedRate(moveType) > clampedSpeedRate)
+            {
+                player->SetSpeedRate(moveType, clampedSpeedRate);
+                snared = true;
+            }
+        }
+
+        return snared;
+    }
+
+    void RemoveStarfireSnare(Player* player)
+    {
+        for (UnitMoveType moveType : StarfireSnareMoveTypes)
+            player->UpdateSpeed(moveType);
     }
 
     // Allow trap game objects to continue casting regardless of target check failures so feedback is handled during hit resolution.
@@ -720,6 +750,7 @@ m_caster((info->HasAttribute(SPELL_ATTR6_CAST_BY_CHARMER) && caster->GetCharmerO
     m_timer = 0;                                            // will set to castime in prepare
     m_channeledDuration = 0;                                // will be setup in Spell::handle_immediate
     m_immediateHandled = false;
+    m_resetStarfireSnareAfterCast = false;
 
     m_channelTargetEffectMask = 0;
 
@@ -3280,9 +3311,10 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
     // Prepare data for triggers
     prepareDataForTriggerSystem();
 
-    if (Player* player = m_caster->ToPlayer())
+    Player* playerCaster = m_caster->ToPlayer();
+    if (playerCaster)
     {
-        if (!player->GetCommandStatus(CHEAT_CASTTIME))
+        if (!playerCaster->GetCommandStatus(CHEAT_CASTTIME))
         {
             // calculate cast time (calculated after first CheckCast check to prevent charge counting for first CheckCast fail)
             m_casttime = m_spellInfo->CalcCastTime(this);
@@ -3293,6 +3325,10 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
     else
         m_casttime = m_spellInfo->CalcCastTime(this);
 
+    float starfireSnareSpeedRate = 0.0f;
+    if (playerCaster && m_casttime && m_spellInfo->IsStarfire())
+        starfireSnareSpeedRate = playerCaster->GetStarfireSnareSpeedRate();
+
     // don't allow channeled spells / spells with cast time to be cast while moving
     // exception are only channeled spells that have no casttime and SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING
     // (even if they are interrupted on moving, spells with almost immediate effect get to have their effect processed before movement interrupter kicks in)
@@ -3301,10 +3337,19 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
         // 1. Has casttime, 2. Or doesn't have flag to allow movement during channel
         if (m_casttime || !m_spellInfo->IsMoveAllowedChannel())
         {
-            SendCastResult(SPELL_FAILED_MOVING);
-            finish(false);
-            return SPELL_FAILED_MOVING;
+            if (!(starfireSnareSpeedRate > 0.0f && m_spellInfo->IsStarfire()))
+            {
+                SendCastResult(SPELL_FAILED_MOVING);
+                finish(false);
+                return SPELL_FAILED_MOVING;
+            }
         }
+    }
+
+    if (starfireSnareSpeedRate > 0.0f)
+    {
+        if (ApplyStarfireSnare(playerCaster, starfireSnareSpeedRate))
+            m_resetStarfireSnareAfterCast = true;
     }
 
     // Creatures focus their target when possible
@@ -3956,18 +4001,25 @@ void Spell::update(uint32 difftime)
     }
 
     // check if the player caster has moved before the spell finished
-    if (m_caster->GetTypeId() == TYPEID_PLAYER && m_timer != 0 &&
-        m_caster->ToPlayer()->isMoving() && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT &&
-        (!m_spellInfo->HasEffect(SPELL_EFFECT_STUCK) || !m_caster->ToPlayer()->HasUnitMovementFlag(MOVEMENTFLAG_FALLING_FAR)))
+    if (m_caster->GetTypeId() == TYPEID_PLAYER && m_timer != 0)
     {
-        // don't cancel for melee, autorepeat, triggered and instant spells
-        if (!m_spellInfo->IsNextMeleeSwingSpell() && !IsAutoRepeat() && !IsTriggered() && !(IsChannelActive() && m_spellInfo->IsMoveAllowedChannel()))
+        Player* playerCaster = m_caster->ToPlayer();
+        bool const playerMoved = playerCaster->isMoving();
+        bool const starfireMovementAllowed = m_spellInfo->IsStarfire() && playerCaster->GetStarfireSnareSpeedRate() > 0.0f;
+
+        if (playerMoved && !starfireMovementAllowed &&
+            m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT &&
+            (!m_spellInfo->HasEffect(SPELL_EFFECT_STUCK) || !playerCaster->HasUnitMovementFlag(MOVEMENTFLAG_FALLING_FAR)))
         {
-            // if charmed by creature, trust the AI not to cheat and allow the cast to proceed
-            // @todo this is a hack, "creature" movesplines don't differentiate turning/moving right now
-            // however, checking what type of movement the spline is for every single spline would be really expensive
-            if (!m_caster->ToPlayer()->GetCharmerGUID().IsCreature())
-                cancel();
+            // don't cancel for melee, autorepeat, triggered and instant spells
+            if (!m_spellInfo->IsNextMeleeSwingSpell() && !IsAutoRepeat() && !IsTriggered() && !(IsChannelActive() && m_spellInfo->IsMoveAllowedChannel()))
+            {
+                // if charmed by creature, trust the AI not to cheat and allow the cast to proceed
+                // @todo this is a hack, "creature" movesplines don't differentiate turning/moving right now
+                // however, checking what type of movement the spline is for every single spline would be really expensive
+                if (!playerCaster->GetCharmerGUID().IsCreature())
+                    cancel();
+            }
         }
     }
 
@@ -4042,6 +4094,14 @@ void Spell::finish(bool ok)
     Unit* unitCaster = m_caster->ToUnit();
     if (!unitCaster)
         return;
+
+    if (m_resetStarfireSnareAfterCast)
+    {
+        if (Player* playerCaster = unitCaster->ToPlayer())
+            RemoveStarfireSnare(playerCaster);
+
+        m_resetStarfireSnareAfterCast = false;
+    }
 
     if (m_spellInfo->IsChanneled())
         unitCaster->UpdateInterruptMask();

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -511,6 +511,7 @@ class TC_GAME_API Spell
         uint64 m_delayStart;                                // time of spell delay start, filled by event handler, zero = just started
         uint64 m_delayMoment;                               // moment of next delay call, used internally
         bool m_immediateHandled;                            // were immediate actions handled? (used by delayed spells only)
+        bool m_resetStarfireSnareAfterCast;
 
         // These vars are used in both delayed spell system and modified immediate spell system
         bool m_referencedFromCurrentSpell;                  // mark as references to prevent deleted and access by dead pointers

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1246,6 +1246,32 @@ bool SpellInfo::IsMoveAllowedChannel() const
     return IsChanneled() && (HasAttribute(SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING) || (!(ChannelInterruptFlags & (AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING))));
 }
 
+bool SpellInfo::IsStarfire() const
+{
+    return SpellFamilyName == SPELLFAMILY_DRUID && (SpellFamilyFlags[0] & 0x00000004);
+}
+
+float SpellInfo::GetStarfireSnareSpeedRate() const
+{
+    switch (Id)
+    {
+        case 16814: // Starlight Wrath (Rank 1)
+            return 0.05f;
+        case 16815: // Rank 2
+            return 0.10f;
+        case 16816: // Rank 3
+            return 0.15f;
+        case 16817: // Rank 4
+            return 0.20f;
+        case 16818: // Rank 5
+            return 0.25f;
+        default:
+            break;
+    }
+
+    return 0.0f;
+}
+
 bool SpellInfo::NeedsComboPoints() const
 {
     return HasAttribute(SpellAttr1(SPELL_ATTR1_REQ_COMBO_POINTS1 | SPELL_ATTR1_REQ_COMBO_POINTS2));

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -167,6 +167,7 @@ enum SpellCustomAttributes
     SPELL_ATTR0_CU_DEPRECATED_LIQUID_AURA        = 0x00400000, // DO NOT REUSE
     SPELL_ATTR0_CU_IS_TALENT                     = 0x00800000, // reserved for master branch
     SPELL_ATTR0_CU_AURA_CANNOT_BE_SAVED          = 0x01000000,
+    SPELL_ATTR0_CU_ALLOW_STARFIRE_SNARE_CAST     = 0x02000000,
 
     SPELL_ATTR0_CU_NEGATIVE                      = SPELL_ATTR0_CU_NEGATIVE_EFF0 | SPELL_ATTR0_CU_NEGATIVE_EFF1 | SPELL_ATTR0_CU_NEGATIVE_EFF2
 };
@@ -416,6 +417,8 @@ class TC_GAME_API SpellInfo
         bool IsPositiveEffect(uint8 effIndex) const;
         bool IsChanneled() const;
         bool IsMoveAllowedChannel() const;
+        bool IsStarfire() const;
+        float GetStarfireSnareSpeedRate() const;
         bool NeedsComboPoints() const;
         bool IsNextMeleeSwingSpell() const;
         bool IsBreakingStealth() const;


### PR DESCRIPTION
## Summary
- keep `Spell::update` from canceling Starfire casts whenever the caster has the snare-granting talent so moving during the cast no longer interrupts it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c8757d58832795c247fae79da299)