### PR TITLE
Ensure taunt effects initialize threat on empty lists

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -499,7 +499,12 @@ void ThreatManager::ScaleThreat(Unit* target, float factor)
 void ThreatManager::MatchUnitThreatToHighestThreat(Unit* target)
 {
     if (_sortedThreatList->empty())
+    {
+        // Taunts on a target without a threat list entry should still create one so the caster
+        // actually gains aggro instead of only forcing attacks for the aura duration.
+        AddThreat(target, 1.0f, nullptr, true, true);
         return;
+    }
 
     auto it = _sortedThreatList->ordered_begin(), end = _sortedThreatList->ordered_end();
     ThreatReference const* highest = *it;


### PR DESCRIPTION
## Summary
- ensure taunt effects create a threat entry when none exists so casters gain aggro instead of just forcing attacks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692018e1b8fc832788313fa2d2c66271)