### PR TITLE
Propagate crits for paladin redirect aura

### DIFF
--- a/sql/custom/world/.gitignore
+++ b/sql/custom/world/.gitignore
@@ -2,4 +2,5 @@
 !2024_05_04_00_world_arena_4v4.sql
 !2024_07_05_00_world_starfire_walk.sql
 !2024_07_05_01_world_starfire_snare_talent.sql
+!2024_07_05_02_world_party_damage_redirect.sql
 !2024_07_12_00_world_gurubashi_hourly_chest.sql

--- a/sql/custom/world/2024_07_05_02_world_party_damage_redirect.sql
+++ b/sql/custom/world/2024_07_05_02_world_party_damage_redirect.sql
@@ -1,0 +1,4 @@
+-- Bind the custom Paladin party damage redirect aura to its script implementation.
+DELETE FROM `spell_script_names` WHERE `spell_id` = 83256 AND `ScriptName` = 'spell_pal_party_damage_redirect';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(83256, 'spell_pal_party_damage_redirect');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -768,13 +768,20 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
         // Let's copy the list so we can prevent iterator invalidation
         AuraEffectList vCopyDamageCopy(victim->GetAuraEffectsByType(SPELL_AURA_SHARE_DAMAGE_PCT));
         // copy damage to casters of this aura
