### PR TITLE
Add modular chest drops for Stockades and Dire Maul

### DIFF
--- a/src/server/scripts/Custom/custom_diremaul_beads.cpp
+++ b/src/server/scripts/Custom/custom_diremaul_beads.cpp
@@ -30,6 +30,7 @@
 #include "SpellAuraEffects.h"
 #include "UpdateFields.h"
 #include "Util.h"
+#include "custom_loot_chest_helper.h"
 #include <algorithm>
 #include <cctype>
 #include <charconv>
@@ -204,56 +205,6 @@ namespace DireMaulBeads
         return Seconds(s_BeadChestDespawnSeconds);
     }
 
-    GameObject* SpawnBeadChest(Player* player, uint32 beadCount)
-    {
-        if (!player || !beadCount)
-            return nullptr;
-
-        uint32 const beadItemId = GetOgreBeadItemId();
-        uint32 const chestEntry = GetBeadChestGameObjectId();
-        if (!beadItemId || !chestEntry)
-            return nullptr;
-
-        GameObject* chest = player->SummonGameObject(chestEntry, player->GetPosition(), QuaternionData(), GetChestDespawnDuration(), GO_SUMMON_TIMED_DESPAWN);
-        if (!chest)
-        {
-            TC_LOG_WARN("scripts", "DireMaulBeads: failed to summon bead chest {} for player {} ({})", chestEntry, player->GetName(), player->GetGUID().ToString());
-            return nullptr;
-        }
-
-        player->RemoveGameObject(chest, false);
-        chest->SetOwnerGUID(ObjectGuid::Empty);
-
-        Loot& loot = chest->loot;
-        loot.clear();
-        loot.loot_type = LOOT_CORPSE;
-        loot.lootOwnerGUID.Clear();
-
-        uint32 remaining = beadCount;
-        while (remaining && loot.items.size() < MAX_NR_LOOT_ITEMS)
-        {
-            uint8 const stack = static_cast<uint8>(std::min<uint32>(remaining, 255));
-
-            LootItem lootItem;
-            lootItem.itemid = beadItemId;
-            lootItem.itemIndex = static_cast<uint32>(loot.items.size());
-            lootItem.count = stack;
-            lootItem.freeforall = false;
-            lootItem.follow_loot_rules = false;
-
-            loot.items.push_back(lootItem);
-            ++loot.unlootedCount;
-            remaining -= stack;
-        }
-
-        chest->SetLootRecipient(nullptr);
-        chest->SetLootState(GO_READY);
-        chest->SetGoState(GO_STATE_READY);
-        chest->ForceValuesUpdateAtIndex(GAMEOBJECT_DYNAMIC);
-        chest->ForceValuesUpdateAtIndex(GAMEOBJECT_FLAGS);
-        return chest;
-    }
-
     void DropBeadChest(Player* victim)
     {
         if (!victim)
@@ -271,11 +222,14 @@ namespace DireMaulBeads
         if (!beadCount)
             return;
 
-        if (!SpawnBeadChest(victim, beadCount))
-            return;
+        CustomLootChests::PlayerChestBuilder chest(victim, chestEntry, GetChestDespawnDuration());
+        chest.AddStackableItem(beadItemId, beadCount);
 
-        victim->DestroyItemCount(beadItemId, beadCount, true);
-        UpdateBeadAura(victim);
+        if (GameObject* spawnedChest = chest.Summon())
+        {
+            victim->DestroyItemCount(beadItemId, beadCount, true);
+            UpdateBeadAura(victim);
+        }
     }
 
     void OnItemStored(Player* player, uint32 itemId, uint32 count)

