### PR TITLE
Refresh attack power when debuffs fade

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4197,6 +4197,12 @@ void AuraEffect::HandleAuraModAttackPower(AuraApplication const* aurApp, uint8 m
     Unit* target = aurApp->GetTarget();
 
     target->HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE, float(GetAmount()), apply);
+
+    // Ensure the client attack power display gets refreshed immediately when the debuff is
+    // applied or removed. Some debuffs (e.g. Demoralizing Roar) could leave the old modifier
+    // visible in the character pane after they expire because no update was pushed.
+    if (target->GetTypeId() == TYPEID_PLAYER)
+        target->ToPlayer()->UpdateAttackPowerAndDamage(true);
 }
 
 void AuraEffect::HandleAuraModRangedAttackPower(AuraApplication const* aurApp, uint8 mode, bool apply) const


### PR DESCRIPTION
## Summary
- trigger an attack power refresh for players whenever flat attack power auras are applied or removed
- prevent stale attack power reductions (such as Demoralizing Roar) from persisting in the client display after expiration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263c67b3c48327a844b4f1a6938ca2)