### PR TITLE
Allow Feign Death to drop combat in dungeons

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2246,14 +2246,11 @@ void AuraEffect::HandleFeignDeath(AuraApplication const* aurApp, uint8 mode, boo
         for (auto& pair : target->GetThreatManager().GetThreatenedByMeList())
           pair.second->ScaleThreat(0.0f);
 
-        if (target->GetMap()->IsDungeon()) // feign death does not remove combat in dungeons
-        {
-            target->AttackStop();
-            if (Player* targetPlayer = target->ToPlayer())
-                targetPlayer->SendAttackSwingCancelAttack();
-        }
-        else
-            target->CombatStop(false, false);
+        target->AttackStop();
+        if (Player* targetPlayer = target->ToPlayer())
+            targetPlayer->SendAttackSwingCancelAttack();
+
+        target->CombatStop(false, false);
 
         target->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_IMMUNE_OR_LOST_SELECTION);
 


### PR DESCRIPTION
## Summary
- always stop attacks and combat state when Feign Death is applied, even inside dungeons

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c332080c88327a9ddb9c47b871b86)