### PR TITLE
Prevent Claw from applying Mangle on avoided hits

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2192,8 +2192,18 @@ class spell_dru_claw : public SpellScript
 {
     PrepareSpellScript(spell_dru_claw);
 
+    bool _shouldMangle = false;
+
+    void HandleBeforeHit(SpellMissInfo missInfo)
+    {
+        _shouldMangle = missInfo == SPELL_MISS_NONE;
+    }
+
     void HandleAfterHit()
     {
+        if (!_shouldMangle)
+            return;
+
         if (GetCaster()->IsPlayer())
         {
             Player* p = GetCaster()->ToPlayer();
@@ -2206,6 +2216,7 @@ class spell_dru_claw : public SpellScript
 
     void Register() override
     {
+        BeforeHit += BeforeSpellHitFn(spell_dru_claw::HandleBeforeHit);
         AfterHit += SpellHitFn(spell_dru_claw::HandleAfterHit);
     }
 };


### PR DESCRIPTION
## Summary
- ensure the Claw spell only applies Mangle when the hit lands successfully
- use the BeforeHit hook to skip the Mangle application on blocks, dodges, parries, and misses

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae96bd7e88327933a732cd0854567)