### PR TITLE
Learn all ranks when gaining talent spells

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26052,6 +26052,14 @@ void Player::LearnTalent(uint32 talentId, uint32 talentRank)
 
     // learn! (other talent ranks will unlearned at learning)
     LearnSpell(spellid, false);
+
+    // Talent-granted spells should provide the entire spell rank chain
+    for (uint32 rankSpell = sSpellMgr->GetFirstSpellInChain(spellid); rankSpell; rankSpell = sSpellMgr->GetNextSpellInChain(rankSpell))
+    {
+        if (rankSpell != spellid)
+            LearnSpell(rankSpell, false);
+    }
+
     AddTalent(spellid, m_activeSpec, true);
 
     TC_LOG_DEBUG("misc", "Player::LearnTalent: TalentID: {} Spell: {} Group: {}\n", talentId, spellid, uint32(m_activeSpec));


### PR DESCRIPTION
## Summary
- learn the full spell rank chain when a talent grants a spell
- ensure talent-taught spells are fully acquired alongside the talent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69259b8806608327bac46a746318ffad)