### PR TITLE
Keep Stockades logout chest standard loot

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -823,6 +823,17 @@ public:
     {
         HandleStockadesPveHonorKill(killer, killed);
     }
+
+    void OnLogout(Player* player) override
+    {
+        if (!player)
+            return;
+
+        if (player->GetMapId() != StockadesPvPvE::StockadesMapId)
+            return;
+
+        DropDeathChest(player);
+    }
 };
 
 struct go_stockades_boss_doorAI : public GameObjectAI


### PR DESCRIPTION
## Summary
- remove free-for-all handling from custom loot chest helper and death chest creation
- keep Stockades logout chest spawning without changing loot rules

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920038a350483279316faa4d1940e3f)