### PR TITLE
Improve PvPvE queue lockouts and teleport gating

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -504,6 +504,19 @@ void PvpveDungeonMgr::Update(uint32 /*diff*/)
                 continue;
             }
 
+            std::unordered_set<uint32> memberInstanceLocks;
+            for (ObjectGuid const& memberGuid : queueItr->second.Members)
+            {
+                if (Player* member = ObjectAccessor::FindPlayer(memberGuid))
+                {
+                    if (InstancePlayerBind* bind = member->GetBoundInstance(dungeonTemplate->MapId, member->GetDifficulty(false)))
+                    {
+                        if (InstanceSave* save = bind->save)
+                            memberInstanceLocks.insert(save->GetInstanceId());
+                    }
+                }
+            }
+
             auto const runEligible = [&](PvpveDungeonRun& candidate)
             {
                 if (candidate.TemplateId != dungeonTemplate->Id)
@@ -543,6 +556,9 @@ void PvpveDungeonMgr::Update(uint32 /*diff*/)
                     auto lockoutItr = _playerRunLockouts.find(guid);
                     return lockoutItr != _playerRunLockouts.end() && lockoutItr->second == candidate.Id;
                 });
+
+                if (!memberInstanceLocks.empty() && candidate.InstanceId && memberInstanceLocks.count(candidate.InstanceId))
+                    return false;
 
                 return !memberHasLockout;
             };
@@ -1444,7 +1460,7 @@ public:
             return;
 
         PvpveDungeonRun* run = sPvpveDungeonMgr->GetRunForPlayer(player->GetGUID());
-        if (!run || run->BossDefeated)
+        if (!run || run->BossDefeated || run->Finished)
             return;
 
         DungeonTemplate const* dungeonTemplate = sPvpveDungeonMgr->GetDungeonTemplate(run->TemplateId);


### PR DESCRIPTION
## Summary
- have the queue master skip existing PvPvE runs that match a member's active instance lockouts, favoring new instances instead
- allow mage teleport spells once a Stockades PvPvE run has finished so they are no longer blocked after a boss kill

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921447effd88327944a7d7656f3e1cb)