### PR TITLE
Handle Stockades boss detection without Containers::Contains

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -598,7 +598,8 @@ public:
                 group->HandleDeath(creature);
 
             uint32 const honorTokens = GetHonorTokensForCreatureEntry(creature->GetEntry());
-            bool const isStockadesBoss = Trinity::Containers::Contains(StockadesPvPvE::GetBossEntries(), creature->GetEntry());
+            auto const& bossEntries = StockadesPvPvE::GetBossEntries();
+            bool const isStockadesBoss = std::find(bossEntries.begin(), bossEntries.end(), creature->GetEntry()) != bossEntries.end();
 
             if (isStockadesBoss)
             {


### PR DESCRIPTION
## Summary
- replace the missing Trinity::Containers::Contains call in the Stockades PvPvE script with a std::find lookup
- maintain boss defeat handling without relying on removed helper

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692126ef9df48327a2c4f9a036a65b08)