### PR TITLE
Add honor token kill bonus for Stockades death chests

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -58,6 +58,7 @@ constexpr uint32 StockadesMapId = 34;
 constexpr uint32 StockadesExteriorMapId = 0;
 constexpr uint32 BossKeyItemId = 43650;
 constexpr uint32 HonorTokenItemId = 100529;
+constexpr uint32 HonorTokenKillBonus = 10;
 
 namespace
 {
@@ -317,8 +318,7 @@ void DropDeathChest(Player* victim)
     if (beadCount)
         chest.AddStackableItem(beadItemId, beadCount);
 
-    if (honorTokenCount)
-        chest.AddStackableItem(StockadesPvPvE::HonorTokenItemId, honorTokenCount);
+    chest.AddStackableItem(StockadesPvPvE::HonorTokenItemId, honorTokenCount + StockadesPvPvE::HonorTokenKillBonus);
 
     if (bossKeyCount)
         chest.AddStackableItem(StockadesPvPvE::BossKeyItemId, bossKeyCount);


### PR DESCRIPTION
## Summary
- add a dedicated Stockades PvPvE honor token kill bonus constant
- ensure death chests include the bonus plus any honor tokens the victim was carrying

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e52b88e148327b022d9f87f827a50)