### PR TITLE
Disable evade on Stockades map

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -213,6 +213,10 @@ void CreatureAI::JustEnteredCombat(Unit* who)
 
 void CreatureAI::EnterEvadeMode(EvadeReason why)
 {
+    // Hack requested by user: disable evade for Stockades (map 34)
+    if (me->GetMapId() == 34)
+        return;
+
     if (!_EnterEvadeMode(why))
         return;
 


### PR DESCRIPTION
## Summary
- short-circuit `CreatureAI::EnterEvadeMode` whenever a creature is on map 34 (The Stockade), preventing the core from resetting the mob

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d079cd32c8327aa80feade2fe38e7)