### PR TITLE
Return players to entry location after Stockades run

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -129,6 +129,7 @@ PvpveDungeonMgr::PvpveDungeonMgr()
     _templates.clear();
     _spawns.clear();
     _queuedPlayers.clear();
+    _playerReturnLocations.clear();
     _lastStatsLog = 0;
 }
 
@@ -522,6 +523,8 @@ void PvpveDungeonMgr::AssignTeamToRun(PvpveDungeonRun& run, QueuedTeam const& qu
         if (instanceSave)
             player->BindToInstance(instanceSave, false);
 
+        StoreReturnLocation(player);
+
         if (!player->TeleportTo(dungeonTemplate->MapId, spawnItr->X, spawnItr->Y, spawnItr->Z, spawnItr->O))
             TC_LOG_WARN("server.custom", "PvpveDungeonMgr: teleport failed for player {} joining run {}.", memberGuid.ToString(), run.Id);
 
@@ -750,6 +753,7 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
     _playerToRun.erase(runItr);
 
     _playerToTeam.erase(guid);
+    ClearReturnLocation(guid);
 
     if (run->Finished)
         _playerRunLockouts.erase(guid);
@@ -757,6 +761,38 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
         _playerRunLockouts[guid] = run->Id;
 
     EvaluateRunState(*run);
+}
+
+WorldLocation const* PvpveDungeonMgr::GetReturnLocation(ObjectGuid const& guid) const
+{
+    auto itr = _playerReturnLocations.find(guid);
+    if (itr == _playerReturnLocations.end())
+        return nullptr;
+
+    return &itr->second;
+}
+
+void PvpveDungeonMgr::StoreReturnLocation(Player* player)
+{
+    if (!player)
+        return;
+
+    ObjectGuid const guid = player->GetGUID();
+    if (!guid)
+        return;
+
+    if (_playerReturnLocations.find(guid) != _playerReturnLocations.end())
+        return;
+
+    _playerReturnLocations.emplace(guid, player->GetWorldLocation());
+}
+
+void PvpveDungeonMgr::ClearReturnLocation(ObjectGuid const& guid)
+{
+    if (!guid)
+        return;
+
+    _playerReturnLocations.erase(guid);
 }
 
 void PvpveDungeonMgr::OnBossDefeated(uint64 runId, ObjectGuid const& creditGuid)
@@ -1088,6 +1124,18 @@ private:
     {
         if (!player)
             return kAllianceTeleportDestination;
+
+        if (WorldLocation const* savedLocation = sPvpveDungeonMgr->GetReturnLocation(player->GetGUID()))
+        {
+            return TeleportDestination
+            {
+                savedLocation->GetMapId(),
+                savedLocation->GetPositionX(),
+                savedLocation->GetPositionY(),
+                savedLocation->GetPositionZ(),
+                savedLocation->GetOrientation()
+            };
+        }
 
         return player->GetTeamId() == TEAM_ALLIANCE ? kAllianceTeleportDestination : kHordeTeleportDestination;
     }

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -2,6 +2,7 @@
 #define MOD_PVPVE_DUNGEON_H
 
 #include "ObjectGuid.h"
+#include "Position.h"
 
 #include <cstdint>
 #include <ctime>
@@ -116,6 +117,7 @@ public:
     void OnBossDefeated(uint64 runId, ObjectGuid const& creditGuid);
     bool IsPlayerInPvpveRun(ObjectGuid const& guid) const;
     bool IsPlayerInPvpveRun(Player const* player) const;
+    WorldLocation const* GetReturnLocation(ObjectGuid const& guid) const;
 
     PvpveDungeonRun* GetRun(uint64 runId);
     PvpveTeam* GetTeam(uint64 teamId);
@@ -142,6 +144,8 @@ private:
     void LogQueueStats(time_t now) const;
     uint32 CountActiveRuns() const;
     void ClearRunLockouts(uint64 runId);
+    void StoreReturnLocation(Player* player);
+    void ClearReturnLocation(ObjectGuid const& guid);
 
     using QueueContainer = std::map<uint64, QueuedTeam>;
     using RunContainer = std::map<uint64, PvpveDungeonRun>;
@@ -150,6 +154,7 @@ private:
     using PlayerTeamMap = std::map<ObjectGuid, uint64>;
     using TemplateContainer = std::map<uint32, DungeonTemplate>;
     using SpawnContainer = std::map<uint32, std::vector<SpawnPoint>>;
+    using PlayerLocationMap = std::map<ObjectGuid, WorldLocation>;
 
     QueueContainer _queue;
     RunContainer _runs;
@@ -160,6 +165,7 @@ private:
     TemplateContainer _templates;
     SpawnContainer _spawns;
     GuidSet _queuedPlayers;
+    PlayerLocationMap _playerReturnLocations;
     uint64 _nextRunId = 1;
     uint64 _nextTeamId = 1;
     time_t _lastStatsLog = 0;


### PR DESCRIPTION
## Summary
- track each player's location before they are teleported into the Stockades PvPvE instance and reuse it as their exit destination
- clear the stored location when the player leaves the PvPvE map so future queues can store a fresh entry point
- fall back to the faction defaults only when no stored return location exists

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a8bab64988327b4015681fe461246)