### PR TITLE
Send Darkness dispel GCD reduction to client

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -648,6 +648,22 @@ void SpellHistory::CancelGlobalCooldown(SpellInfo const* spellInfo)
     _globalCooldowns[spellInfo->StartRecoveryCategory] = Clock::time_point(Clock::duration(0));
 }
 
+uint32 SpellHistory::GetRemainingGlobalCooldown(SpellInfo const* spellInfo) const
+{
+    if (!spellInfo || !spellInfo->StartRecoveryCategory)
+        return 0;
+
+    auto itr = _globalCooldowns.find(spellInfo->StartRecoveryCategory);
+    if (itr == _globalCooldowns.end())
+        return 0;
+
+    Clock::time_point now = GameTime::GetSystemTime();
+    if (itr->second <= now)
+        return 0;
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(itr->second - now).count();
+}
+
 void SpellHistory::ReduceGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds reduction)
 {
     if (!spellInfo || !spellInfo->StartRecoveryCategory || !spellInfo->StartRecoveryTime || reduction.count() <= 0)
@@ -755,6 +771,28 @@ void SpellHistory::ReduceGlobalCooldown(SpellInfo const* spellInfo, std::chrono:
     WorldPacket data;
     BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_INCLUDE_GCD, gcdUpdates);
     player->SendDirectMessage(&data);
+}
+
+void SpellHistory::ClampGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds duration)
+{
+    if (!spellInfo || !spellInfo->StartRecoveryCategory || duration.count() <= 0)
+        return;
+
+    auto gcdItr = _globalCooldowns.find(spellInfo->StartRecoveryCategory);
+    if (gcdItr == _globalCooldowns.end())
+        return;
+
+    Clock::time_point now = GameTime::GetSystemTime();
+    Clock::time_point currentEnd = gcdItr->second;
+    if (currentEnd <= now)
+        return;
+
+    Clock::time_point desiredEnd = now + std::chrono::duration_cast<Clock::duration>(duration);
+    if (currentEnd > desiredEnd)
+    {
+        auto reduction = std::chrono::duration_cast<std::chrono::milliseconds>(currentEnd - desiredEnd);
+        ReduceGlobalCooldown(spellInfo, reduction);
+    }
 }
 
 Player* SpellHistory::GetPlayerOwner() const

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -130,7 +130,9 @@ public:
     bool HasGlobalCooldown(SpellInfo const* spellInfo) const;
     void AddGlobalCooldown(SpellInfo const* spellInfo, uint32 duration);
     void CancelGlobalCooldown(SpellInfo const* spellInfo);
+    uint32 GetRemainingGlobalCooldown(SpellInfo const* spellInfo) const;
     void ReduceGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds reduction);
+    void ClampGlobalCooldown(SpellInfo const* spellInfo, std::chrono::milliseconds duration);
 
     void BuildCooldownPacket(WorldPacket& data, uint8 flags, uint32 spellId, uint32 cooldown) const;
 

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -34,6 +34,9 @@
 #include "SpellScript.h"
 #include "TemporarySummon.h"
 #include "SpellHistory.h"
+#include "WorldPacket.h"
+#include <algorithm>
+#include <chrono>
 
 enum PriestSpells
 {
@@ -82,7 +85,8 @@ enum PriestSpells
     SPELL_PRIEST_SPIRIT_DURATION_INCREASE_R1        = 81322,
     SPELL_PRIEST_SPIRIT_DURATION_INCREASE_R2        = 81323,
     SPELL_PRIEST_SPIRIT_OF_REDEMPTION               = 27827,
-    SPELL_PRIEST_VAMPIRIC_EMBRACE_MANA              = 81356
+    SPELL_PRIEST_VAMPIRIC_EMBRACE_MANA              = 81356,
+    SPELL_PRIEST_DARKNESS_R1                        = 15259
 };
 
 enum PriestSpellIcons
@@ -1491,7 +1495,7 @@ class spell_pri_dispel_magic : public SpellScript
 
     bool Validate(SpellInfo const* spellInfo) override
     {
-        return true;
+        return ValidateSpellInfo({ SPELL_PRIEST_DARKNESS_R1 });
     }
 
     void HandleSuccessfulDispel(SpellEffIndex effIndex)
@@ -1512,6 +1516,21 @@ class spell_pri_dispel_magic : public SpellScript
         {
             CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
             caster->CastSpell(caster, 81436, args);
+        }
+
+        if (AuraEffect const* darkness = caster->GetAuraEffectOfRankedSpell(SPELL_PRIEST_DARKNESS_R1, EFFECT_0))
+        {
+            uint32 const rank = std::max<uint32>(1, darkness->GetSpellInfo()->GetRank());
+            uint32 const baseRecoveryTime = GetSpellInfo()->StartRecoveryTime ? GetSpellInfo()->StartRecoveryTime : 1500;
+            uint32 const desiredGcd = baseRecoveryTime > 100 * rank ? baseRecoveryTime - 100 * rank : 0;
+            caster->GetSpellHistory()->ClampGlobalCooldown(GetSpellInfo(), std::chrono::milliseconds(desiredGcd));
+
+            if (Player* player = caster->ToPlayer())
+            {
+                WorldPacket data;
+                caster->GetSpellHistory()->BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_INCLUDE_GCD, GetSpellInfo()->Id, caster->GetSpellHistory()->GetRemainingGlobalCooldown(GetSpellInfo()));
+                player->SendDirectMessage(&data);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- keep the Darkness talent reducing Dispel Magic's GCD by 0.1 seconds per rank (up to 0.5 seconds)
- notify the client of the shortened global cooldown after an offensive Dispel Magic so the reduction is visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692380fff1b083279dbd68be974ac539)