### PR TITLE
Fix honor warchief appearance for moonkin druids

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2274,13 +2274,16 @@ bool Creature::CopyAppearanceFromPlayer(Player const* player, bool copyName, boo
     return true;
 }
 
-bool Creature::CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool copyName, bool copyEquipment, bool persist)
+bool Creature::CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool copyName, bool copyEquipment, bool persist, bool useOnline)
 {
     if (!playerGuid || !playerGuid.IsPlayer())
         return false;
 
-    if (Player* player = ObjectAccessor::FindConnectedPlayer(playerGuid))
-        return CopyAppearanceFromPlayer(player, copyName, copyEquipment, persist);
+    if (useOnline)
+    {
+        if (Player* player = ObjectAccessor::FindConnectedPlayer(playerGuid))
+            return CopyAppearanceFromPlayer(player, copyName, copyEquipment, persist);
+    }
 
     CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARACTER_APPEARANCE_BY_GUID);
     stmt->setUInt32(0, playerGuid.GetCounter());

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -83,7 +83,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void LoadTemplateRoot();
 
         bool CopyAppearanceFromPlayer(Player const* player, bool copyName = true, bool copyEquipment = true, bool persist = false);
-        bool CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool copyName = true, bool copyEquipment = true, bool persist = false);
+        bool CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool copyName = true, bool copyEquipment = true, bool persist = false, bool useOnline = true);
         bool CopyAppearanceFromPlayerName(std::string const& playerName, bool copyName = true, bool copyEquipment = true, bool persist = false);
 
         std::array<uint32, CreaturePlayerBytes::VisibleItemSlotCount> const& GetVisibleItemDisplayIds() const { return _playerVisibleItemDisplayIds; }

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -3406,7 +3406,12 @@ namespace
         float const originalScale = creature->GetObjectScale();
         UnitStandStateType const originalStandState = creature->GetStandState();
 
-        if (!creature->CopyAppearanceFromPlayerGuid(winnerGuid, true, true, true))
+        bool useOnlineAppearance = true;
+        if (Player* player = ObjectAccessor::FindConnectedPlayer(winnerGuid))
+            if (player->GetShapeshiftForm() == FORM_MOONKIN)
+                useOnlineAppearance = false;
+
+        if (!creature->CopyAppearanceFromPlayerGuid(winnerGuid, true, true, true, useOnlineAppearance))
         {
             TC_LOG_ERROR("misc", "Weekly honor warchief: Failed to copy appearance from {}.", winnerGuid.ToString());
             return false;


### PR DESCRIPTION
### Motivation
- The `.honor warchief` flow failed when the chosen player was a druid in Moonkin form because the online appearance (shapeshift state) was copied onto the NPC. 
- Other forms were handled fine, so the intended behavior is to copy the stored player appearance when Moonkin form would otherwise be used.

### Description
- Added an optional `useOnline` parameter to `CopyAppearanceFromPlayerGuid` with the signature `bool CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool copyName = true, bool copyEquipment = true, bool persist = false, bool useOnline = true)` in the header `Creature.h`.
- Changed `Creature::CopyAppearanceFromPlayerGuid` to only attempt `ObjectAccessor::FindConnectedPlayer` when `useOnline` is true and otherwise fall back to loading appearance from the character DB.
- Updated the weekly warchief handling in `World.cpp` to detect an online winner in `FORM_MOONKIN` and pass `useOnline = false` to `CopyAppearanceFromPlayerGuid` so stored appearance is used instead of the Moonkin form.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69507c8369a48327a506098b6d36d4e3)