--- a/src/server/scripts/Custom/custom_loot_chest_helper.cpp
+++ b/src/server/scripts/Custom/custom_loot_chest_helper.cpp
@@ -1,0 +1,99 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "custom_loot_chest_helper.h"
+
+#include "Log.h"
+#include "ObjectGuid.h"
+#include <algorithm>
+
+namespace CustomLootChests
+{
+PlayerChestBuilder::PlayerChestBuilder(Player* player, uint32 chestEntry, Seconds despawnTime)
+    : _player(player), _chestEntry(chestEntry), _despawnTime(despawnTime)
+{
+}
+
+LootItem PlayerChestBuilder::CreateLootItem(uint32 itemId, uint8 count, uint32 randomSuffix, int32 randomPropertyId) const
+{
+    LootItem lootItem;
+    lootItem.itemid = itemId;
+    lootItem.itemIndex = static_cast<uint32>(_items.size());
+    lootItem.count = count;
+    lootItem.randomSuffix = randomSuffix;
+    lootItem.randomPropertyId = randomPropertyId;
+    lootItem.freeforall = false;
+    lootItem.follow_loot_rules = false;
+    return lootItem;
+}
+
+void PlayerChestBuilder::AddStackableItem(uint32 itemId, uint32 count)
+{
+    if (!itemId || !count)
+        return;
+
+    while (count && _items.size() < MAX_NR_LOOT_ITEMS)
+    {
+        uint8 const stack = static_cast<uint8>(std::min<uint32>(count, 255));
+        _items.push_back(CreateLootItem(itemId, stack, 0, 0));
+        count -= stack;
+    }
+}
+
+void PlayerChestBuilder::AddItem(Item* item)
+{
+    if (!item || _items.size() >= MAX_NR_LOOT_ITEMS)
+        return;
+
+    _items.push_back(CreateLootItem(item->GetEntry(), item->GetCount(), item->GetItemSuffixFactor(), item->GetItemRandomPropertyId()));
+}
+
+GameObject* PlayerChestBuilder::Summon() const
+{
+    if (!_player || !_chestEntry || _items.empty())
+        return nullptr;
+
+    GameObject* chest = _player->SummonGameObject(_chestEntry, _player->GetPosition(), QuaternionData(), _despawnTime, GO_SUMMON_TIMED_DESPAWN);
+    if (!chest)
+    {
+        TC_LOG_WARN("scripts", "CustomLootChests: failed to summon chest {} for player {} ({})", _chestEntry, _player->GetName(), _player->GetGUID().ToString());
+        return nullptr;
+    }
+
+    _player->RemoveGameObject(chest, false);
+    chest->SetOwnerGUID(ObjectGuid::Empty);
+
+    Loot& loot = chest->loot;
+    loot.clear();
+    loot.loot_type = LOOT_CORPSE;
+    loot.lootOwnerGUID.Clear();
+
+    for (LootItem& item : _items)
+    {
+        item.itemIndex = static_cast<uint32>(loot.items.size());
+        loot.items.push_back(item);
+        ++loot.unlootedCount;
+    }
+
+    chest->SetLootRecipient(nullptr);
+    chest->SetLootState(GO_READY);
+    chest->SetGoState(GO_STATE_READY);
+    chest->ForceValuesUpdateAtIndex(GAMEOBJECT_DYNAMIC);
+    chest->ForceValuesUpdateAtIndex(GAMEOBJECT_FLAGS);
+    return chest;
+}
+}

--- a/src/server/scripts/Custom/custom_loot_chest_helper.h
+++ b/src/server/scripts/Custom/custom_loot_chest_helper.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CUSTOM_LOOT_CHEST_HELPER_H
+#define CUSTOM_LOOT_CHEST_HELPER_H
+
+#include "Duration.h"
+#include "GameObject.h"
+#include "Loot.h"
+#include "Player.h"
+#include <vector>
+
+namespace CustomLootChests
+{
+class PlayerChestBuilder
+{
+public:
+    PlayerChestBuilder(Player* player, uint32 chestEntry, Seconds despawnTime);
+
+    bool HasLoot() const { return !_items.empty(); }
+    void AddStackableItem(uint32 itemId, uint32 count);
+    void AddItem(Item* item);
+
+    GameObject* Summon() const;
+
+private:
+    LootItem CreateLootItem(uint32 itemId, uint8 count, uint32 randomSuffix, int32 randomPropertyId) const;
+
+    Player* _player = nullptr;
+    uint32 _chestEntry = 0;
+    Seconds _despawnTime = Seconds(0);
+    mutable std::vector<LootItem> _items;
+};
+}
+
+#endif // CUSTOM_LOOT_CHEST_HELPER_H

