### PR TITLE
Recalculate speed when mounting

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2695,6 +2695,14 @@ void AuraEffect::HandleAuraMounted(AuraApplication const* aurApp, uint8 mode, bo
         if (mode & AURA_EFFECT_HANDLE_REAL)
             target->RemoveAurasByType(SPELL_AURA_MOUNTED);
     }
+
+    // Mounted speed modifiers are only meant to apply while mounted, so always recalculate
+    // movement speeds whenever the mounted state toggles.
+    target->UpdateSpeed(MOVE_RUN);
+
+    // Update flight speed as well for flying mounts.
+    if (target->HasUnitMovementFlag(MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_FLYING))
+        target->UpdateSpeed(MOVE_FLIGHT);
 }
 
 void AuraEffect::HandleAuraAllowFlight(AuraApplication const* aurApp, uint8 mode, bool apply) const


### PR DESCRIPTION
## Summary
- recalculate movement speeds whenever a mount aura is applied or removed
- update flight speed too when mounting flying creatures to avoid stale or stacked bonuses

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7ecdae048327982dea64ea0ec9db)