### PR TITLE
Prevent movement control while taunted

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11756,6 +11756,10 @@ void Unit::SetTaunted(bool apply)
 {
     if (apply)
     {
+        // block control to real player in control (e.g. charmer)
+        if (GetCharmerOrSelfPlayer())
+            GetCharmerOrSelfPlayer()->SetClientControl(this, false);
+
         Unit* caster = nullptr;
         Unit::AuraEffectList const& tauntAuras = GetAuraEffectsByType(SPELL_AURA_MOD_TAUNT);
         if (!tauntAuras.empty())
@@ -11786,6 +11790,10 @@ void Unit::SetTaunted(bool apply)
             if (GetVictim())
                 SetTarget(EnsureVictim()->GetGUID());
         }
+
+        // allow control to real player in control (e.g. charmer)
+        if (GetCharmerOrSelfPlayer())
+            GetCharmerOrSelfPlayer()->SetClientControl(this, true);
     }
 }
 


### PR DESCRIPTION
## Summary
- block player control while taunt is active so victims are forced to chase their taunter
- restore client control when taunt ends

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239b6d814883279cfa8b4569821740)