--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -17,29 +17,47 @@
 
 #include "ScriptMgr.h"
 
+#include "Bag.h"
 #include "Configuration/Config.h"
+#include "Containers.h"
+#include "Creature.h"
 #include "Duration.h"
 #include "GameObject.h"
-#include "Creature.h"
-#include "Map.h"
+#include "GameObjectAI.h"
+#include "Group.h"
 #include "InstanceScript.h"
 #include "Log.h"
+#include "Loot.h"
+#include "Item.h"
+#include "Map.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "Position.h"
 #include "SharedDefines.h"
 #include "StringFormat.h"
 #include "WorldSession.h"
-#include "Group.h"
+#include "custom_loot_chest_helper.h"
 
 #include "../../Custom/mod_pvpve_dungeon.h"
 
+#include <algorithm>
+#include <charconv>
 #include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace DireMaulBeads
+{
+uint32 GetOgreBeadItemId();
+void UpdateBeadAura(Player* player);
+}
 
 namespace StockadesPvPvE
 {
 constexpr uint32 StockadesMapId = 34;
 constexpr uint32 StockadesExteriorMapId = 0;
+constexpr uint32 BossKeyItemId = 43650;
+constexpr uint32 HonorTokenItemId = 100529;
 
 namespace
 {
@@ -50,11 +68,18 @@ namespace
 {
 constexpr uint32 DefaultChestDespawnSeconds = 300;
 Position const DefaultChestPosition = { 71.879f, -15.478f, -20.215f, 0.0f };
+constexpr uint32 DefaultDeathChestDespawnSeconds = 300;
 
 uint32 s_ChestGameObjectId = 0;
 Seconds s_ChestDespawn = Seconds(DefaultChestDespawnSeconds);
 Position s_ChestPosition = DefaultChestPosition;
 uint32 s_BossCreatureEntry = 0;
+uint32 s_DeathChestGameObjectId = 0;
+Seconds s_DeathChestDespawn = Seconds(DefaultDeathChestDespawnSeconds);
+
+std::vector<uint32> s_ScarletDefenderEntries;
+std::vector<uint32> s_BigBadWolfEntries;
+std::vector<uint32> s_WrathboneSkeletonEntries;
 
 void LoadConfig()
 {
@@ -65,17 +90,45 @@ void LoadConfig()
     float const configuredZ = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnZ", DefaultChestPosition.GetPositionZ());
     float const configuredO = sConfigMgr->GetFloatDefault("StockadesPvPvE.ChestSpawnO", DefaultChestPosition.GetOrientation());
     int32 const configuredBoss = sConfigMgr->GetIntDefault("StockadesPvPvE.BossCreatureEntry", 0);
+    int32 const configuredDeathChest = sConfigMgr->GetIntDefault("StockadesPvPvE.DeathChestGameObjectId", 0);
+    int32 const configuredDeathDespawn = sConfigMgr->GetIntDefault("StockadesPvPvE.DeathChestDespawnSeconds", int32(DefaultDeathChestDespawnSeconds));
+    std::string const scarletEntries = sConfigMgr->GetStringDefault("StockadesPvPvE.ScarletDefenderEntries", "");
+    std::string const wolfEntries = sConfigMgr->GetStringDefault("StockadesPvPvE.BigBadWolfEntries", "");
+    std::string const skeletonEntries = sConfigMgr->GetStringDefault("StockadesPvPvE.WrathboneSkeletonEntries", "");
 
     s_ChestGameObjectId = configuredEntry > 0 ? uint32(configuredEntry) : 0u;
     s_ChestDespawn = Seconds(configuredDespawn >= 0 ? uint32(configuredDespawn) : DefaultChestDespawnSeconds);
     s_ChestPosition.Relocate(configuredX, configuredY, configuredZ, configuredO);
     s_BossCreatureEntry = configuredBoss > 0 ? uint32(configuredBoss) : 0u;
+    s_DeathChestGameObjectId = configuredDeathChest > 0 ? uint32(configuredDeathChest) : 0u;
+    s_DeathChestDespawn = Seconds(configuredDeathDespawn >= 0 ? uint32(configuredDeathDespawn) : DefaultDeathChestDespawnSeconds);
+
+    auto const loadEntries = [](std::string const& rawList, std::vector<uint32>& destination, char const* label)
+    {
+        destination.clear();
+        for (std::string_view token : Trinity::Tokenize(rawList, ',', false))
+        {
+            uint32 value = 0;
+            if (!token.empty() && std::from_chars(token.data(), token.data() + token.size(), value).ec == std::errc())
+                destination.push_back(value);
+        }
+
+        if (destination.empty())
+            TC_LOG_WARN("server.custom", "Stockades PvPvE: no entries configured for {} key group; boss keys will not drop for that group.", label);
+    };
+
+    loadEntries(scarletEntries, s_ScarletDefenderEntries, "Scarlet Defender");
+    loadEntries(wolfEntries, s_BigBadWolfEntries, "Big Bad Wolf");
+    loadEntries(skeletonEntries, s_WrathboneSkeletonEntries, "Wrathbone Skeleton");
 
     if (!s_ChestGameObjectId)
         TC_LOG_WARN("server.custom", "Stockades PvPvE: reward chest entry is 0; chest spawning is disabled.");
 
     if (!s_BossCreatureEntry)
         TC_LOG_WARN("server.custom", "Stockades PvPvE: boss creature entry is 0; boss defeat tracking is disabled.");
+
+    if (!s_DeathChestGameObjectId)
+        TC_LOG_WARN("server.custom", "Stockades PvPvE: death chest entry is 0; death loot chests are disabled.");
 }
 
 QuaternionData GetChestRotation()
@@ -118,6 +171,223 @@ QuaternionData GetChestQuaternion()
 {
     return GetChestRotation();
 }
+
+uint32 GetDeathChestGameObjectId()
+{
+    return s_DeathChestGameObjectId;
+}
+
+Seconds GetDeathChestDespawnTime()
+{
+    return s_DeathChestDespawn;
+}
+
+std::vector<uint32> const& GetScarletDefenderEntries()
+{
+    return s_ScarletDefenderEntries;
+}
+
+std::vector<uint32> const& GetBigBadWolfEntries()
+{
+    return s_BigBadWolfEntries;
+}
+
+std::vector<uint32> const& GetWrathboneSkeletonEntries()
+{
+    return s_WrathboneSkeletonEntries;
+}
+}
+
+namespace
+{
+struct KeyDropGroup
+{
+    KeyDropGroup(char const* name, std::vector<uint32> const& entries) : Label(name), EntrySet(entries.begin(), entries.end()) { }
+
+    bool Matches(uint32 entry) const
+    {
+        return EntrySet.contains(entry);
+    }
+
+    void AddMember(Creature* creature)
+    {
+        if (!creature)
+            return;
+
+        Members.push_back(creature->GetGUID());
+    }
+
+    void RemoveMember(ObjectGuid const& guid)
+    {
+        Members.erase(std::remove(Members.begin(), Members.end(), guid), Members.end());
+        if (KeyCarrier == guid)
+            KeyCarrier.Clear();
+    }
+
+    void EnsureCarrier(Map* map)
+    {
+        if (KeyDropped || KeyCarrier || EntrySet.empty() || !map)
+            return;
+
+        std::vector<Creature*> available;
+        available.reserve(Members.size());
+        for (ObjectGuid const& guid : Members)
+        {
+            if (Creature* candidate = map->GetCreature(guid))
+            {
+                if (candidate->IsAlive())
+                    available.push_back(candidate);
+            }
+        }
+
+        if (available.empty())
+            return;
+
+        KeyCarrier = Trinity::Containers::SelectRandomContainerElement(available)->GetGUID();
+    }
+
+    void AddKeyToLoot(Creature* creature) const
+    {
+        if (!creature)
+            return;
+
+        Loot& loot = creature->loot;
+        LootItem lootItem;
+        lootItem.itemid = StockadesPvPvE::BossKeyItemId;
+        lootItem.itemIndex = static_cast<uint32>(loot.items.size());
+        lootItem.count = 1;
+        lootItem.freeforall = false;
+        lootItem.follow_loot_rules = false;
+
+        loot.items.push_back(lootItem);
+        ++loot.unlootedCount;
+    }
+
+    void HandleDeath(Creature* creature)
+    {
+        if (!creature || KeyDropped)
+            return;
+
+        RemoveMember(creature->GetGUID());
+
+        if (!KeyCarrier)
+            KeyCarrier = creature->GetGUID();
+
+        if (KeyCarrier == creature->GetGUID())
+        {
+            AddKeyToLoot(creature);
+            KeyDropped = true;
+            KeyCarrier.Clear();
+        }
+    }
+
+    std::string const Label;
+    std::unordered_set<uint32> const EntrySet;
+    std::vector<ObjectGuid> Members;
+    ObjectGuid KeyCarrier;
+    bool KeyDropped = false;
+};
+
+struct ItemLocation
+{
+    uint8 Bag = INVENTORY_SLOT_BAG_0;
+    uint8 Slot = 0;
+};
+
+void RemoveBossKeys(Player* player)
+{
+    if (!player)
+        return;
+
+    uint32 const keyCount = player->GetItemCount(StockadesPvPvE::BossKeyItemId, false);
+    if (keyCount)
+        player->DestroyItemCount(StockadesPvPvE::BossKeyItemId, keyCount, true);
+}
+
+void CollectArtifactItems(Player* player, CustomLootChests::PlayerChestBuilder& chest, std::vector<ItemLocation>& removedItems)
+{
+    if (!player)
+        return;
+
+    auto const tryStoreItem = [&](Item* item, uint8 bag, uint8 slot)
+    {
+        if (!item)
+            return;
+
+        if (ItemTemplate const* proto = item->GetTemplate())
+        {
+            if (proto->Quality == ITEM_QUALITY_ARTIFACT)
+            {
+                chest.AddItem(item);
+                removedItems.push_back({ bag, slot });
+            }
+        }
+    };
+
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+        tryStoreItem(player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot), INVENTORY_SLOT_BAG_0, slot);
+
+    for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+        tryStoreItem(player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot), INVENTORY_SLOT_BAG_0, slot);
+
+    for (uint8 bagSlot = INVENTORY_SLOT_BAG_START; bagSlot < INVENTORY_SLOT_BAG_END; ++bagSlot)
+    {
+        if (Bag* bag = player->GetBagByPos(bagSlot))
+        {
+            for (uint32 slot = 0; slot < bag->GetBagSize(); ++slot)
+                tryStoreItem(bag->GetItemByPos(slot), bagSlot, slot);
+        }
+    }
+}
+
+void DropDeathChest(Player* victim)
+{
+    if (!victim || victim->GetMapId() != StockadesPvPvE::StockadesMapId)
+        return;
+
+    uint32 const chestEntry = StockadesPvPvE::GetDeathChestGameObjectId();
+    if (!chestEntry)
+        return;
+
+    CustomLootChests::PlayerChestBuilder chest(victim, chestEntry, StockadesPvPvE::GetDeathChestDespawnTime());
+
+    uint32 const beadItemId = DireMaulBeads::GetOgreBeadItemId();
+    uint32 const beadCount = beadItemId ? victim->GetItemCount(beadItemId, false) : 0;
+    uint32 const honorTokenCount = victim->GetItemCount(StockadesPvPvE::HonorTokenItemId, false);
+    uint32 const bossKeyCount = victim->GetItemCount(StockadesPvPvE::BossKeyItemId, false);
+
+    if (beadCount)
+        chest.AddStackableItem(beadItemId, beadCount);
+
+    if (honorTokenCount)
+        chest.AddStackableItem(StockadesPvPvE::HonorTokenItemId, honorTokenCount);
+
+    if (bossKeyCount)
+        chest.AddStackableItem(StockadesPvPvE::BossKeyItemId, bossKeyCount);
+
+    std::vector<ItemLocation> artifactItems;
+    CollectArtifactItems(victim, chest, artifactItems);
+
+    if (GameObject* chestGO = chest.Summon())
+    {
+        if (beadCount)
+            victim->DestroyItemCount(beadItemId, beadCount, true);
+
+        if (honorTokenCount)
+            victim->DestroyItemCount(StockadesPvPvE::HonorTokenItemId, honorTokenCount, true);
+
+        if (bossKeyCount)
+            victim->DestroyItemCount(StockadesPvPvE::BossKeyItemId, bossKeyCount, true);
+
+        for (ItemLocation const& removed : artifactItems)
+            victim->RemoveItem(removed.Bag, removed.Slot, true);
+
+        if (beadCount)
+            DireMaulBeads::UpdateBeadAura(victim);
+
+        chestGO->SetLootRecipient(nullptr);
+    }
+}
 }
 
 class instance_the_stockade_pvpve : public InstanceMapScript
