### PR TITLE
Gate Lightning Shield Defense effects on active Lightning Shield

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -1264,12 +1264,24 @@ private:
     void CalculateSnareReduction(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
     {
         canBeRecalculated = true;
+        if (!GetTarget() || !GetTarget()->GetAuraEffect(SPELL_AURA_PROC_TRIGGER_SPELL, SPELLFAMILY_SHAMAN, 0x400, 0, 0))
+        {
+            amount = 0;
+            return;
+        }
+
         amount = -45;
     }
 
     void CalculateDamageReduction(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
     {
         canBeRecalculated = true;
+        if (!GetTarget() || !GetTarget()->GetAuraEffect(SPELL_AURA_PROC_TRIGGER_SPELL, SPELLFAMILY_SHAMAN, 0x400, 0, 0))
+        {
+            amount = 0;
+            return;
+        }
+
         amount = -7;
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the `spell_sha_lightning_shield_defense` aura only provides reductions while the actual Lightning Shield is active.
- Previously the snare and damage reductions returned constant negative values regardless of shield presence.
- Prevent unintended defensive benefits when the Lightning Shield proc aura is not present.

### Description
- Add presence checks in `CalculateSnareReduction` and `CalculateDamageReduction` to return `amount = 0` when `GetTarget()` does not have the Lightning Shield proc aura detected via `GetAuraEffect(SPELL_AURA_PROC_TRIGGER_SPELL, SPELLFAMILY_SHAMAN, 0x400, 0, 0)`.
- Keep recalculation behavior via `UpdateEffectAmounts` unchanged so effects are recalculated when the shield is applied/removed.
- Change made in `src/server/scripts/Spells/spell_shaman.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69547b5f6eac8327884f7a2c2090472e)