### PR TITLE
Add PvPvE Stockades elimination handling

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -541,6 +541,7 @@ enum AtLoginFlags
     AT_LOGIN_CHANGE_FACTION    = 0x040,
     AT_LOGIN_CHANGE_RACE       = 0x080,
     AT_LOGIN_RESURRECT         = 0x100,
+    AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME = 0x200,
 };
 
 typedef std::map<uint32, QuestStatusData> QuestStatusMap;

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -19,6 +19,9 @@
 
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
+void AddSC_stockades_pvpve();
+
 void AddCustomScripts()
 {
+    AddSC_stockades_pvpve();
 }

--- a/src/server/scripts/Custom/stockades_pvpve.cpp
+++ b/src/server/scripts/Custom/stockades_pvpve.cpp
@@ -1,0 +1,124 @@
+#include "Config.h"
+#include "Player.h"
+#include "Position.h"
+#include "ScriptMgr.h"
+#include "World.h"
+#include "WorldSession.h"
+#include <string>
+
+namespace
+{
+uint32 constexpr StockadesMapId = 34;
+uint32 constexpr StockadesFailMapId = 0;
+Position const StockadesFailTeleport = { -8762.38f, 848.01f, 86.3139f, 0.0f };
+
+bool IsFeatureEnabled()
+{
+    return sConfigMgr->GetOption<bool>("PvPvEDungeon.Stockades.Enable", false);
+}
+
+bool ShouldHandle(Player const* player)
+{
+    return IsFeatureEnabled() && player && !player->IsGameMaster();
+}
+
+bool IsInsideStockades(Player const* player)
+{
+    return player && player->GetMapId() == StockadesMapId;
+}
+
+std::string GetEliminationMessage()
+{
+    return sConfigMgr->GetOption<std::string>(
+        "PvPvEDungeon.Stockades.EliminationMessage",
+        "The Stockades PvPvE dungeon ended while you were offline; you have been eliminated.");
+}
+
+void TeleportPlayerOut(Player* player)
+{
+    if (!player)
+        return;
+
+    if (!player->IsBeingTeleported())
+        player->TeleportTo(StockadesFailMapId, StockadesFailTeleport.GetPositionX(), StockadesFailTeleport.GetPositionY(),
+            StockadesFailTeleport.GetPositionZ(), StockadesFailTeleport.GetOrientation());
+}
+
+void NotifyElimination(Player* player)
+{
+    if (WorldSession* session = player->GetSession())
+    {
+        std::string const message = GetEliminationMessage();
+        if (!message.empty())
+            session->SendNotification("%s", message.c_str());
+    }
+}
+
+void HandleUnsafeLogout(Player* player)
+{
+    if (!player)
+        return;
+
+    player->RemoveAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME);
+    NotifyElimination(player);
+    TeleportPlayerOut(player);
+}
+}
+
+class StockadesPvPvEPlayerScript : public PlayerScript
+{
+public:
+    StockadesPvPvEPlayerScript() : PlayerScript("StockadesPvPvEPlayerScript") { }
+
+    void OnLogin(Player* player, bool /*firstLogin*/) override
+    {
+        if (!ShouldHandle(player))
+        {
+            if (player && player->HasAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME))
+                player->RemoveAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME);
+            return;
+        }
+
+        if (!IsInsideStockades(player))
+        {
+            if (player->HasAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME))
+                player->RemoveAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME);
+            return;
+        }
+
+        if (player->HasAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME))
+        {
+            player->RemoveAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME);
+            return;
+        }
+
+        HandleUnsafeLogout(player);
+    }
+
+    void OnLogout(Player* player) override
+    {
+        if (!ShouldHandle(player))
+        {
+            if (player && player->HasAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME))
+                player->RemoveAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME);
+            return;
+        }
+
+        if (IsInsideStockades(player))
+        {
+            if (sWorld->IsShuttingDown())
+                player->RemoveAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME);
+            else
+                player->SetAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME);
+            return;
+        }
+
+        if (player->HasAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME))
+            player->RemoveAtLoginFlag(AT_LOGIN_PVPVE_STOCKADES_SAFE_RESUME);
+    }
+};
+
+void AddSC_stockades_pvpve()
+{
+    new StockadesPvPvEPlayerScript();
+}