@@ -132,7 +402,13 @@ public:
 
     struct instance_the_stockade_pvpve_InstanceMapScript : public InstanceScript, public PvpveDungeonInstance
     {
-        instance_the_stockade_pvpve_InstanceMapScript(InstanceMap* map) : InstanceScript(map) { }
+        instance_the_stockade_pvpve_InstanceMapScript(InstanceMap* map)
+            : InstanceScript(map),
+            _scarletDefenders("Scarlet Defenders", StockadesPvPvE::GetScarletDefenderEntries()),
+            _bigBadWolves("Big Bad Wolves", StockadesPvPvE::GetBigBadWolfEntries()),
+            _wrathboneSkeletons("Wrathbone Skeletons", StockadesPvPvE::GetWrathboneSkeletonEntries())
+        {
+        }
 
         void OnPlayerEnter(Player* player) override
         {
@@ -181,6 +457,8 @@ public:
 
             if (!sPvpveDungeonMgr->IsPlayerInPvpveRun(player))
                 return;
+
+            RemoveBossKeys(player);
         }
 
         void OnPvpveRunFinished(uint32 runId, PvpveTeam const& winningTeam) override
@@ -204,6 +482,9 @@ public:
             Creature* creature = unit->ToCreature();
             if (!creature)
                 return;
+
+            if (KeyDropGroup* group = GetKeyDropGroup(creature->GetEntry()))
+                group->HandleDeath(creature);
 
             uint32 const bossEntry = StockadesPvPvE::GetBossCreatureEntry();
             if (!bossEntry || creature->GetEntry() != bossEntry)
@@ -317,14 +598,92 @@ public:
             }
         }
 
