### PR TITLE
Trigger Stockades completion on boss honor kill

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -498,6 +498,25 @@ namespace
             return; // this mob doesn't award tokens
 
         AwardHonorTokensToKillerTeam(killer, tokens);
+
+        // Also treat boss kills as the Stockades completion trigger so teleport
+        // spells unlock even if the instance death hook misses the GUID match.
+        auto const& bossEntries = StockadesPvPvE::GetBossEntries();
+        bool const killedBoss = killed->GetEntry() == StockadesPvPvE::GetBossCreatureEntry() ||
+            std::find(bossEntries.begin(), bossEntries.end(), killed->GetEntry()) != bossEntries.end();
+
+        if (!killedBoss)
+            return;
+
+        PvpveDungeonRun* run = sPvpveDungeonMgr->GetRunForPlayer(killer->GetGUID());
+        if (!run || run->Finished || run->BossDefeated)
+            return;
+
+        DungeonTemplate const* dungeonTemplate = sPvpveDungeonMgr->GetDungeonTemplate(run->TemplateId);
+        if (!dungeonTemplate || dungeonTemplate->MapId != StockadesPvPvE::StockadesMapId)
+            return;
+
+        sPvpveDungeonMgr->OnBossDefeated(run->Id, killer->GetGUID());
     }
 } // anonymous namespace
 
@@ -603,7 +622,8 @@ public:
 
             uint32 const honorTokens = GetHonorTokensForCreatureEntry(creature->GetEntry());
             auto const& bossEntries = StockadesPvPvE::GetBossEntries();
-            bool const isStockadesBoss = std::find(bossEntries.begin(), bossEntries.end(), creature->GetEntry()) != bossEntries.end();
+            bool const isStockadesBoss = creature->GetGUID() == _bossGuid ||
+                std::find(bossEntries.begin(), bossEntries.end(), creature->GetEntry()) != bossEntries.end();
 
             if (isStockadesBoss)
             {


### PR DESCRIPTION
**Changes proposed**:

- Trigger Stockades PvPvE run completion when a configured boss is killed in the honor token handler.
- Prevent teleport lockouts persisting by notifying the dungeon manager even if the instance death hook misses the boss GUID.
- Keep run validation intact by checking run state and template before sending completion.

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

- Not run (not requested)

**Known issues and TODO list**:

- [ ]
- [ ]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214a6689748327aaf11ae092891e4b)