### PR TITLE
Clear fleeing flag when chase/follow end

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -249,6 +249,8 @@ void ChaseMovementGenerator::Deactivate(Unit* owner)
 {
     AddFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
+    if (owner)
+        owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
     owner->ClearUnitState(UNIT_STATE_CHASE_MOVE);
     if (Creature* cOwner = owner->ToCreature())
         cOwner->SetCannotReachTarget(false);
@@ -259,6 +261,8 @@ void ChaseMovementGenerator::Finalize(Unit* owner, bool active, bool/* movementI
     AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
     if (active)
     {
+        if (owner)
+            owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
         owner->ClearUnitState(UNIT_STATE_CHASE_MOVE);
         if (Creature* cOwner = owner->ToCreature())
             cOwner->SetCannotReachTarget(false);

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -82,6 +82,8 @@ void FollowMovementGenerator::Deactivate(Unit* owner)
 {
     AddFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
+    if (owner)
+        owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
     owner->ClearUnitState(UNIT_STATE_FOLLOW_MOVE);
 }
 
@@ -90,6 +92,8 @@ void FollowMovementGenerator::Finalize(Unit* owner, bool active, bool/* movement
     AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
     if (active)
     {
+        if (owner)
+            owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
         owner->ClearUnitState(UNIT_STATE_FOLLOW_MOVE);
         UpdatePetSpeed(owner);
     }


### PR DESCRIPTION
## Summary
- remove lingering fleeing unit flag when chase or follow movement generators finish
- prevent players from staying marked as fleeing after follow-fear auras expire

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923cf8a7ff883278e9bf9fb8e284e08)