### PR TITLE
Handle taunt-type fear auras via taunt logic

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2872,6 +2872,15 @@ void AuraEffect::HandleModFear(AuraApplication const* aurApp, uint8 mode, bool a
     if (!(mode & AURA_EFFECT_HANDLE_REAL))
         return;
 
+    if (SpellInfo const* spellInfo = GetSpellInfo())
+    {
+        if (spellInfo->HasEffect(SPELL_EFFECT_ATTACK_ME))
+        {
+            HandleModTaunt(aurApp, mode, apply);
+            return;
+        }
+    }
+
     Unit* target = aurApp->GetTarget();
 
     target->SetControlled(apply, UNIT_STATE_FLEEING);


### PR DESCRIPTION
## Summary
- route fear aura handlers to taunt logic when the spell also uses ATTACK_ME

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239cd93b44832784fbb933f58ab23f)