### PR TITLE
Preserve paladin auras when entering arenas

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4290,6 +4290,11 @@ void Unit::RemoveArenaAuras()
         if (aura->GetSpellInfo()->GetSpellSpecific() == SPELL_SPECIFIC_AURA)
             return false;
 
+        // Paladin class auras might miss SpellSpecific classification in some data sets,
+        // keep them explicitly
+        if (aura->GetSpellInfo()->SpellFamilyName == SPELLFAMILY_PALADIN && (aura->GetSpellInfo()->SpellFamilyFlags[2] & 0x00000020))
+            return false;
+
         return (!aura->GetSpellInfo()->HasAttribute(SPELL_ATTR4_DONT_REMOVE_IN_ARENA)                          // don't remove stances, shadowform, pally/hunter auras
             && !aura->IsPassive()                                                                              // don't remove passive auras
             && (aurApp->IsPositive() || !aura->GetSpellInfo()->HasAttribute(SPELL_ATTR3_DEATH_PERSISTENT))) || // not negative death persistent auras


### PR DESCRIPTION
## Summary
- prevent paladin auras from being stripped when entering arenas by explicitly exempting them in arena aura removal

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692240b0911483279f3b31178469d7c3)