### PR TITLE
Fix spells_keep_mounts to clear talent-only spells

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23659,17 +23659,19 @@ void Player::ResetNonQuestAndMountSpells()
         if (!classEntry || spellInfo->SpellFamilyName != classEntry->SpellClassSet)
             continue;
 
-        // skip server-side/triggered spells
-        if (spellInfo->SpellLevel == 0)
+        uint32 const firstRank = spellInfo->GetFirstRankSpell()->Id;
+        bool const isTalentSpell = GetTalentSpellCost(firstRank) > 0;
+
+        // skip server-side/triggered spells except talent-learned ones
+        if (spellInfo->SpellLevel == 0 && !isTalentSpell)
             continue;
 
         // skip wrong class/race skills
         if (!IsSpellFitByClassAndRace(spellInfo->Id))
             continue;
 
-        uint32 const firstRank = spellInfo->GetFirstRankSpell()->Id;
         // remove talent-learned spells too
-        if (GetTalentSpellCost(firstRank) > 0 || SpellMgr::IsSpellValid(spellInfo, this, false))
+        if (isTalentSpell || SpellMgr::IsSpellValid(spellInfo, this, false))
         {
             RemoveAurasDueToSpell(itr->first);
             RemoveSpell(itr->first, false, false);


### PR DESCRIPTION
## Summary
- ensure .reset spells_keep_mounts also removes talent spells that have no spell level

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692678b7568c83279f7b88c8489de1d6)