### PR TITLE
Add per-instance pooling state for instanced Stockades spawns

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2697,7 +2697,7 @@ void Creature::Respawn(bool force)
 
             uint32 poolid = GetSpawnId() ? sPoolMgr->IsPartOfAPool<Creature>(GetSpawnId()) : 0;
             if (poolid)
-                sPoolMgr->UpdatePool<Creature>(poolid, GetSpawnId());
+                sPoolMgr->UpdatePool<Creature>(poolid, GetSpawnId(), GetMap());
         }
         UpdateObjectVisibility();
     }

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -636,7 +636,7 @@ void GameObject::Update(uint32 diff)
                         // Respawn timer
                         uint32 poolid = GetSpawnId() ? sPoolMgr->IsPartOfAPool<GameObject>(GetSpawnId()) : 0;
                         if (poolid)
-                            sPoolMgr->UpdatePool<GameObject>(poolid, GetSpawnId());
+                            sPoolMgr->UpdatePool<GameObject>(poolid, GetSpawnId(), GetMap());
                         else
                             GetMap()->AddToMap(this);
                     }
@@ -996,7 +996,7 @@ void GameObject::Delete()
 
     uint32 poolid = GetSpawnId() ? sPoolMgr->IsPartOfAPool<GameObject>(GetSpawnId()) : 0;
     if (poolid)
-        sPoolMgr->UpdatePool<GameObject>(poolid, GetSpawnId());
+        sPoolMgr->UpdatePool<GameObject>(poolid, GetSpawnId(), GetMap());
     else
         AddObjectToRemoveList();
 }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3285,7 +3285,7 @@ void Map::ProcessRespawns()
             GetRespawnMapForType(next->type).erase(next->spawnId);
 
             // step 2: tell pooling logic to do its thing
-            sPoolMgr->UpdatePool(poolId, next->type, next->spawnId);
+            sPoolMgr->UpdatePool(poolId, next->type, next->spawnId, this);
 
             // step 3: get rid of the actual entry
             RemoveRespawnTime(next->type, next->spawnId, nullptr, true);

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -19,6 +19,7 @@
 #include "Containers.h"
 #include "DatabaseEnv.h"
 #include "Log.h"
+#include "Map.h"
 #include "MapManager.h"
 #include "ObjectMgr.h"
 
@@ -435,6 +436,24 @@ void PoolMgr::Initialize()
 {
     mGameobjectSearchMap.clear();
     mCreatureSearchMap.clear();
+    mSpawnedData.clear();
+}
+
+ActivePoolData& PoolMgr::GetActivePoolData(Map* map) const
+{
+    return mSpawnedData[GetActivePoolDataKey(map)];
+}
+
+uint64 PoolMgr::GetActivePoolDataKey(Map* map) const
+{
+    if (!map)
+        return 0;
+
+    uint64 key = static_cast<uint64>(map->GetId()) << 32;
+    if (map->Instanceable())
+        key |= static_cast<uint64>(map->GetInstanceId());
+
+    return key;
 }
 
 PoolMgr* PoolMgr::instance()
@@ -743,31 +762,31 @@ void PoolMgr::LoadFromDB()
 // Call to spawn a pool, if cache if true the method will spawn only if cached entry is different
 // If it's same, the creature is respawned only (added back to map)
 template<>
-void PoolMgr::SpawnPool<Creature>(uint32 pool_id, uint32 db_guid)
+void PoolMgr::SpawnPool<Creature>(uint32 pool_id, uint32 db_guid, Map* map)
 {
     auto it = mPoolCreatureGroups.find(pool_id);
     if (it != mPoolCreatureGroups.end() && !it->second.isEmpty())
-        it->second.SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, db_guid);
+        it->second.SpawnObject(GetActivePoolData(map), mPoolTemplate[pool_id].MaxLimit, db_guid);
 }
 
 // Call to spawn a pool, if cache if true the method will spawn only if cached entry is different
 // If it's same, the gameobject is respawned only (added back to map)
 template<>
