### PR TITLE
Delay ghost wolf removal until charge landing

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3758,6 +3758,12 @@ void Creature::SetDisplayId(uint32 modelId)
     }
 }
 
+void Creature::MovementInform(uint32 type, uint32 id)
+{
+    if (AI())
+        AI()->MovementInform(type, id);
+}
+
 void Creature::SetTarget(ObjectGuid guid)
 {
     if (HasSpellFocus())

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -70,6 +70,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         float GetNativeObjectScale() const override;
         void SetObjectScale(float scale) override;
         void SetDisplayId(uint32 modelId) override;
+        void MovementInform(uint32 type, uint32 id) override;
 
         void DisappearAndDie() { ForcedDespawn(0); }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -38,6 +38,7 @@
 #include "CinematicMgr.h"
 #include "CombatLogPackets.h"
 #include "CombatPackets.h"
+#include "MovementDefines.h"
 #include "Common.h"
 #include "ConditionMgr.h"
 #include "Containers.h"
@@ -24907,6 +24908,23 @@ void Player::UpdateAreaDependentAuras(uint32 newArea)
         if (itr->second->autocast && itr->second->IsFitToRequirements(this, m_zoneUpdateId, newArea))
             if (!HasAura(itr->second->spellId))
                 CastSpell(this, itr->second->spellId, true);
+}
+
+void Player::MovementInform(uint32 type, uint32 id)
+{
+    if (type == POINT_MOTION_TYPE && (id == EVENT_CHARGE || id == EVENT_CHARGE_PREPATH) && _pendingGhostWolfChargeTarget)
+    {
+        ObjectGuid const targetGuid = _pendingGhostWolfChargeTarget;
+        _pendingGhostWolfChargeTarget.Clear();
+
+        if (Unit* target = ObjectAccessor::GetUnit(*this, targetGuid))
+            CompleteGhostWolfCharge(target);
+    }
+}
+
+void Player::SetPendingGhostWolfChargeTarget(ObjectGuid const& targetGuid)
+{
+    _pendingGhostWolfChargeTarget = targetGuid;
 }
 
 uint32 Player::GetCorpseReclaimDelay(bool pvp) const

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1870,6 +1870,9 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         int32 CalculateCorpseReclaimDelay(bool load = false) const;
         void SendCorpseReclaimDelay(uint32 delay) const;
 
+        void MovementInform(uint32 type, uint32 id) override;
+        void SetPendingGhostWolfChargeTarget(ObjectGuid const& targetGuid);
+
         uint32 GetShieldBlockValue() const override;                 // overwrite Unit version (virtual)
         bool CanParry() const { return m_canParry; }
         void SetCanParry(bool value);
@@ -2609,6 +2612,8 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         uint32 _pendingBindTimer;
 
         uint32 _activeCheats;
+
+        ObjectGuid _pendingGhostWolfChargeTarget;
 
         // variables to save health and mana before duel and restore them after duel
         uint32 healthBeforeDuel;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -18,6 +18,7 @@
 #include "Unit.h"
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include "AbstractFollower.h"
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
@@ -2218,6 +2219,49 @@ void Unit::AddExtraAttacks(uint32 count)
     }
 
     extraAttacksTargets[targetGUID] += count;
+}
+
+void Unit::CompleteGhostWolfCharge(Unit* target)
+{
+    RemoveAurasDueToSpell(SPELL_SHAMAN_GHOST_WOLF);
+
+    if (SpellHistory* spellHistory = GetSpellHistory())
+    {
+        static constexpr std::chrono::seconds GhostWolfCooldown(12);
+        SpellInfo const* ghostWolfInfo = sSpellMgr->GetSpellInfo(SPELL_SHAMAN_GHOST_WOLF);
+
+        if (ghostWolfInfo)
+        {
+            SpellHistory::Clock::time_point const now = GameTime::GetSystemTime();
+            SpellHistory::Clock::time_point const cooldownEnd = now + GhostWolfCooldown;
+            SpellHistory::Clock::time_point const categoryEnd = ghostWolfInfo->GetCategory() ? cooldownEnd : now;
+
+            spellHistory->AddCooldown(ghostWolfInfo->Id, 0, cooldownEnd, ghostWolfInfo->GetCategory(), categoryEnd);
+        }
+        else
+            spellHistory->AddCooldown(SPELL_SHAMAN_GHOST_WOLF, 0, GhostWolfCooldown);
+
+        if (Player* playerCaster = ToPlayer())
+        {
+            WorldPacket cooldownData;
+            uint32 const ghostWolfCooldownMs = static_cast<uint32>(std::chrono::duration_cast<std::chrono::milliseconds>(GhostWolfCooldown).count());
+            spellHistory->BuildCooldownPacket(cooldownData, SPELL_COOLDOWN_FLAG_NONE, SPELL_SHAMAN_GHOST_WOLF, ghostWolfCooldownMs);
+            playerCaster->SendDirectMessage(&cooldownData);
+        }
+    }
+
+    if (GetShapeshiftForm() == FORM_GHOSTWOLF)
+        RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+
+    if (!target || !target->IsAlive())
+        return;
+
+    resetAttackTimer(BASE_ATTACK);
+    resetAttackTimer(OFF_ATTACK);
+
+    bool const startedMelee = Attack(target, true);
+    if (!startedMelee && GetVictim() != target)
+        return;
 }
 
 MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* victim, WeaponAttackType attType) const

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1053,6 +1053,10 @@ class TC_GAME_API Unit : public WorldObject
         void SetLastDamagedTargetGuid(ObjectGuid guid) { _lastDamagedTargetGuid = guid; }
         ObjectGuid GetLastDamagedTargetGuid() const { return _lastDamagedTargetGuid; }
 
