### PR TITLE
Add reset command to keep mount and quest spells

### DIFF
--- a/src/server/game/Accounts/RBAC.h
+++ b/src/server/game/Accounts/RBAC.h
@@ -583,6 +583,7 @@ enum RBACPermissions
     RBAC_PERM_COMMAND_RESET_STATS                            = 715,
     RBAC_PERM_COMMAND_RESET_TALENTS                          = 716,
     RBAC_PERM_COMMAND_RESET_ALL                              = 717,
+    RBAC_PERM_COMMAND_RESET_SPELLS_KEEP_MOUNTS               = 883,
     RBAC_PERM_COMMAND_SERVER                                 = 718,
     RBAC_PERM_COMMAND_SERVER_CORPSES                         = 719,
     RBAC_PERM_COMMAND_SERVER_EXIT                            = 720,

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -17,6 +17,7 @@
 
 #include "Player.h"
 #include <algorithm>
+#include <unordered_set>
 #include "AccountMgr.h"
 #include "AccountBankMgr.h"
 #include "AchievementMgr.h"
@@ -23593,6 +23594,59 @@ void Player::ResetSpells(bool myClassOnly)
     LearnDefaultSkills();
     LearnCustomSpells();
     LearnQuestRewardedSpells();
+}
+
+void Player::ResetNonQuestAndMountSpells()
+{
+    if (HasAtLoginFlag(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS))
+        RemoveAtLoginFlag(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS, true);
+
+    PlayerSpellMap spells = GetSpellMap();
+    std::unordered_set<uint32> preservedSpells;
+
+    // Preserve mount spells
+    for (PlayerSpellMap::const_iterator itr = spells.begin(); itr != spells.end(); ++itr)
+    {
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itr->first);
+        if (!spellInfo)
+            continue;
+
+        if (spellInfo->HasAura(SPELL_AURA_MOUNTED))
+            preservedSpells.insert(itr->first);
+    }
+
+    // Preserve spells rewarded by completed quests
+    for (RewardedQuestSet::const_iterator itr = m_RewardedQuests.begin(); itr != m_RewardedQuests.end(); ++itr)
+    {
+        Quest const* quest = sObjectMgr->GetQuestTemplate(*itr);
+        if (!quest)
+            continue;
+
+        int32 rewardSpellId = quest->GetRewSpellCast();
+        if (rewardSpellId <= 0)
+            continue;
+
+        SpellInfo const* rewardSpellInfo = sSpellMgr->GetSpellInfo(rewardSpellId);
+        if (!rewardSpellInfo)
+            continue;
+
+        for (SpellEffectInfo const& spellEffectInfo : rewardSpellInfo->GetEffects())
+        {
+            if (spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL) && spellEffectInfo.TriggerSpell)
+                preservedSpells.insert(uint32(spellEffectInfo.TriggerSpell));
+        }
+    }
+
+    for (PlayerSpellMap::const_iterator itr = spells.begin(); itr != spells.end(); ++itr)
+    {
+        if (preservedSpells.find(itr->first) != preservedSpells.end())
+            continue;
+
+        RemoveSpell(itr->first, false, false);
+    }
+
+    ResetTalents(true);
+    SetAtLoginFlag(AT_LOGIN_RESET_TALENTS);
 }
 
 void Player::LearnCustomSpells()

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -469,6 +469,7 @@ enum AtLoginFlags
     AT_LOGIN_CHANGE_FACTION    = 0x040,
     AT_LOGIN_CHANGE_RACE       = 0x080,
     AT_LOGIN_RESURRECT         = 0x100,
+    AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS = 0x200,
 };
 
 typedef std::map<uint32, QuestStatusData> QuestStatusMap;
@@ -1460,6 +1461,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void LearnSpell(uint32 spell_id, bool dependent, uint32 fromSkill = 0);
         void RemoveSpell(uint32 spell_id, bool disabled = false, bool learn_low_rank = true);
         void ResetSpells(bool myClassOnly = false);
+        void ResetNonQuestAndMountSpells();
         void LearnCustomSpells();
         void LearnDefaultSkills();
         void LearnDefaultSkill(uint32 skillId, uint16 rank);

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -938,6 +938,15 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
         pCurrChar->SetContestedPvP();
 
     // Apply at_login requests