--- a/src/server/scripts/EasternKingdoms/TheStockade/instance_the_stockade.cpp
+++ b/src/server/scripts/EasternKingdoms/TheStockade/instance_the_stockade.cpp
@@ -120,6 +120,17 @@ bool ShouldHandle(Player* player)
     return IsPvPvEEnabled() && player && !player->IsGameMaster() && player->GetMapId() == StockadesMapId;
 }
 
+ObjectGuid GetTeamIdentifier(Player* player)
+{
+    if (!player)
+        return ObjectGuid::Empty;
+
+    if (Group* group = player->GetGroup())
+        return group->GetGUID();
+
+    return player->GetGUID();
+}
+
 void NotifySpawnsFull(Player* player)
 {
     if (!player)
@@ -161,7 +172,7 @@ public:
         void Initialize() override
         {
             InstanceScript::Initialize();
-            _playerSpawnAssignments.clear();
+            _teamSpawnAssignments.clear();
             _availableSpawnIndices.clear();
 
             if (!IsPvPvEEnabled())
@@ -183,29 +194,37 @@ public:
             if (std::vector<Position> const& spawnPoints = GetConfiguredSpawnPoints(); spawnPoints.empty())
                 return;
 
-            ObjectGuid const guid = player->GetGUID();
-
-            if (_playerSpawnAssignments.find(guid) != _playerSpawnAssignments.end())
+            ObjectGuid const teamGuid = GetTeamIdentifier(player);
+            if (!teamGuid)
                 return;
 
-            if (_availableSpawnIndices.empty())
+            auto const teamAssignment = _teamSpawnAssignments.find(teamGuid);
+            uint32 spawnIndex = 0;
+            if (teamAssignment != _teamSpawnAssignments.end())
             {
-                NotifySpawnsFull(player);
-                TeleportPlayerOut(player);
-                return;
+                spawnIndex = teamAssignment->second;
             }
+            else
+            {
+                if (_availableSpawnIndices.empty())
+                {
+                    NotifySpawnsFull(player);
+                    TeleportPlayerOut(player);
+                    return;
+                }
 
-            uint32 const randomSlotIndex = urand(0, _availableSpawnIndices.size() - 1);
-            uint32 const spawnIndex = _availableSpawnIndices[randomSlotIndex];
-            _availableSpawnIndices.erase(_availableSpawnIndices.begin() + randomSlotIndex);
-            _playerSpawnAssignments.emplace(guid, spawnIndex);
+                uint32 const randomSlotIndex = urand(0, _availableSpawnIndices.size() - 1);
+                spawnIndex = _availableSpawnIndices[randomSlotIndex];
+                _availableSpawnIndices.erase(_availableSpawnIndices.begin() + randomSlotIndex);
+                _teamSpawnAssignments.emplace(teamGuid, spawnIndex);
+            }
 
             if (spawnIndex < spawnPoints.size())
                 player->NearTeleportTo(spawnPoints[spawnIndex]);
         }
 
     private:
-        std::unordered_map<ObjectGuid, uint32, ObjectGuid::Hash> _playerSpawnAssignments;
+        std::unordered_map<ObjectGuid, uint32, ObjectGuid::Hash> _teamSpawnAssignments;
         std::vector<uint32> _availableSpawnIndices;
     };
 

--- a/src/server/scripts/EasternKingdoms/TheStockade/instance_the_stockade.cpp
+++ b/src/server/scripts/EasternKingdoms/TheStockade/instance_the_stockade.cpp
@@ -18,12 +18,14 @@
 #include "Config.h"
 #include "InstanceScript.h"
 #include "Log.h"
+#include "MapManager.h"
 #include "Optional.h"
 #include "Player.h"
 #include "Random.h"
 #include "ScriptMgr.h"
 #include "StringConvert.h"
 #include "Util.h"
