### PR TITLE
Verify starfire movement speed after cast start

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22567,7 +22567,8 @@ void Player::VerifyStarfireSnare()
 
     for (UnitMoveType moveType : StarfireSnareMoveTypes)
     {
-        if (GetSpeedRate(moveType) > desiredRate)
+        float const allowedSpeed = desiredRate * playerBaseMoveSpeed[moveType];
+        if (GetSpeedRate(moveType) > desiredRate || GetSpeed(moveType) > allowedSpeed)
         {
             ApplyActiveStarfireSnare();
             return;


### PR DESCRIPTION
## Summary
- add a movement-speed sanity check for Starfire snares one update after casting begins
- clamp players back to the Starfire snare limit if actual movement exceeds the allowed speed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922362418748327a9bee05a29d281dd)