### PR TITLE
Ensure attack power desync guard updates client

### DIFF
--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -468,22 +468,12 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
         attPowerFlatFromAuras += aurEff->GetAmount();
 
     // If there are NO flat AP auras, but the UnitMod group still says we have a NEGATIVE
-    // modifier, it almost certainly means a debuff (Demoralizing Roar / Shout) didn?t fully unwind.
+    // modifier, it almost certainly means a debuff (Demoralizing Roar / Shout) didn't fully unwind.
     if (attPowerFlatFromAuras == 0.0f && attPowerMod < 0.0f)
     {
-        /*
-        TC_LOG_ERROR("spells",
-            "AP flat negative desync for player %s (GUID %s, ranged=%u): "
-            "UnitMod TOTAL_VALUE=%.1f but no SPELL_AURA_MOD_%sATTACK_POWER auras active. "
-            "Resetting flat AP mod to 0.",
-            GetName().c_str(),
-            GetGUID().ToString().c_str(),
-            ranged ? 1u : 0u,
-            attPowerMod,
-            ranged ? "RANGED_" : "");
-
+        // Use the helper to keep dependent stats in sync and notify the client
+        SetStatFlatModifier(unitMod, TOTAL_VALUE, 0.0f);
         attPowerMod = 0.0f;
-        */
     }
 
     // --- END: desync guard ---


### PR DESCRIPTION
## Summary
- reset stale negative attack power mods via SetStatFlatModifier so dependent stats and client fields update

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692afbd8c6a48327b5a7a0cd4a4b9091)