### PR TITLE
Prevent premature InstanceSave deletion

### DIFF
--- a/src/server/game/Instances/InstanceSaveMgr.h
+++ b/src/server/game/Instances/InstanceSaveMgr.h
@@ -93,7 +93,7 @@ class TC_GAME_API InstanceSave
             _playerListLock.unlock();
 
             //delete here if needed, after releasing the lock
-            if (m_toDelete)
+            if (m_toDelete && !isStillValid)
                 delete this;
 
             return isStillValid;
@@ -104,7 +104,7 @@ class TC_GAME_API InstanceSave
         {
             m_groupList.remove(group);
             bool isStillValid = UnloadIfEmpty();
-            if (m_toDelete)
+            if (m_toDelete && !isStillValid)
                 delete this;
             return isStillValid;
         }


### PR DESCRIPTION
## Summary
- avoid deleting InstanceSave objects when they are still considered valid
- gate self-deletion in RemovePlayer and RemoveGroup on the instance no longer being valid

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69213037de08832780ddf7b827573619)