### PR TITLE
Keep paladin redirected damage physical while ignoring armor

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1159,6 +1159,7 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
     damageInfo->ProcVictim       = PROC_FLAG_NONE;
     damageInfo->CleanDamage      = 0;
     damageInfo->HitOutCome       = MELEE_HIT_EVADE;
+    damageInfo->IgnoreArmor      = false;
 
     if (!victim)
         return;
@@ -1219,7 +1220,7 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
         sScriptMgr->ModifyMeleeDamage(damageInfo->Target, damageInfo->Attacker, damage);
 
         // Calculate armor reduction
-        if (Unit::IsDamageReducedByArmor(SpellSchoolMask(damageInfo->Damages[i].DamageSchoolMask)))
+        if (!damageInfo->IgnoreArmor && Unit::IsDamageReducedByArmor(SpellSchoolMask(damageInfo->Damages[i].DamageSchoolMask)))
         {
             damageInfo->Damages[i].Damage = Unit::CalcArmorReducedDamage(damageInfo->Attacker, damageInfo->Target, damage, nullptr, damageInfo->AttackType);
             damageInfo->CleanDamage += damage - damageInfo->Damages[i].Damage;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -560,6 +560,7 @@ struct CalcDamageInfo
     uint32 ProcVictim;
     uint32 CleanDamage;          // Used only for rage calculation
     MeleeHitOutcome HitOutCome;  /// @todo remove this field (need use TargetState)
+    bool IgnoreArmor;            // Skip physical armor mitigation when true
 };
 
 // Spell damage info structure based on structure sending in SMSG_SPELLNONMELEEDAMAGELOG opcode

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -873,7 +873,9 @@ class spell_pal_party_damage_redirect : public AuraScript
         CalcDamageInfo redirectInfo{};
         redirectInfo.Attacker = attacker ? attacker : caster;
         redirectInfo.Target = caster;
+        // Keep the redirected swing physical for immunity interactions but explicitly flag it to ignore armor mitigation.
         redirectInfo.Damages[0].DamageSchoolMask = SPELL_SCHOOL_MASK_NORMAL;
+        redirectInfo.IgnoreArmor = true;
         redirectInfo.Damages[0].Damage = redirected;
         redirectInfo.Damages[1].DamageSchoolMask = SPELL_SCHOOL_MASK_NORMAL;
         redirectInfo.AttackType = BASE_ATTACK;


### PR DESCRIPTION
## Summary
- add an ignore-armor flag to melee damage calculations so redirects can bypass armor without changing damage school
- keep paladin party damage redirect physical while marking the transferred hit to ignore armor mitigation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ede56de308327a16673631b5cae19)