### PR TITLE
Add chance to trigger improved counterattack

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10279,7 +10279,7 @@ void Unit::ProcSkillsAndReactives(bool isVictim, Unit* procTarget, uint32 typeMa
                         StartReactiveTimer(REACTIVE_DEFENSE);
                     }
                     // For Hunters only improved Counterattack
-                    if (GetClass() == CLASS_HUNTER && HasAura(81283))
+                    if (GetClass() == CLASS_HUNTER && HasAura(81283) && roll_chance_i(50))
                     {
                         ModifyAuraState(AURA_STATE_HUNTER_PARRY, true);
                         StartReactiveTimer(REACTIVE_HUNTER_PARRY);


### PR DESCRIPTION
**Changes proposed**:

- Add a 50% roll before activating the hunter parry reactive state granted by Improved Counterattack.
- 
- 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ]
- [ ]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b783a5cc8327bdc430c94d13ba7e)