### PR TITLE
Prevent damage redirect from breaking CC

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -788,11 +788,6 @@ class spell_pal_party_damage_redirect : public AuraScript
         return ValidateSpellInfo({ SPELL_PALADIN_PARTY_DAMAGE_REDIRECT });
     }
 
-    bool IsInBreakableCrowdControl(Unit* unit) const
-    {
-        return unit->HasBreakableByDamageCrowdControlAura();
-    }
-
     MeleeHitOutcome RollAvoidance(Unit* attacker, Unit* paladin) const
     {
         Unit* swingAttacker = attacker ? attacker : paladin;
@@ -832,7 +827,12 @@ class spell_pal_party_damage_redirect : public AuraScript
 
         if (IsInBreakableCrowdControl(caster) || IsInBreakableCrowdControl(target))
         {
+            uint32 redirected = std::min(splitAmount, dmgInfo.GetDamage());
             splitAmount = 0;
+
+            if (redirected)
+                dmgInfo.AbsorbDamage(redirected);
+
             return;
         }
 


### PR DESCRIPTION
## Summary
- absorb and drop redirected damage when the paladin or target is in breakable crowd control to avoid breaking CC

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692698ad27488327be98070d11b5de42)