### PR TITLE
Clear taunt stop flag when re-attacking

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -254,6 +254,7 @@ Player::Player(WorldSession* session) : Unit(true)
     m_team = 0;
 
     m_needsZoneUpdate = false;
+    m_attackStopPendingOnTauntEnd = false;
 
     m_nextSave = sWorld->getIntConfig(CONFIG_INTERVAL_SAVE);
 
@@ -7314,6 +7315,15 @@ void Player::UpdateArea(uint32 newArea)
         SetRestFlag(REST_FLAG_IN_FACTION_AREA);
     else
         RemoveRestFlag(REST_FLAG_IN_FACTION_AREA);
+}
+
+void Player::HandleAttackStopAfterTaunt()
+{
+    if (!m_attackStopPendingOnTauntEnd)
+        return;
+
+    m_attackStopPendingOnTauntEnd = false;
+    AttackStop();
 }
 
 void Player::UpdateZone(uint32 newZone, uint32 newArea)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1572,6 +1572,9 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void UpdateZone(uint32 newZone, uint32 newArea);
         void UpdateArea(uint32 newArea);
         void SetNeedsZoneUpdate(bool needsUpdate) { m_needsZoneUpdate = needsUpdate; }
+        void RequestAttackStopAfterTaunt() { m_attackStopPendingOnTauntEnd = true; }
+        void HandleAttackStopAfterTaunt();
+        void ClearAttackStopRequestAfterTaunt() { m_attackStopPendingOnTauntEnd = false; }
 
         void UpdateZoneDependentAuras(uint32 zone_id);    // zones
         void UpdateAreaDependentAuras(uint32 area_id);    // subzones
@@ -2530,6 +2533,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         uint8 m_fishingSteps;
 
         bool m_needsZoneUpdate;
+        bool m_attackStopPendingOnTauntEnd;
 
         TimeTracker m_groupUpdateTimer;
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11793,6 +11793,8 @@ void Unit::SetTaunted(bool apply)
             if (GetVictim())
                 SetTarget(EnsureVictim()->GetGUID());
         }
+        if (Player* player = ToPlayer())
+            player->HandleAttackStopAfterTaunt();
         RemoveUnitFlag(UNIT_FLAG_TAUNTED);
         // allow control to real player in control (eg charmer)
         if (GetCharmerOrSelfPlayer())

--- a/src/server/game/Handlers/CombatHandler.cpp
+++ b/src/server/game/Handlers/CombatHandler.cpp
@@ -58,6 +58,7 @@ void WorldSession::HandleAttackSwingOpcode(WorldPackets::Combat::AttackSwing& pa
         }
     }
 
+    _player->ClearAttackStopRequestAfterTaunt();
     _player->Attack(enemy, true);
 }
 
@@ -68,10 +69,14 @@ void WorldSession::HandleAttackStopOpcode(WorldPackets::Combat::AttackStop& /*pa
         if (Unit* tauntTarget = ObjectAccessor::GetUnit(*_player, GetPlayer()->GetTarget()))
         {
             if (GetPlayer()->IsValidAttackTarget(tauntTarget))
+            {
+                GetPlayer()->RequestAttackStopAfterTaunt();
                 return;
+            }
         }
     }
 
+    GetPlayer()->ClearAttackStopRequestAfterTaunt();
     GetPlayer()->AttackStop();
 }
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2924,6 +2924,9 @@ void AuraEffect::HandleModFear(AuraApplication const* aurApp, uint8 mode, bool a
                 target->SetControlled(false, UNIT_STATE_FLEEING);
         }
 
+        if (Player* player = target->ToPlayer())
+            player->HandleAttackStopAfterTaunt();
+
         return;
     }
 


### PR DESCRIPTION
## Summary
- clear taunt-based pending attack-stop requests when the player initiates a new attack swing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69241b0571a08327b66b76dd6edd54a6)