### PR TITLE
Clean stale quiver auras and refresh weapon attack time on item swaps

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8637,6 +8637,24 @@ void Player::_ApplyAmmoBonuses()
 
 void Player::ReapplyAmmoBagEquipSpells()
 {
+    for (AuraApplicationMap::iterator iter = m_appliedAuras.begin(); iter != m_appliedAuras.end();)
+    {
+        Aura* aura = iter->second->GetBase();
+        ObjectGuid castItemGuid = aura->GetCastItemGUID();
+        if (!castItemGuid.IsEmpty())
+        {
+            Item* castItem = GetItemByGuid(castItemGuid);
+            if (!castItem || !IsEquipmentPos(castItem->GetBagSlot(), castItem->GetSlot()))
+            {
+                RemoveAura(iter);
+                iter = m_appliedAuras.begin();
+                continue;
+            }
+        }
+
+        ++iter;
+    }
+
     for (uint8 slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; ++slot)
     {
         Item* bag = GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
@@ -13414,6 +13432,15 @@ void Player::SwapItem(uint16 src, uint16 dst)
     if (!pSrcItem)
         return;
 
+    auto refreshWeaponAttackTime = [this, src, dst]()
+    {
+        if (IsEquipmentPos(src) || IsEquipmentPos(dst))
+        {
+            SetRegularAttackTime();
+            UpdateDamagePhysical(RANGED_ATTACK);
+        }
+    };
+
     TC_LOG_DEBUG("entities.player.items", "Player::SwapItem: Player '{}' ({}), Bag: {}, Slot: {}, Item: {}",
         GetName(), GetGUID().ToString(), dstbag, dstslot, pSrcItem->GetEntry());
 
@@ -13518,6 +13545,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
             AutoUnequipOffhandIfNeed();
         }
 
+        refreshWeaponAttackTime();
         return;
     }
 
@@ -13566,6 +13594,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
                 }
             }
             SendRefundInfo(pDstItem);
+            refreshWeaponAttackTime();
             return;
         }
     }
@@ -13745,6 +13774,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
     }
 
     AutoUnequipOffhandIfNeed();
+    refreshWeaponAttackTime();
 }
 
 void Player::AddItemToBuyBackSlot(Item* pItem)


### PR DESCRIPTION
### Motivation
- Prevent stale item-equip auras (for example quiver ammo spells) from remaining active after the source item is unequipped and stacking ranged haste incorrectly.
- Ensure attack timing and ranged damage are recalculated whenever equipment positions change to avoid incorrect or extremely fast ranged attack speed.

### Description
- In `ReapplyAmmoBagEquipSpells` added a pre-flight sweep that removes applied auras whose `GetCastItemGUID()` no longer points to an equipped item by calling `RemoveAura(iter)`.
- Centralised attack-timing refresh in `Player::SwapItem` by introducing a `refreshWeaponAttackTime` lambda that calls `SetRegularAttackTime()` and `UpdateDamagePhysical(RANGED_ATTACK)` when either `src` or `dst` is an equipment position, and invoked it after equip/unequip/merge/swap code paths.
- Changes are contained in `src/server/game/Entities/Player/Player.cpp` and ensure quiver/ ammo-related spells are reapplied only when their source item remains equipped.

### Testing
- No automated tests were run for this change.
- No CI/test results are available for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee28810548327be3e446fed7950ba)