### PR TITLE
Centralize attack-timing refresh in Player::SwapItem

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13414,6 +13414,15 @@ void Player::SwapItem(uint16 src, uint16 dst)
     if (!pSrcItem)
         return;
 
+    auto refreshWeaponAttackTime = [this, src, dst]()
+    {
+        if (IsEquipmentPos(src) || IsEquipmentPos(dst))
+        {
+            SetRegularAttackTime();
+            UpdateDamagePhysical(RANGED_ATTACK);
+        }
+    };
+
     TC_LOG_DEBUG("entities.player.items", "Player::SwapItem: Player '{}' ({}), Bag: {}, Slot: {}, Item: {}",
         GetName(), GetGUID().ToString(), dstbag, dstslot, pSrcItem->GetEntry());
 
@@ -13518,6 +13527,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
             AutoUnequipOffhandIfNeed();
         }
 
+        refreshWeaponAttackTime();
         return;
     }
 
@@ -13566,6 +13576,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
                 }
             }
             SendRefundInfo(pDstItem);
+            refreshWeaponAttackTime();
             return;
         }
     }
@@ -13745,6 +13756,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
     }
 
     AutoUnequipOffhandIfNeed();
+    refreshWeaponAttackTime();
 }
 
 void Player::AddItemToBuyBackSlot(Item* pItem)


### PR DESCRIPTION
### Motivation
- Equipping multiple items (for example via macros or equipment-set swaps) could leave ranged attack timing stale or incorrect if refreshes were only performed in specific handlers. 
- Refreshing attack timers and ranged damage must occur whenever equipment positions change to avoid extremely fast ranged attack speed or wrong tooltip values. 

### Description
- Removed the equipment-set-specific `SetRegularAttackTime()` / `UpdateDamagePhysical(RANGED_ATTACK)` calls from `HandleEquipmentSetUse` and instead centralised the refresh in `Player::SwapItem`.
- Added a `refreshWeaponAttackTime` lambda in `src/server/game/Entities/Player/Player.cpp` that calls `SetRegularAttackTime()` and `UpdateDamagePhysical(RANGED_ATTACK)` when either `src` or `dst` is an equipment position.
- Invoked `refreshWeaponAttackTime()` at key points in `Player::SwapItem` after equip/unequip/merge/swap code paths so any `SwapItem` (including macros or multiple sequential swaps) triggers a refresh.
- Files modified: `src/server/game/Entities/Player/Player.cpp` and `src/server/game/Handlers/CharacterHandler.cpp` (removed redundant refresh there).

### Testing
- No automated tests were run for this change.
- No CI/test results available for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee28810548327be3e446fed7950ba)