### PR TITLE
Avoid fleeing flag for non-player chase units

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -82,7 +82,11 @@ void ChaseMovementGenerator::Initialize(Unit* owner)
 
     if (!owner || !owner->IsAlive())
         return;
-    owner->SetUnitFlag(UNIT_FLAG_FLEEING);
+
+    if (owner->GetTypeId() == TYPEID_PLAYER)
+        owner->SetUnitFlag(UNIT_FLAG_FLEEING);
+    else
+        owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
 
     _path = nullptr;
     _lastTargetPosition.reset();


### PR DESCRIPTION
## Summary
- prevent chase movement from applying the fleeing unit flag to creatures
- clear any existing fleeing flag when non-player units initialize chase movement

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f18a8ff48327a3a3e5db7ffeabe4)