### PR TITLE
Avoid stacking ammo bag equip spells

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7641,6 +7641,11 @@ void Player::_ApplyItemMods(Item* item, uint8 slot, bool apply, bool updateItemA
         if (apply)
             ReapplyAmmoBagEquipSpells();
     }
+    else if (apply && GetWeaponForAttack(RANGED_ATTACK))
+    {
+        // Ensure ranged speed modifiers from ammo bags are refreshed when equipping other items.
+        ReapplyAmmoBagEquipSpells();
+    }
 
     ApplyItemEquipSpell(item, apply);
     if (updateItemAuras)
@@ -8640,6 +8645,40 @@ void Player::ReapplyAmmoBagEquipSpells()
 
         ItemTemplate const* bagTemplate = bag->GetTemplate();
         if (!bagTemplate || bagTemplate->Class != ITEM_CLASS_QUIVER)
+            continue;
+
+        bool needsReapply = false;
+
+        for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+        {
+            _Spell const& spellData = bagTemplate->Spells[i];
+
+            if (spellData.SpellId <= 0 || spellData.SpellTrigger != ITEM_SPELLTRIGGER_ON_EQUIP)
+                continue;
+
+            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellData.SpellId);
+            if (!spellInfo)
+                continue;
+
+            AuraApplicationMapBounds range = GetAppliedAuras().equal_range(spellInfo->Id);
+            bool hasAuraForItem = false;
+            for (AuraApplicationMap::const_iterator itr = range.first; itr != range.second; ++itr)
+            {
+                if (itr->second->GetBase()->GetCastItemGUID() == bag->GetGUID())
+                {
+                    hasAuraForItem = true;
+                    break;
+                }
+            }
+
+            if (!hasAuraForItem)
+            {
+                needsReapply = true;
+                break;
+            }
+        }
+
+        if (!needsReapply)
             continue;
 
         ApplyItemEquipSpell(bag, false);


### PR DESCRIPTION
### Motivation
- Equipping equipment sets could reapply ammo-bag equip spells repeatedly and stack the same aura, producing abnormally low ranged attack/cast times.
- `ReapplyAmmoBagEquipSpells` was being called in situations where the bag's equip aura was already active, allowing duplicate auras to accumulate.
- The intent is to refresh ammo-bag ranged modifiers when appropriate without creating duplicate equip auras.

### Description
- Added an `else if (apply && GetWeaponForAttack(RANGED_ATTACK))` branch in `Player::_ApplyItemMods` to refresh ammo-bag effects when equipping non-ranged items while a ranged weapon is present.
- Rewrote `Player::ReapplyAmmoBagEquipSpells` to inspect each quiver's `ITEM_SPELLTRIGGER_ON_EQUIP` spells and check applied auras via `GetAppliedAuras()`/`GetCastItemGUID()`, and only call `ApplyItemEquipSpell` when the bag's equip aura is missing.
- Preserved the existing ranged-slot handling that still calls `_ApplyAmmoBonuses()` and conditionally re-applies equip spells.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c306840d48327baa04a62f267416c)