### PR TITLE
Allow Stockades teams to teleport out after PvP kills

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -775,6 +775,15 @@ PvpveDungeonRun* PvpveDungeonMgr::GetRunForTeam(uint64 teamId)
     return nullptr;
 }
 
+uint64 PvpveDungeonMgr::GetTeamIdForPlayer(ObjectGuid const& guid) const
+{
+    auto itr = _playerToTeam.find(guid);
+    if (itr == _playerToTeam.end())
+        return 0;
+
+    return itr->second;
+}
+
 bool PvpveDungeonMgr::PickSpawnIndex(PvpveDungeonRun const& run, uint8& outIndex)
 {
     if (run.BossDefeated)
@@ -830,6 +839,37 @@ void PvpveDungeonMgr::HandleServerShutdown()
 
         OnPlayerLeftMap(player);
     }
+}
+
+bool PvpveDungeonMgr::UnlockTeamTeleport(uint64 teamId)
+{
+    PvpveTeam* team = GetTeam(teamId);
+    if (!team || team->TeleportUnlockedOnKill)
+        return false;
+
+    PvpveDungeonRun* run = GetRunForTeam(teamId);
+    if (!run || run->Finished)
+        return false;
+
+    DungeonTemplate const* dungeonTemplate = GetDungeonTemplate(run->TemplateId);
+    if (!dungeonTemplate || dungeonTemplate->MapId != kStockadesMapId)
+        return false;
+
+    team->TeleportUnlockedOnKill = true;
+
+    for (ObjectGuid const& memberGuid : team->Members)
+    {
+        if (Player* member = ObjectAccessor::FindPlayer(memberGuid))
+        {
+            if (member->GetMapId() != dungeonTemplate->MapId)
+                continue;
+
+            if (WorldSession* session = member->GetSession())
+                session->SendNotification("Your team has slain an enemy inside the Stockades. Teleport spells can now return you to the city.");
+        }
+    }
+
+    return true;
 }
 
 void PvpveDungeonMgr::OnInstanceCreated(uint32 templateId, uint64 runId, uint32 instanceId)
@@ -1504,6 +1544,11 @@ public:
         if (!run || run->BossDefeated || run->Finished)
             return;
 
+        uint64 const teamId = sPvpveDungeonMgr->GetTeamIdForPlayer(player->GetGUID());
+        PvpveTeam* team = sPvpveDungeonMgr->GetTeam(teamId);
+        if (team && team->TeleportUnlockedOnKill)
+            return;
+
         DungeonTemplate const* dungeonTemplate = sPvpveDungeonMgr->GetDungeonTemplate(run->TemplateId);
         if (!dungeonTemplate || dungeonTemplate->MapId != kStockadesMapId)
             return;
@@ -1518,8 +1563,23 @@ public:
             session->SendNotification("You cannot teleport out until the Stockades boss has been defeated.");
     }
 
-    void OnPVPKill(Player* /*killer*/, Player* killed) override
+    void OnPVPKill(Player* killer, Player* killed) override
     {
+        if (killer && killed && killer->GetMapId() == kStockadesMapId)
+        {
+            PvpveDungeonRun* killerRun = sPvpveDungeonMgr->GetRunForPlayer(killer->GetGUID());
+            PvpveDungeonRun* victimRun = sPvpveDungeonMgr->GetRunForPlayer(killed->GetGUID());
+
+            if (killerRun && killerRun == victimRun)
+            {
+                uint64 const killerTeamId = sPvpveDungeonMgr->GetTeamIdForPlayer(killer->GetGUID());
+                uint64 const victimTeamId = sPvpveDungeonMgr->GetTeamIdForPlayer(killed->GetGUID());
+
+                if (killerTeamId && victimTeamId && killerTeamId != victimTeamId)
+                    sPvpveDungeonMgr->UnlockTeamTeleport(killerTeamId);
+            }
+        }
+
         HandlePlayerDeath(killed);
     }
 

--- a/src/server/scripts/Custom/mod_pvpve_dungeon.h
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.h
@@ -49,6 +49,7 @@ struct PvpveTeam
     uint8 SpawnIndex = 0;
     bool Ready = false;
     bool Eliminated = false;
+    bool TeleportUnlockedOnKill = false;
 };
 
 class PvpveDungeonInstance
@@ -126,10 +127,13 @@ public:
     PvpveTeam* GetTeam(uint64 teamId);
     PvpveDungeonRun* GetRunForPlayer(ObjectGuid const& guid);
     PvpveDungeonRun* GetRunForTeam(uint64 teamId);
+    uint64 GetTeamIdForPlayer(ObjectGuid const& guid) const;
 
     void Reset();
     void PurgeDungeonInstances();
     void HandleServerShutdown();
+
+    bool UnlockTeamTeleport(uint64 teamId);
 
 private:
     PvpveDungeonMgr();


### PR DESCRIPTION
## Summary
- track teams that score PvP kills inside the Stockades PvPvE instance
- allow those teams to use teleport spells to leave and notify members when unlocked
- keep teleport blocking in place otherwise until the boss is defeated or run ends

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c121136e083278e8f5ef9a2b2afe5)