### PR TITLE
Allow blocked hits to trigger proc spells

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -610,8 +610,9 @@ bool SpellMgr::CanSpellTriggerProcOnEvent(SpellProcEntry const& procEntry, ProcE
         if (!hitMask)
         {
             // for taken procs allow normal + critical hits by default
+            // blocked hits should still be able to trigger default procs
             if (eventInfo.GetTypeMask() & TAKEN_HIT_PROC_FLAG_MASK)
-                hitMask |= PROC_HIT_NORMAL | PROC_HIT_CRITICAL;
+                hitMask |= PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_BLOCK;
             // for done procs allow normal + critical + absorbs by default
             else
                 hitMask |= PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_ABSORB;


### PR DESCRIPTION
## Summary
- allow blocked hits to satisfy default proc hit masks so trigger spells still fire when blocks occur

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4677d7348327b9a07d5b16241397)