### PR TITLE
Fix Gurubashi chest ownership

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -289,6 +289,8 @@ private:
 
         if (GameObject* chest = summoner->SummonGameObject(GURUBASHI_CHEST_ENTRY, ChestSpawnPosition, QuaternionData::fromEulerAnglesZYX(ChestSpawnPosition.GetOrientation(), 0.f, 0.f), CHEST_DESPAWN_TIME))
         {
+            // Clear temporary ownership so all players in the arena can interact with the chest.
+            summoner->RemoveGameObject(chest, false);
             chest->SetRespawnTime(0);
             _currentChestGuid = chest->GetGUID();
             YellFromChromie();


### PR DESCRIPTION
## Summary
- clear the summoned Gurubashi chest owner so any player in the arena can interact with it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cc3d9f5b48327b1cb633e08a2f276)