### PR TITLE
Remove Forbearance from Lay on Hands

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1692,7 +1692,6 @@ class spell_pal_lay_on_hands : public SpellScript
         Unit* caster = GetCaster();
         if (caster == GetHitUnit())
         {
-            caster->CastSpell(caster, SPELL_PALADIN_FORBEARANCE, true);
             caster->CastSpell(caster, SPELL_PALADIN_AVENGING_WRATH_MARKER, true);
             caster->CastSpell(caster, SPELL_PALADIN_IMMUNE_SHIELD_MARKER, true);
         }


### PR DESCRIPTION
## Summary
- stop Lay on Hands from applying the Forbearance debuff when self-cast

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2bc97a348327a6731938854452a4)