+#include "WorldLocation.h"
 #include "the_stockade.h"
 #include <algorithm>
 #include <string>
@@ -41,20 +43,10 @@ DungeonEncounterData const encounters[] =
 namespace
 {
 constexpr uint32 StockadesMapId = 34;
-constexpr uint32 StockadesFailMapId = 0;
-Position const StockadesFailTeleport = { -8762.38f, 848.01f, 86.3139f, 0.0f };
 
 bool IsPvPvEEnabled()
 {
     return sConfigMgr->GetOption<bool>("PvPvEDungeon.Stockades.Enable", false);
-}
-
-std::string const& GetSpawnsFullMessage()
-{
-    static std::string const message = sConfigMgr->GetOption<std::string>(
-        "PvPvEDungeon.Stockades.SpawnsFullMessage",
-        "The Stockades PvPvE dungeon is currently full. Please wait for the next run.");
-    return message;
 }
 
 bool TryParseSpawnEntry(std::string_view entry, Position& out)
@@ -131,32 +123,10 @@ ObjectGuid GetTeamIdentifier(Player* player)
     return player->GetGUID();
 }
 
-void NotifySpawnsFull(Player* player)
-{
-    if (!player)
-        return;
-
-    if (WorldSession* session = player->GetSession())
-    {
-        std::string const& message = GetSpawnsFullMessage();
-        if (!message.empty())
-            session->SendNotification("%s", message.c_str());
-    }
-}
-
-void TeleportPlayerOut(Player* player)
-{
-    if (!player)
-        return;
-
-    if (!player->IsBeingTeleported())
-        player->TeleportTo(StockadesFailMapId, StockadesFailTeleport.GetPositionX(), StockadesFailTeleport.GetPositionY(),
-            StockadesFailTeleport.GetPositionZ(), StockadesFailTeleport.GetOrientation());
-}
 }
 
 class instance_the_stockade : public InstanceMapScript
