### PR TITLE
Fix fatal signal formatting usage

### DIFF
--- a/src/common/Debugging/Errors.cpp
+++ b/src/common/Debugging/Errors.cpp
@@ -86,7 +86,7 @@ namespace
 
     void HandleFatalSignal(int signalId, char const* signalName)
     {
-        std::string formattedMessage = StringFormat("\nCaught fatal signal {} ({})\n", signalId, signalName);
+        std::string formattedMessage = Trinity::StringFormat("\nCaught fatal signal {} ({})\n", signalId, signalName);
         LogCrashMessage(formattedMessage);
         fprintf(stderr, "%s", formattedMessage.c_str());
         fflush(stderr);


### PR DESCRIPTION
## Summary
- use Trinity namespaced StringFormat when building fatal signal crash message

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692123bb073883278595f2a35077fb8d)