### PR TITLE
Fix mail sending to deduct gold

### DIFF
--- a/src/server/game/Handlers/MailHandler.cpp
+++ b/src/server/game/Handlers/MailHandler.cpp
@@ -134,13 +134,11 @@ void WorldSession::HandleSendMail(WorldPackets::Mail::SendMail& sendMail)
         if (_player != player)
             return;
 
-        /*
         if (!player->HasEnoughMoney(reqmoney) && !player->IsGameMaster())
         {
             player->SendMailResult(0, MAIL_SEND, MAIL_ERR_NOT_ENOUGH_MONEY);
             return;
         }
-        */
 
         // do not allow to have more than 100 mails in mailbox.. mails count is in opcode uint8!!! - so max can be 255..
         if (mailsCount > 100)
@@ -233,7 +231,8 @@ void WorldSession::HandleSendMail(WorldPackets::Mail::SendMail& sendMail)
 
         player->SendMailResult(0, MAIL_SEND, MAIL_OK);
 
-        //player->ModifyMoney(-int32(reqmoney));
+        if (!player->IsGameMaster())
+            player->ModifyMoney(-int32(reqmoney));
         player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_GOLD_SPENT_FOR_MAIL, cost);
 
         bool needItemDelay = false;


### PR DESCRIPTION
## Summary
- check players have enough gold before sending mail
- deduct postage and attached money when successfully sending mail

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692391d739388327acc72b063327cf43)