+    bool handledTalentReset = false;
+    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS))
+    {
+        pCurrChar->ResetNonQuestAndMountSpells();
+        SendNotification(LANG_RESET_SPELLS);
+        SendNotification(LANG_RESET_TALENTS);
+        handledTalentReset = true;
+    }
+
     if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS))
     {
         pCurrChar->ResetSpells();
@@ -946,9 +955,15 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
 
     if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_TALENTS))
     {
-        pCurrChar->ResetTalents(true);
+        if (!handledTalentReset)
+        {
+            pCurrChar->ResetTalents(true);
+            SendNotification(LANG_RESET_TALENTS);
+        }
+        else
+            pCurrChar->RemoveAtLoginFlag(AT_LOGIN_RESET_TALENTS, true);
+
         pCurrChar->SendTalentsInfoData(false);              // original talents send already in to SendInitialPacketsBeforeAddToMap, resend reset state
-        SendNotification(LANG_RESET_TALENTS);
     }
 
     bool firstLogin = pCurrChar->HasAtLoginFlag(AT_LOGIN_FIRST);

--- a/src/server/scripts/Commands/cs_reset.cpp
+++ b/src/server/scripts/Commands/cs_reset.cpp
@@ -52,6 +52,7 @@ public:
             { "honor",        rbac::RBAC_PERM_COMMAND_RESET_HONOR,        true, &HandleResetHonorCommand,        "" },
             { "level",        rbac::RBAC_PERM_COMMAND_RESET_LEVEL,        true, &HandleResetLevelCommand,        "" },
             { "spells",       rbac::RBAC_PERM_COMMAND_RESET_SPELLS,       true, &HandleResetSpellsCommand,       "" },
+            { "spells_keep_mounts", rbac::RBAC_PERM_COMMAND_RESET_SPELLS_KEEP_MOUNTS, true, &HandleResetSpellsKeepMountsCommand, "" },
             { "stats",        rbac::RBAC_PERM_COMMAND_RESET_STATS,        true, &HandleResetStatsCommand,        "" },
             { "talents",      rbac::RBAC_PERM_COMMAND_RESET_TALENTS,      true, &HandleResetTalentsCommand,      "" },
             { "all",          rbac::RBAC_PERM_COMMAND_RESET_ALL,          true, &HandleResetAllCommand,          "" },
@@ -187,6 +188,36 @@ public:
 
             handler->PSendSysMessage(LANG_RESET_SPELLS_OFFLINE, targetName.c_str());
         }
+
+        return true;
+    }
+
+    static bool HandleResetSpellsKeepMountsCommand(ChatHandler* handler, char const* args)
+    {
+        Player* target;
+        ObjectGuid targetGuid;
+        std::string targetName;
+        if (!handler->extractPlayerTarget((char*)args, &target, &targetGuid, &targetName))
+            return false;
+
+        if (target)
+        {
+            target->ResetNonQuestAndMountSpells();
+            target->SendTalentsInfoData(false);
+            ChatHandler(target->GetSession()).SendSysMessage("Removed all non-mount, non-quest spells and reset talents.");
+
+            if (!handler->GetSession() || handler->GetSession()->GetPlayer() != target)
+                handler->PSendSysMessage("Cleaned non-mount, non-quest spells and talents for %s.", handler->GetNameLink(target).c_str());
+
+            return true;
+        }
+
+        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ADD_AT_LOGIN_FLAG);
+        stmt->setUInt16(0, uint16(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS | AT_LOGIN_RESET_TALENTS));
+        stmt->setUInt32(1, targetGuid.GetCounter());
+        CharacterDatabase.Execute(stmt);
+
+        handler->PSendSysMessage("Cleaned non-mount, non-quest spells and talents for %s at next login.", targetName.c_str());
 
         return true;
     }


### PR DESCRIPTION
## Summary
- add a GM reset command that removes all non-mount, non-quest spells and clears talents
- support a new at-login flag so the operation can be triggered from the database
- ensure the custom reset runs automatically on login and avoids duplicate talent resets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237bc2afe883278b9f230d59c8afaa)