### PR TITLE
Add name entry for PvPvE invasion queue

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -142,7 +142,7 @@ void PvpveDungeonMgr::LoadConfigFromDB()
             entry.Enabled = fields[2].GetBool();
             entry.MinLevel = fields[3].GetUInt8();
             entry.MaxLevel = fields[4].GetUInt8();
-            entry.MaxTeams = std::max<uint8>(1, fields[5].GetUInt8());
+            entry.MaxTeams = fields[5].GetUInt8();
             entry.MinPlayers = fields[6].GetUInt8();
             entry.MaxPlayers = fields[7].GetUInt8();
             entry.MaxRuntimeSecs = fields[8].GetUInt32();
@@ -180,7 +180,7 @@ void PvpveDungeonMgr::LoadConfigFromDB()
     TC_LOG_INFO("server.custom", "PvpveDungeonMgr: loaded spawn point data for {} templates.", _spawns.size());
 }
 
-bool PvpveDungeonMgr::QueueTeam(uint32 templateId, std::vector<ObjectGuid> const& memberGuids)
+bool PvpveDungeonMgr::QueueTeam(uint32 templateId, std::vector<ObjectGuid> const& memberGuids, uint64 preferredRunId)
 {
     if (memberGuids.empty())
     {
@@ -254,7 +254,7 @@ bool PvpveDungeonMgr::QueueTeam(uint32 templateId, std::vector<ObjectGuid> const
     for (ObjectGuid const& guid : memberGuids)
         _playerToTeam[guid] = teamId;
 
-    if (!QueueTeam(teamId))
+    if (!QueueTeam(teamId, preferredRunId))
     {
         for (ObjectGuid const& guid : memberGuids)
             _playerToTeam.erase(guid);
@@ -266,7 +266,7 @@ bool PvpveDungeonMgr::QueueTeam(uint32 templateId, std::vector<ObjectGuid> const
     return true;
 }
 
-bool PvpveDungeonMgr::QueueTeam(uint64 teamId)
+bool PvpveDungeonMgr::QueueTeam(uint64 teamId, uint64 preferredRunId)
 {
     auto teamItr = _teams.find(teamId);
     if (teamItr == _teams.end())
@@ -306,6 +306,7 @@ bool PvpveDungeonMgr::QueueTeam(uint64 teamId)
     queued.QueueTime = std::time(nullptr);
     queued.Members = teamItr->second.Members;
     queued.Ready = teamItr->second.Ready;
+    queued.PreferredRunId = preferredRunId;
 
     auto queueItr = _queue.find(teamId);
     if (queueItr != _queue.end())
@@ -371,18 +372,16 @@ void PvpveDungeonMgr::Update(uint32 /*diff*/)
                 continue;
             }
 
-            PvpveDungeonRun* selectedRun = nullptr;
-            for (auto& runPair : _runs)
+            auto const runEligible = [&](PvpveDungeonRun& candidate)
             {
-                PvpveDungeonRun& candidate = runPair.second;
                 if (candidate.TemplateId != dungeonTemplate->Id)
-                    continue;
+                    return false;
 
                 if (candidate.Completed)
-                    continue;
+                    return false;
 
-                if (candidate.Teams.size() >= dungeonTemplate->MaxTeams)
-                    continue;
+                if (dungeonTemplate->MaxTeams && candidate.Teams.size() >= dungeonTemplate->MaxTeams)
+                    return false;
 
                 bool const memberHasLockout = std::any_of(queueItr->second.Members.begin(), queueItr->second.Members.end(),
                     [this, &candidate](ObjectGuid const& guid)
@@ -391,11 +390,28 @@ void PvpveDungeonMgr::Update(uint32 /*diff*/)
                     return lockoutItr != _playerRunLockouts.end() && lockoutItr->second == candidate.Id;
                 });
 
-                if (memberHasLockout)
-                    continue;
+                return !memberHasLockout;
+            };
 
-                selectedRun = &candidate;
-                break;
+            PvpveDungeonRun* selectedRun = nullptr;
+            if (queueItr->second.PreferredRunId)
+            {
+                auto runItr = _runs.find(queueItr->second.PreferredRunId);
+                if (runItr != _runs.end() && runEligible(runItr->second))
+                    selectedRun = &runItr->second;
+            }
+
+            if (!selectedRun)
+            {
+                for (auto& runPair : _runs)
+                {
+                    PvpveDungeonRun& candidate = runPair.second;
+                    if (!runEligible(candidate))
+                        continue;
+
+                    selectedRun = &candidate;
+                    break;
+                }
             }
 
             if (!selectedRun)

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -17,6 +17,7 @@
 
 #include "mod_pvpve_dungeon.h"
 
+#include "Chat.h"
 #include "Duration.h"
 #include "DatabaseEnv.h"
 #include "InstanceSaveMgr.h"
@@ -96,6 +97,17 @@ void PvpveDungeonMgr::OnPlayerEnteredInstance(Player* player, PvpveDungeonInstan
     // ejected for not being in the instance owner’s party.
     player->m_InstanceValid = true;
     player->SetInstanceValidityOverride(true);
+
+    if (WorldSession* session = player->GetSession())
+    {
+        uint32 instanceId = player->GetInstanceId();
+        if (!instanceId)
+            if (Map* map = player->GetMap())
+                instanceId = map->GetInstanceId();
+
+        if (instanceId)
+            ChatHandler(session).PSendSysMessage("PvPvE Stockades instance ID: %u", instanceId);
+    }
 }
 
 PvpveDungeonMgr* PvpveDungeonMgr::Instance()

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -83,6 +83,7 @@ struct QueuedTeam
     time_t QueueTime = 0;
     std::vector<ObjectGuid> Members;
     bool Ready = false;
+    uint64 PreferredRunId = 0;
 };
 
 class PvpveDungeonMgr
@@ -101,8 +102,8 @@ public:
 
     uint64 CreateTeam(std::vector<Player*> const& players, uint32 templateId);
     void RemoveTeam(uint64 teamId);
-    bool QueueTeam(uint64 teamId);
-    bool QueueTeam(uint32 templateId, std::vector<ObjectGuid> const& memberGuids);
+    bool QueueTeam(uint64 teamId, uint64 preferredRunId = 0);
+    bool QueueTeam(uint32 templateId, std::vector<ObjectGuid> const& memberGuids, uint64 preferredRunId = 0);
     void CancelQueue(uint64 teamId);
 
     void Update(uint32 diff);

--- a/src/server/scripts/Custom/npc_pvpve_dungeon_queue.cpp
+++ b/src/server/scripts/Custom/npc_pvpve_dungeon_queue.cpp
@@ -18,6 +18,8 @@
 #include "Group.h"
 #include "GroupReference.h"
 #include "Map.h"
+#include "ObjectAccessor.h"
+#include "ObjectMgr.h"
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
@@ -31,7 +33,8 @@
 namespace
 {
 constexpr uint32 ACTION_QUEUE = GOSSIP_ACTION_INFO_DEF + 1;
-constexpr uint32 ACTION_CLOSE = GOSSIP_ACTION_INFO_DEF + 2;
+constexpr uint32 ACTION_INVADE = GOSSIP_ACTION_INFO_DEF + 2;
+constexpr uint32 ACTION_CLOSE = GOSSIP_ACTION_INFO_DEF + 3;
 constexpr uint32 STOCKADES_TEMPLATE_ID = 1;
 
 void SendQueueError(Player* player, char const* text)
@@ -72,6 +75,8 @@ public:
 
             ClearGossipMenuFor(player);
             AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue for Stockades PvPvE", GOSSIP_SENDER_MAIN, ACTION_QUEUE);
+            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Invade someone's Stockades run", GOSSIP_SENDER_MAIN, ACTION_INVADE,
+                "Enter the name of a player who is already inside the Stockades PvPvE instance:", 0, true);
             AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Maybe later", GOSSIP_SENDER_MAIN, ACTION_CLOSE);
             SendGossipMenuFor(player, player->GetGossipTextId(me), me);
             return true;
@@ -86,7 +91,10 @@ public:
             switch (action)
             {
                 case ACTION_QUEUE:
-                    HandleQueue(player);
+                    HandleQueue(player, 0);
+                    return true;
+                case ACTION_INVADE:
+                    SendQueueError(player, "You must enter a player name to invade their run.");
                     return true;
                 case ACTION_CLOSE:
                     CloseGossipMenuFor(player);
@@ -98,8 +106,26 @@ public:
             return false;
         }
 
+        bool OnGossipSelectCode(Player* player, uint32 /*menuId*/, uint32 gossipListId, char const* code) override
+        {
+            if (!player)
+                return false;
+
+            uint32 const action = player->PlayerTalkClass->GetGossipOptionAction(gossipListId);
+            switch (action)
+            {
+                case ACTION_INVADE:
+                    HandleInvade(player, code ? code : "");
+                    return true;
+                default:
+                    break;
+            }
+
+            return false;
+        }
+
     private:
-        void HandleQueue(Player* player)
+        void HandleQueue(Player* player, uint64 preferredRunId)
         {
             if (!player)
                 return;
@@ -109,6 +135,28 @@ public:
             {
                 SendQueueError(player, "The Stockades PvPvE queue is currently unavailable.");
                 return;
+            }
+
+            if (preferredRunId)
+            {
+                PvpveDungeonRun* preferredRun = PvpveDungeonMgr::instance()->GetRun(preferredRunId);
+                if (!preferredRun || preferredRun->TemplateId != STOCKADES_TEMPLATE_ID)
+                {
+                    SendQueueError(player, "That run is no longer available for invasion.");
+                    return;
+                }
+
+                if (preferredRun->Completed)
+                {
+                    SendQueueError(player, "That run has already finished.");
+                    return;
+                }
+
+                if (dungeonTemplate->MaxTeams && preferredRun->Teams.size() >= dungeonTemplate->MaxTeams)
+                {
+                    SendQueueError(player, "That run already has the maximum number of teams.");
+                    return;
+                }
             }
 
             Group* group = player->GetGroup();
@@ -177,18 +225,65 @@ public:
                 }
             }
 
-            if (!PvpveDungeonMgr::instance()->QueueTeam(STOCKADES_TEMPLATE_ID, memberGuids))
+            if (!PvpveDungeonMgr::instance()->QueueTeam(STOCKADES_TEMPLATE_ID, memberGuids, preferredRunId))
             {
                 SendQueueError(player, "Failed to join the queue. Please try again shortly.");
                 return;
             }
 
+            char const* successText = preferredRunId ? "You are preparing to invade an active Stockades PvPvE run!" :
+                "You have joined the Stockades PvPvE queue!";
+
             if (group)
-                BroadcastToGroup(group, "You have joined the Stockades PvPvE queue!");
+                BroadcastToGroup(group, successText);
             else if (WorldSession* session = player->GetSession())
-                session->SendNotification("You have joined the Stockades PvPvE queue!");
+                session->SendNotification("%s", successText);
 
             CloseGossipMenuFor(player);
+        }
+
+        void HandleInvade(Player* player, std::string targetName)
+        {
+            if (!player)
+                return;
+
+            auto firstNonSpace = targetName.find_first_not_of(" \t\r\n");
+            if (firstNonSpace == std::string::npos)
+            {
+                SendQueueError(player, "You must enter a player name to invade their run.");
+                return;
+            }
+
+            auto lastNonSpace = targetName.find_last_not_of(" \t\r\n");
+            targetName = targetName.substr(firstNonSpace, lastNonSpace - firstNonSpace + 1);
+
+            if (!normalizePlayerName(targetName))
+            {
+                SendQueueError(player, "That is not a valid player name.");
+                return;
+            }
+
+            Player* target = ObjectAccessor::FindPlayerByName(targetName);
+            if (!target)
+            {
+                SendQueueError(player, "That player is not currently online.");
+                return;
+            }
+
+            if (target == player)
+            {
+                SendQueueError(player, "You cannot invade your own run.");
+                return;
+            }
+
+            PvpveDungeonRun* targetRun = PvpveDungeonMgr::instance()->GetRunForPlayer(target->GetGUID());
+            if (!targetRun || targetRun->TemplateId != STOCKADES_TEMPLATE_ID)
+            {
+                SendQueueError(player, "Your target is not inside an active Stockades PvPvE run.");
+                return;
+            }
+
+            HandleQueue(player, targetRun->Id);
         }
     };
 


### PR DESCRIPTION
## Summary
- add a text-entry "Invade" gossip option so players can type the name of the Stockades target even when they cannot select them directly
- validate the supplied name, ensure the player is online and in a Stockades PvPvE run, and reuse the queue helper to attach the invading party to that run

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6c23c1988327ae9efe2bb7fbd82a)