### PR TITLE
Handle orphaned account bank sessions on login

### DIFF
--- a/src/server/game/Accounts/AccountBankMgr.cpp
+++ b/src/server/game/Accounts/AccountBankMgr.cpp
@@ -636,6 +636,7 @@ void HandleLogin(Player* player)
     if (!session)
         return;
 
+    SaveAccountBankView(player);
     RestoreCharacterBankItems(player, *session);
     AccountSessions.erase(player->GetGUID().GetCounter());
 }

--- a/src/server/game/Accounts/AccountBankMgr.cpp
+++ b/src/server/game/Accounts/AccountBankMgr.cpp
@@ -624,8 +624,19 @@ void UpdateAccountBankSessions()
         ObjectGuid guid = ObjectGuid::Create<HighGuid::Player>(guidLow);
         if (Player* player = ObjectAccessor::FindPlayer(guid))
             UpdateAccountBankSession(player);
-        else
-            AccountSessions.erase(guidLow);
     }
+}
+
+void HandleLogin(Player* player)
+{
+    if (!player)
+        return;
+
+    SessionState* session = GetSession(player);
+    if (!session)
+        return;
+
+    RestoreCharacterBankItems(player, *session);
+    AccountSessions.erase(player->GetGUID().GetCounter());
 }
 }

--- a/src/server/game/Accounts/AccountBankMgr.h
+++ b/src/server/game/Accounts/AccountBankMgr.h
@@ -43,6 +43,7 @@ namespace AccountBank
     void CloseAccountBank(Player* player);
     void UpdateAccountBankSession(Player* player);
     void UpdateAccountBankSessions();
+    void HandleLogin(Player* player);
     bool IsAccountBankOpen(Player const* player);
     bool IsAccountBanker(Player const* player, ObjectGuid bankerGuid);
 }

--- a/src/server/scripts/Custom/npc_account_banker.cpp
+++ b/src/server/scripts/Custom/npc_account_banker.cpp
@@ -61,6 +61,11 @@ class account_bank_player_script : public PlayerScript
 public:
     account_bank_player_script() : PlayerScript("account_bank_player_script") { }
 
+    void OnLogin(Player* player) override
+    {
+        AccountBank::HandleLogin(player);
+    }
+
     void OnLogout(Player* player) override
     {
         AccountBank::CloseAccountBank(player);


### PR DESCRIPTION
## Summary
- add an account bank login handler to restore any lingering session data
- keep account bank sessions open until the player returns instead of dropping stored items

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921603ec5448327aad0e058cad1ec51)