### PR TITLE
Prevent Stockades bosses from evading when unreachable

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3520,6 +3520,9 @@ float Creature::GetPetChaseDistance() const
 
 void Creature::SetCannotReachTarget(bool cannotReach)
 {
+    if (cannotReach && GetMapId() == 34)
+        return;
+
     if (cannotReach == m_cannotReachTarget)
         return;
     m_cannotReachTarget = cannotReach;


### PR DESCRIPTION
## Summary
- avoid setting the cannot-reach target flag for Stockades creatures so they stay engaged
- prevents unintended evasion, missed attacks, and regeneration when kited in the Stockades

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692286b8ca18832782d9c2e08583a0d3)