### PR TITLE
Ensure GM toggle respects battleground team

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2496,7 +2496,19 @@ void Player::SetGameMaster(bool on)
         SetPhaseMask(newPhase, false);
 
         m_ExtraFlags &= ~PLAYER_EXTRA_GM_ON;
-        SetFactionForRace(GetRace());
+
+        if (GetBattleground())
+        {
+            uint32 const bgTeam = GetBGTeam();
+            if (bgTeam == ALLIANCE)
+                SetFactionForRace(RACE_HUMAN);
+            else if (bgTeam == HORDE)
+                SetFactionForRace(RACE_BLOODELF);
+            else
+                SetFactionForRace(GetRace());
+        }
+        else
+            SetFactionForRace(GetRace());
         RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_GM);
         RemoveUnitFlag2(UNIT_FLAG2_ALLOW_CHEAT_SPELLS);
 


### PR DESCRIPTION
## Summary
- preserve the player's battleground faction when disabling GM mode
- avoid team switching for cross-faction participants while toggling GM state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5cc750a08327834d3ea0c4090daf)