### PR TITLE
Remove duplicate talent reset handling

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -914,36 +914,6 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
     ObjectAccessor::AddObject(pCurrChar);
     //TC_LOG_DEBUG("Player {} added to Map.", pCurrChar->GetName());
 
-    // Apply at_login requests before initial packets so the client receives the
-    // cleaned spell/talent state in the initial spell list and talent data.
-    bool handledTalentReset = false;
-    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS))
-    {
-        pCurrChar->ResetNonQuestAndMountSpells();
-        SendNotification(LANG_RESET_SPELLS);
-        SendNotification(LANG_RESET_TALENTS);
-        handledTalentReset = true;
-    }
-
-    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS))
-    {
-        pCurrChar->ResetSpells();
-        SendNotification(LANG_RESET_SPELLS);
-    }
-
-    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_TALENTS))
-    {
-        if (!handledTalentReset)
-        {
-            pCurrChar->ResetTalents(true);
-            SendNotification(LANG_RESET_TALENTS);
-        }
-        else
-            pCurrChar->RemoveAtLoginFlag(AT_LOGIN_RESET_TALENTS, true);
-
-        pCurrChar->SendTalentsInfoData(false);              // original talents send already in to SendInitialPacketsBeforeAddToMap, resend reset state
-    }
-
     pCurrChar->SendInitialPacketsAfterAddToMap();
 
     CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_ONLINE);


### PR DESCRIPTION
## Summary
- remove duplicate talent and spell reset handling block during player login to avoid redefinition
- rely on initial at-login reset logic to prevent redundant declarations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69259275591c8327a98433d72fbb3b57)