### PR TITLE
Fix aura reapply iterator type

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8679,7 +8679,7 @@ void Player::ReapplyAmmoBagEquipSpells()
             if (!spellInfo)
                 continue;
 
-            AuraApplicationMapBounds range = GetAppliedAuras().equal_range(spellInfo->Id);
+            AuraApplicationMapBoundsNonConst range = GetAppliedAuras().equal_range(spellInfo->Id);
             bool hasAuraForItem = false;
             for (AuraApplicationMap::iterator itr = range.first; itr != range.second;)
             {


### PR DESCRIPTION
### Motivation
- Calling `GetAppliedAuras().equal_range` in `Player::ReapplyAmmoBagEquipSpells` returned a const iterator pair, which prevented using non-const `AuraApplicationMap::iterator` for removal.
- The change is intended to allow removing duplicate aura entries associated with equipped ammo bags without iterator-type conversion errors.

### Description
- Replace `AuraApplicationMapBounds` with `AuraApplicationMapBoundsNonConst` for the `equal_range` result in `Player::ReapplyAmmoBagEquipSpells` to obtain non-const iterators.
- No other logic was changed; the loop that finds and removes duplicate bag auras remains the same and continues to use `RemoveAura` with proper iterator advancement.

### Testing
- No automated tests were executed for this change.
- Change is a minimal type fix to resolve a compilation-time iterator conversion error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eeee72fe48327bf0e9cdec137b5cf)