### PR TITLE
Close account bank before saving player data

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -19678,6 +19678,9 @@ void Player::SaveToDB(CharacterDatabaseTransaction trans, bool create /* = false
     // delay auto save at any saves (manual, in code, or autosave)
     m_nextSave = sWorld->getIntConfig(CONFIG_INTERVAL_SAVE);
 
+    if (AccountBank::IsAccountBankOpen(this))
+        AccountBank::CloseAccountBank(this);
+
     //lets allow only players in world to be saved
     if (IsBeingTeleportedFar())
     {

--- a/src/server/game/Handlers/BankHandler.cpp
+++ b/src/server/game/Handlers/BankHandler.cpp
@@ -192,7 +192,10 @@ void WorldSession::HandleBuyBankSlotOpcode(WorldPackets::Bank::BuyBankSlot& buyB
 void WorldSession::SendShowBank(ObjectGuid guid)
 {
     if (_player && AccountBank::IsAccountBankOpen(_player) && !AccountBank::IsAccountBanker(_player, guid))
+    {
         AccountBank::CloseAccountBank(_player);
+        SendNotification("Switched back to your personal bank.");
+    }
 
     m_currentBankerGUID = guid;
     WorldPackets::Bank::ShowBank packet;


### PR DESCRIPTION
## Summary
- close any active account bank session before persisting player data to avoid account items being written into character banks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922bdc1bf7c83279db21740a428000d)