### PR TITLE
Fix reset spells keep mounts handling

### DIFF
--- a/sql/base/auth_database.sql
+++ b/sql/base/auth_database.sql
@@ -1098,6 +1098,7 @@ INSERT INTO `rbac_linked_permissions` VALUES
 (199,525),
 (199,534),
 (199,797),
+(199,883),
 (199,882);
 /*!40000 ALTER TABLE `rbac_linked_permissions` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -1676,6 +1677,7 @@ INSERT INTO `rbac_permissions` VALUES
 (712,'Command: reset honor'),
 (713,'Command: reset level'),
 (714,'Command: reset spells'),
+(883,'Command: reset spells_keep_mounts'),
 (715,'Command: reset stats'),
 (716,'Command: reset talents'),
 (717,'Command: reset all'),

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23612,9 +23612,9 @@ void Player::ResetNonQuestAndMountSpells()
         RemoveAtLoginFlag(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS, true);
 
     PlayerSpellMap spells = GetSpellMap();
-    std::unordered_set<uint32> preservedSpells;
+    std::unordered_set<uint32> mountSpells;
 
-    // Preserve mount spells
+    // Preserve mount spells explicitly so class spell pruning does not remove them.
     for (PlayerSpellMap::const_iterator itr = spells.begin(); itr != spells.end(); ++itr)
     {
         SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itr->first);
@@ -23622,46 +23622,48 @@ void Player::ResetNonQuestAndMountSpells()
             continue;
 
         if (spellInfo->HasAura(SPELL_AURA_MOUNTED))
-            preservedSpells.insert(itr->first);
+            mountSpells.insert(itr->first);
     }
 
-    // Preserve base race/class spells and racials from playercreateinfo_spell_custom
-    if (PlayerInfo const* info = sObjectMgr->GetPlayerInfo(GetRace(), GetClass()))
-        preservedSpells.insert(info->customSpells.begin(), info->customSpells.end());
-
-    // Preserve spells rewarded by completed quests
-    for (RewardedQuestSet::const_iterator itr = m_RewardedQuests.begin(); itr != m_RewardedQuests.end(); ++itr)
-    {
-        Quest const* quest = sObjectMgr->GetQuestTemplate(*itr);
-        if (!quest)
-            continue;
-
-        int32 rewardSpellId = quest->GetRewSpellCast();
-        if (rewardSpellId <= 0)
-            continue;
-
-        SpellInfo const* rewardSpellInfo = sSpellMgr->GetSpellInfo(rewardSpellId);
-        if (!rewardSpellInfo)
-            continue;
-
-        for (SpellEffectInfo const& spellEffectInfo : rewardSpellInfo->GetEffects())
-        {
-            if (spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL) && spellEffectInfo.TriggerSpell)
-                preservedSpells.insert(uint32(spellEffectInfo.TriggerSpell));
-        }
-    }
+    ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(GetClass());
 
     for (PlayerSpellMap::const_iterator itr = spells.begin(); itr != spells.end(); ++itr)
     {
-        if (preservedSpells.find(itr->first) != preservedSpells.end())
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itr->first);
+        if (!spellInfo)
             continue;
 
-        RemoveAurasDueToSpell(itr->first);
-        RemoveSpell(itr->first, false, false);
+        if (mountSpells.find(itr->first) != mountSpells.end())
+            continue;
+
+        // Only clear class spells/talents so languages, racials, attack command, and quest spells stay intact.
+        if (!classEntry || spellInfo->SpellFamilyName != classEntry->SpellClassSet)
+            continue;
+
+        // skip server-side/triggered spells
+        if (spellInfo->SpellLevel == 0)
+            continue;
+
+        // skip wrong class/race skills
+        if (!IsSpellFitByClassAndRace(spellInfo->Id))
+            continue;
+
+        uint32 const firstRank = spellInfo->GetFirstRankSpell()->Id;
+        // remove talent-learned spells too
+        if (GetTalentSpellCost(firstRank) > 0 || SpellMgr::IsSpellValid(spellInfo, this, false))
+        {
+            RemoveAurasDueToSpell(itr->first);
+            RemoveSpell(itr->first, false, false);
+        }
     }
 
+    // Ensure preserved mounts remain available.
+    for (uint32 spellId : mountSpells)
+        if (!HasSpell(spellId))
+            LearnSpell(spellId, true);
+
     ResetTalents(true);
-    SetAtLoginFlag(AT_LOGIN_RESET_TALENTS);
+    SendTalentsInfoData(false);
 }
 
 void Player::LearnCustomSpells()

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -854,14 +854,14 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
     if (handledTalentReset)
     {
         pCurrChar->ResetNonQuestAndMountSpells();
-        SendNotification(LANG_RESET_SPELLS);
-        SendNotification(LANG_RESET_TALENTS);
+        SendNotification(GetTrinityString(LANG_RESET_SPELLS));
+        SendNotification(GetTrinityString(LANG_RESET_TALENTS));
     }
 
     if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS))
     {
         pCurrChar->ResetSpells();
-        SendNotification(LANG_RESET_SPELLS);
+        SendNotification(GetTrinityString(LANG_RESET_SPELLS));
     }
 
     if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_TALENTS))
@@ -869,7 +869,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
         if (!handledTalentReset)
         {
             pCurrChar->ResetTalents(true);
-            SendNotification(LANG_RESET_TALENTS);
+            SendNotification(GetTrinityString(LANG_RESET_TALENTS));
         }
         else
             pCurrChar->RemoveAtLoginFlag(AT_LOGIN_RESET_TALENTS, true);
@@ -913,36 +913,6 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
 
     ObjectAccessor::AddObject(pCurrChar);
     //TC_LOG_DEBUG("Player {} added to Map.", pCurrChar->GetName());
-
-    // Apply at_login requests before initial packets so the client receives the
-    // cleaned spell/talent state in the initial spell list and talent data.
-    bool handledTalentReset = false;
-    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS))
-    {
-        pCurrChar->ResetNonQuestAndMountSpells();
-        SendNotification(LANG_RESET_SPELLS);
-        SendNotification(LANG_RESET_TALENTS);
-        handledTalentReset = true;
-    }
-
-    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS))
-    {
-        pCurrChar->ResetSpells();
-        SendNotification(LANG_RESET_SPELLS);
-    }
-
-    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_TALENTS))
-    {
-        if (!handledTalentReset)
-        {
-            pCurrChar->ResetTalents(true);
-            SendNotification(LANG_RESET_TALENTS);
-        }
-        else
-            pCurrChar->RemoveAtLoginFlag(AT_LOGIN_RESET_TALENTS, true);
-
-        pCurrChar->SendTalentsInfoData(false);              // original talents send already in to SendInitialPacketsBeforeAddToMap, resend reset state
-    }
 
     pCurrChar->SendInitialPacketsAfterAddToMap();
 

--- a/src/server/scripts/Commands/cs_reset.cpp
+++ b/src/server/scripts/Commands/cs_reset.cpp
@@ -203,8 +203,8 @@ public:
         if (target)
         {
             target->ResetNonQuestAndMountSpells();
-            target->SendTalentsInfoData(false);
-            ChatHandler(target->GetSession()).SendSysMessage("Removed all non-mount, non-quest spells and reset talents.");
+            ChatHandler(target->GetSession()).SendSysMessage(LANG_RESET_SPELLS);
+            ChatHandler(target->GetSession()).SendSysMessage(LANG_RESET_TALENTS);
 
             if (!handler->GetSession() || handler->GetSession()->GetPlayer() != target)
                 handler->PSendSysMessage("Cleaned non-mount, non-quest spells and talents for %s.", handler->GetNameLink(target).c_str());


### PR DESCRIPTION
## Summary
- ensure .reset spells_keep_mounts removes only class spells, keeps mounts and protected abilities, and resets talents
- send consistent reset notifications during login and command handling
- add RBAC permission entry for the new reset subcommand so it appears in help

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69259275591c8327a98433d72fbb3b57)