### PR TITLE
Prevent stealth charge loss while aura 81439 is active

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -973,6 +973,13 @@ bool Aura::ModCharges(int32 num, AuraRemoveMode removeMode)
 {
     if (IsUsingCharges())
     {
+        if (num < 0 && GetId() == 1784)
+        {
+            if (Unit* owner = m_owner->ToUnit())
+                if (owner->HasAura(81439))
+                    return false;
+        }
+
         int32 charges = m_procCharges + num;
         int32 maxCharges = CalcMaxCharges();
 
@@ -2366,10 +2373,7 @@ void Aura::TriggerProcOnEvent(uint8 procEffectMask, AuraApplication* aurApp, Pro
 
     // Remove aura if we've used last charge to proc
     if (IsUsingCharges() && !GetCharges())
-    {
-        if(!(GetUnitOwner()->HasAura(81439) && aurApp->GetBase()->GetId() == 1784))
-            Remove();
-    }
+        Remove();
 }
 
 void Aura::_DeleteRemovedApplications()


### PR DESCRIPTION
## Summary
- prevent Stealth (1784) charges from decrementing while aura 81439 is active
- restore standard proc charge removal path to avoid persistent stealth after immunity

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd21001f08327b06746366d6b9a07)