+        virtual void MovementInform(uint32 /*type*/, uint32 /*id*/) { }
+
+        void CompleteGhostWolfCharge(Unit* target);
+
         void CalculateSpellDamageTaken(SpellNonMeleeDamage* damageInfo, int32 damage, SpellInfo const* spellInfo, WeaponAttackType attackType = BASE_ATTACK, bool crit = false, bool blocked = false, Spell* spell = nullptr);
         void DealSpellDamage(SpellNonMeleeDamage const* damageInfo, bool durabilityLoss);
 

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
@@ -154,13 +154,9 @@ void PointMovementGenerator<T>::DoFinalize(T* owner, bool active, bool movementI
 }
 
 template<class T>
-void PointMovementGenerator<T>::MovementInform(T*) { }
-
-template <>
-void PointMovementGenerator<Creature>::MovementInform(Creature* owner)
+void PointMovementGenerator<T>::MovementInform(T* owner)
 {
-    if (owner->AI())
-        owner->AI()->MovementInform(POINT_MOTION_TYPE, _movementId);
+    owner->MovementInform(POINT_MOTION_TYPE, _movementId);
 }
 
 template PointMovementGenerator<Player>::PointMovementGenerator(uint32, float, float, float, bool, float, Optional<float>);

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -1680,45 +1680,13 @@ class spell_sha_ghost_wolf_charge : public SpellScript
 
         _chargeHandled = true;
 
-        caster->RemoveAurasDueToSpell(SPELL_SHAMAN_GHOST_WOLF);
-
-        if (SpellHistory* spellHistory = caster->GetSpellHistory())
+        if (Player* playerCaster = caster->ToPlayer())
         {
-            static constexpr std::chrono::seconds GhostWolfCooldown(12);
-            SpellInfo const* ghostWolfInfo = sSpellMgr->GetSpellInfo(SPELL_SHAMAN_GHOST_WOLF);
-
-            if (ghostWolfInfo)
-            {
-                SpellHistory::Clock::time_point const now = GameTime::GetSystemTime();
-                SpellHistory::Clock::time_point const cooldownEnd = now + GhostWolfCooldown;
-                SpellHistory::Clock::time_point const categoryEnd = ghostWolfInfo->GetCategory() ? cooldownEnd : now;
-
-                spellHistory->AddCooldown(ghostWolfInfo->Id, 0, cooldownEnd, ghostWolfInfo->GetCategory(), categoryEnd);
-            }
-            else
-                spellHistory->AddCooldown(SPELL_SHAMAN_GHOST_WOLF, 0, GhostWolfCooldown);
-
-            if (Player* playerCaster = caster->ToPlayer())
-            {
-                WorldPacket cooldownData;
-                uint32 const ghostWolfCooldownMs = static_cast<uint32>(std::chrono::duration_cast<std::chrono::milliseconds>(GhostWolfCooldown).count());
-                spellHistory->BuildCooldownPacket(cooldownData, SPELL_COOLDOWN_FLAG_NONE, SPELL_SHAMAN_GHOST_WOLF, ghostWolfCooldownMs);
-                playerCaster->SendDirectMessage(&cooldownData);
-            }
+            playerCaster->SetPendingGhostWolfChargeTarget(target->GetGUID());
+            return;
         }
 
-        if (caster->GetShapeshiftForm() == FORM_GHOSTWOLF)
-            caster->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
-
-        if (!target->IsAlive())
-            return;
-
-        caster->resetAttackTimer(BASE_ATTACK);
-        caster->resetAttackTimer(OFF_ATTACK);
-
-        bool const startedMelee = caster->Attack(target, true);
-        if (!startedMelee && caster->GetVictim() != target)
-            return;
+        caster->CompleteGhostWolfCharge(target);
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)


### PR DESCRIPTION
## Summary
- add player movement inform handling for charge paths
- delay Ghost Wolf removal and cooldown application until Spirit Walk charge completes
- centralize Ghost Wolf charge completion logic for reuse

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69304da838ac832780c5a837abd0f1ff)