### PR TITLE
Run warrior disarm wrapper on effect hit

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -978,21 +978,24 @@ class spell_warr_disarm_wrapper : public SpellScript
 {
     PrepareSpellScript(spell_warr_disarm_wrapper);
 
-    void HandleDummy()
+    void HandleDummy(SpellEffIndex /*effIndex*/)
     {
-        AuraApplication* aa = GetCaster()->GetAuraApplication(81491);
-        if (aa)
+        if (Unit* target = GetHitUnit())
         {
-            GetCaster()->CastSpell(GetExplTargetUnit(), 81493, true);
-        }
-        else
-        {
-            GetCaster()->CastSpell(GetExplTargetUnit(), 676, true);
+            AuraApplication* aa = GetCaster()->GetAuraApplication(81491);
+            if (aa)
+            {
+                GetCaster()->CastSpell(target, 81493, true);
+            }
+            else
+            {
+                GetCaster()->CastSpell(target, 676, true);
+            }
         }
     }
     void Register() override
     {
-        AfterCast += SpellCastFn(spell_warr_disarm_wrapper::HandleDummy);
+        OnEffectHitTarget += SpellEffectFn(spell_warr_disarm_wrapper::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
     }
 };
 


### PR DESCRIPTION
**Changes proposed**:

- Trigger the warrior disarm wrapper only when the spell effect hits its target instead of after casting
- Cast follow-up disarm spells on the actual hit unit based on the caster's aura state

**Target branch(es)**: 335/6x

**Issues addressed**: N/A

**Tests performed**: Not run (not requested)

**Known issues and TODO list**:

- [ ] None

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692355060a1c8327921ad16121baeca5)