### PR TITLE
Fix npc copy fallback for online appearance

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2282,7 +2282,8 @@ bool Creature::CopyAppearanceFromPlayerGuid(ObjectGuid const& playerGuid, bool c
     if (useOnline)
     {
         if (Player* player = ObjectAccessor::FindConnectedPlayer(playerGuid))
-            return CopyAppearanceFromPlayer(player, copyName, copyEquipment, persist);
+            if (CopyAppearanceFromPlayer(player, copyName, copyEquipment, persist))
+                return true;
     }
 
     CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARACTER_APPEARANCE_BY_GUID);


### PR DESCRIPTION
### Motivation
- Prevent `npc set copy` from failing with "player not found" when copying from players in special forms (e.g. moonkin) where the online-copy path can fail.
- Allow the command to fall back to the database-backed appearance when copying from a connected player does not succeed.

### Description
- Change `CopyAppearanceFromPlayerGuid` so it only returns immediately when `CopyAppearanceFromPlayer` succeeds for an online player, otherwise it falls through to the DB lookup fallback.
- Replace the previous `return CopyAppearanceFromPlayer(...)` with an `if (CopyAppearanceFromPlayer(...)) return true;` check to preserve successful online copies while allowing fallback.
- No other behavior or persistence logic was modified.

### Testing
- No automated tests were run for this change.
- Manual verification expected when exercising `npc set copy` against connected players in and out of shapeshifted forms (not performed automatically).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69507dbe87748327bab90aaa30feedbe)