### PR TITLE
Prevent duplicate stackable chest entries

### DIFF
--- a/src/server/scripts/Custom/custom_diremaul_beads.cpp
+++ b/src/server/scripts/Custom/custom_diremaul_beads.cpp
@@ -230,7 +230,8 @@ namespace DireMaulBeads
         chest.AddStackableItem(beadItemId, beadCount);
         if (honorTokenCount)
             chest.AddStackableItem(HonorTokenItemId, honorTokenCount);
-        CustomLootChests::CollectItemsWithQuality(victim, ITEM_QUALITY_ARTIFACT, chest, artifactItems);
+
+        CustomLootChests::CollectItemsWithQuality(victim, ITEM_QUALITY_ARTIFACT, chest, artifactItems, { HonorTokenItemId });
 
         if (GameObject* spawnedChest = chest.Summon())
         {

--- a/src/server/scripts/Custom/custom_diremaul_beads.cpp
+++ b/src/server/scripts/Custom/custom_diremaul_beads.cpp
@@ -231,7 +231,11 @@ namespace DireMaulBeads
         if (honorTokenCount)
             chest.AddStackableItem(HonorTokenItemId, honorTokenCount);
 
-        CustomLootChests::CollectItemsWithQuality(victim, ITEM_QUALITY_ARTIFACT, chest, artifactItems, { HonorTokenItemId });
+        std::unordered_set<uint32> excludedArtifacts = { HonorTokenItemId };
+        if (beadItemId)
+            excludedArtifacts.insert(beadItemId);
+
+        CustomLootChests::CollectItemsWithQuality(victim, ITEM_QUALITY_ARTIFACT, chest, artifactItems, excludedArtifacts);
 
         if (GameObject* spawnedChest = chest.Summon())
         {

--- a/src/server/scripts/Custom/custom_loot_chest_helper.cpp
+++ b/src/server/scripts/Custom/custom_loot_chest_helper.cpp
@@ -48,6 +48,22 @@ void PlayerChestBuilder::AddStackableItem(uint32 itemId, uint32 count)
     if (!itemId || !count)
         return;
 
+    // First, try to top off any existing stacks of the same item instead of
+    // creating additional entries in the loot list.
+    for (LootItem& item : _items)
+    {
+        if (item.itemid != itemId || item.count >= 255)
+            continue;
+
+        uint32 const room = 255 - item.count;
+        uint32 const toAdd = std::min<uint32>(count, room);
+        item.count += toAdd;
+        count -= toAdd;
+
+        if (!count)
+            return;
+    }
+
     while (count && _items.size() < MAX_NR_LOOT_ITEMS)
     {
         uint8 const stack = static_cast<uint8>(std::min<uint32>(count, 255));

--- a/src/server/scripts/Custom/custom_loot_chest_helper.cpp
+++ b/src/server/scripts/Custom/custom_loot_chest_helper.cpp
@@ -115,7 +115,8 @@ GameObject* PlayerChestBuilder::Summon() const
     return chest;
 }
 
-void CollectItemsWithQuality(Player* player, ItemQualities quality, PlayerChestBuilder& chest, std::vector<ItemLocation>& removedItems)
+void CollectItemsWithQuality(Player* player, ItemQualities quality, PlayerChestBuilder& chest, std::vector<ItemLocation>& removedItems,
+    std::unordered_set<uint32> const& excludedEntries)
 {
     if (!player)
         return;
@@ -127,7 +128,7 @@ void CollectItemsWithQuality(Player* player, ItemQualities quality, PlayerChestB
 
         if (ItemTemplate const* proto = item->GetTemplate())
         {
-            if (proto->Quality == quality)
+            if (proto->Quality == quality && !excludedEntries.count(item->GetEntry()))
             {
                 chest.AddItem(item);
                 removedItems.push_back({ bag, slot });

--- a/src/server/scripts/Custom/custom_loot_chest_helper.h
+++ b/src/server/scripts/Custom/custom_loot_chest_helper.h
@@ -23,6 +23,7 @@
 #include "Loot.h"
 #include "Player.h"
 #include "SharedDefines.h"
+#include <unordered_set>
 #include <vector>
 
 namespace CustomLootChests
@@ -53,7 +54,8 @@ private:
     mutable std::vector<LootItem> _items;
 };
 
-void CollectItemsWithQuality(Player* player, ItemQualities quality, PlayerChestBuilder& chest, std::vector<ItemLocation>& removedItems);
+void CollectItemsWithQuality(Player* player, ItemQualities quality, PlayerChestBuilder& chest, std::vector<ItemLocation>& removedItems,
+    std::unordered_set<uint32> const& excludedEntries = {});
 }
 
 #endif // CUSTOM_LOOT_CHEST_HELPER_H

--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -354,7 +354,8 @@ namespace
             chest.AddStackableItem(StockadesPvPvE::BossKeyItemId, bossKeyCount);
 
         std::vector<CustomLootChests::ItemLocation> artifactItems;
-        CustomLootChests::CollectItemsWithQuality(victim, ITEM_QUALITY_ARTIFACT, chest, artifactItems);
+        CustomLootChests::CollectItemsWithQuality(victim, ITEM_QUALITY_ARTIFACT, chest, artifactItems,
+            { StockadesPvPvE::HonorTokenItemId });
 
         if (GameObject* chestGO = chest.Summon())
         {

--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -354,8 +354,11 @@ namespace
             chest.AddStackableItem(StockadesPvPvE::BossKeyItemId, bossKeyCount);
 
         std::vector<CustomLootChests::ItemLocation> artifactItems;
-        CustomLootChests::CollectItemsWithQuality(victim, ITEM_QUALITY_ARTIFACT, chest, artifactItems,
-            { StockadesPvPvE::HonorTokenItemId });
+        std::unordered_set<uint32> excludedArtifacts = { StockadesPvPvE::HonorTokenItemId };
+        if (beadItemId)
+            excludedArtifacts.insert(beadItemId);
+
+        CustomLootChests::CollectItemsWithQuality(victim, ITEM_QUALITY_ARTIFACT, chest, artifactItems, excludedArtifacts);
 
         if (GameObject* chestGO = chest.Summon())
         {


### PR DESCRIPTION
## Summary
- fill existing loot stacks before adding new entries to death chests

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69213dcea6348327875ee690872359c7)