+        void OnCreatureCreate(Creature* creature) override
+        {
+            InstanceScript::OnCreatureCreate(creature);
+
+            if (KeyDropGroup* group = GetKeyDropGroup(creature->GetEntry()))
+            {
+                group->AddMember(creature);
+                group->EnsureCarrier(instance);
+            }
+        }
+
+        void OnCreatureRemove(Creature* creature) override
+        {
+            if (KeyDropGroup* group = GetKeyDropGroup(creature->GetEntry()))
+                group->RemoveMember(creature->GetGUID());
+
+            InstanceScript::OnCreatureRemove(creature);
+        }
+
+        KeyDropGroup* GetKeyDropGroup(uint32 entry)
+        {
+            if (_scarletDefenders.Matches(entry))
+                return &_scarletDefenders;
+
+            if (_bigBadWolves.Matches(entry))
+                return &_bigBadWolves;
+
+            if (_wrathboneSkeletons.Matches(entry))
+                return &_wrathboneSkeletons;
+
+            return nullptr;
+        }
+
         ObjectGuid _rewardChestGuid;
         uint32 _rewardChestRunId = 0;
         uint64 _pvpveRunId = 0;
+        KeyDropGroup _scarletDefenders;
+        KeyDropGroup _bigBadWolves;
+        KeyDropGroup _wrathboneSkeletons;
     };
