### PR TITLE
Queue eliminated players for new Stockades runs

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -1513,6 +1513,21 @@ public:
         PvpveDungeonRun* run = sPvpveDungeonMgr->GetRunForPlayer(guid);
         if (!run)
         {
+            if (sPvpveDungeonMgr->IsPvpveDungeonMap(player->GetMapId()))
+            {
+                bool queuedNewRun = QueueForNewStockadesRun(player);
+
+                if (WorldSession* session = player->GetSession())
+                {
+                    if (queuedNewRun)
+                        session->SendNotification("You have been eliminated from this PvPvE Stockades run. You have been queued for a new run.");
+                    else
+                        session->SendNotification("You have been eliminated from this PvPvE Stockades run.");
+                }
+
+                TeleportOutImmediately(player);
+            }
+
             ClearPendingState(guid);
             return;
         }
@@ -1609,6 +1624,31 @@ private:
 
         sPvpveDungeonMgr->OnPlayerDeath(player);
         // Actual elimination is handled on release / timeout / leaving map.
+    }
+
+    bool QueueForNewStockadesRun(Player* player)
+    {
+        if (!player)
+            return false;
+
+        uint32 templateId = 0;
+        for (auto const& templatePair : sPvpveDungeonMgr->_templates)
+        {
+            DungeonTemplate const& dungeonTemplate = templatePair.second;
+            if (!dungeonTemplate.Enabled || dungeonTemplate.MapId != kStockadesMapId)
+                continue;
+
+            templateId = dungeonTemplate.Id;
+            break;
+        }
+
+        if (!templateId)
+            return false;
+
+        std::vector<ObjectGuid> memberGuids;
+        memberGuids.push_back(player->GetGUID());
+
+        return sPvpveDungeonMgr->QueueTeam(templateId, memberGuids);
     }
 
     bool MarkPlayerEliminated(Player* player)

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -129,6 +129,32 @@ bool PvpveDungeonMgr::IsPvpveDungeonMap(uint32 mapId) const
     return false;
 }
 
+bool PvpveDungeonMgr::HasRunLockoutForMap(ObjectGuid const& guid, uint32 mapId) const
+{
+    if (!guid || !mapId)
+        return false;
+
+    auto lockoutItr = _playerRunLockouts.find(guid);
+    if (lockoutItr == _playerRunLockouts.end())
+        return false;
+
+    auto runItr = _runs.find(lockoutItr->second);
+    if (runItr == _runs.end())
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: player {} has a lockout for missing run {}.", guid.ToString(), lockoutItr->second);
+        return true;
+    }
+
+    DungeonTemplate const* dungeonTemplate = GetDungeonTemplate(runItr->second.TemplateId);
+    if (!dungeonTemplate)
+    {
+        TC_LOG_WARN("server.custom", "PvpveDungeonMgr: player {} has a lockout for run {} with unknown template {}.", guid.ToString(), lockoutItr->second, runItr->second.TemplateId);
+        return true;
+    }
+
+    return dungeonTemplate->MapId == mapId;
+}
+
 void PvpveDungeonMgr::OnPlayerEnteredInstance(Player* player, PvpveDungeonInstance* instanceScript)
 {
     if (!player || !instanceScript)
@@ -1515,14 +1541,24 @@ public:
         {
             if (sPvpveDungeonMgr->IsPvpveDungeonMap(player->GetMapId()))
             {
-                bool queuedNewRun = QueueForNewStockadesRun(player);
+                bool queuedNewRun = false;
 
-                if (WorldSession* session = player->GetSession())
+                if (sPvpveDungeonMgr->HasRunLockoutForMap(guid, player->GetMapId()))
                 {
-                    if (queuedNewRun)
-                        session->SendNotification("You have been eliminated from this PvPvE Stockades run. You have been queued for a new run.");
-                    else
-                        session->SendNotification("You have been eliminated from this PvPvE Stockades run.");
+                    if (WorldSession* session = player->GetSession())
+                        session->SendNotification("You have been eliminated from this PvPvE Stockades run and cannot rejoin this instance.");
+                }
+                else
+                {
+                    queuedNewRun = QueueForNewStockadesRun(player);
+
+                    if (WorldSession* session = player->GetSession())
+                    {
+                        if (queuedNewRun)
+                            session->SendNotification("You have been eliminated from this PvPvE Stockades run. You have been queued for a new run.");
+                        else
+                            session->SendNotification("You have been eliminated from this PvPvE Stockades run.");
+                    }
                 }
 
                 TeleportOutImmediately(player);

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -119,6 +119,7 @@ public:
     bool IsPlayerInPvpveRun(ObjectGuid const& guid) const;
     bool IsPlayerInPvpveRun(Player const* player) const;
     bool IsPvpveDungeonMap(uint32 mapId) const;
+    bool HasRunLockoutForMap(ObjectGuid const& guid, uint32 mapId) const;
     WorldLocation const* GetReturnLocation(ObjectGuid const& guid) const;
 
     PvpveDungeonRun* GetRun(uint64 runId);


### PR DESCRIPTION
## Summary
- queue eliminated Stockades players for a new run when they attempt to re-enter
- notify eliminated players that they were queued before teleporting them out

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69212a3c5d248327a8c5a976dfd700a8)