### PR TITLE
Clamp starfire walk speed during refresh

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22605,6 +22605,22 @@ void Player::VerifyStarfireSnare()
     _verifyStarfireSnareNextUpdate = false;
 }
 
+float Player::GetActiveStarfireSnareSpeedRate(UnitMoveType moveType) const
+{
+    if (!HasActiveStarfireSnare())
+        return 0.0f;
+
+    float const desiredRate = std::clamp(_activeStarfireSnareSpeedRate, MinStarfireSnareSpeedRate, MaxStarfireSnareSpeedRate);
+    if (desiredRate <= 0.0f)
+        return 0.0f;
+
+    for (UnitMoveType snareMoveType : StarfireSnareMoveTypes)
+        if (snareMoveType == moveType)
+            return desiredRate;
+
+    return 0.0f;
+}
+
 bool Player::HasActiveStarfireSnare() const
 {
     return _activeStarfireSnareRefCount > 0 || _pendingStarfireSnareRemoval;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1529,6 +1529,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void HandleStarfireSnareOnSpeedUpdate(UnitMoveType moveType);
         void UpdateStarfireSnare();
         void VerifyStarfireSnare();
+        float GetActiveStarfireSnareSpeedRate(UnitMoveType moveType) const;
 
         bool HasActiveStarfireSnare() const;
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8862,6 +8862,10 @@ void Unit::SetSpeedRate(UnitMoveType mtype, float rate)
     if (rate < 0)
         rate = 0.0f;
 
+    if (Player* player = ToPlayer())
+        if (float const starfireRateLimit = player->GetActiveStarfireSnareSpeedRate(mtype))
+            rate = std::min(rate, starfireRateLimit);
+
     // Update speed only on change
     MovementChangeType changeType = MovementPacketSender::GetChangeTypeByMoveType(mtype);
     if (m_speed_rate[mtype] == rate && !HasPendingMovementChange(changeType)) //todo: is the "!HasPendingMovementChange" part necessary here?


### PR DESCRIPTION
## Summary
- add a helper to expose the active Starfire walk snare rate for specific move types
- clamp player speed changes to the active Starfire walk snare to prevent refreshes from exceeding the intended rate

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8e08970c8327944ed3ea1c5249d9)