### PR TITLE
Strengthen PvPvE Stockades lockouts

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -344,7 +344,7 @@ bool PvpveDungeonMgr::QueueTeam(uint32 templateId, std::vector<ObjectGuid> const
         if (preferredRunId)
         {
             auto lockoutItr = _playerRunLockouts.find(guid);
-            if (lockoutItr != _playerRunLockouts.end() && lockoutItr->second == preferredRunId)
+            if (lockoutItr != _playerRunLockouts.end() && lockoutItr->second.RunId == preferredRunId)
             {
                 TC_LOG_WARN("server.custom", "PvpveDungeonMgr: player {} was eliminated from run {} and cannot rejoin it.", guid.ToString(), preferredRunId);
                 return false;
@@ -399,7 +399,7 @@ bool PvpveDungeonMgr::QueueTeam(uint64 teamId, uint64 preferredRunId)
                 continue;
 
             auto lockoutItr = _playerRunLockouts.find(guid);
-            if (lockoutItr != _playerRunLockouts.end() && lockoutItr->second == preferredRunId)
+            if (lockoutItr != _playerRunLockouts.end() && lockoutItr->second.RunId == preferredRunId)
             {
                 TC_LOG_WARN("server.custom", "PvpveDungeonMgr: cannot queue team {} for run {}; player {} has already been eliminated from it.",
                     teamId, preferredRunId, guid.ToString());
@@ -504,6 +504,19 @@ void PvpveDungeonMgr::Update(uint32 /*diff*/)
                 continue;
             }
 
+            std::unordered_set<uint32> memberInstanceLocks;
+            for (ObjectGuid const& memberGuid : queueItr->second.Members)
+            {
+                if (Player* member = ObjectAccessor::FindPlayer(memberGuid))
+                {
+                    if (InstancePlayerBind* bind = member->GetBoundInstance(dungeonTemplate->MapId, member->GetDifficulty(false)))
+                    {
+                        if (InstanceSave* save = bind->save)
+                            memberInstanceLocks.insert(save->GetInstanceId());
+                    }
+                }
+            }
+
             auto const runEligible = [&](PvpveDungeonRun& candidate)
             {
                 if (candidate.TemplateId != dungeonTemplate->Id)
@@ -541,8 +554,21 @@ void PvpveDungeonMgr::Update(uint32 /*diff*/)
                     [this, &candidate](ObjectGuid const& guid)
                 {
                     auto lockoutItr = _playerRunLockouts.find(guid);
-                    return lockoutItr != _playerRunLockouts.end() && lockoutItr->second == candidate.Id;
+                    if (lockoutItr == _playerRunLockouts.end())
+                        return false;
+
+                    PlayerRunLockout const& lockout = lockoutItr->second;
+                    if (lockout.RunId && lockout.RunId == candidate.Id)
+                        return true;
+
+                    if (lockout.InstanceId && candidate.InstanceId && lockout.InstanceId == candidate.InstanceId)
+                        return true;
+
+                    return false;
                 });
+
+                if (!memberInstanceLocks.empty() && candidate.InstanceId && memberInstanceLocks.count(candidate.InstanceId))
+                    return false;
 
                 return !memberHasLockout;
             };
@@ -995,6 +1021,8 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
     _playerToTeam.erase(guid);
     ClearReturnLocation(guid);
 
+    uint32 const runInstanceId = run->InstanceId ? run->InstanceId : (run->InstanceMap ? run->InstanceMap->GetInstanceId() : player->GetInstanceId());
+
     if (DungeonTemplate const* dungeonTemplate = GetDungeonTemplate(run->TemplateId))
     {
         if (run->Finished)
@@ -1004,13 +1032,13 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
         }
         else
         {
-            _playerRunLockouts[guid] = run->Id;
+            _playerRunLockouts[guid] = PlayerRunLockout{ run->Id, runInstanceId };
         }
     }
     else if (run->Finished)
         _playerRunLockouts.erase(guid);
     else
-        _playerRunLockouts[guid] = run->Id;
+        _playerRunLockouts[guid] = PlayerRunLockout{ run->Id, runInstanceId };
 
     EvaluateRunState(*run);
 
@@ -1273,7 +1301,7 @@ void PvpveDungeonMgr::ClearRunLockouts(uint64 runId)
 {
     for (auto itr = _playerRunLockouts.begin(); itr != _playerRunLockouts.end();)
     {
-        if (itr->second == runId)
+        if (itr->second.RunId == runId)
             itr = _playerRunLockouts.erase(itr);
         else
             ++itr;
@@ -1444,7 +1472,7 @@ public:
             return;
 
         PvpveDungeonRun* run = sPvpveDungeonMgr->GetRunForPlayer(player->GetGUID());
-        if (!run || run->BossDefeated)
+        if (!run || run->BossDefeated || run->Finished)
             return;
 
         DungeonTemplate const* dungeonTemplate = sPvpveDungeonMgr->GetDungeonTemplate(run->TemplateId);

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -155,10 +155,16 @@ private:
     void ForceEliminateTeam(PvpveTeam& team, PvpveDungeonRun& run);
     void MaintainActivePlayerPvpState();
 
+    struct PlayerRunLockout
+    {
+        uint64 RunId = 0;
+        uint32 InstanceId = 0;
+    };
+
     using QueueContainer = std::map<uint64, QueuedTeam>;
     using RunContainer = std::map<uint64, PvpveDungeonRun>;
     using TeamContainer = std::map<uint64, PvpveTeam>;
-    using PlayerRunMap = std::map<ObjectGuid, uint64>;
+    using PlayerRunMap = std::map<ObjectGuid, PlayerRunLockout>;
     using PlayerTeamMap = std::map<ObjectGuid, uint64>;
     using TemplateContainer = std::map<uint32, DungeonTemplate>;
     using SpawnContainer = std::map<uint32, std::vector<SpawnPoint>>;


### PR DESCRIPTION
## Summary
- track both run IDs and instance IDs for PvPvE lockouts
- reject queue assignments into runs matching a player's elimination run or instance
- store lockouts when leaving Stockades so eliminated players cannot re-enter the same instance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921447effd88327944a7d7656f3e1cb)