### PR TITLE
Reset dual-spec talents when keeping mounts

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23681,7 +23681,19 @@ void Player::ResetNonQuestAndMountSpells()
         if (!HasSpell(spellId))
             LearnSpell(spellId, true);
 
-    ResetTalents(true);
+    uint8 const activeSpec = GetActiveSpec();
+    uint8 const specsCount = GetSpecsCount();
+
+    for (uint8 i = 0; i < specsCount; ++i)
+    {
+        SetActiveSpec(i);
+        ResetTalents(true);
+    }
+
+    SetActiveSpec(activeSpec);
+    m_usedTalentCount = 0;
+    SetFreeTalentPoints(CalculateTalentsPoints());
+
     SendTalentsInfoData(false);
 }
 


### PR DESCRIPTION
## Summary
- ensure the `.reset spells_keep_mounts` command clears talents for every available spec
- restore the player's original active spec and free talent points after the reset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a3c3bf148327ad98f692cd944aeb)