### PR TITLE
Unbind players from finished PvPvE Stockades runs

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -943,7 +943,19 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
     _playerToTeam.erase(guid);
     ClearReturnLocation(guid);
 
-    if (run->Finished)
+    if (DungeonTemplate const* dungeonTemplate = GetDungeonTemplate(run->TemplateId))
+    {
+        if (run->Finished)
+        {
+            player->UnbindInstance(dungeonTemplate->MapId, player->GetDifficulty(false));
+            _playerRunLockouts.erase(guid);
+        }
+        else
+        {
+            _playerRunLockouts[guid] = run->Id;
+        }
+    }
+    else if (run->Finished)
         _playerRunLockouts.erase(guid);
     else
         _playerRunLockouts[guid] = run->Id;


### PR DESCRIPTION
## Summary
- unbind players from completed PvPvE Stockades runs when they leave the instance
- clear lockouts in the no-template case to avoid stale bindings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e050bd2a0832794d77dbf9a39b2c0)