### PR TITLE
Fix Vanish flag include in PvPvE dungeon script

### DIFF
--- a/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
+++ b/src/server/scripts/Custom/mod_pvpve_dungeon.cpp
@@ -33,6 +33,7 @@
 #include "ScriptMgr.h"
 #include "Spell.h"
 #include "SpellInfo.h"
+#include "SpellMgr.h"
 #include "WorldSession.h"
 
 #include <algorithm>
@@ -1517,6 +1518,29 @@ namespace
         32272  // Teleport: Silvermoon
     };
 
+    bool IsRogueVanish(SpellInfo const* spellInfo)
+    {
+        if (!spellInfo)
+            return false;
+
+        if (spellInfo->SpellFamilyName != SPELLFAMILY_ROGUE)
+            return false;
+
+        if (!spellInfo->SpellFamilyFlags.HasFlag(SPELLFAMILYFLAG_ROGUE_VANISH))
+            return false;
+
+        for (SpellEffectInfo const& effect : spellInfo->GetEffects())
+        {
+            if (!effect.IsEffect())
+                continue;
+
+            if (effect.ApplyAuraName == SPELL_AURA_MOD_STEALTH)
+                return true;
+        }
+
+        return false;
+    }
+
     bool IsStockadesMageTeleport(uint32 spellId)
     {
         return kMageTeleportSpellIds.find(spellId) != kMageTeleportSpellIds.end();
@@ -1543,6 +1567,9 @@ public:
         PvpveDungeonRun* run = sPvpveDungeonMgr->GetRunForPlayer(player->GetGUID());
         if (!run || run->BossDefeated || run->Finished)
             return;
+
+        if (player->GetMapId() == kStockadesMapId && IsRogueVanish(spellInfo))
+            player->GetCombatManager().EndAllPvECombat();
 
         uint64 const teamId = sPvpveDungeonMgr->GetTeamIdForPlayer(player->GetGUID());
         PvpveTeam* team = sPvpveDungeonMgr->GetTeam(teamId);


### PR DESCRIPTION
## Summary
- include SpellMgr so rogue Vanish flag resolves in the PvPvE Stockades script

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd2c4adc88327bc7df31375c296f1)