### PR TITLE
Ensure stealth only breaks by owner under aura 81439

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4118,6 +4118,14 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
     if (!(m_interruptMask & flag))
         return;
 
+    static uint32 const ROGUE_STEALTH_PROTECTION_AURA = 81439;
+    static uint32 const STEALTH_BREAKER_OWNER_FLAGS = AURA_INTERRUPT_FLAG_CAST | AURA_INTERRUPT_FLAG_MOVE |
+        AURA_INTERRUPT_FLAG_TURNING | AURA_INTERRUPT_FLAG_JUMP | AURA_INTERRUPT_FLAG_NOT_MOUNTED |
+        AURA_INTERRUPT_FLAG_TALK | AURA_INTERRUPT_FLAG_LOOTING | AURA_INTERRUPT_FLAG_MELEE_ATTACK |
+        AURA_INTERRUPT_FLAG_SPELL_ATTACK | AURA_INTERRUPT_FLAG_MOUNT;
+
+    bool ignoreStealthBreak = HasAura(ROGUE_STEALTH_PROTECTION_AURA) && !(flag & STEALTH_BREAKER_OWNER_FLAGS);
+
     // interrupt auras
     for (AuraApplicationList::iterator iter = m_interruptableAuras.begin(); iter != m_interruptableAuras.end();)
     {
@@ -4125,6 +4133,9 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
         ++iter;
         if ((aura->GetSpellInfo()->AuraInterruptFlags & flag) && (!except || aura->GetId() != except))
         {
+            if (ignoreStealthBreak && (aura->HasEffectType(SPELL_AURA_MOD_STEALTH) || aura->HasEffectType(SPELL_AURA_MOD_INVISIBILITY)))
+                continue;
+
             uint32 removedAuras = m_removedAurasCount;
             RemoveAura(aura);
             if (m_removedAurasCount > removedAuras + 1)


### PR DESCRIPTION
## Summary
- prevent stealth and invisibility auras from being interrupted by external events while aura 81439 is active
- allow player-driven actions such as casting, moving, mounting, or attacking to still break stealth even under aura 81439

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692faf14652c83278378e867cbee4841)