### PR TITLE
Fix inconsistent group loot threshold handling

### DIFF
--- a/doc/LootRollingBehavior.md
+++ b/doc/LootRollingBehavior.md
@@ -1,0 +1,8 @@
+# Loot rolling behavior
+
+When loot is generated for a group, the server applies the party's loot method and threshold to decide whether players roll on an item or receive it without a roll:
+
+- **Group Loot** and **Need Before Greed** only start a roll when the item quality meets or exceeds the group's loot threshold (or when the item is account-bound). Items below the threshold are flagged as under-threshold and are handed out via round-robin instead of triggering a roll prompt.
+- Items that do not meet the threshold are still subject to the group's ownership rules (round-robin owner or released loot) but do not show a roll window because they are explicitly marked as under-threshold.
+
+If you see some drops triggering rolls while others do not, check the group's loot threshold. Raising the threshold will make more items require rolls; lowering it will allow more items to be distributed automatically.

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1055,6 +1055,8 @@ void Group::GroupLoot(Loot* loot, WorldObject* pLootedObject)
 
             Roll* r = new Roll(newitemGUID, *i);
 
+            i->is_underthreshold = false;
+
             //a vector is filled with only near party members
             for (GroupReference* itr = GetFirstMember(); itr != nullptr; itr = itr->next())
             {
@@ -1205,6 +1207,8 @@ void Group::NeedBeforeGreed(Loot* loot, WorldObject* lootedObject)
             ObjectGuid newitemGUID = ObjectGuid::Create<HighGuid::Item>(sObjectMgr->GetGenerator<HighGuid::Item>().Generate());
 
             Roll* r = new Roll(newitemGUID, *i);
+
+            i->is_underthreshold = false;
 
             for (GroupReference* itr = GetFirstMember(); itr != nullptr; itr = itr->next())
             {

--- a/src/server/game/Loot/Loot.cpp
+++ b/src/server/game/Loot/Loot.cpp
@@ -238,6 +238,9 @@ bool Loot::FillLoot(uint32 lootId, LootStore const& store, Player* lootOwner, bo
     {
         roundRobinPlayer = lootOwner->GetGUID();
 
+        LootMethod lootMethod = group->GetLootMethod();
+        bool useThreshold = lootMethod == GROUP_LOOT || lootMethod == NEED_BEFORE_GREED || lootMethod == MASTER_LOOT;
+
         for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
             if (Player* player = itr->GetSource())   // should actually be looted object instead of lootOwner but looter has to be really close so doesnt really matter
                 if (player->IsInMap(lootOwner))
@@ -246,7 +249,7 @@ bool Loot::FillLoot(uint32 lootId, LootStore const& store, Player* lootOwner, bo
         for (uint8 i = 0; i < items.size(); ++i)
         {
             if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(items[i].itemid))
-                if (proto->Quality < uint32(group->GetLootThreshold()))
+                if (useThreshold && proto->Quality < uint32(group->GetLootThreshold()))
                     items[i].is_underthreshold = true;
         }
     }


### PR DESCRIPTION
## Summary
- only apply under-threshold flag when the group loot method uses thresholds
- reset under-threshold state when starting Group Loot or Need Before Greed rolls to avoid stale auto-loot behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a4962e00c8327b35ad5036247e909)