### PR TITLE
Fix Stockade engagement reactivation access

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -211,6 +211,12 @@ void CreatureAI::JustEnteredCombat(Unit* who)
         EngagementStart(who);
 }
 
+void CreatureAI::EnsureEngaged(Unit* who)
+{
+    if (!IsEngaged() && who)
+        EngagementStart(who);
+}
+
 void CreatureAI::EnterEvadeMode(EvadeReason why)
 {
     // Hack requested by user: disable evade for Stockades (map 34)

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -250,6 +250,8 @@ class TC_GAME_API CreatureAI : public UnitAI
         static bool IsInBounds(CreatureBoundary const& boundary, Position const* who);
         bool IsInBoundary(Position const* who = nullptr) const;
 
+        void EnsureEngaged(Unit* who);
+
     protected:
         void EngagementStart(Unit* who);
         void EngagementOver();

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -794,6 +794,18 @@ void Creature::Update(uint32 diff)
                 break;
 
             GetThreatManager().Update(diff);
+
+            // Stockade creatures (map 34) should remain engaged once aggroed so
+            // they do not reset into out-of-combat regeneration while players are
+            // still fighting them.
+            if (GetMapId() == 34 && IsAIEnabled() && IsInCombat() && !IsEngaged())
+            {
+                if (Unit* victim = GetVictim())
+                    AI()->EnsureEngaged(victim);
+                else if (Unit* victim = GetThreatManager().GetCurrentVictim())
+                    AI()->EnsureEngaged(victim);
+            }
+
             if (_spellFocusInfo.Delay)
             {
                 if (_spellFocusInfo.Delay <= diff)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2976,8 +2976,8 @@ void Player::InitStatsForLevel(bool reapplyMods)
 
     if (GetClass() == CLASS_ROGUE || GetClass() == CLASS_DRUID)
     {
-        SetFloatValue(UNIT_FIELD_POWER_REGEN_FLAT_MODIFIER + POWER_ENERGY, -10.f);
-        SetFloatValue(UNIT_FIELD_POWER_REGEN_INTERRUPTED_FLAT_MODIFIER + POWER_ENERGY, -10.f);
+        SetFloatValue(UNIT_FIELD_POWER_REGEN_FLAT_MODIFIER + uint16(POWER_ENERGY), -10.f);
+        SetFloatValue(UNIT_FIELD_POWER_REGEN_INTERRUPTED_FLAT_MODIFIER + uint16(POWER_ENERGY), -10.f);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a public CreatureAI helper to safely ensure engagement is started when a victim is available
- use the new helper for Stockade creatures to restore their engaged state without accessing protected APIs
- resolve deprecated enum arithmetic warnings when initializing rogue/druid energy regen values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e41e0bd108327ad9d14f8acf0ef56)