### PR TITLE
Reapply ammo bag equip spells on melee weapon swaps

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7641,6 +7641,12 @@ void Player::_ApplyItemMods(Item* item, uint8 slot, bool apply, bool updateItemA
         if (apply)
             ReapplyAmmoBagEquipSpells();
     }
+    else if (apply && (slot == EQUIPMENT_SLOT_MAINHAND || slot == EQUIPMENT_SLOT_OFFHAND))
+    {
+        // Ensure ranged speed modifiers from ammo bags are refreshed when swapping melee weapons.
+        if (GetWeaponForAttack(RANGED_ATTACK))
+            ReapplyAmmoBagEquipSpells();
+    }
 
     ApplyItemEquipSpell(item, apply);
     if (updateItemAuras)


### PR DESCRIPTION
### Motivation

- Ammo-bag (quiver) ranged attack speed modifiers can be lost when swapping weapons because ammo effects are only reapplied on ranged weapon equip.  
- Swapping melee weapons (mainhand/offhand) can leave the player temporarily without the correct ranged haste shown in the character pane.  
- Ensure ammo-bag-derived ranged speed modifiers are refreshed whenever a weapon swap could affect the effective ranged state.  

### Description

- Modified `Player::_ApplyItemMods` in `src/server/game/Entities/Player/Player.cpp` to handle melee weapon swaps.  
- Added an `else if` branch for `EQUIPMENT_SLOT_MAINHAND` and `EQUIPMENT_SLOT_OFFHAND` that, when `apply` is true and a ranged weapon is present (checked with `GetWeaponForAttack(RANGED_ATTACK)`), calls `ReapplyAmmoBagEquipSpells()`.  
- Preserves the existing behavior for `EQUIPMENT_SLOT_RANGED` which still calls `_ApplyAmmoBonuses()` and `ReapplyAmmoBagEquipSpells()` when appropriate.  

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c306840d48327baa04a62f267416c)