### PR TITLE
Fix taunt CastStop null dereference

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11725,7 +11725,7 @@ void Unit::SetTaunted(bool apply)
         if (caster)
         {
             GetMotionMaster()->MoveChase(caster);
-            ToPlayer()->CastStop();
+            CastStop();
             Attack(caster, true);
         }
     }


### PR DESCRIPTION
## Summary
- replace player-only CastStop call in taunt handling with unit-safe CastStop
- prevent null dereference when non-player units become taunted

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921201309cc8327a43d684c83bfbe99)