### PR TITLE
Prevent party damage redirect during crowd control

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -788,10 +788,10 @@ class spell_pal_party_damage_redirect : public AuraScript
         return ValidateSpellInfo({ SPELL_PALADIN_PARTY_DAMAGE_REDIRECT });
     }
 
-    bool IsCasterInBreakableCrowdControl(Unit* caster) const
+    bool IsInBreakableCrowdControl(Unit* unit) const
     {
         // Mirror the crowd-control exclusions used by Ignite Spread.
-        return caster->HasAuraWithMechanic((1 << MECHANIC_DISORIENTED) | (1 << MECHANIC_POLYMORPH) | (1 << MECHANIC_SAPPED));
+        return unit && unit->HasAuraWithMechanic((1 << MECHANIC_DISORIENTED) | (1 << MECHANIC_POLYMORPH) | (1 << MECHANIC_SAPPED));
     }
 
     MeleeHitOutcome RollAvoidance(Unit* attacker, Unit* paladin) const
@@ -830,7 +830,7 @@ class spell_pal_party_damage_redirect : public AuraScript
         if (!splitAmount)
             return;
 
-        if (IsCasterInBreakableCrowdControl(caster))
+        if (IsInBreakableCrowdControl(caster) || IsInBreakableCrowdControl(target))
         {
             splitAmount = 0;
             return;


### PR DESCRIPTION
## Summary
- stop Party Damage Redirect from triggering when either the paladin or the protected target is under breakable crowd control
- reuse the existing crowd-control mechanic check for both caster and target to avoid redirecting damage in those cases

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925945f5900832798f670c48efc15e8)