### PR TITLE
Fix quiver aura duplication and refresh ranged attack timing on item swaps

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8637,6 +8637,25 @@ void Player::_ApplyAmmoBonuses()
 
 void Player::ReapplyAmmoBagEquipSpells()
 {
+    for (AuraApplicationMap::iterator iter = m_appliedAuras.begin(); iter != m_appliedAuras.end();)
+    {
+        Aura* aura = iter->second->GetBase();
+        ObjectGuid castItemGuid = aura->GetCastItemGUID();
+        if (!castItemGuid.IsEmpty())
+        {
+            Item* castItem = GetItemByGuid(castItemGuid);
+            if (!castItem || !IsEquipmentPos(castItem->GetBagSlot(), castItem->GetSlot()))
+            {
+                AuraApplicationMap::iterator next = std::next(iter);
+                RemoveAura(iter);
+                iter = next;
+                continue;
+            }
+        }
+
+        ++iter;
+    }
+
     for (uint8 slot = INVENTORY_SLOT_BAG_START; slot < INVENTORY_SLOT_BAG_END; ++slot)
     {
         Item* bag = GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
@@ -8662,13 +8681,24 @@ void Player::ReapplyAmmoBagEquipSpells()
 
             AuraApplicationMapBounds range = GetAppliedAuras().equal_range(spellInfo->Id);
             bool hasAuraForItem = false;
-            for (AuraApplicationMap::const_iterator itr = range.first; itr != range.second; ++itr)
+            for (AuraApplicationMap::iterator itr = range.first; itr != range.second;)
             {
                 if (itr->second->GetBase()->GetCastItemGUID() == bag->GetGUID())
                 {
-                    hasAuraForItem = true;
-                    break;
+                    if (!hasAuraForItem)
+                    {
+                        hasAuraForItem = true;
+                        ++itr;
+                    }
+                    else
+                    {
+                        AuraApplicationMap::iterator next = std::next(itr);
+                        RemoveAura(itr);
+                        itr = next;
+                    }
                 }
+                else
+                    ++itr;
             }
 
             if (!hasAuraForItem)
@@ -13414,6 +13444,15 @@ void Player::SwapItem(uint16 src, uint16 dst)
     if (!pSrcItem)
         return;
 
+    auto refreshWeaponAttackTime = [this, src, dst]()
+    {
+        if (IsEquipmentPos(src) || IsEquipmentPos(dst))
+        {
+            SetRegularAttackTime();
+            UpdateDamagePhysical(RANGED_ATTACK);
+        }
+    };
+
     TC_LOG_DEBUG("entities.player.items", "Player::SwapItem: Player '{}' ({}), Bag: {}, Slot: {}, Item: {}",
         GetName(), GetGUID().ToString(), dstbag, dstslot, pSrcItem->GetEntry());
 
@@ -13518,6 +13557,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
             AutoUnequipOffhandIfNeed();
         }
 
+        refreshWeaponAttackTime();
         return;
     }
 
@@ -13566,6 +13606,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
                 }
             }
             SendRefundInfo(pDstItem);
+            refreshWeaponAttackTime();
             return;
         }
     }
@@ -13745,6 +13786,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
     }
 
     AutoUnequipOffhandIfNeed();
+    refreshWeaponAttackTime();
 }
 
 void Player::AddItemToBuyBackSlot(Item* pItem)


### PR DESCRIPTION
### Motivation
- Prevent multiple equip auras from the same quiver bag stacking ranged haste when several item changes happen at once.
- Remove stale item-cast auras whose source item is no longer equipped to avoid lingering effects.
- Ensure ranged attack timing (autoshot) is recalculated after equipment changes to prevent excessively fast ranged attacks.

### Description
- In `Player::ReapplyAmmoBagEquipSpells` iterate `m_appliedAuras` using a safe next iterator and remove applications whose `GetCastItemGUID()` no longer points to an equipped item by calling `RemoveAura` with the preserved next iterator (`std::next`).
- Deduplicate applied equip auras for a given bag by keeping the first matching aura per `GetCastItemGUID()` and removing any additional duplicates using safe iteration.
- Centralized refresh of attack timing in `Player::SwapItem` via a `refreshWeaponAttackTime` lambda that calls `SetRegularAttackTime()` and `UpdateDamagePhysical(RANGED_ATTACK)` when `src` or `dst` are equipment positions, and invoked it at the relevant return points.

### Testing
- No automated tests were run for these changes.
- No CI or test results are available for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee28810548327be3e446fed7950ba)