### PR TITLE
Add lockouts for eliminated PvPvE teams

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -972,6 +972,13 @@ void PvpveDungeonMgr::OnPlayerEliminated(Player* player)
     _teamEliminationDeadlines.erase(team->Id);
     TC_LOG_INFO("server.custom", "PvpveDungeonMgr: team {} eliminated in run {} (triggered by player {}).", team->Id, run->Id, guid.ToString());
 
+    uint32 const runInstanceId = run->InstanceId ? run->InstanceId : (run->InstanceMap ? run->InstanceMap->GetInstanceId() : 0u);
+    if (runInstanceId)
+    {
+        for (ObjectGuid const& memberGuid : team->Members)
+            _playerRunLockouts[memberGuid] = PlayerRunLockout{ run->Id, runInstanceId };
+    }
+
     EvaluateRunState(*run);
 }
 


### PR DESCRIPTION
## Summary
- record instance lockouts for all team members when a PvPvE team is eliminated
- use the stored lockout to prevent eliminated players from re-entering the same run instance when requeueing

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692158d2d8c48327ae1bae8b6d8eeaf2)