### PR TITLE
Adjust Darkness talent dispel GCD bonus

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -757,6 +757,28 @@ void SpellHistory::ReduceGlobalCooldown(SpellInfo const* spellInfo, std::chrono:
     player->SendDirectMessage(&data);
 }
 
+void SpellHistory::ClampGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds duration)
+{
+    if (!spellInfo || !spellInfo->StartRecoveryCategory || duration.count() <= 0)
+        return;
+
+    auto gcdItr = _globalCooldowns.find(spellInfo->StartRecoveryCategory);
+    if (gcdItr == _globalCooldowns.end())
+        return;
+
+    Clock::time_point now = GameTime::GetSystemTime();
+    Clock::time_point currentEnd = gcdItr->second;
+    if (currentEnd <= now)
+        return;
+
+    Clock::time_point desiredEnd = now + std::chrono::duration_cast<Clock::duration>(duration);
+    if (currentEnd > desiredEnd)
+    {
+        auto reduction = std::chrono::duration_cast<std::chrono::milliseconds>(currentEnd - desiredEnd);
+        ReduceGlobalCooldown(spellInfo, reduction);
+    }
+}
+
 Player* SpellHistory::GetPlayerOwner() const
 {
     return _owner->GetCharmerOrOwnerPlayerOrPlayerItself();

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -131,6 +131,7 @@ public:
     void AddGlobalCooldown(SpellInfo const* spellInfo, uint32 duration);
     void CancelGlobalCooldown(SpellInfo const* spellInfo);
     void ReduceGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds reduction);
+    void ClampGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds duration);
 
     void BuildCooldownPacket(WorldPacket& data, uint8 flags, uint32 spellId, uint32 cooldown) const;
 

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -34,6 +34,8 @@
 #include "SpellScript.h"
 #include "TemporarySummon.h"
 #include "SpellHistory.h"
+#include <algorithm>
+#include <chrono>
 
 enum PriestSpells
 {
@@ -82,7 +84,8 @@ enum PriestSpells
     SPELL_PRIEST_SPIRIT_DURATION_INCREASE_R1        = 81322,
     SPELL_PRIEST_SPIRIT_DURATION_INCREASE_R2        = 81323,
     SPELL_PRIEST_SPIRIT_OF_REDEMPTION               = 27827,
-    SPELL_PRIEST_VAMPIRIC_EMBRACE_MANA              = 81356
+    SPELL_PRIEST_VAMPIRIC_EMBRACE_MANA              = 81356,
+    SPELL_PRIEST_DARKNESS_R1                        = 15259
 };
 
 enum PriestSpellIcons
@@ -1491,7 +1494,7 @@ class spell_pri_dispel_magic : public SpellScript
 
     bool Validate(SpellInfo const* spellInfo) override
     {
-        return true;
+        return ValidateSpellInfo({ SPELL_PRIEST_DARKNESS_R1 });
     }
 
     void HandleSuccessfulDispel(SpellEffIndex effIndex)
@@ -1512,6 +1515,14 @@ class spell_pri_dispel_magic : public SpellScript
         {
             CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
             caster->CastSpell(caster, 81436, args);
+        }
+
+        if (AuraEffect const* darkness = caster->GetAuraEffectOfRankedSpell(SPELL_PRIEST_DARKNESS_R1, EFFECT_0))
+        {
+            uint32 const rank = std::max<uint32>(1, darkness->GetSpellInfo()->GetRank());
+            uint32 const baseRecoveryTime = GetSpellInfo()->StartRecoveryTime ? GetSpellInfo()->StartRecoveryTime : 1500;
+            uint32 const desiredGcd = baseRecoveryTime > 50 * rank ? baseRecoveryTime - 50 * rank : 0;
+            caster->GetSpellHistory()->ClampGlobalCooldown(GetSpellInfo(), std::chrono::milliseconds(desiredGcd));
         }
     }
 


### PR DESCRIPTION
## Summary
- apply the dispel global cooldown reduction through the Darkness talent ranks
- scale the clamped global cooldown by the Darkness rank instead of a fixed aura

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692380fff1b083279dbd68be974ac539)