+        static uint32 const PARTY_DAMAGE_REDIRECT_SPELL_ID = 83256;
+
         for (AuraEffectList::iterator i = vCopyDamageCopy.begin(); i != vCopyDamageCopy.end(); ++i)
         {
             // Check if aura was removed during iteration - we don't need to work on such auras
             if (!((*i)->GetBase()->IsAppliedOnTarget(victim->GetGUID())))
                 continue;
             // check damage school mask
-            if (((*i)->GetMiscValue() & damageSchoolMask) == 0)
+            uint32 splitSchoolMask = (*i)->GetMiscValue();
+            // Party Damage Redirect should share all damage schools but re-route as physical on the paladin.
+            if ((*i)->GetId() == PARTY_DAMAGE_REDIRECT_SPELL_ID)
+                splitSchoolMask = SPELL_SCHOOL_MASK_ALL;
+
+            if ((splitSchoolMask & damageSchoolMask) == 0)
                 continue;
 
             Unit* shareDamageTarget = (*i)->GetCaster();
@@ -1959,6 +1966,8 @@ void Unit::HandleEmoteCommand(Emote emoteId)
     // split damage auras - only when not damaging self
     if (damageInfo.GetVictim() != damageInfo.GetAttacker())
     {
+        static uint32 const PARTY_DAMAGE_REDIRECT_SPELL_ID = 83256;
+
         // We're going to call functions which can modify content of the list during iteration over it's elements
         // Let's copy the list so we can prevent iterator invalidation
         AuraEffectList vSplitDamageFlatCopy(damageInfo.GetVictim()->GetAuraEffectsByType(SPELL_AURA_SPLIT_DAMAGE_FLAT));
@@ -1968,7 +1977,11 @@ void Unit::HandleEmoteCommand(Emote emoteId)
             if (!((*itr)->GetBase()->IsAppliedOnTarget(damageInfo.GetVictim()->GetGUID())))
                 continue;
             // check damage school mask
-            if (!((*itr)->GetMiscValue() & damageInfo.GetSchoolMask()))
+            uint32 splitSchoolMask = (*itr)->GetMiscValue();
+            if ((*itr)->GetId() == PARTY_DAMAGE_REDIRECT_SPELL_ID)
+                splitSchoolMask = SPELL_SCHOOL_MASK_ALL;
+
+            if (!(splitSchoolMask & damageInfo.GetSchoolMask()))
                 continue;
 
             // Damage can be splitted only if aura has an alive caster
@@ -2012,7 +2025,11 @@ void Unit::HandleEmoteCommand(Emote emoteId)
                 continue;
 
             // check damage school mask
-            if (!((*itr)->GetMiscValue() & damageInfo.GetSchoolMask()))
+            uint32 splitSchoolMask = (*itr)->GetMiscValue();
+            if ((*itr)->GetId() == PARTY_DAMAGE_REDIRECT_SPELL_ID)
+                splitSchoolMask = SPELL_SCHOOL_MASK_ALL;
+
+            if (!(splitSchoolMask & damageInfo.GetSchoolMask()))
                 continue;
 
             // Damage can be splitted only if aura has an alive caster

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -137,6 +137,7 @@ enum PaladinSpells
     SPELL_PALADIN_HAND_OF_FREEDOM = 1044,
     SPELL_PALADIN_LESSER_HAND_OF_FREEDOM = 81277,
     SPELL_PALADIN_IMP_HAND_OF_FREEDOM = 81278,
+    SPELL_PALADIN_PARTY_DAMAGE_REDIRECT          = 83256,
 
     SPELL_PALADIN_SANCTIFIED_SEALS = 81279
 };
@@ -774,6 +775,172 @@ class spell_pal_hand_of_sacrifice : public AuraScript
     void Register() override
     {
         OnEffectSplit += AuraEffectSplitFn(spell_pal_hand_of_sacrifice::Split, EFFECT_0);
+    }
+};
+
+// 81280 - Party Damage Redirect
+class spell_pal_party_damage_redirect : public AuraScript
+{
+    PrepareAuraScript(spell_pal_party_damage_redirect);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_PALADIN_PARTY_DAMAGE_REDIRECT });
+    }
+
+    bool IsInBreakableCrowdControl(Unit* unit) const
+    {
+        // Mirror the crowd-control exclusions used by Ignite Spread.
+        return unit && unit->HasAuraWithMechanic((1 << MECHANIC_DISORIENTED) | (1 << MECHANIC_POLYMORPH) | (1 << MECHANIC_SAPPED));
+    }
+
+    MeleeHitOutcome RollAvoidance(Unit* attacker, Unit* paladin) const
+    {
+        Unit* swingAttacker = attacker ? attacker : paladin;
+
+        float dodgeChance = swingAttacker->GetUnitDodgeChance(BASE_ATTACK, paladin);
+        float parryChance = swingAttacker->GetUnitParryChance(BASE_ATTACK, paladin);
+        float blockChance = swingAttacker->GetUnitBlockChance(BASE_ATTACK, paladin);
+
+        uint32 roll = urand(0, 9999);
+        uint32 cumulativeChance = 0;
+
+        cumulativeChance += static_cast<uint32>(dodgeChance * 100.0f);
+        if (cumulativeChance && roll < cumulativeChance)
+            return MELEE_HIT_DODGE;
+
+        cumulativeChance += static_cast<uint32>(parryChance * 100.0f);
+        if (cumulativeChance && roll < cumulativeChance)
+            return MELEE_HIT_PARRY;
+
+        cumulativeChance += static_cast<uint32>(blockChance * 100.0f);
+        if (cumulativeChance && roll < cumulativeChance)
+            return MELEE_HIT_BLOCK;
+
+        return MELEE_HIT_NORMAL;
+    }
+
+    void Split(AuraEffect* aurEff, DamageInfo& dmgInfo, uint32& splitAmount)
+    {
+        Unit* caster = GetCaster();
+        Unit* target = GetTarget();
+        if (!caster || !target || caster == target)
+            return;
+
+        if (!splitAmount)
+            return;
+
+        if (IsInBreakableCrowdControl(caster) || IsInBreakableCrowdControl(dmgInfo.GetAttacker()))
+        {
+            splitAmount = 0;
+            return;
+        }
+
+        Unit* attacker = dmgInfo.GetAttacker();
+
+        uint32 redirected = std::min(splitAmount, dmgInfo.GetDamage());
+        splitAmount = 0;
+
+        if (!redirected)
+            return;
+
+        dmgInfo.AbsorbDamage(redirected);
+
+        CalcDamageInfo redirectInfo{};
+        redirectInfo.Attacker = attacker ? attacker : caster;
+        redirectInfo.Target = caster;
+        redirectInfo.Damages[0].DamageSchoolMask = SPELL_SCHOOL_MASK_NORMAL;
+        redirectInfo.Damages[0].Damage = redirected;
+        redirectInfo.Damages[1].DamageSchoolMask = SPELL_SCHOOL_MASK_NORMAL;
+        redirectInfo.AttackType = BASE_ATTACK;
+        redirectInfo.ProcAttacker = PROC_FLAG_DONE_MELEE_AUTO_ATTACK | PROC_FLAG_DONE_MAINHAND_ATTACK;
+        redirectInfo.ProcVictim = PROC_FLAG_TAKEN_MELEE_AUTO_ATTACK;
+        redirectInfo.HitInfo = HITINFO_NORMALSWING;
+
+        MeleeHitOutcome outcome = RollAvoidance(attacker, caster);
+        redirectInfo.HitOutCome = outcome;
+
+        uint32 const preBlockDamage = redirectInfo.Damages[0].Damage;
+
+        switch (outcome)
+        {
+            case MELEE_HIT_DODGE:
+                redirectInfo.TargetState = VICTIMSTATE_DODGE;
+                redirectInfo.CleanDamage = redirectInfo.Damages[0].Damage;
+                redirectInfo.Damages[0].Damage = 0;
+                break;
+            case MELEE_HIT_PARRY:
+                redirectInfo.TargetState = VICTIMSTATE_PARRY;
+                redirectInfo.CleanDamage = redirectInfo.Damages[0].Damage;
+                redirectInfo.Damages[0].Damage = 0;
+                break;
+            case MELEE_HIT_BLOCK:
+            {
+                redirectInfo.TargetState = VICTIMSTATE_HIT;
+                redirectInfo.HitInfo |= HITINFO_BLOCK;
+                redirectInfo.Blocked = caster->GetShieldBlockValue();
+                if (caster->IsBlockCritical())
+                    redirectInfo.Blocked *= 2;
+
+                uint32 remainingBlock = redirectInfo.Blocked;
+                if (remainingBlock >= redirectInfo.Damages[0].Damage)
+                {
+                    redirectInfo.TargetState = VICTIMSTATE_BLOCKS;
+                    redirectInfo.CleanDamage = redirectInfo.Damages[0].Damage;
+                    redirectInfo.Damages[0].Damage = 0;
+                    redirectInfo.Blocked = preBlockDamage;
+                }
+                else
+                {
+                    redirectInfo.CleanDamage = remainingBlock;
+                    redirectInfo.Damages[0].Damage -= remainingBlock;
+                }
+                break;
+            }
+            default:
+                redirectInfo.TargetState = VICTIMSTATE_HIT;
+                break;
+        }
+
+        if (redirectInfo.Damages[0].Damage && redirectInfo.HitOutCome == MELEE_HIT_NORMAL)
+        {
+            bool const wasCritical = (dmgInfo.GetHitMask() & PROC_HIT_CRITICAL) != 0;
+            if (wasCritical)
+            {
+                redirectInfo.HitOutCome = MELEE_HIT_CRIT;
+                redirectInfo.HitInfo |= HITINFO_CRITICALHIT;
+            }
+        }
+
+        if (redirectInfo.Damages[0].Damage)
+        {
+            uint32 redirectedAbsorb = 0;
+            Unit::DealDamageMods(caster, redirectInfo.Damages[0].Damage, &redirectedAbsorb);
+            redirectInfo.Damages[0].Absorb = redirectedAbsorb;
+        }
+
+        redirectInfo.CleanDamage += redirectInfo.Damages[0].Absorb;
+
+        redirectInfo.ProcVictim |= PROC_FLAG_TAKEN_DAMAGE;
+
+        redirectInfo.Damages[1].Damage = 0;
+
+        if (redirectInfo.Target->IsAlive())
+        {
+            redirectInfo.Blocked = std::min<uint32>(redirectInfo.Blocked, preBlockDamage);
+
+            redirectInfo.Attacker->SendAttackStateUpdate(&redirectInfo);
+            redirectInfo.Attacker->DealMeleeDamage(&redirectInfo, false);
+
+            DamageInfo procDamage(redirectInfo);
+            Unit::ProcSkillsAndAuras(redirectInfo.Attacker, redirectInfo.Target, redirectInfo.ProcAttacker, redirectInfo.ProcVictim, PROC_SPELL_TYPE_NONE, PROC_SPELL_PHASE_NONE, procDamage.GetHitMask(), nullptr, &procDamage, nullptr);
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectSplit += AuraEffectSplitFn(spell_pal_party_damage_redirect::Split, EFFECT_0);
+        OnEffectSplit += AuraEffectSplitFn(spell_pal_party_damage_redirect::Split, EFFECT_1);
     }
 };
 
@@ -2325,6 +2492,7 @@ void AddSC_paladin_spell_scripts()
     RegisterSpellScript(spell_pal_judgements_of_the_wise);
     RegisterSpellScript(spell_pal_lay_on_hands);
     RegisterSpellScript(spell_pal_light_s_beacon);
+    RegisterSpellScript(spell_pal_party_damage_redirect);
     RegisterSpellScript(spell_pal_righteous_defense);
     RegisterSpellScript(spell_pal_righteous_vengeance);
     RegisterSpellScript(spell_pal_sacred_shield);


### PR DESCRIPTION
## Summary
- prevent redirected party damage when either the paladin or the attacker is under breakable crowd control
- flag redirected hits as critical when the source hit crits so crit visuals and procs trigger

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692232b46fac8327a85ef26dd6e2c16f)