### PR TITLE
Fix player lockout assignment when leaving PvPvE map

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -1036,7 +1036,7 @@ void PvpveDungeonMgr::OnPlayerLeftMap(Player* player)
             // binding so a future queue attempt cannot reattach them to the same in-progress
             // instance before the lockout check runs.
             player->UnbindInstance(dungeonTemplate->MapId, player->GetDifficulty(false));
-            _playerRunLockouts[guid] = run->Id;
+            _playerRunLockouts[guid] = PlayerRunLockout{ run->Id, runInstanceId };
         }
     }
     else if (run->Finished)


### PR DESCRIPTION
## Summary
- assign the PlayerRunLockout struct when recording lockouts after a player leaves a PvPvE run

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692156ba06088327a836143a87eaaacc)