### PR TITLE
Stop PvE pursuit after Vanish

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -1114,6 +1114,8 @@ class spell_rog_vanish : public AuraScript
         Unit* unitTarget = GetTarget();
         unitTarget->RemoveAurasByType(SPELL_AURA_MOD_STALKED);
 
+        unitTarget->CombatStop(true, false);
+
         // See if we already are stealthed. If so, we're done.
         if (unitTarget->HasAura(SPELL_ROGUE_STEALTH))
             return;


### PR DESCRIPTION
## Summary
- stop rogue Vanish from leaving the caster in PvE combat by clearing threat as stealth is applied

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936e156b2e88327b18ea9e96f9ef219)