### PR TITLE
Adjust queued pet chase range

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -43,12 +43,89 @@ int32 PetAI::Permissible(Creature const* creature)
     return PERMIT_BASE_NO;
 }
 
-PetAI::PetAI(Creature* creature) : CreatureAI(creature), _tracker(TIME_INTERVAL_LOOK), _lastCrowdControlledVictim(ObjectGuid::Empty)
+PetAI::PetAI(Creature* creature) : CreatureAI(creature), _tracker(TIME_INTERVAL_LOOK), _lastCrowdControlledVictim(ObjectGuid::Empty), _queuedSpellTarget(ObjectGuid::Empty), _queuedSpellId(0)
 {
     if (!me->GetCharmInfo())
         throw InvalidAIException("Creature doesn't have a valid charm info");
 
     UpdateAllies();
+}
+
+void PetAI::QueueSpell(uint32 spellId, SpellCastTargets const& targets)
+{
+    _queuedSpellId = spellId;
+    _queuedSpellTargets = targets;
+    _queuedSpellTarget = targets.GetUnitTargetGUID();
+
+    if (Unit* target = _queuedSpellTargets.GetUnitTarget())
+        _AttackStart(target);
+}
+
+void PetAI::ClearQueuedSpell()
+{
+    _queuedSpellTargets = SpellCastTargets();
+    _queuedSpellTarget.Clear();
+    _queuedSpellId = 0;
+}
+
+void PetAI::ProcessSpellQueue()
+{
+    if (!_queuedSpellId || me->HasUnitState(UNIT_STATE_CASTING))
+        return;
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(_queuedSpellId);
+    if (!spellInfo)
+    {
+        ClearQueuedSpell();
+        return;
+    }
+
+    Unit* target = _queuedSpellTargets.GetUnitTarget();
+    if (!target && !_queuedSpellTarget.IsEmpty())
+        target = ObjectAccessor::GetUnit(*me, _queuedSpellTarget);
+
+    if (!target || !target->IsAlive())
+    {
+        ClearQueuedSpell();
+        return;
+    }
+
+    _queuedSpellTargets.SetUnitTarget(target);
+
+    Spell* spell = new Spell(me, spellInfo, TRIGGERED_NONE);
+    spell->m_targets = _queuedSpellTargets;
+
+    SpellCastResult result = spell->CheckPetCast(target);
+
+    if (result == SPELL_CAST_OK)
+    {
+        spell->prepare(spell->m_targets);
+        ClearQueuedSpell();
+        return;
+    }
+
+    float minRange = spellInfo->GetMinRange(false);
+    float maxRange = spellInfo->GetMaxRange(false);
+
+    spell->finish(false);
+    delete spell;
+
+    if (result == SPELL_FAILED_OUT_OF_RANGE)
+    {
+        _AttackStart(target);
+        float chaseRange = maxRange > 0.0f ? maxRange : me->GetAttackDistance(target);
+        me->GetMotionMaster()->MoveChase(target, chaseRange);
+        return;
+    }
+
+    if (result == SPELL_FAILED_TOO_CLOSE)
+    {
+        float chaseRange = minRange > 0.0f ? minRange : me->GetAttackDistance(target);
+        me->GetMotionMaster()->MoveChase(target, chaseRange);
+        return;
+    }
+
+    ClearQueuedSpell();
 }
 
 void PetAI::UpdateAI(uint32 diff)
@@ -57,6 +134,8 @@ void PetAI::UpdateAI(uint32 diff)
         return;
 
     Unit* owner = me->GetCharmerOrOwner();
+
+    ProcessSpellQueue();
 
     if (_updateAlliesTimer <= diff)
         // UpdateAllies self set update timer

--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -21,6 +21,7 @@
 #include "CreatureAI.h"
 #include "ObjectGuid.h"
 #include "Timer.h"
+#include "Spell.h"
 
 class Creature;
 class Spell;
@@ -48,6 +49,7 @@ class TC_GAME_API PetAI : public CreatureAI
         void JustEnteredCombat(Unit* who) override { EngagementStart(who); }
         void JustExitedCombat() override { EngagementOver(); }
         void OnCharmed(bool isNew) override;
+        void QueueSpell(uint32 spellId, SpellCastTargets const& targets);
 
         // The following aren't used by the PetAI but need to be defined to override
         // default CreatureAI functions which interfere with the PetAI
@@ -59,6 +61,8 @@ class TC_GAME_API PetAI : public CreatureAI
         void HandleReturnMovement();
 
     private:
+        void ClearQueuedSpell();
+        void ProcessSpellQueue();
         bool NeedToStop();
         void StopAttack();
         void UpdateAllies();
@@ -72,6 +76,9 @@ class TC_GAME_API PetAI : public CreatureAI
         GuidSet _allySet;
         uint32 _updateAlliesTimer;
         ObjectGuid _lastCrowdControlledVictim;
+        ObjectGuid _queuedSpellTarget;
+        SpellCastTargets _queuedSpellTargets;
+        uint32 _queuedSpellId;
 };
 
 #endif

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -808,6 +808,7 @@ void WorldSession::HandlePetCastSpellOpcode(WorldPacket& recvPacket)
     spell->m_targets = targets;
 
     SpellCastResult result = spell->CheckPetCast(nullptr);
+    SpellCastTargets queuedTargets = spell->m_targets;
 
     if (result == SPELL_CAST_OK)
     {
@@ -828,6 +829,17 @@ void WorldSession::HandlePetCastSpellOpcode(WorldPacket& recvPacket)
     }
     else
     {
+        if (result == SPELL_FAILED_OUT_OF_RANGE || result == SPELL_FAILED_TOO_CLOSE)
+        {
+            if (Creature* creature = caster->ToCreature())
+                if (PetAI* petAI = dynamic_cast<PetAI*>(creature->AI()))
+                    petAI->QueueSpell(spellId, queuedTargets);
+
+            spell->finish(false);
+            delete spell;
+            return;
+        }
+
         spell->SendPetCastResult(result);
 
         if (!caster->GetSpellHistory()->HasCooldown(spellId))


### PR DESCRIPTION
## Summary
- use spell max range when chasing queued pet casts that start out of range
- fall back to min range or attack distance when repositioning for queued casts that are too close

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925cb2adb088327957b533b5dc4ffd3)