### PR TITLE
Fix Vanish aggro reset in Stockades PvPvE

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -1517,6 +1517,29 @@ namespace
         32272  // Teleport: Silvermoon
     };
 
+    bool IsRogueVanish(SpellInfo const* spellInfo)
+    {
+        if (!spellInfo)
+            return false;
+
+        if (spellInfo->SpellFamilyName != SPELLFAMILY_ROGUE)
+            return false;
+
+        if (!spellInfo->SpellFamilyFlags.HasFlag(SPELLFAMILYFLAG_ROGUE_VANISH))
+            return false;
+
+        for (SpellEffectInfo const& effect : spellInfo->GetEffects())
+        {
+            if (!effect.IsEffect())
+                continue;
+
+            if (effect.ApplyAuraName == SPELL_AURA_MOD_STEALTH)
+                return true;
+        }
+
+        return false;
+    }
+
     bool IsStockadesMageTeleport(uint32 spellId)
     {
         return kMageTeleportSpellIds.find(spellId) != kMageTeleportSpellIds.end();
@@ -1543,6 +1566,9 @@ public:
         PvpveDungeonRun* run = sPvpveDungeonMgr->GetRunForPlayer(player->GetGUID());
         if (!run || run->BossDefeated || run->Finished)
             return;
+
+        if (player->GetMapId() == kStockadesMapId && IsRogueVanish(spellInfo))
+            player->GetCombatManager().EndAllPvECombat();
 
         uint64 const teamId = sPvpveDungeonMgr->GetTeamIdForPlayer(player->GetGUID());
         PvpveTeam* team = sPvpveDungeonMgr->GetTeam(teamId);


### PR DESCRIPTION
## Summary
- use flag96 HasFlag to detect rogue Vanish spells without indexing
- check spell effects with IsEffect to avoid calling missing helpers

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd2c4adc88327bc7df31375c296f1)