### PR TITLE
Handle queued pet spells when out of range

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -43,12 +43,77 @@ int32 PetAI::Permissible(Creature const* creature)
     return PERMIT_BASE_NO;
 }
 
-PetAI::PetAI(Creature* creature) : CreatureAI(creature), _tracker(TIME_INTERVAL_LOOK), _lastCrowdControlledVictim(ObjectGuid::Empty)
+PetAI::PetAI(Creature* creature) : CreatureAI(creature), _tracker(TIME_INTERVAL_LOOK), _lastCrowdControlledVictim(ObjectGuid::Empty), _queuedSpellTarget(ObjectGuid::Empty), _queuedSpellId(0)
 {
     if (!me->GetCharmInfo())
         throw InvalidAIException("Creature doesn't have a valid charm info");
 
     UpdateAllies();
+}
+
+void PetAI::QueueSpell(uint32 spellId, SpellCastTargets const& targets)
+{
+    _queuedSpellId = spellId;
+    _queuedSpellTargets = targets;
+    _queuedSpellTarget = targets.GetUnitTargetGUID();
+
+    if (Unit* target = _queuedSpellTargets.GetUnitTarget())
+        _AttackStart(target);
+}
+
+void PetAI::ClearQueuedSpell()
+{
+    _queuedSpellTargets = SpellCastTargets();
+    _queuedSpellTarget.Clear();
+    _queuedSpellId = 0;
+}
+
+void PetAI::ProcessSpellQueue()
+{
+    if (!_queuedSpellId || me->HasUnitState(UNIT_STATE_CASTING))
+        return;
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(_queuedSpellId);
+    if (!spellInfo)
+    {
+        ClearQueuedSpell();
+        return;
+    }
+
+    Unit* target = _queuedSpellTargets.GetUnitTarget();
+    if (!target && !_queuedSpellTarget.IsEmpty())
+        target = ObjectAccessor::GetUnit(*me, _queuedSpellTarget);
+
+    if (!target || !target->IsAlive())
+    {
+        ClearQueuedSpell();
+        return;
+    }
+
+    _queuedSpellTargets.SetUnitTarget(target);
+
+    Spell* spell = new Spell(me, spellInfo, TRIGGERED_NONE);
+    spell->m_targets = _queuedSpellTargets;
+
+    SpellCastResult result = spell->CheckPetCast(target);
+
+    if (result == SPELL_CAST_OK)
+    {
+        spell->prepare(spell->m_targets);
+        ClearQueuedSpell();
+        return;
+    }
+
+    spell->finish(false);
+    delete spell;
+
+    if (result != SPELL_FAILED_OUT_OF_RANGE)
+    {
+        ClearQueuedSpell();
+        return;
+    }
+
+    _AttackStart(target);
 }
 
 void PetAI::UpdateAI(uint32 diff)
@@ -57,6 +122,8 @@ void PetAI::UpdateAI(uint32 diff)
         return;
 
     Unit* owner = me->GetCharmerOrOwner();
+
+    ProcessSpellQueue();
 
     if (_updateAlliesTimer <= diff)
         // UpdateAllies self set update timer

--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -21,6 +21,7 @@
 #include "CreatureAI.h"
 #include "ObjectGuid.h"
 #include "Timer.h"
+#include "Spell.h"
 
 class Creature;
 class Spell;
@@ -48,6 +49,7 @@ class TC_GAME_API PetAI : public CreatureAI
         void JustEnteredCombat(Unit* who) override { EngagementStart(who); }
         void JustExitedCombat() override { EngagementOver(); }
         void OnCharmed(bool isNew) override;
+        void QueueSpell(uint32 spellId, SpellCastTargets const& targets);
 
         // The following aren't used by the PetAI but need to be defined to override
         // default CreatureAI functions which interfere with the PetAI
@@ -59,6 +61,8 @@ class TC_GAME_API PetAI : public CreatureAI
         void HandleReturnMovement();
 
     private:
+        void ClearQueuedSpell();
+        void ProcessSpellQueue();
         bool NeedToStop();
         void StopAttack();
         void UpdateAllies();
@@ -72,6 +76,9 @@ class TC_GAME_API PetAI : public CreatureAI
         GuidSet _allySet;
         uint32 _updateAlliesTimer;
         ObjectGuid _lastCrowdControlledVictim;
+        ObjectGuid _queuedSpellTarget;
+        SpellCastTargets _queuedSpellTargets;
+        uint32 _queuedSpellId;
 };
 
 #endif

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -808,6 +808,7 @@ void WorldSession::HandlePetCastSpellOpcode(WorldPacket& recvPacket)
     spell->m_targets = targets;
 
     SpellCastResult result = spell->CheckPetCast(nullptr);
+    SpellCastTargets queuedTargets = spell->m_targets;
 
     if (result == SPELL_CAST_OK)
     {
@@ -828,6 +829,17 @@ void WorldSession::HandlePetCastSpellOpcode(WorldPacket& recvPacket)
     }
     else
     {
+        if (result == SPELL_FAILED_OUT_OF_RANGE)
+        {
+            if (Creature* creature = caster->ToCreature())
+                if (PetAI* petAI = dynamic_cast<PetAI*>(creature->AI()))
+                    petAI->QueueSpell(spellId, queuedTargets);
+
+            spell->finish(false);
+            delete spell;
+            return;
+        }
+
         spell->SendPetCastResult(result);
 
         if (!caster->GetSpellHistory()->HasCooldown(spellId))


### PR DESCRIPTION
## Summary
- queue pet spell casts that initially fail due to range and have pets chase their targets
- add PetAI handling to process queued spells once in range and discard invalid requests

## Testing
- Not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925cb2adb088327957b533b5dc4ffd3)