-void PoolMgr::SpawnPool<GameObject>(uint32 pool_id, uint32 db_guid)
+void PoolMgr::SpawnPool<GameObject>(uint32 pool_id, uint32 db_guid, Map* map)
 {
     auto it = mPoolGameobjectGroups.find(pool_id);
     if (it != mPoolGameobjectGroups.end() && !it->second.isEmpty())
-        it->second.SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, db_guid);
+        it->second.SpawnObject(GetActivePoolData(map), mPoolTemplate[pool_id].MaxLimit, db_guid);
 }
 
 // Call to spawn a pool, if cache if true the method will spawn only if cached entry is different
 // If it's same, the pool is respawned only
 template<>
-void PoolMgr::SpawnPool<Pool>(uint32 pool_id, uint32 sub_pool_id)
+void PoolMgr::SpawnPool<Pool>(uint32 pool_id, uint32 sub_pool_id, Map* map)
 {
     auto it = mPoolPoolGroups.find(pool_id);
     if (it != mPoolPoolGroups.end() && !it->second.isEmpty())
-        it->second.SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, sub_pool_id);
+        it->second.SpawnObject(GetActivePoolData(map), mPoolTemplate[pool_id].MaxLimit, sub_pool_id);
 }
 
 void PoolMgr::SpawnPool(uint32 pool_id)
@@ -780,20 +799,21 @@ void PoolMgr::SpawnPool(uint32 pool_id)
 // Call to despawn a pool, all gameobjects/creatures in this pool are removed
 void PoolMgr::DespawnPool(uint32 pool_id, bool alwaysDeleteRespawnTime)
 {
+    ActivePoolData& activePoolData = GetActivePoolData(nullptr);
     {
         auto it = mPoolCreatureGroups.find(pool_id);
         if (it != mPoolCreatureGroups.end() && !it->second.isEmpty())
-            it->second.DespawnObject(mSpawnedData, 0, alwaysDeleteRespawnTime);
+            it->second.DespawnObject(activePoolData, 0, alwaysDeleteRespawnTime);
     }
     {
         auto it = mPoolGameobjectGroups.find(pool_id);
         if (it != mPoolGameobjectGroups.end() && !it->second.isEmpty())
-            it->second.DespawnObject(mSpawnedData, 0, alwaysDeleteRespawnTime);
+            it->second.DespawnObject(activePoolData, 0, alwaysDeleteRespawnTime);
     }
     {
         auto it = mPoolPoolGroups.find(pool_id);
         if (it != mPoolPoolGroups.end() && !it->second.isEmpty())
-            it->second.DespawnObject(mSpawnedData, 0, alwaysDeleteRespawnTime);
+            it->second.DespawnObject(activePoolData, 0, alwaysDeleteRespawnTime);
     }
 }
 
@@ -837,27 +857,27 @@ bool PoolMgr::CheckPool(uint32 pool_id) const
 // Here we cache only the creature/gameobject whose guid is passed as parameter
 // Then the spawn pool call will use this cache to decide
 template<typename T>
-void PoolMgr::UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id)
+void PoolMgr::UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id, Map* map)
 {
     if (uint32 motherpoolid = IsPartOfAPool<Pool>(pool_id))
-        SpawnPool<Pool>(motherpoolid, pool_id);
+        SpawnPool<Pool>(motherpoolid, pool_id, map);
     else
-        SpawnPool<T>(pool_id, db_guid_or_pool_id);
+        SpawnPool<T>(pool_id, db_guid_or_pool_id, map);
 }
 
