### PR TITLE
Prevent duplicate item equip aura casts

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8178,11 +8178,17 @@ void Player::ApplyEquipSpell(SpellInfo const* spellInfo, Item* item, bool apply,
         if (spellInfo->CheckShapeshift(GetShapeshiftForm()) != SPELL_CAST_OK)
             return;
 
-        if (form_change)                                    // check aura active state from other form
+        AuraApplicationMapBounds range = m_appliedAuras.equal_range(spellInfo->Id);
+        if (item)
         {
-            AuraApplicationMapBounds range = m_appliedAuras.equal_range(spellInfo->Id);
             for (AuraApplicationMap::const_iterator itr = range.first; itr != range.second; ++itr)
-                if (!item || itr->second->GetBase()->GetCastItemGUID() == item->GetGUID())
+                if (itr->second->GetBase()->GetCastItemGUID() == item->GetGUID())
+                    return;
+        }
+        else if (form_change)                               // check aura active state from other form
+        {
+            for (AuraApplicationMap::const_iterator itr = range.first; itr != range.second; ++itr)
+                if (!item)
                     return;
         }
 


### PR DESCRIPTION
### Motivation
- Prevent equipping the same item repeatedly from causing its equip spell to be cast again and producing duplicate auras.
- Ensure item-set (no specific item) form-change behavior remains unchanged.
- Reduce unexpected ranged attack speed / haste side-effects caused by duplicated equip auras.

### Description
- Updated `Player::ApplyEquipSpell` to inspect existing `m_appliedAuras` for the `spellInfo->Id` and skip casting when the same item already provided that aura. 
- Distinguishes between an item-specific equip spell (`item` non-null) and item-set/form-change equip spells (`item` null) so only the matching case suppresses the cast. 
- Kept the original form-change path for item-set auras so existing form-change compatibility behavior is preserved. 

### Testing
- No automated tests were executed for this change.
- Change was compiled and committed locally (manual verification step not included as an automated test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eefce9b9c8327a0d548fb736ef7f0)