### PR TITLE
Persist shapeshift display when copying player appearance

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2243,7 +2243,11 @@ bool Creature::CopyAppearanceFromPlayer(Player const* player, bool copyName, boo
     SetFloatValue(UNIT_FIELD_COMBATREACH, player->GetFloatValue(UNIT_FIELD_COMBATREACH));
 
     if (player->GetDisplayId() != player->GetNativeDisplayId())
+    {
         SetDisplayId(player->GetDisplayId());
+        if (player->GetShapeshiftForm() != FORM_NONE)
+            SetNativeDisplayId(player->GetDisplayId());
+    }
 
     SetPowerType(player->GetPowerType(), false);
 


### PR DESCRIPTION
### Motivation
- Copying a player's appearance onto a creature via commands like `.npc set copy` or the weekly honor warchief routine did not persist shapeshifted models (e.g. moonkin) because the native display id remained unchanged.
- This caused creatures to revert to the base model despite being shown correctly briefly after the copy operation.

### Description
- Update `Creature::CopyAppearanceFromPlayer` in `src/server/game/Entities/Creature/Creature.cpp` to set the creature's native display id when the source player is currently shapeshifted by checking `player->GetShapeshiftForm()` and `player->GetDisplayId()`.
- The code now calls `SetDisplayId(player->GetDisplayId())` and, if `player->GetShapeshiftForm() != FORM_NONE`, also calls `SetNativeDisplayId(player->GetDisplayId())` so the shapeshifted model persists when saved.
- This change ensures both interactive commands (`HandleNpcCopyPlayerCommand`) and automated code paths that use `CopyAppearanceFromPlayerGuid` (such as the honor warchief updater) keep the intended model.

### Testing
- No automated tests were run for this change (not requested).
- The change was committed after local edit of `src/server/game/Entities/Creature/Creature.cpp` and is ready for CI/build verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69507b94b4408327863d237063c10d1c)