-{ 
+{
 public:
     instance_the_stockade() : InstanceMapScript("instance_the_stockade", StockadesMapId) { }
 
@@ -208,8 +178,7 @@ public:
             {
                 if (_availableSpawnIndices.empty())
                 {
-                    NotifySpawnsFull(player);
-                    TeleportPlayerOut(player);
+                    RedirectTeamToFreshInstance(player, teamGuid);
                     return;
                 }
 
@@ -224,8 +193,32 @@ public:
         }
 
     private:
+        void RedirectTeamToFreshInstance(Player* player, ObjectGuid const& teamGuid)
+        {
+            if (!player || !teamGuid)
+                return;
+
+            uint32 redirectInstanceId = 0;
+            if (auto const redirect = _teamRedirectInstanceIds.find(teamGuid); redirect != _teamRedirectInstanceIds.end())
+            {
+                redirectInstanceId = redirect->second;
+            }
+            else
+            {
+                redirectInstanceId = sMapMgr->GenerateInstanceId();
+                _teamRedirectInstanceIds.emplace(teamGuid, redirectInstanceId);
+            }
+
+            if (!player->IsBeingTeleported())
+            {
+                WorldLocation const currentLocation = player->GetWorldLocation();
+                player->TeleportTo(currentLocation, TELE_TO_NONE, redirectInstanceId);
+            }
+        }
+
         std::unordered_map<ObjectGuid, uint32, ObjectGuid::Hash> _teamSpawnAssignments;
         std::vector<uint32> _availableSpawnIndices;
+        std::unordered_map<ObjectGuid, uint32, ObjectGuid::Hash> _teamRedirectInstanceIds;
     };
 
     InstanceScript* GetInstanceScript(InstanceMap* map) const override

--- a/src/server/scripts/EasternKingdoms/TheStockade/instance_the_stockade.cpp
+++ b/src/server/scripts/EasternKingdoms/TheStockade/instance_the_stockade.cpp
@@ -15,9 +15,21 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Config.h"
 #include "InstanceScript.h"
+#include "Log.h"
+#include "Optional.h"
+#include "Player.h"
+#include "Random.h"
 #include "ScriptMgr.h"
+#include "StringConvert.h"
+#include "Util.h"
 #include "the_stockade.h"
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
 
 DungeonEncounterData const encounters[] =
 {
@@ -26,10 +38,116 @@ DungeonEncounterData const encounters[] =
     { DATA_HOGGER, {{ 1144 }} }
 };
 
-class instance_the_stockade : public InstanceMapScript
+namespace
 {
+constexpr uint32 StockadesMapId = 34;
+constexpr uint32 StockadesFailMapId = 0;
+Position const StockadesFailTeleport = { -8762.38f, 848.01f, 86.3139f, 0.0f };
+
+bool IsPvPvEEnabled()
+{
+    return sConfigMgr->GetOption<bool>("PvPvEDungeon.Stockades.Enable", false);
+}
+
+std::string const& GetSpawnsFullMessage()
+{
+    static std::string const message = sConfigMgr->GetOption<std::string>(
+        "PvPvEDungeon.Stockades.SpawnsFullMessage",
+        "The Stockades PvPvE dungeon is currently full. Please wait for the next run.");
+    return message;
+}
+
+bool TryParseSpawnEntry(std::string_view entry, Position& out)
+{
+    std::string normalized(entry);
+    std::replace(normalized.begin(), normalized.end(), ',', ' ');
+    std::replace(normalized.begin(), normalized.end(), '|', ' ');
+
+    std::vector<std::string_view> tokens = Trinity::Tokenize(normalized, ' ', false);
+    if (tokens.size() < 3)
+    {
+        TC_LOG_WARN("server.loading", "PvPvEDungeon.Stockades.SpawnPoints entry '%s' is invalid (needs at least X Y Z).", normalized.c_str());
+        return false;
+    }
+
+    auto const parseFloat = [](std::string_view token) -> Optional<float>
+    {
+        return Trinity::StringTo<float>(token);
+    };
+
+    Optional<float> x = parseFloat(tokens[0]);
+    Optional<float> y = parseFloat(tokens[1]);
+    Optional<float> z = parseFloat(tokens[2]);
+    Optional<float> o = tokens.size() >= 4 ? parseFloat(tokens[3]) : Optional<float>(0.0f);
+
+    if (!x || !y || !z || !o)
+    {
+        TC_LOG_WARN("server.loading", "PvPvEDungeon.Stockades.SpawnPoints entry '%s' could not be parsed into coordinates.", normalized.c_str());
+        return false;
+    }
+
+    out.Relocate(*x, *y, *z, *o);
+    return true;
+}
+
+std::vector<Position> const& GetConfiguredSpawnPoints()
+{
+    static std::vector<Position> const spawnPoints = []()
+    {
+        std::vector<Position> result;
+        std::string const config = sConfigMgr->GetOption<std::string>("PvPvEDungeon.Stockades.SpawnPoints", "");
+        if (config.empty())
+            return result;
+
+        for (std::string_view entry : Trinity::Tokenize(config, ';', false))
+        {
+            Position position;
+            if (TryParseSpawnEntry(entry, position))
+                result.push_back(position);
+        }
+
+        if (result.empty())
+            TC_LOG_WARN("server.loading", "PvPvEDungeon.Stockades.SpawnPoints configured but no valid coordinates were parsed.");
+
+        return result;
+    }();
+
+    return spawnPoints;
+}
+
+bool ShouldHandle(Player* player)
+{
+    return IsPvPvEEnabled() && player && !player->IsGameMaster() && player->GetMapId() == StockadesMapId;
+}
+
+void NotifySpawnsFull(Player* player)
+{
+    if (!player)
+        return;
+
+    if (WorldSession* session = player->GetSession())
+    {
+        std::string const& message = GetSpawnsFullMessage();
+        if (!message.empty())
+            session->SendNotification("%s", message.c_str());
+    }
+}
+
+void TeleportPlayerOut(Player* player)
+{
+    if (!player)
+        return;
+
+    if (!player->IsBeingTeleported())
+        player->TeleportTo(StockadesFailMapId, StockadesFailTeleport.GetPositionX(), StockadesFailTeleport.GetPositionY(),
+            StockadesFailTeleport.GetPositionZ(), StockadesFailTeleport.GetOrientation());
+}
+}
+
+class instance_the_stockade : public InstanceMapScript
+{ 
 public:
-    instance_the_stockade() : InstanceMapScript("instance_the_stockade", 34) { }
+    instance_the_stockade() : InstanceMapScript("instance_the_stockade", StockadesMapId) { }
 
     struct instance_the_stockade_InstanceMapScript : public InstanceScript
     {
@@ -39,6 +157,56 @@ public:
             SetBossNumber(EncounterCount);
             LoadDungeonEncounterData(encounters);
         }
+
+        void Initialize() override
+        {
+            InstanceScript::Initialize();
+            _playerSpawnAssignments.clear();
+            _availableSpawnIndices.clear();
+
+            if (!IsPvPvEEnabled())
+                return;
+
+            std::vector<Position> const& spawnPoints = GetConfiguredSpawnPoints();
+            _availableSpawnIndices.reserve(spawnPoints.size());
+            for (uint32 i = 0; i < spawnPoints.size(); ++i)
+                _availableSpawnIndices.push_back(i);
+        }
+
+        void OnPlayerEnter(Player* player) override
+        {
+            InstanceScript::OnPlayerEnter(player);
+
+            if (!ShouldHandle(player))
+                return;
+
+            if (std::vector<Position> const& spawnPoints = GetConfiguredSpawnPoints(); spawnPoints.empty())
+                return;
+
+            ObjectGuid const guid = player->GetGUID();
+
+            if (_playerSpawnAssignments.find(guid) != _playerSpawnAssignments.end())
+                return;
+
+            if (_availableSpawnIndices.empty())
+            {
+                NotifySpawnsFull(player);
+                TeleportPlayerOut(player);
+                return;
+            }
+
+            uint32 const randomSlotIndex = urand(0, _availableSpawnIndices.size() - 1);
+            uint32 const spawnIndex = _availableSpawnIndices[randomSlotIndex];
+            _availableSpawnIndices.erase(_availableSpawnIndices.begin() + randomSlotIndex);
+            _playerSpawnAssignments.emplace(guid, spawnIndex);
+
+            if (spawnIndex < spawnPoints.size())
+                player->NearTeleportTo(spawnPoints[spawnIndex]);
+        }
+
+    private:
+        std::unordered_map<ObjectGuid, uint32, ObjectGuid::Hash> _playerSpawnAssignments;
+        std::vector<uint32> _availableSpawnIndices;
     };
 
     InstanceScript* GetInstanceScript(InstanceMap* map) const override

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4398,19 +4398,14 @@ Metric.OverallStatusInterval = 1
 #                     include at least X Y Z values; orientation (O) is optional. The first member of a
 #                     team (party) that zones in claims one of the entries, all of their teammates are
 #                     teleported to the same location, and the point cannot be reused by invading teams.
-#                     Once every configured entry is consumed, additional players are denied entry.
+#                     Once every configured entry is consumed, subsequent teams are automatically
+#                     redirected into a brand new Stockades instance.
 #        Example:     "-27.16 -11.85 -14.89 3.14; -14.24 -4.72 -15.02 0.00"
 #        Default:     ""
-#
-#    PvPvEDungeon.Stockades.SpawnsFullMessage
-#        Description: Message sent to players who attempt to enter when all configured spawn points
-#                     have been consumed.
-#        Default:     "The Stockades PvPvE dungeon is currently full. Please wait for the next run."
 #
 PvPvEDungeon.Stockades.Enable = 0
 PvPvEDungeon.Stockades.EliminationMessage = "The Stockades PvPvE dungeon ended while you were offline; you have been eliminated."
 PvPvEDungeon.Stockades.SpawnPoints = ""
-PvPvEDungeon.Stockades.SpawnsFullMessage = "The Stockades PvPvE dungeon is currently full. Please wait for the next run."
 
 ###################################################################################################
 

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4392,8 +4392,24 @@ Metric.OverallStatusInterval = 1
 #                     they were still inside The Stockades PvPvE dungeon.
 #        Default:     "The Stockades PvPvE dungeon ended while you were offline; you have been eliminated."
 #
+#    PvPvEDungeon.Stockades.SpawnPoints
+#        Description: Semicolon-separated list of spawn coordinates (X Y Z O) used to randomly place
+#                     players when they first enter the Stockades PvPvE instance. Each entry must
+#                     include at least X Y Z values; orientation (O) is optional. Once a spawn entry is
+#                     consumed it will not be reused for that instance, preventing additional players
+#                     from entering when the list is exhausted.
+#        Example:     "-27.16 -11.85 -14.89 3.14; -14.24 -4.72 -15.02 0.00"
+#        Default:     ""
+#
+#    PvPvEDungeon.Stockades.SpawnsFullMessage
+#        Description: Message sent to players who attempt to enter when all configured spawn points
+#                     have been consumed.
+#        Default:     "The Stockades PvPvE dungeon is currently full. Please wait for the next run."
+#
 PvPvEDungeon.Stockades.Enable = 0
 PvPvEDungeon.Stockades.EliminationMessage = "The Stockades PvPvE dungeon ended while you were offline; you have been eliminated."
+PvPvEDungeon.Stockades.SpawnPoints = ""
+PvPvEDungeon.Stockades.SpawnsFullMessage = "The Stockades PvPvE dungeon is currently full. Please wait for the next run."
 
 ###################################################################################################
 

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4379,6 +4379,23 @@ Metric.OverallStatusInterval = 1
 
 #
 ###################################################################################################
+# PVPVE DUNGEON SETTINGS
+#
+#    PvPvEDungeon.Stockades.Enable
+#        Description: Enables enforcement that unsafe disconnects inside The Stockades PvPvE dungeon
+#                     result in elimination and teleporting the player outside.
+#        Default:     0 - (Disabled)
+#                     1 - (Enabled)
+#
+#    PvPvEDungeon.Stockades.EliminationMessage
+#        Description: Message shown to players who are eliminated because the server ended while
+#                     they were still inside The Stockades PvPvE dungeon.
+#        Default:     "The Stockades PvPvE dungeon ended while you were offline; you have been eliminated."
+#
+PvPvEDungeon.Stockades.Enable = 0
+PvPvEDungeon.Stockades.EliminationMessage = "The Stockades PvPvE dungeon ended while you were offline; you have been eliminated."
+
+###################################################################################################
 
 ###################################################################################################
 # PVP SETTINGS

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4394,10 +4394,11 @@ Metric.OverallStatusInterval = 1
 #
 #    PvPvEDungeon.Stockades.SpawnPoints
 #        Description: Semicolon-separated list of spawn coordinates (X Y Z O) used to randomly place
-#                     players when they first enter the Stockades PvPvE instance. Each entry must
-#                     include at least X Y Z values; orientation (O) is optional. Once a spawn entry is
-#                     consumed it will not be reused for that instance, preventing additional players
-#                     from entering when the list is exhausted.
+#                     teams when they first enter the Stockades PvPvE instance. Each entry must
+#                     include at least X Y Z values; orientation (O) is optional. The first member of a
+#                     team (party) that zones in claims one of the entries, all of their teammates are
+#                     teleported to the same location, and the point cannot be reused by invading teams.
+#                     Once every configured entry is consumed, additional players are denied entry.
 #        Example:     "-27.16 -11.85 -14.89 3.14; -14.24 -4.72 -15.02 0.00"
 #        Default:     ""
 #


### PR DESCRIPTION
## Summary
- add a custom player script that tracks Stockades PvPvE participation and removes anyone who reconnects there without a safe logout
- persist a new at-login flag so intentional disconnects can resume while crashes/shutdowns trigger elimination and teleport out
- document and gate the feature behind new worldserver configuration options

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca259a98083279958ba0973da20a6)