### PR TITLE
Remove Neilyo immunity when leaving stealth

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1529,6 +1529,9 @@ void AuraEffect::HandleModStealth(AuraApplication const* aurApp, uint8 mode, boo
         {
             target->m_stealth.DelFlag(type);
 
+            if (target->HasAura(81439))
+                target->RemoveAurasDueToSpell(81439);
+
             target->RemoveVisFlag(UNIT_VIS_FLAGS_CREEP);
             if (target->GetTypeId() == TYPEID_PLAYER)
                 target->RemoveByteFlag(PLAYER_FIELD_BYTES2, PLAYER_FIELD_BYTES_2_OFFSET_AURA_VISION, PLAYER_FIELD_BYTE2_STEALTH);


### PR DESCRIPTION
## Summary
- remove the Neilyo immunity aura (81439) when the last stealth aura is removed to ensure it ends with stealth

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935bf41349c8327a0275684e4b87d08)