### PR TITLE
Allow account-bound items to roll regardless of quality

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1049,7 +1049,7 @@ void Group::GroupLoot(Loot* loot, WorldObject* pLootedObject)
         }
 
         //roll for over-threshold item if it's one-player loot
-        if (item->Quality >= uint32(m_lootThreshold))
+        if (item->Quality >= uint32(m_lootThreshold) || item->HasFlag(ITEM_FLAG_IS_BOUND_TO_ACCOUNT))
         {
             ObjectGuid newitemGUID = ObjectGuid::Create<HighGuid::Item>(sObjectMgr->GetGenerator<HighGuid::Item>().Generate());
 
@@ -1200,7 +1200,7 @@ void Group::NeedBeforeGreed(Loot* loot, WorldObject* lootedObject)
         ASSERT(item);
 
         //roll for over-threshold item if it's one-player loot
-        if (item->Quality >= uint32(m_lootThreshold))
+        if (item->Quality >= uint32(m_lootThreshold) || item->HasFlag(ITEM_FLAG_IS_BOUND_TO_ACCOUNT))
         {
             ObjectGuid newitemGUID = ObjectGuid::Create<HighGuid::Item>(sObjectMgr->GetGenerator<HighGuid::Item>().Generate());
 


### PR DESCRIPTION
## Summary
- allow group and need-before-greed loot modes to start rolls on account-bound items even when they are below the loot threshold

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f3090fec832782ea3ad40c7cc3a0)