-template void PoolMgr::UpdatePool<Pool>(uint32 pool_id, uint32 db_guid_or_pool_id);
-template void PoolMgr::UpdatePool<GameObject>(uint32 pool_id, uint32 db_guid_or_pool_id);
-template void PoolMgr::UpdatePool<Creature>(uint32 pool_id, uint32 db_guid_or_pool_id);
+template void PoolMgr::UpdatePool<Pool>(uint32 pool_id, uint32 db_guid_or_pool_id, Map* map);
+template void PoolMgr::UpdatePool<GameObject>(uint32 pool_id, uint32 db_guid_or_pool_id, Map* map);
+template void PoolMgr::UpdatePool<Creature>(uint32 pool_id, uint32 db_guid_or_pool_id, Map* map);
 
-void PoolMgr::UpdatePool(uint32 pool_id, SpawnObjectType type, uint32 spawnId)
+void PoolMgr::UpdatePool(uint32 pool_id, SpawnObjectType type, uint32 spawnId, Map* map)
 {
     switch (type)
     {
         case SPAWN_TYPE_CREATURE:
-            UpdatePool<Creature>(pool_id, spawnId);
+            UpdatePool<Creature>(pool_id, spawnId, map);
             break;
         case SPAWN_TYPE_GAMEOBJECT:
-            UpdatePool<GameObject>(pool_id, spawnId);
+            UpdatePool<GameObject>(pool_id, spawnId, map);
             break;
         default:
             ABORT_MSG("Invalid spawn type %u passed to PoolMgr::IsPartOfPool (with spawnId %u)", uint32(type), spawnId);

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -41,6 +41,7 @@ class Pool                                                  // for Pool of Pool 
 
 typedef std::set<ObjectGuid::LowType> ActivePoolObjects;
 typedef std::map<uint32, uint32> ActivePoolPools;
+class Map;
 
 class TC_GAME_API ActivePoolData
 {
@@ -111,7 +112,7 @@ class TC_GAME_API PoolMgr
         uint32 IsPartOfAPool(SpawnObjectType type, ObjectGuid::LowType spawnId) const;
 
         template<typename T>
-        bool IsSpawnedObject(uint32 db_guid_or_pool_id) const { return mSpawnedData.IsActiveObject<T>(db_guid_or_pool_id); }
+        bool IsSpawnedObject(uint32 db_guid_or_pool_id, Map* map = nullptr) const { return GetActivePoolData(map).IsActiveObject<T>(db_guid_or_pool_id); }
 
         bool CheckPool(uint32 pool_id) const;
 
@@ -119,12 +120,12 @@ class TC_GAME_API PoolMgr
         void DespawnPool(uint32 pool_id, bool alwaysDeleteRespawnTime = false);
 
         template<typename T>
-        void UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id);
-        void UpdatePool(uint32 pool_id, SpawnObjectType type, ObjectGuid::LowType spawnId);
+        void UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id, Map* map = nullptr);
+        void UpdatePool(uint32 pool_id, SpawnObjectType type, ObjectGuid::LowType spawnId, Map* map = nullptr);
 
     private:
         template<typename T>
-        void SpawnPool(uint32 pool_id, uint32 db_guid_or_pool_id);
+        void SpawnPool(uint32 pool_id, uint32 db_guid_or_pool_id, Map* map = nullptr);
 
         typedef std::unordered_map<uint32, PoolTemplateData>      PoolTemplateDataMap;
         typedef std::unordered_map<uint32, PoolGroup<Creature>>   PoolGroupCreatureMap;
@@ -142,7 +143,9 @@ class TC_GAME_API PoolMgr
         SearchMap mPoolSearchMap;
 
         // dynamic data
-        ActivePoolData mSpawnedData;
+        ActivePoolData& GetActivePoolData(Map* map) const;
+        uint64 GetActivePoolDataKey(Map* map) const;
+        mutable std::unordered_map<uint64, ActivePoolData> mSpawnedData;
 };
 
 #define sPoolMgr PoolMgr::instance()


### PR DESCRIPTION
## Summary
- track pooled spawn state per map instance instead of globally
- update creature and gameobject respawn handling to pass map context
- ensure instance respawns trigger fresh pool selections for Stockades and other dungeons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e427e5028832785b31b097f7be5ee)