### PR TITLE
Fix string handling in PvPvE dungeon purge query

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -272,7 +272,8 @@ void PvpveDungeonMgr::PurgeDungeonInstances()
         mapList << *itr;
     }
 
-    QueryResult result = CharacterDatabase.Query("SELECT id FROM instance WHERE map IN (" + mapList.str() + ")");
+    std::string query = "SELECT id FROM instance WHERE map IN (" + mapList.str() + ")";
+    QueryResult result = CharacterDatabase.Query(query.c_str());
     if (!result)
         return;
 


### PR DESCRIPTION
## Summary
- build the PvPvE dungeon purge SQL query as a std::string and pass its C-string to CharacterDatabase

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692125942f8c83279a87ce75f60549d2)