### PR TITLE
Stop movement when follow fear ends

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2913,7 +2913,10 @@ void AuraEffect::HandleModFear(AuraApplication const* aurApp, uint8 mode, bool a
         else
         {
             if (target->IsAlive())
+            {
                 target->GetMotionMaster()->Remove(CHASE_MOTION_TYPE);
+                target->StopMoving();
+            }
 
             if (target->HasAuraType(SPELL_AURA_MOD_FEAR))
                 target->SetControlled(true, UNIT_STATE_FLEEING);


### PR DESCRIPTION
## Summary
- stop chase movement for follow-fear spells by removing the chase generator and halting movement when the effect ends
- ensure players regain control immediately after follow-fear effects are removed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ec1468148327840addd3b3e408f5)