### PR TITLE
Treat attack-me fears as taunt follow

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5789,7 +5789,7 @@ bool Unit::AttackStop()
 
     if (!victim)
     {
-        if (!HasAuraType(SPELL_AURA_MOD_TAUNT))
+        if (!IsTaunted())
             return false;
 
         // Nothing to detach but still clear any residual attack state
@@ -11464,9 +11464,20 @@ bool Unit::InitTamedPet(Pet* pet, uint8 level, uint32 spell_id)
         }
     }
 }
+bool Unit::HasAttackMeFearAura() const
+{
+    Unit::AuraEffectList const& fearAuras = GetAuraEffectsByType(SPELL_AURA_MOD_FEAR);
+
+    for (AuraEffect const* aurEff : fearAuras)
+        if (aurEff->GetSpellInfo()->HasEffect(SPELL_EFFECT_ATTACK_ME))
+            return true;
+
+    return false;
+}
+
 bool Unit::IsTaunted()
 {
-    return HasAuraType(SPELL_AURA_MOD_TAUNT);
+    return HasAttackMeFearAura() || HasUnitFlag(UNIT_FLAG_TAUNTED) || HasUnitState(UNIT_STATE_TAUNTED);
 }
 void Unit::SetControlled(bool apply, UnitState state)
 {
@@ -11552,7 +11563,7 @@ void Unit::SetControlled(bool apply, UnitState state)
                 break;
 
             case UNIT_STATE_TAUNTED:
-                if (HasAuraType(SPELL_AURA_MOD_TAUNT))
+                if (HasAttackMeFearAura())
                     return;
                 ClearUnitState(state);
                 SetTaunted(false);
@@ -11580,7 +11591,7 @@ void Unit::ApplyControlStatesIfNeeded()
     if (HasUnitState(UNIT_STATE_FLEEING) || HasAuraType(SPELL_AURA_MOD_FEAR))
         SetFeared(true);
 
-    if (HasUnitState(UNIT_STATE_TAUNTED) || HasAuraType(SPELL_AURA_MOD_TAUNT))
+    if (HasUnitState(UNIT_STATE_TAUNTED) || HasAttackMeFearAura())
         SetTaunted(true);
 }
 
@@ -11746,9 +11757,15 @@ void Unit::SetTaunted(bool apply)
             GetCharmerOrSelfPlayer()->SetClientControl(this, false);
 
         Unit* caster = nullptr;
-        Unit::AuraEffectList const& tauntAuras = GetAuraEffectsByType(SPELL_AURA_MOD_TAUNT);
-        if (!tauntAuras.empty())
-            caster = ObjectAccessor::GetUnit(*this, tauntAuras.front()->GetCasterGUID());
+        Unit::AuraEffectList const& fearAuras = GetAuraEffectsByType(SPELL_AURA_MOD_FEAR);
+        for (AuraEffect const* aurEff : fearAuras)
+        {
+            if (!aurEff->GetSpellInfo()->HasEffect(SPELL_EFFECT_ATTACK_ME))
+                continue;
+
+            caster = ObjectAccessor::GetUnit(*this, aurEff->GetCasterGUID());
+            break;
+        }
         if (!caster)
             caster = getAttackerForHelper();
 
@@ -11765,6 +11782,9 @@ void Unit::SetTaunted(bool apply)
             CastStop();
             Attack(caster, true);
         }
+
+        RemoveUnitFlag(UNIT_FLAG_FLEEING);
+        SetUnitFlag(UNIT_FLAG_TAUNTED);
     }
     else
     {
@@ -11775,6 +11795,7 @@ void Unit::SetTaunted(bool apply)
             if (GetVictim())
                 SetTarget(EnsureVictim()->GetGUID());
         }
+        RemoveUnitFlag(UNIT_FLAG_TAUNTED);
         // allow control to real player in control (eg charmer)
         if (GetCharmerOrSelfPlayer())
             GetCharmerOrSelfPlayer()->SetClientControl(this, true);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1287,6 +1287,7 @@ class TC_GAME_API Unit : public WorldObject
         bool IsCharmed() const { return !GetCharmerGUID().IsEmpty(); }
         bool IsCharming() const { return !GetCharmedGUID().IsEmpty(); }
         bool isPossessed() const { return HasUnitState(UNIT_STATE_POSSESSED); }
+        bool HasAttackMeFearAura() const;
         bool IsTaunted();
         bool isPossessedByPlayer() const;
         bool isPossessing() const;

--- a/src/server/game/Handlers/CombatHandler.cpp
+++ b/src/server/game/Handlers/CombatHandler.cpp
@@ -63,6 +63,15 @@ void WorldSession::HandleAttackSwingOpcode(WorldPackets::Combat::AttackSwing& pa
 
 void WorldSession::HandleAttackStopOpcode(WorldPackets::Combat::AttackStop& /*packet*/)
 {
+    if (GetPlayer()->IsTaunted())
+    {
+        if (Unit* tauntTarget = ObjectAccessor::GetUnit(*_player, GetPlayer()->GetTarget()))
+        {
+            if (GetPlayer()->IsValidAttackTarget(tauntTarget))
+                return;
+        }
+    }
+
     GetPlayer()->AttackStop();
 }
 

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -472,6 +472,16 @@ void WorldSession::HandleSetSelectionOpcode(WorldPacket& recvData)
     ObjectGuid guid;
     recvData >> guid;
 
+    if (_player->IsTaunted())
+    {
+        ObjectGuid const tauntTarget = _player->GetTarget();
+        if (!tauntTarget.IsEmpty() && tauntTarget != guid)
+        {
+            _player->SetSelection(tauntTarget);
+            return;
+        }
+    }
+
     _player->SetSelection(guid);
 }
 

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -84,7 +84,14 @@ void ChaseMovementGenerator::Initialize(Unit* owner)
         return;
 
     // TODO: UNIT_FIELD_FLAGS should not be handled by generators
