### PR TITLE
Adjust player damage requirement after autobalance scaling

### DIFF
--- a/src/server/game/AutoBalance/AutoBalanceCreature.cpp
+++ b/src/server/game/AutoBalance/AutoBalanceCreature.cpp
@@ -600,6 +600,17 @@ void ScaleCreature(Creature* creature)
     uint32 const scaledHealth = std::clamp<uint32>(static_cast<uint32>(std::round(newHealth * healthPct)), 1u, newHealth);
     creature->SetHealth(scaledHealth);
 
+    // Keep the player-damage requirement aligned with the scaled health pool.
+    if (creature->m_PlayerDamageReq)
+    {
+        uint32 newDamageReq = newHealth / 2;
+
+        if (oldMaxHealth)
+            newDamageReq = static_cast<uint32>(std::round(static_cast<float>(creature->m_PlayerDamageReq) * newHealth / oldMaxHealth));
+
+        creature->m_PlayerDamageReq = std::min(newDamageReq, newHealth / 2);
+    }
+
     uint32 const oldMaxMana = creature->GetMaxPower(POWER_MANA);
     uint32 const baseMana = info.BaseValues.Mana;
     if (baseMana || oldMaxMana)


### PR DESCRIPTION
## Summary
- keep the player-damage requirement in sync with autobalanced creature health so kills still grant loot and quest credit

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692af7bd6edc8327b7111183c4c3af64)