### PR TITLE
Refresh ammo bag bonuses after ranged weapon changes

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7615,7 +7615,14 @@ void Player::_ApplyItemMods(Item* item, uint8 slot, bool apply, bool updateItemA
     _ApplyItemBonuses(proto, slot, apply);
 
     if (slot == EQUIPMENT_SLOT_RANGED)
+    {
         _ApplyAmmoBonuses();
+
+        // Refresh ammo bag equip effects that may have been removed when the player temporarily lacked
+        // a valid ranged weapon (for example during teleports or weapon swaps).
+        if (apply)
+            ReapplyAmmoBagEquipSpells();
+    }
 
     ApplyItemEquipSpell(item, apply);
     if (updateItemAuras)
@@ -8603,6 +8610,23 @@ void Player::_ApplyAmmoBonuses()
 
     if (CanModifyStats())
         UpdateDamagePhysical(RANGED_ATTACK);
+}
+
+void Player::ReapplyAmmoBagEquipSpells()
+{
+    for (uint8 slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; ++slot)
+    {
+        Item* bag = GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+        if (!bag)
+            continue;
+
+        ItemTemplate const* bagTemplate = bag->GetTemplate();
+        if (!bagTemplate || bagTemplate->Class != ITEM_CLASS_QUIVER)
+            continue;
+
+        ApplyItemEquipSpell(bag, false);
+        ApplyItemEquipSpell(bag, true);
+    }
 }
 
 bool Player::CheckAmmoCompatibility(ItemTemplate const* ammo_proto) const

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1153,6 +1153,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void ApplyEquipCooldown(Item* pItem);
         void SetAmmo(uint32 item);
         void RemoveAmmo();
+        void ReapplyAmmoBagEquipSpells();
         float GetAmmoDPS() const { return m_ammoDPS; }
         bool CheckAmmoCompatibility(ItemTemplate const* ammo_proto) const;
         void QuickEquipItem(uint16 pos, Item* pItem);


### PR DESCRIPTION
## Summary
- reapply ammo bag equip spells when ranged weapon stats are recalculated
- ensure quiver or ammo pouch haste bonuses are restored after teleports or weapon swaps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d4cf9e2bc83279e5a1921216d7cbf)