### PR TITLE
Clear lingering negative Attack Power modifiers on AP aura removal

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4236,6 +4236,28 @@ void AuraEffect::HandleAuraModAttackPower(AuraApplication const* aurApp, uint8 m
     // Apply/remove the actual flat AP modifier
     target->HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE, float(GetAmount()), apply);
 
+    if (!apply)
+    {
+        float attPowerMod = target->GetFlatModifierValue(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE);
+        if (attPowerMod < 0.0f)
+        {
+            bool hasNegativeFlatAPAura = false;
+            AuraEffectList const& flatAPAuras = target->GetAuraEffectsByType(SPELL_AURA_MOD_ATTACK_POWER);
+
+            for (AuraEffect const* aurEff : flatAPAuras)
+            {
+                if (aurEff->GetAmount() < 0)
+                {
+                    hasNegativeFlatAPAura = true;
+                    break;
+                }
+            }
+
+            if (!hasNegativeFlatAPAura)
+                target->SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE, 0.0f);
+        }
+    }
+
     if (Player* player = target->ToPlayer())
     {
         float afterFlat = target->GetFlatModifierValue(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE);


### PR DESCRIPTION
### Motivation
- Prevent a lingering negative Attack Power (AP) modifier from remaining after flat AP debuffs (e.g. Demoralizing Roar/Shout) expire and causing the character pane to show a stuck negative value until relog.
- Ensure the server-side AP modifier state stays in sync with active auras so dependent stats and the client update correctly.

### Description
- Added a removal-path desync guard inside `AuraEffect::HandleAuraModAttackPower` in `src/server/game/Spells/Auras/SpellAuraEffects.cpp` that runs when `apply` is false.
- The guard reads `GetFlatModifierValue(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE)` and, if negative, scans `GetAuraEffectsByType(SPELL_AURA_MOD_ATTACK_POWER)` for any remaining negative flat AP auras.
- If no negative flat AP auras remain the code resets the modifier by calling `SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE, 0.0f)` so the leftover debuff is cleared.
- Left the existing `player->UpdateAttackPowerAndDamage(false)` call to force recalculation and client update after removal.

### Testing
- No automated tests were executed as part of this change.
- Compile/time-sensitive/run tests were not requested or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69506f3868948327a3a6d84090a68522)