### PR TITLE
Fix Gawain's Protection target on Holy Shock

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1055,7 +1055,7 @@ class spell_pal_holy_shock : public SpellScript
                 caster->CastSpell(unitTarget, sSpellMgr->GetSpellWithRank(SPELL_PALADIN_HOLY_SHOCK_R1_DAMAGE, rank), true);
                 if (caster->HasAura(81489))
                 {
-                    caster->CastSpell(caster, 81490, true);
+                    caster->CastSpell(unitTarget, 81490, true);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure Holy Shock applies Gawain's Protection to the Holy Shock target rather than the caster

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ce952eb5083278ac91cc44ce780ea)