### PR TITLE
Add crash signal handlers on non-Windows

### DIFF
--- a/src/common/Debugging/Errors.cpp
+++ b/src/common/Debugging/Errors.cpp
@@ -18,9 +18,12 @@
 #include "Errors.h"
 #include "Log.h"
 #include "StringFormat.h"
+#include <atomic>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <cstdarg>
+#include <cstring>
 #include <thread>
 #include <sstream>
 
@@ -77,6 +80,18 @@ namespace
         fflush(stderr);
 
         free(symbols);
+    }
+
+    std::atomic_bool HandlingFatalSignal = false;
+
+    void HandleFatalSignal(int signalId, char const* signalName)
+    {
+        std::string formattedMessage = StringFormat("\nCaught fatal signal {} ({})\n", signalId, signalName);
+        LogCrashMessage(formattedMessage);
+        fprintf(stderr, "%s", formattedMessage.c_str());
+        fflush(stderr);
+
+        LogStackTrace();
     }
 #endif
 
@@ -200,6 +215,40 @@ void AbortHandler(int sigval)
     fflush(stderr);
     Crash(formattedMessage.c_str());
 }
+
+#if TRINITY_PLATFORM != TRINITY_PLATFORM_WINDOWS
+void FatalSignalHandler(int sigval)
+{
+    // prevent recursive handling that might occur if the crash originates inside the handler itself
+    if (HandlingFatalSignal.exchange(true))
+        raise(sigval);
+
+    char const* name = strsignal(sigval);
+    HandleFatalSignal(sigval, name ? name : "unknown");
+
+    // Restore default handler and re-raise so normal core dumps or debugger hooks still occur
+    signal(sigval, SIG_DFL);
+    raise(sigval);
+}
+
+void InitCrashSignalHandlers()
+{
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = &FatalSignalHandler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_RESETHAND;
+
+    sigaction(SIGSEGV, &action, nullptr);
+    sigaction(SIGFPE, &action, nullptr);
+    sigaction(SIGILL, &action, nullptr);
+#ifdef SIGBUS
+    sigaction(SIGBUS, &action, nullptr);
+#endif
+
+    signal(SIGABRT, &AbortHandler);
+}
+#endif
 
 } // namespace Trinity
 

--- a/src/common/Debugging/Errors.h
+++ b/src/common/Debugging/Errors.h
@@ -36,6 +36,10 @@ namespace Trinity
     TC_COMMON_API void Warning(char const* file, int line, char const* function, char const* message);
 
     [[noreturn]] TC_COMMON_API void AbortHandler(int sigval);
+#if TRINITY_PLATFORM != TRINITY_PLATFORM_WINDOWS
+    TC_COMMON_API void FatalSignalHandler(int sigval);
+    TC_COMMON_API void InitCrashSignalHandlers();
+#endif
 
 } // namespace Trinity
 

--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -84,7 +84,11 @@ variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, s
 int main(int argc, char** argv)
 {
     Trinity::Impl::CurrentServerProcessHolder::_type = SERVER_PROCESS_AUTHSERVER;
+#if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
     signal(SIGABRT, &Trinity::AbortHandler);
+#else
+    Trinity::InitCrashSignalHandlers();
+#endif
 
     Trinity::VerifyOsVersion();
 

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -125,7 +125,11 @@ variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, s
 extern int main(int argc, char** argv)
 {
     Trinity::Impl::CurrentServerProcessHolder::_type = SERVER_PROCESS_WORLDSERVER;
+#if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
     signal(SIGABRT, &Trinity::AbortHandler);
+#else
+    Trinity::InitCrashSignalHandlers();
+#endif
 
     Trinity::VerifyOsVersion();
 


### PR DESCRIPTION
## Summary
- add fatal signal handlers on non-Windows builds to log crashes before termination
- ensure authserver and worldserver install the new handlers during startup
- record caught signals and stack traces to crash log while preserving default core dumps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211ed964f08327a8232e1ff270d9e8)