### PR TITLE
Ensure ZG enchants from different items stack correctly

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3308,6 +3308,9 @@ Aura* Unit::_TryStackingOrRefreshingExistingAura(AuraCreateInfo& createInfo)
         // find current aura from spell and change it's stackamount, or refresh it's duration
         if (Aura* foundAura = GetOwnedAura(createInfo.GetSpellInfo()->Id, createInfo.GetSpellInfo()->IsStackableOnOneSlotWithDifferentCasters() ? ObjectGuid::Empty : createInfo.CasterGUID, createInfo.GetSpellInfo()->HasAttribute(SPELL_ATTR0_CU_ENCHANT_PROC) ? castItemGUID : ObjectGuid::Empty))
         {
+            if (sSpellMgr->IsZulGurubClassEnchant(createInfo.GetSpellInfo()->Id) && foundAura->GetCastItemGUID() != castItemGUID)
+                return nullptr;
+
             // effect masks do not match
             // extremely rare case
             // let's just recreate aura

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1858,44 +1858,10 @@ bool Aura::CanStackWith(Aura const* existingAura) const
     if (this == existingAura)
         return true;
 
-    // HACK: Allow Prophetic Aura (spell 24167) to stack with itself
-    // (e.g. from helm + legs both enchanted)
-    if (m_spellInfo->Id == existingAura->GetSpellInfo()->Id)
-    {
-        switch (m_spellInfo->Id)
-        {
-            // Warrior ? Presence of Might
-        case 24148:
-        case 24149:
-            // Paladin ? Syncretist's Sigil
-        case 24151:
-        case 24160:
-            // Rogue ? Death's Embrace
-        case 24153:
-        case 24161:
-            // Hunter ? Falcon's Call
-        case 24154:
-        case 24162:
-            // Warlock/Shaman ? Vodouisant's Vigilant Embrace
-        case 24155:
-        case 24163:
-            // Mage ? Presence of Sight
-        case 24156:
-        case 24164:
-            // Warlock ? Hoodoo Hex
-        case 24157:
-        case 24165:
-            // Priest ? Prophetic Aura
-        case 24158:
-        case 24167:
-            // Druid ? Animist's Caress
-        case 24159:
-        case 24168:
-            return true;
-        default:
-            break;
-        }
-    }
+    // HACK: Allow ZG class head/leg enchants to stack with each other (e.g. helm + legs)
+    uint32 const existingSpellId = existingAura->GetSpellInfo()->Id;
+    if (IsZulGurubClassEnchant(m_spellInfo->Id) && IsZulGurubClassEnchant(existingSpellId))
+        return true;
 
     bool sameCaster = GetCasterGUID() == existingAura->GetCasterGUID();
     SpellInfo const* existingSpellInfo = existingAura->GetSpellInfo();

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -31,6 +31,7 @@
 #include "Spell.h"
 #include "SpellAuraDefines.h"
 #include "SpellInfo.h"
+#include <array>
 
 bool IsNaturesGraspAura(uint32 spellId)
 {
@@ -48,6 +49,27 @@ bool IsNaturesGraspAura(uint32 spellId)
         default:
             return false;
     }
+}
+
+bool IsZulGurubClassEnchant(uint32 spellId)
+{
+    static constexpr std::array<uint32, 18> zulGurubEnchantSpells = {
+        24148, 24149, // Warrior – Presence of Might
+        24151, 24160, // Paladin – Syncretist's Sigil
+        24153, 24161, // Rogue – Death's Embrace
+        24154, 24162, // Hunter – Falcon's Call
+        24155, 24163, // Warlock/Shaman – Vodouisant's Vigilant Embrace
+        24156, 24164, // Mage – Presence of Sight
+        24157, 24165, // Warlock – Hoodoo Hex
+        24158, 24167, // Priest – Prophetic Aura
+        24159, 24168  // Druid – Animist's Caress
+    };
+
+    for (uint32 zulGurubEnchantSpell : zulGurubEnchantSpells)
+        if (zulGurubEnchantSpell == spellId)
+            return true;
+
+    return false;
 }
 
 bool IsPrimaryProfessionSkill(uint32 skill)
@@ -456,6 +478,9 @@ SpellGroupStackRule SpellMgr::CheckSpellGroupStackRules(SpellInfo const* spellIn
 {
     ASSERT(spellInfo1);
     ASSERT(spellInfo2);
+
+    if (IsZulGurubClassEnchant(spellInfo1->Id) && IsZulGurubClassEnchant(spellInfo2->Id))
+        return SPELL_GROUP_STACK_RULE_DEFAULT;
 
     uint32 spellid_1 = spellInfo1->GetFirstRankSpell()->Id;
     uint32 spellid_2 = spellInfo2->GetFirstRankSpell()->Id;

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -737,6 +737,7 @@ class TC_GAME_API SpellMgr
 
 
 bool IsNaturesGraspAura(uint32 spellId);
+bool IsZulGurubClassEnchant(uint32 spellId);
 
 #define sSpellMgr SpellMgr::instance()
 


### PR DESCRIPTION
## Summary
- expose Zul'Gurub class enchant helper for reuse across stacking checks
- allow head and leg ZG enchants from different items to create separate auras instead of refreshing
- keep enchant stacking logic aligned by reusing the helper in aura stack checks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd339ac348327aafacaba6b16cda2)