### PR TITLE
Avoid resetting mana regen timer on free casts

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5031,10 +5031,10 @@ void Spell::TakePower()
         return;
     }
 
-    unitCaster->ModifyPower(powerType, -m_powerCost);
+    int32 const powerChange = unitCaster->ModifyPower(powerType, -m_powerCost);
 
-    // Set the five second timer
-    if (powerType == POWER_MANA && m_powerCost > 0)
+    // Set the five second timer only if mana was actually spent
+    if (powerType == POWER_MANA && powerChange < 0)
         unitCaster->SetLastManaUse(GameTime::GetGameTimeMS());
 }
 


### PR DESCRIPTION
## Summary
- ensure mana regen delay starts only when mana is actually spent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343cc7f2288327a36f1671781f6f01)