### PR TITLE
Fix format string usage in login notifications

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -854,14 +854,14 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
     if (handledTalentReset)
     {
         pCurrChar->ResetNonQuestAndMountSpells();
-        SendNotification(GetTrinityString(LANG_RESET_SPELLS));
-        SendNotification(GetTrinityString(LANG_RESET_TALENTS));
+        SendNotification(LANG_RESET_SPELLS);
+        SendNotification(LANG_RESET_TALENTS);
     }
 
     if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_SPELLS))
     {
         pCurrChar->ResetSpells();
-        SendNotification(GetTrinityString(LANG_RESET_SPELLS));
+        SendNotification(LANG_RESET_SPELLS);
     }
 
     if (pCurrChar->HasAtLoginFlag(AT_LOGIN_RESET_TALENTS))
@@ -869,7 +869,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
         if (!handledTalentReset)
         {
             pCurrChar->ResetTalents(true);
-            SendNotification(GetTrinityString(LANG_RESET_TALENTS));
+            SendNotification(LANG_RESET_TALENTS);
         }
         else
             pCurrChar->RemoveAtLoginFlag(AT_LOGIN_RESET_TALENTS, true);


### PR DESCRIPTION
## Summary
- use the string-id overload of SendNotification for reset spells/talents login messages
- avoid format string security warnings from non-literal message pointers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a32658588327a2f79dea8358dc7d)