### PR TITLE
Lock PvPvE entrants to active instance

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -160,7 +160,15 @@ void PvpveDungeonMgr::OnPlayerEnteredInstance(Player* player, PvpveDungeonInstan
                 instanceId = map->GetInstanceId();
 
         if (instanceId)
+        {
             ChatHandler(session).PSendSysMessage("PvPvE Stockades instance ID: %u", instanceId);
+
+            // Flag the player as locked to this run as soon as they enter the instance so they cannot
+            // re-enter it after leaving, even if they were not eliminated inside the run.
+            _playerRunLockouts[player->GetGUID()] = PlayerRunLockout{ run->Id, instanceId };
+            if (!run->InstanceId)
+                run->InstanceId = instanceId;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- set PvPvE players' run lockout when they enter the instance
- persist instance id on entry if missing to align with lockout tracking

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69215feacb908327b1328ab69fa6aee4)