### PR TITLE
Ensure Stockades PvPvE boss kills unlock teleports

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -603,7 +603,8 @@ public:
 
             uint32 const honorTokens = GetHonorTokensForCreatureEntry(creature->GetEntry());
             auto const& bossEntries = StockadesPvPvE::GetBossEntries();
-            bool const isStockadesBoss = std::find(bossEntries.begin(), bossEntries.end(), creature->GetEntry()) != bossEntries.end();
+            bool const isStockadesBoss = creature->GetGUID() == _bossGuid ||
+                std::find(bossEntries.begin(), bossEntries.end(), creature->GetEntry()) != bossEntries.end();
 
             if (isStockadesBoss)
             {


### PR DESCRIPTION
## Summary
- recognize the summoned Stockades PvPvE boss by its GUID when handling deaths
- guarantee boss defeat triggers completion so teleport spells unlock

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214a6689748327aaf11ae092891e4b)