### PR TITLE
Correct player lockout map mapping type

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -164,8 +164,9 @@ private:
     using QueueContainer = std::map<uint64, QueuedTeam>;
     using RunContainer = std::map<uint64, PvpveDungeonRun>;
     using TeamContainer = std::map<uint64, PvpveTeam>;
-    using PlayerRunMap = std::map<ObjectGuid, PlayerRunLockout>;
+    using PlayerRunMap = std::map<ObjectGuid, uint64>;
     using PlayerTeamMap = std::map<ObjectGuid, uint64>;
+    using PlayerLockoutMap = std::map<ObjectGuid, PlayerRunLockout>;
     using TemplateContainer = std::map<uint32, DungeonTemplate>;
     using SpawnContainer = std::map<uint32, std::vector<SpawnPoint>>;
     using PlayerLocationMap = std::map<ObjectGuid, WorldLocation>;
@@ -175,7 +176,7 @@ private:
     TeamContainer _teams;
     PlayerRunMap _playerToRun;
     PlayerTeamMap _playerToTeam;
-    PlayerRunMap _playerRunLockouts;
+    PlayerLockoutMap _playerRunLockouts;
     TemplateContainer _templates;
     SpawnContainer _spawns;
     GuidSet _queuedPlayers;


### PR DESCRIPTION
## Summary
- add a dedicated player lockout map type using the PlayerRunLockout struct
- update the lockout map member to use the struct rather than a run id

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214dbf4db88327b1ad3bc067a1ea9d)