### PR TITLE
Auto-learn spell_required dependencies for talent spells

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26052,6 +26052,50 @@ void Player::LearnTalent(uint32 talentId, uint32 talentRank)
 
     // learn! (other talent ranks will unlearned at learning)
     LearnSpell(spellid, false);
+    if (SpellInfo const* talentSpellInfo = sSpellMgr->GetSpellInfo(spellid))
+    {
+        auto learnNextActivatableRanks = [this](uint32 currentRankSpellId)
+        {
+            uint32 nextRankSpellId = sSpellMgr->GetNextSpellInChain(currentRankSpellId);
+            while (nextRankSpellId)
+            {
+                SpellInfo const* nextRankSpellInfo = sSpellMgr->GetSpellInfo(nextRankSpellId);
+                if (!nextRankSpellInfo)
+                    break;
+
+                // Stop if next rank requires a higher level
+                uint32 requiredLevel = std::max(nextRankSpellInfo->BaseLevel, nextRankSpellInfo->SpellLevel);
+                if (requiredLevel && requiredLevel > GetLevel())
+                    break;
+
+                LearnSpell(nextRankSpellId, false);
+                nextRankSpellId = sSpellMgr->GetNextSpellInChain(nextRankSpellId);
+            }
+        };
+
+        // Only auto-learn ranks and dependencies for activatable spells
+        if (!talentSpellInfo->IsPassive())
+        {
+            learnNextActivatableRanks(spellid);
+
+            SpellsRequiringSpellMapBounds spellsRequiringSpell = sSpellMgr->GetSpellsRequiringSpellBounds(spellid);
+            for (SpellsRequiringSpellMap::const_iterator itr = spellsRequiringSpell.first; itr != spellsRequiringSpell.second; ++itr)
+            {
+                uint32 dependentSpellId = itr->second;
+                SpellInfo const* dependentSpellInfo = sSpellMgr->GetSpellInfo(dependentSpellId);
+
+                if (!dependentSpellInfo || dependentSpellInfo->IsPassive())
+                    continue;
+
+                uint32 requiredLevel = std::max(dependentSpellInfo->BaseLevel, dependentSpellInfo->SpellLevel);
+                if (requiredLevel && requiredLevel > GetLevel())
+                    continue;
+
+                LearnSpell(dependentSpellId, false);
+                learnNextActivatableRanks(dependentSpellId);
+            }
+        }
+    }
     AddTalent(spellid, m_activeSpec, true);
 
     TC_LOG_DEBUG("misc", "Player::LearnTalent: TalentID: {} Spell: {} Group: {}\n", talentId, spellid, uint32(m_activeSpec));


### PR DESCRIPTION
## Summary
- auto-learn higher ranks of activatable talent spells up to the player's level using a shared helper
- automatically learn activatable spells from `spell_required` dependencies when learning a talent spell, respecting level requirements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a21d9ca08327b676fed420261482)