### PR TITLE
Adjust artifact banking and instance pool handling

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11846,7 +11846,10 @@ InventoryResult Player::CanBankItem(uint8 bag, uint8 slot, ItemPosCountVec& dest
         return EQUIP_ERR_DONT_OWN_THAT_ITEM;
 
     if (pItem->GetTemplate()->Quality == 6)
-        return EQUIP_ERR_ITEM_DOESNT_GO_TO_SLOT;
+    {
+        if (pItem->IsSoulBound() || pItem->IsBoundAccountWide() || pItem->IsBoundByEnchant())
+            return EQUIP_ERR_ITEM_DOESNT_GO_TO_SLOT;
+    }
 
     if (AccountBank::IsAccountBankOpen(this))
     {

--- a/src/server/game/Maps/MapInstanced.cpp
+++ b/src/server/game/Maps/MapInstanced.cpp
@@ -24,6 +24,7 @@
 #include "MapManager.h"
 #include "MMapFactory.h"
 #include "ObjectMgr.h"
+#include "PoolMgr.h"
 #include "Player.h"
 #include "VMapFactory.h"
 #include "VMapManager2.h"
@@ -233,6 +234,8 @@ InstanceMap* MapInstanced::CreateInstance(uint32 InstanceId, InstanceSave* save,
 
     bool load_data = save != nullptr;
     map->CreateInstanceData(load_data);
+
+    sPoolMgr->EnsurePoolDataForMap(map);
 
     if (sWorld->getBoolConfig(CONFIG_INSTANCEMAP_LOAD_GRIDS))
         map->LoadAllCells();

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -437,6 +437,8 @@ void PoolMgr::Initialize()
     mGameobjectSearchMap.clear();
     mCreatureSearchMap.clear();
     mSpawnedData.clear();
+    mPoolPoolRelations.clear();
+    mPoolMapAssociations.clear();
 }
 
 ActivePoolData& PoolMgr::GetActivePoolData(Map* map) const
@@ -460,6 +462,28 @@ PoolMgr* PoolMgr::instance()
 {
     static PoolMgr instance;
     return &instance;
+}
+
+bool PoolMgr::PoolMatchesMap(uint32 pool_id, uint32 map_id) const
+{
+    auto const assoc = mPoolMapAssociations.find(pool_id);
+    return assoc != mPoolMapAssociations.end() && assoc->second.count(map_id);
+}
+
+void PoolMgr::EnsurePoolDataForMap(Map* map)
+{
+    if (!map || !map->Instanceable())
+        return;
+
+    uint64 const key = GetActivePoolDataKey(map);
+    if (mSpawnedData.find(key) != mSpawnedData.end())
+        return;
+
+    for (auto const& [poolId, poolTemplate] : mPoolTemplate)
+    {
+        if (PoolMatchesMap(poolId, map->GetId()))
+            SpawnPool(poolId, map);
+    }
 }
 
 void PoolMgr::LoadFromDB()
@@ -541,6 +565,7 @@ void PoolMgr::LoadFromDB()
                 cregroup.AddEntry(plObject, pPoolTemplate->MaxLimit);
                 SearchPair p(guid, pool_id);
                 mCreatureSearchMap.insert(p);
+                mPoolMapAssociations[pool_id].insert(data->mapId);
 
                 ++count;
             }
@@ -611,6 +636,7 @@ void PoolMgr::LoadFromDB()
                 gogroup.AddEntry(plObject, pPoolTemplate->MaxLimit);
                 SearchPair p(guid, pool_id);
                 mGameobjectSearchMap.insert(p);
+                mPoolMapAssociations[pool_id].insert(data->mapId);
 
                 ++count;
             }
@@ -677,6 +703,7 @@ void PoolMgr::LoadFromDB()
                 plgroup.AddEntry(plObject, pPoolTemplateMother->MaxLimit);
                 SearchPair p(child_pool_id, mother_pool_id);
                 mPoolSearchMap.insert(p);