+};
+
+class stockades_pvpve_player : public PlayerScript
+{
+public:
+    stockades_pvpve_player() : PlayerScript("stockades_pvpve_player") { }
+
+    void OnPVPKill(Player* /*killer*/, Player* victim) override
+    {
+        DropDeathChest(victim);
+    }
+
+    void OnPlayerKilledByCreature(Creature* /*killer*/, Player* victim) override
+    {
+        DropDeathChest(victim);
+    }
+};
+
+struct go_stockades_boss_doorAI : public GameObjectAI
+{
+    using GameObjectAI::GameObjectAI;
+
+    bool OnReportUse(Player* player) override
+    {
+        if (player && player->GetMapId() == StockadesPvPvE::StockadesMapId)
+            RemoveBossKeys(player);
+
+        return false;
+    }
+};
+
+class go_stockades_boss_door : public GameObjectScript
+{
+public:
+    go_stockades_boss_door() : GameObjectScript("go_stockades_boss_door") { }
+
+    GameObjectAI* GetAI(GameObject* go) const override
+    {
+        return new go_stockades_boss_doorAI(go);
+    }
 };
 
 void AddSC_instance_the_stockade_pvpve()
 {
     StockadesPvPvE::EnsureConfigLoaded();
     new instance_the_stockade_pvpve();
+    new stockades_pvpve_player();
+    new go_stockades_boss_door();
 }

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3217,6 +3217,19 @@ DireMaulBeads.ChestDespawnSeconds = 300
 #    StockadesPvPvE.ChestSpawnO
 #        Description: Coordinates and facing used for the Stockades PvPvE reward chest.
 #        Default:     71.879 / -15.478 / -20.215 / 0.0
