### PR TITLE
Block spells from casting during school lockouts

### DIFF
--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -190,9 +190,8 @@ void SpellHistory::HandleCooldowns(SpellInfo const* spellInfo, uint32 itemID, Sp
 
 bool SpellHistory::IsReady(SpellInfo const* spellInfo, uint32 itemId /*= 0*/, bool ignoreCategoryCooldown /*= false*/) const
 {
-    if (spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE)
-        if (IsSchoolLocked(spellInfo->GetSchoolMask()))
-            return false;
+    if (IsSchoolLocked(spellInfo->GetSchoolMask()))
+        return false;
 
     if (HasCooldown(spellInfo->Id, itemId, ignoreCategoryCooldown))
         return false;


### PR DESCRIPTION
## Summary
- ensure spell school lockouts block all spells of the locked school

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694637951224832797f0da5557fce471)