### PR TITLE
Add Freezing Trap to disorient diminishing returns

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2300,6 +2300,10 @@ void SpellInfo::_LoadSpellDiminishInfo()
             return DIMINISHING_TAUNT;
 
         // Explicit Diminishing Groups
+        // Freezing Trap effects (including Freezing Arrow) should share the disorient DR in Classic
+        if (Id == 3355 || Id == 14308 || Id == 14309 || Id == 60210)
+            return DIMINISHING_DISORIENT;
+
         switch (SpellFamilyName)
         {
             case SPELLFAMILY_GENERIC:


### PR DESCRIPTION
## Summary
- ensure Freezing Trap and Freezing Arrow effects use the disorient diminishing return for classic-like behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f005669f48327bf458dfe809857ad)