### PR TITLE
Unbind eliminated players from active PvPvE runs

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -1004,6 +1004,10 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
         }
         else
         {
+            // The player was eliminated while the run is still active. Clear any existing instance
+            // binding so a future queue attempt cannot reattach them to the same in-progress
+            // instance before the lockout check runs.
+            player->UnbindInstance(dungeonTemplate->MapId, player->GetDifficulty(false));
             _playerRunLockouts[guid] = run->Id;
         }
     }


### PR DESCRIPTION
## Summary
- clear PvPvE instance bindings when players leave an active run
- keep lockout tracking intact so requeues cannot reattach to the same in-progress instance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214362fe4883279e4df731c8a634fe)