### PR TITLE
Allow player-controlled orientation on fixed jump splines

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -563,7 +563,7 @@ void Unit::UpdateSplinePosition()
 {
     Movement::Location loc = movespline->ComputePosition();
 
-    if (GetTypeId() == TYPEID_PLAYER && movespline->IsOrientationFixed())
+    if (GetTypeId() == TYPEID_PLAYER && (!movespline->HasFinalFacing() || movespline->IsOrientationFixed()))
         loc.orientation = GetOrientation();
 
     if (movespline->onTransport)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -563,6 +563,9 @@ void Unit::UpdateSplinePosition()
 {
     Movement::Location loc = movespline->ComputePosition();
 
+    if (GetTypeId() == TYPEID_PLAYER && movespline->IsOrientationFixed())
+        loc.orientation = GetOrientation();
+
     if (movespline->onTransport)
     {
         Position& pos = m_movementInfo.transport.pos;

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -808,12 +808,12 @@ void MotionMaster::MoveJumpTo(float angle, float speedXY, float speedZ)
     MoveJump(x, y, z, 0.0f, speedXY, speedZ);
 }
 
-void MotionMaster::MoveJump(Position const& pos, float speedXY, float speedZ, uint32 id/* = EVENT_JUMP*/, bool hasOrientation/* = false*/)
+void MotionMaster::MoveJump(Position const& pos, float speedXY, float speedZ, uint32 id/* = EVENT_JUMP*/, bool hasOrientation/* = false*/, bool orientationFixed/* = false*/)
 {
-    MoveJump(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation(), speedXY, speedZ, id, hasOrientation);
+    MoveJump(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation(), speedXY, speedZ, id, hasOrientation, orientationFixed);
 }
 
-void MotionMaster::MoveJump(float x, float y, float z, float o, float speedXY, float speedZ, uint32 id, bool hasOrientation /* = false*/)
+void MotionMaster::MoveJump(float x, float y, float z, float o, float speedXY, float speedZ, uint32 id, bool hasOrientation /* = false*/, bool orientationFixed /* = false*/)
 {
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveJump: '{}', jumps to point Id: {} (X: {}, Y: {}, Z: {})", _owner->GetGUID().ToString(), id, x, y, z);
     if (speedXY < 0.01f)
@@ -827,6 +827,8 @@ void MotionMaster::MoveJump(float x, float y, float z, float o, float speedXY, f
         init.MoveTo(x, y, z, false);
         init.SetParabolic(max_height, 0);
         init.SetVelocity(speedXY);
+        if (orientationFixed)
+            init.SetOrientationFixed(true);
         if (hasOrientation)
             init.SetFacing(o);
     };

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -175,8 +175,8 @@ class TC_GAME_API MotionMaster
         void MoveCharge(PathGenerator const& path, float speed = SPEED_CHARGE);
         void MoveKnockbackFrom(float srcX, float srcY, float speedXY, float speedZ);
         void MoveJumpTo(float angle, float speedXY, float speedZ);
-        void MoveJump(Position const& pos, float speedXY, float speedZ, uint32 id = EVENT_JUMP, bool hasOrientation = false);
-        void MoveJump(float x, float y, float z, float o, float speedXY, float speedZ, uint32 id = EVENT_JUMP, bool hasOrientation = false);
+        void MoveJump(Position const& pos, float speedXY, float speedZ, uint32 id = EVENT_JUMP, bool hasOrientation = false, bool orientationFixed = false);
+        void MoveJump(float x, float y, float z, float o, float speedXY, float speedZ, uint32 id = EVENT_JUMP, bool hasOrientation = false, bool orientationFixed = false);
         void MoveCirclePath(float x, float y, float z, float radius, bool clockwise, uint8 stepCount);
         void MoveSmoothPath(uint32 pointId, Position const* pathPoints, size_t pathSize, bool walk);
         // Walk along spline chain stored in DB (script_spline_chain_meta and script_spline_chain_waypoints)

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -127,6 +127,7 @@ namespace Movement
 
         bool HasAnimation() const { return splineflags.animation; }
         AnimTier GetAnimTier() const { return static_cast<AnimTier>(splineflags.animTier); }
+        bool IsOrientationFixed() const { return splineflags.orientationFixed; }
 
         bool onTransport;
         std::string ToString() const;

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -128,6 +128,7 @@ namespace Movement
         bool HasAnimation() const { return splineflags.animation; }
         AnimTier GetAnimTier() const { return static_cast<AnimTier>(splineflags.animTier); }
         bool IsOrientationFixed() const { return splineflags.orientationFixed; }
+        bool HasFinalFacing() const { return splineflags.isFacing(); }
 
         bool onTransport;
         std::string ToString() const;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1336,17 +1336,21 @@ void Spell::EffectJumpDest()
 
     float speedXY, speedZ;
     CalculateJumpSpeeds(*effectInfo, unitCaster->GetExactDist2d(destTarget), speedXY, speedZ);
+    bool hasOrientation = !m_targets.GetObjectTargetGUID().IsEmpty();
+    bool orientationFixed = false;
     if (m_spellInfo->Id == 81271)
     {
         speedZ = sWorld->getIntConfig(CONFIG_CENTURION_LEAP_Z_SPEED);
         speedXY = sWorld->getIntConfig(CONFIG_CENTURION_LEAP_XY_SPEED);
     }
-    if (m_spellInfo->Id == 83111)
+    if (m_spellInfo->Id == 83111 || m_spellInfo->Id == 8311)
     {
         speedZ = 20;
         speedXY = 7;
+        hasOrientation = false;
+        orientationFixed = true;
     }
-    unitCaster->GetMotionMaster()->MoveJump(*destTarget, speedXY, speedZ, EVENT_JUMP, !m_targets.GetObjectTargetGUID().IsEmpty());
+    unitCaster->GetMotionMaster()->MoveJump(*destTarget, speedXY, speedZ, EVENT_JUMP, hasOrientation, orientationFixed);
 }
 
 void Spell::EffectTeleportUnits()


### PR DESCRIPTION
## Summary
- expose a MoveSpline helper to detect when orientation is fixed
- keep player orientation unchanged during fixed-orientation jump splines so client turning is honored

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930546c82cc8327b6b184bb57368995)