### PR TITLE
Fix player run map to store run ids

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -164,7 +164,7 @@ private:
     using QueueContainer = std::map<uint64, QueuedTeam>;
     using RunContainer = std::map<uint64, PvpveDungeonRun>;
     using TeamContainer = std::map<uint64, PvpveTeam>;
-    using PlayerRunMap = std::map<ObjectGuid, PlayerRunLockout>;
+    using PlayerRunMap = std::map<ObjectGuid, uint64>;
     using PlayerTeamMap = std::map<ObjectGuid, uint64>;
     using TemplateContainer = std::map<uint32, DungeonTemplate>;
     using SpawnContainer = std::map<uint32, std::vector<SpawnPoint>>;


### PR DESCRIPTION
## Summary
- change the player-to-run map to store run identifiers directly
- resolve type mismatches when retrieving runs for players

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214dbf4db88327b1ad3bc067a1ea9d)