### PR TITLE
Keep artifact-equipped players queued on Gurubashi redirect

### DIFF
--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -35,9 +35,54 @@
 #include "ObjectMgr.h"
 #include "Opcodes.h"
 #include "Player.h"
+#include "Item.h"
 #include "World.h"
 #include "WorldPacket.h"
 #include "CharacterCache.h"
+
+#include <string>
+
+namespace
+{
+    uint32 constexpr ChromieEntry = 27915;
+    char const* const ChromieName = "Chromie";
+
+    uint32 constexpr GurubashiArenaMapId = 0;
+    float constexpr GurubashiArenaX = -13235.707031f;
+    float constexpr GurubashiArenaY = 214.336441;
+    float constexpr GurubashiArenaZ = 31.276190;
+    float constexpr GurubashiArenaO = 1.010225f;
+
+    bool HasArtifactEquipment(Player const* player)
+    {
+        if (!player)
+            return false;
+
+        for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+            if (Item const* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+                if (ItemTemplate const* proto = item->GetTemplate())
+                    if (proto->Quality == ITEM_QUALITY_ARTIFACT)
+                        return true;
+
+        return false;
+    }
+
+    void TeleportToGurubashiWithChromieWhisper(Player* player)
+    {
+        if (!player)
+            return;
+
+        player->TeleportTo(GurubashiArenaMapId, GurubashiArenaX, GurubashiArenaY, GurubashiArenaZ, GurubashiArenaO);
+
+        std::string message = "You can't enter battlegrounds or arenas while wearing artifact gear.";
+
+        WorldPacket data;
+        ObjectGuid chromieGuid = ObjectGuid::Create<HighGuid::Unit>(ChromieEntry, 1);
+        ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_WHISPER, LANG_UNIVERSAL, chromieGuid, player->GetGUID(), message,
+            0, ChromieName, player->GetName());
+        player->SendDirectMessage(&data);
+    }
+}
 
 void WorldSession::HandleBattlemasterHelloOpcode(WorldPacket& recvData)
 {
@@ -425,6 +470,8 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPacket &recvData)
     if (!bracketEntry)
         return;
 
+    bool const artifactEquipped = HasArtifactEquipment(_player);
+
     //some checks if player isn't cheating - it is not exactly cheating, but we cannot allow it
     if (action == 1 && ginfo.ArenaType == 0)
     {
@@ -450,6 +497,17 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPacket &recvData)
     WorldPacket data;
     if (action)
     {
+        if (artifactEquipped)
+        {
+            TeleportToGurubashiWithChromieWhisper(_player);
+
+            uint32 remainingTime = ginfo.RemoveInviteTime ? getMSTimeDiff(GameTime::GetGameTimeMS(), ginfo.RemoveInviteTime) : 0;
+            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_WAIT_JOIN, remainingTime, 0, ginfo.ArenaType, ginfo.Team);
+            _player->SendDirectMessage(&data);
+
+            return;
+        }
+
         // check Freeze debuff
         if (_player->HasAura(9454))
             return;


### PR DESCRIPTION
## Summary
- update the Gurubashi Arena redirect location for artifact-gear battleground/arena attempts
- keep players in the battleground queue while redirecting them, sending a wait-join status instead of removing the queue

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936e731c4f08327bcc3a02c454eb25c)