### PR TITLE
Fix resurrection after releasing spirit in Stockades

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5099,6 +5099,11 @@ void Player::RepopAtGraveyard()
         SpawnCorpseBones();
     }
 
+    // The Stockade sends players to a graveyard on another map; revive them automatically so they
+    // do not remain ghosts after the teleport.
+    if (!shouldResurrect && !IsAlive() && GetMapId() == 34)
+        shouldResurrect = true;
+
     WorldSafeLocsEntry const* ClosestGrave;
 
     // Special handle for battleground maps


### PR DESCRIPTION
## Summary
- automatically revive Stockades players when releasing spirit to the exterior graveyard
- prevent returning as a ghost after teleporting out of the dungeon

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691feafa7ebc8327ad82eac78a8c7d1b)