### PR TITLE
Allow ZG enchants to bypass spell group exclusivity

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -28,6 +28,7 @@
 #include "Opcodes.h"
 #include "Player.h"
 #include "ScriptMgr.h"
+#include <array>
 #include "Spell.h"
 #include "SpellAuraEffects.h"
 #include "SpellHistory.h"
@@ -1858,44 +1859,30 @@ bool Aura::CanStackWith(Aura const* existingAura) const
     if (this == existingAura)
         return true;
 
-    // HACK: Allow Prophetic Aura (spell 24167) to stack with itself
-    // (e.g. from helm + legs both enchanted)
-    if (m_spellInfo->Id == existingAura->GetSpellInfo()->Id)
+    // HACK: Allow ZG class head/leg enchants to stack with each other (e.g. helm + legs)
+    static constexpr std::array<std::array<uint32, 2>, 9> zulGurubEnchantPairs = {
+        std::array<uint32, 2>{24148, 24149}, // Warrior – Presence of Might
+        std::array<uint32, 2>{24151, 24160}, // Paladin – Syncretist's Sigil
+        std::array<uint32, 2>{24153, 24161}, // Rogue – Death's Embrace
+        std::array<uint32, 2>{24154, 24162}, // Hunter – Falcon's Call
+        std::array<uint32, 2>{24155, 24163}, // Warlock/Shaman – Vodouisant's Vigilant Embrace
+        std::array<uint32, 2>{24156, 24164}, // Mage – Presence of Sight
+        std::array<uint32, 2>{24157, 24165}, // Warlock – Hoodoo Hex
+        std::array<uint32, 2>{24158, 24167}, // Priest – Prophetic Aura
+        std::array<uint32, 2>{24159, 24168}  // Druid – Animist's Caress
+    };
+
+    auto const isZulGurubEnchant = [](uint32 spellId) -> bool
     {
-        switch (m_spellInfo->Id)
-        {
-            // Warrior ? Presence of Might
-        case 24148:
-        case 24149:
-            // Paladin ? Syncretist's Sigil
-        case 24151:
-        case 24160:
-            // Rogue ? Death's Embrace
-        case 24153:
-        case 24161:
-            // Hunter ? Falcon's Call
-        case 24154:
-        case 24162:
-            // Warlock/Shaman ? Vodouisant's Vigilant Embrace
-        case 24155:
-        case 24163:
-            // Mage ? Presence of Sight
-        case 24156:
-        case 24164:
-            // Warlock ? Hoodoo Hex
-        case 24157:
-        case 24165:
-            // Priest ? Prophetic Aura
-        case 24158:
-        case 24167:
-            // Druid ? Animist's Caress
-        case 24159:
-        case 24168:
-            return true;
-        default:
-            break;
-        }
-    }
+        for (auto const& pair : zulGurubEnchantPairs)
+            if (spellId == pair[0] || spellId == pair[1])
+                return true;
+        return false;
+    };
+
+    uint32 const existingSpellId = existingAura->GetSpellInfo()->Id;
+    if (isZulGurubEnchant(m_spellInfo->Id) && isZulGurubEnchant(existingSpellId))
+        return true;
 
     bool sameCaster = GetCasterGUID() == existingAura->GetCasterGUID();
     SpellInfo const* existingSpellInfo = existingAura->GetSpellInfo();

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -31,6 +31,7 @@
 #include "Spell.h"
 #include "SpellAuraDefines.h"
 #include "SpellInfo.h"
+#include <array>
 
 bool IsNaturesGraspAura(uint32 spellId)
 {
@@ -47,6 +48,30 @@ bool IsNaturesGraspAura(uint32 spellId)
             return true;
         default:
             return false;
+    }
+}
+
+namespace
+{
+    bool IsZulGurubClassEnchant(uint32 spellId)
+    {
+        static constexpr std::array<uint32, 18> zulGurubEnchantSpells = {
+            24148, 24149, // Warrior – Presence of Might
+            24151, 24160, // Paladin – Syncretist's Sigil
+            24153, 24161, // Rogue – Death's Embrace
+            24154, 24162, // Hunter – Falcon's Call
+            24155, 24163, // Warlock/Shaman – Vodouisant's Vigilant Embrace
+            24156, 24164, // Mage – Presence of Sight
+            24157, 24165, // Warlock – Hoodoo Hex
+            24158, 24167, // Priest – Prophetic Aura
+            24159, 24168  // Druid – Animist's Caress
+        };
+
+        for (uint32 zulGurubEnchantSpell : zulGurubEnchantSpells)
+            if (zulGurubEnchantSpell == spellId)
+                return true;
+
+        return false;
     }
 }
 
@@ -456,6 +481,9 @@ SpellGroupStackRule SpellMgr::CheckSpellGroupStackRules(SpellInfo const* spellIn
 {
     ASSERT(spellInfo1);
     ASSERT(spellInfo2);
+
+    if (IsZulGurubClassEnchant(spellInfo1->Id) && IsZulGurubClassEnchant(spellInfo2->Id))
+        return SPELL_GROUP_STACK_RULE_DEFAULT;
 
     uint32 spellid_1 = spellInfo1->GetFirstRankSpell()->Id;
     uint32 spellid_2 = spellInfo2->GetFirstRankSpell()->Id;


### PR DESCRIPTION
## Summary
- add helper for recognizing Zul'Gurub class enchants
- bypass spell group exclusivity rules when comparing two ZG enchants

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd339ac348327aafacaba6b16cda2)