### PR TITLE
Fix revive command health and adjust Shadowburn consumption

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -747,9 +747,10 @@ public:
         if (!handler->extractPlayerTarget((char*)args, &target, &targetGuid))
             return false;
 
+        bool resurrectWithFullHealth = handler->GetSession()->HasPermission(rbac::RBAC_PERM_RESURRECT_WITH_FULL_HPS);
         if (target)
         {
-            target->ResurrectPlayer(target->GetSession()->HasPermission(rbac::RBAC_PERM_RESURRECT_WITH_FULL_HPS) ? 1.0f : 0.5f);
+            target->ResurrectPlayer(resurrectWithFullHealth ? 1.0f : 0.5f);
             target->SpawnCorpseBones();
             target->SaveToDB();
         }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1237,14 +1237,6 @@ class spell_warl_shadowburn : public SpellScript
             SPELL_WARLOCK_SHADOWBURN_R4,
             SPELL_WARLOCK_SHADOWBURN_R5,
             SPELL_WARLOCK_SHADOWBURN_R6,
-            SPELL_WARLOCK_FEAR_R1,
-            SPELL_WARLOCK_FEAR_R2,
-            SPELL_WARLOCK_FEAR_R3,
-            SPELL_WARLOCK_HOWL_OF_TERROR_R1,
-            SPELL_WARLOCK_HOWL_OF_TERROR_R2,
-            SPELL_WARLOCK_DEATH_COIL_R1,
-            SPELL_WARLOCK_DEATH_COIL_R2,
-            SPELL_WARLOCK_DEATH_COIL_R3,
             SPELL_WARLOCK_SHADOWBURN_CONSUMPTION_AURA
         });
     }
@@ -1257,24 +1249,29 @@ class spell_warl_shadowburn : public SpellScript
 
         if (Unit* target = GetHitUnit())
         {
-            static uint32 const fearAndHorrorSpells[] =
-            {
-                SPELL_WARLOCK_FEAR_R1,
-                SPELL_WARLOCK_FEAR_R2,
-                SPELL_WARLOCK_FEAR_R3,
-                SPELL_WARLOCK_HOWL_OF_TERROR_R1,
-                SPELL_WARLOCK_HOWL_OF_TERROR_R2,
-                SPELL_WARLOCK_DEATH_COIL_R1,
-                SPELL_WARLOCK_DEATH_COIL_R2,
-                SPELL_WARLOCK_DEATH_COIL_R3
-            };
             if (caster->HasAura(81456) && !caster->HasAura(81458))
             {
                 caster->AddAura(SPELL_WARLOCK_SHADOWBURN_CONSUMPTION_AURA, caster);
                 caster->AddAura(81458, caster);
-                for (uint32 spellId : fearAndHorrorSpells)
-                    if (Aura* aura = target->GetAura(spellId, caster->GetGUID()))
-                        aura->Remove();
+
+                std::vector<Aura*> cursesToRemove;
+                Unit::AuraApplicationMap const& appliedAuras = target->GetAppliedAuras();
+                for (auto const& auraApplicationPair : appliedAuras)
+                {
+                    Aura* aura = auraApplicationPair.second->GetBase();
+                    if (!aura)
+                        continue;
+
+                    if (aura->GetCasterGUID() != caster->GetGUID())
+                        continue;
+
+                    SpellInfo const* auraSpellInfo = aura->GetSpellInfo();
+                    if (auraSpellInfo && auraSpellInfo->Dispel == DISPEL_CURSE)
+                        cursesToRemove.push_back(aura);
+                }
+
+                for (Aura* aura : cursesToRemove)
+                    aura->Remove();
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure the .revive command uses the issuer's permissions to determine full-health resurrection
- update Shadowburn's special consumption to remove the caster's curses on the target instead of fear/horror effects

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9f986f2c8327bc1d71cd083c8ad9)