-    owner->SetUnitFlag(UNIT_FLAG_FLEEING);
+    owner->RemoveUnitFlag(UNIT_FLAG_TAUNTED);
+    if (owner->HasAttackMeFearAura())
+    {
+        owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
+        owner->SetUnitFlag(UNIT_FLAG_TAUNTED);
+    }
+    else
+        owner->SetUnitFlag(UNIT_FLAG_FLEEING);
 
     _path = nullptr;
     _lastTargetPosition.reset();
@@ -249,6 +256,8 @@ void ChaseMovementGenerator::Deactivate(Unit* owner)
 {
     AddFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
+    if (owner)
+        owner->RemoveUnitFlag(UNIT_FLAG_FLEEING | UNIT_FLAG_TAUNTED);
     owner->ClearUnitState(UNIT_STATE_CHASE_MOVE);
     if (Creature* cOwner = owner->ToCreature())
         cOwner->SetCannotReachTarget(false);
@@ -259,6 +268,8 @@ void ChaseMovementGenerator::Finalize(Unit* owner, bool active, bool/* movementI
     AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
     if (active)
     {
+        if (owner)
+            owner->RemoveUnitFlag(UNIT_FLAG_FLEEING | UNIT_FLAG_TAUNTED);
         owner->ClearUnitState(UNIT_STATE_CHASE_MOVE);
         if (Creature* cOwner = owner->ToCreature())
             cOwner->SetCannotReachTarget(false);

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -82,6 +82,8 @@ void FollowMovementGenerator::Deactivate(Unit* owner)
 {
     AddFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
+    if (owner)
+        owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
     owner->ClearUnitState(UNIT_STATE_FOLLOW_MOVE);
 }
 
@@ -90,6 +92,8 @@ void FollowMovementGenerator::Finalize(Unit* owner, bool active, bool/* movement
     AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
     if (active)
     {
+        if (owner)
+            owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
         owner->ClearUnitState(UNIT_STATE_FOLLOW_MOVE);
         UpdatePetSpeed(owner);
     }

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -55,7 +55,7 @@ namespace
 
         uint32 const followFearSpellId = 83257;
 
-        if (spellInfo->Id == followFearSpellId)
+        if (spellInfo->HasEffect(SPELL_EFFECT_ATTACK_ME) || spellInfo->Id == followFearSpellId)
             return true;
 
         SpellSpellGroupMapBounds followFearGroups = sSpellMgr->GetSpellSpellGroupMapBounds(followFearSpellId);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6605,7 +6605,7 @@ SpellCastResult Spell::CheckCasterAuras(uint32* param1) const
         else if ((m_spellInfo->Mechanic & MECHANIC_IMMUNE_SHIELD) && m_caster->ToUnit() && m_caster->ToUnit()->HasAuraWithMechanic(1 << MECHANIC_BANISH))
             result = SPELL_FAILED_STUNNED;
     }
-    else if (unitCaster->HasAuraType(SPELL_AURA_MOD_TAUNT) && !CheckSpellCancelsTaunt(param1))
+    else if (taunted && !CheckSpellCancelsTaunt(param1))
         result = SPELL_FAILED_CHARMED;
     else if (unitflag & UNIT_FLAG_SILENCED && m_spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE && !CheckSpellCancelsSilence(param1))
         result = SPELL_FAILED_SILENCED;
@@ -6680,7 +6680,34 @@ bool Spell::CheckSpellCancelsCharm(uint32* param1) const
 
 bool Spell::CheckSpellCancelsTaunt(uint32* param1) const
 {
-    return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_TAUNT, param1);
+    Unit* unitCaster = (m_originalCaster ? m_originalCaster : m_caster->ToUnit());
+    if (!unitCaster)
+        return false;
+
+    Unit::AuraEffectList const& fearAuras = unitCaster->GetAuraEffectsByType(SPELL_AURA_MOD_FEAR);
+    bool hasAttackMeFear = false;
+
+    for (AuraEffect const* aurEff : fearAuras)
+    {
+        if (!aurEff->GetSpellInfo()->HasEffect(SPELL_EFFECT_ATTACK_ME))
+            continue;
+
+        hasAttackMeFear = true;
+
+        if (m_spellInfo->SpellCancelsAuraEffect(aurEff))
+            continue;
+
+        if (param1)
+        {
+            *param1 = aurEff->GetSpellEffectInfo().Mechanic;
+            if (!*param1)
+                *param1 = aurEff->GetSpellInfo()->Mechanic;
+        }
+
+        return false;
+    }
+
+    return !hasAttackMeFear;
 }
 
 bool Spell::CheckSpellCancelsStun(uint32* param1) const


### PR DESCRIPTION
## Summary
- treat fear auras that include an Attack Me effect as follow-fear taunts instead of relying on taunt auras
- base taunt detection, chase initialization, and casting restrictions on these attack-me fears and taunt flags
- limit taunt-cancel checks to fear auras with Attack Me so normal fears remain unaffected

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923cf8a7ff883278e9bf9fb8e284e08)