### PR TITLE
Allow dead players to queue for battlegrounds/arenas

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2375,8 +2375,10 @@ Creature* Player::GetNPCIfCanInteractWith(ObjectGuid const& guid, NPCFlags npcFl
     if (!creature)
         return nullptr;
 
+    bool allowDeadInteraction = npcFlags & UNIT_NPC_FLAG_BATTLEMASTER;
+
     // Deathstate checks
-    if (!IsAlive() && !(creature->GetCreatureTemplate()->type_flags & CREATURE_TYPE_FLAG_VISIBLE_TO_GHOSTS))
+    if (!IsAlive() && !allowDeadInteraction && !(creature->GetCreatureTemplate()->type_flags & CREATURE_TYPE_FLAG_VISIBLE_TO_GHOSTS))
         return nullptr;
 
     // alive or spirit healer


### PR DESCRIPTION
### Motivation
- Allow players who are dead to interact with battlemaster NPCs so they can join battleground and arena queues without needing to resurrect first.
- Improve user experience by enabling queueing actions from corpse/ghost state when interacting with battlemaster NPCs.
- Keep existing visibility/interaction restrictions for other NPC types intact by scoping the change to battlemaster interactions.

### Description
- Added a local `allowDeadInteraction` flag computed from `npcFlags & UNIT_NPC_FLAG_BATTLEMASTER` inside `Player::GetNPCIfCanInteractWith`.
- Changed the death-state check to skip the `VISIBLE_TO_GHOSTS` requirement when `allowDeadInteraction` is true so battlemaster interactions are allowed while dead.
- Modified file `src/server/game/Entities/Player/Player.cpp` to implement this behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69508922082c83278de559a2d12c6e57)