+                mPoolPoolRelations.emplace_back(mother_pool_id, child_pool_id);
 
                 ++count;
             }
@@ -708,6 +735,24 @@ void PoolMgr::LoadFromDB()
             }
 
             TC_LOG_INFO("server.loading", ">> Loaded {} pools in mother pools in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+        }
+    }
+
+    bool updatedAssociations = true;
+    while (updatedAssociations)
+    {
+        updatedAssociations = false;
+        for (auto const& relation : mPoolPoolRelations)
+        {
+            auto const childMaps = mPoolMapAssociations.find(relation.second);
+            if (childMaps == mPoolMapAssociations.end())
+                continue;
+
+            auto& parentMaps = mPoolMapAssociations[relation.first];
+            size_t const beforeSize = parentMaps.size();
+            parentMaps.insert(childMaps->second.begin(), childMaps->second.end());
+            if (parentMaps.size() != beforeSize)
+                updatedAssociations = true;
         }
     }
 
@@ -791,9 +836,14 @@ void PoolMgr::SpawnPool<Pool>(uint32 pool_id, uint32 sub_pool_id, Map* map)
 
 void PoolMgr::SpawnPool(uint32 pool_id)
 {
-    SpawnPool<Pool>(pool_id, 0);
-    SpawnPool<GameObject>(pool_id, 0);
-    SpawnPool<Creature>(pool_id, 0);
+    SpawnPool(pool_id, nullptr);
+}
+
+void PoolMgr::SpawnPool(uint32 pool_id, Map* map)
+{
+    SpawnPool<Pool>(pool_id, 0, map);
+    SpawnPool<GameObject>(pool_id, 0, map);
+    SpawnPool<Creature>(pool_id, 0, map);
 }
 
 // Call to despawn a pool, all gameobjects/creatures in this pool are removed

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -22,6 +22,8 @@
 #include "Creature.h"
 #include "GameObject.h"
 #include "SpawnData.h"
+#include <unordered_set>
+#include <vector>
 
 struct PoolTemplateData
 {
@@ -114,9 +116,12 @@ class TC_GAME_API PoolMgr
         template<typename T>
         bool IsSpawnedObject(uint32 db_guid_or_pool_id, Map* map = nullptr) const { return GetActivePoolData(map).IsActiveObject<T>(db_guid_or_pool_id); }
 
+        void EnsurePoolDataForMap(Map* map);
+
         bool CheckPool(uint32 pool_id) const;
 
         void SpawnPool(uint32 pool_id);
+        void SpawnPool(uint32 pool_id, Map* map);
         void DespawnPool(uint32 pool_id, bool alwaysDeleteRespawnTime = false);
 
         template<typename T>
@@ -126,6 +131,8 @@ class TC_GAME_API PoolMgr
     private:
         template<typename T>
         void SpawnPool(uint32 pool_id, uint32 db_guid_or_pool_id, Map* map = nullptr);
+
+        bool PoolMatchesMap(uint32 pool_id, uint32 map_id) const;
 
         typedef std::unordered_map<uint32, PoolTemplateData>      PoolTemplateDataMap;
         typedef std::unordered_map<uint32, PoolGroup<Creature>>   PoolGroupCreatureMap;
@@ -141,6 +148,8 @@ class TC_GAME_API PoolMgr
         SearchMap mCreatureSearchMap;
         SearchMap mGameobjectSearchMap;
         SearchMap mPoolSearchMap;
+        std::vector<std::pair<uint32, uint32>> mPoolPoolRelations;
+        std::unordered_map<uint32, std::unordered_set<uint32>> mPoolMapAssociations;
 
         // dynamic data
         ActivePoolData& GetActivePoolData(Map* map) const;


### PR DESCRIPTION
## Summary
- allow unbound artifact items to be deposited into the bank
- track pool-to-map associations and seed pool selections per instance map
- ensure instance creation initializes pool rolls so pools respect per-instance randomness

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fec522e9083278bdd24e3b91a887c)