### PR TITLE
Handle attack stop when taunted without target

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5785,12 +5785,22 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
 
 bool Unit::AttackStop()
 {
-    if (!m_attacking && !HasAuraType(SPELL_AURA_MOD_TAUNT))
-        return false;
-
     Unit* victim = m_attacking;
 
-    m_attacking->_removeAttacker(this);
+    if (!victim)
+    {
+        if (!HasAuraType(SPELL_AURA_MOD_TAUNT))
+            return false;
+
+        // Nothing to detach but still clear any residual attack state
+        SetTarget(ObjectGuid::Empty);
+        ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
+        InterruptSpell(CURRENT_MELEE_SPELL);
+        SendMeleeAttackStop();
+        return true;
+    }
+
+    victim->_removeAttacker(this);
     m_attacking = nullptr;
 
     // Clear our target


### PR DESCRIPTION
## Summary
- guard Unit::AttackStop against null m_attacking when taunted to avoid crashes
- clear attack state and notify client even when stopping without a target

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a17f5bd88327a96107fe026e9581)