### PR TITLE
Handle absorbed periodic damage breaking CC effects

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5338,6 +5338,9 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
 
     Unit::DealDamageMods(target, damage, &absorb);
 
+    cleanDamage.absorbed_damage += absorb;
+    cleanDamage.mitigated_damage += resist;
+
     // Set trigger flag
     uint32 procAttacker = PROC_FLAG_DONE_PERIODIC;
     uint32 procVictim   = PROC_FLAG_TAKEN_PERIODIC;


### PR DESCRIPTION
**Changes proposed**:

- Track absorbed and resisted amounts for periodic damage ticks.
- Ensure periodic damage absorbed by shields still flags damage-interruptible auras to break crowd control.

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #N/A

**Tests performed**: Not run (not requested).

**Known issues and TODO list**:

- [ ] None
- [ ]


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bef93979c83279fe02ca655495562)