### PR TITLE
Use learn spell map for hidden itemset bonuses

### DIFF
--- a/src/server/scripts/Custom/custom_hidden_itemset_bonus.cpp
+++ b/src/server/scripts/Custom/custom_hidden_itemset_bonus.cpp
@@ -460,14 +460,22 @@ void LoadHiddenItemsetBonuses()
             continue;
         }
 
+        std::unordered_set<uint32> learnedSpellSet;
+
+        SpellLearnSpellMapBounds learnBounds = sSpellMgr->GetSpellLearnSpellMapBounds(b.spellId);
+        for (auto itr = learnBounds.first; itr != learnBounds.second; ++itr)
+            learnedSpellSet.insert(itr->second.spell);
+
         for (SpellEffectInfo const& effectInfo : spellInfo->GetEffects())
         {
-            if (effectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL) && effectInfo.TriggerSpell)
-                b.learnedSpells.push_back(effectInfo.TriggerSpell);
+            if ((effectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL) || effectInfo.IsEffect(SPELL_EFFECT_SCRIPT_EFFECT)) && effectInfo.TriggerSpell)
+                learnedSpellSet.insert(effectInfo.TriggerSpell);
 
             if ((effectInfo.IsEffect(SPELL_EFFECT_SUMMON) || effectInfo.IsEffect(SPELL_EFFECT_SUMMON_PET)) && effectInfo.MiscValue > 0)
                 b.summonedEntries.push_back(effectInfo.MiscValue);
         }
+
+        b.learnedSpells.assign(learnedSpellSet.begin(), learnedSpellSet.end());
 
         s_HiddenItemsetBonuses[b.itemsetId] = b;
         currentSpells.insert(b.spellId);


### PR DESCRIPTION
## Summary
- build hidden itemset learned-spell lists from the spell learn map to capture all taught spells
- continue collecting triggered and summon effects while deduplicating learned spell entries

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464197864483278a0e00779cbfd75a)