+#
+#    StockadesPvPvE.DeathChestGameObjectId
+#        Description: GameObject entry used for player death loot inside Stockades PvPvE.
+#        Default:     0
+#
+#    StockadesPvPvE.DeathChestDespawnSeconds
+#        Description: Lifetime, in seconds, for the death loot chest inside Stockades PvPvE.
+#        Default:     300
+#
+#    StockadesPvPvE.ScarletDefenderEntries / StockadesPvPvE.BigBadWolfEntries / StockadesPvPvE.WrathboneSkeletonEntries
+#        Description: Comma-separated creature entries that should be grouped for random boss key drops.
+#                     Each list may be empty to disable a group.
+#        Default:     (empty)
 
 StockadesPvPvE.ChestGameObjectId = 0
 StockadesPvPvE.ChestDespawnSeconds = 300
@@ -3224,6 +3237,11 @@ StockadesPvPvE.ChestSpawnX = 71.879
 StockadesPvPvE.ChestSpawnY = -15.478
 StockadesPvPvE.ChestSpawnZ = -20.215
 StockadesPvPvE.ChestSpawnO = 0.0
+StockadesPvPvE.DeathChestGameObjectId = 0
+StockadesPvPvE.DeathChestDespawnSeconds = 300
+StockadesPvPvE.ScarletDefenderEntries =
+StockadesPvPvE.BigBadWolfEntries =
+StockadesPvPvE.WrathboneSkeletonEntries =
 
 #     AllowTrackBothResources
 #        Description: Allows players to track herbs and minerals at the same time (if they have the skills)


### PR DESCRIPTION
## Summary
- add reusable chest builder for player item drops
- refactor Dire Maul beads to use the shared helper
- implement Stockades PvPvE death chests, boss key cleanup, and miniboss key distribution configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e394c8c748327a7b62c0d16da6a5b)