### PR TITLE
Treat attack-me fear auras as charm for removals

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4228,6 +4228,8 @@ void Unit::RemoveMovementImpairingAuras(bool withRoot)
 
 void Unit::RemoveAurasWithMechanic(uint32 mechanicMaskToRemove, AuraRemoveMode removeMode, uint32 exceptSpellId, bool withEffectMechanics)
 {
+    bool const removingFear = (mechanicMaskToRemove & (1 << MECHANIC_FEAR)) != 0;
+    bool const removingCharm = (mechanicMaskToRemove & (1 << MECHANIC_CHARM)) != 0;
     std::vector<Aura*> aurasToUpdateTargets;
     RemoveAppliedAuras([=, &aurasToUpdateTargets](AuraApplication const* aurApp)
     {
@@ -4237,6 +4239,9 @@ void Unit::RemoveAurasWithMechanic(uint32 mechanicMaskToRemove, AuraRemoveMode r
 
         uint32 appliedMechanicMask = aura->GetSpellInfo()->GetSpellMechanicMaskByEffectMask(aurApp->GetEffectMask());
         if (!(appliedMechanicMask & mechanicMaskToRemove))
+            return false;
+
+        if (removingFear && !removingCharm && aura->GetSpellInfo()->HasEffect(SPELL_EFFECT_ATTACK_ME))
             return false;
 
         // spell mechanic matches required mask for removal


### PR DESCRIPTION
### Motivation
- Some spells use `SPELL_EFFECT_ATTACK_ME` (attack-me / taunt-like) but are implemented as fear and therefore get removed by fear-only removals.
- These effects are intended to act like charms/taunts and should not be cleared by effects that only remove fear.
- The change makes sure attack-me auras persist unless a charm removal is explicitly requested.

### Description
- Added local flags `removingFear` and `removingCharm` to `Unit::RemoveAurasWithMechanic` to detect what mechanic mask is being removed.
- When removing fear but not charm, the code now skips removal of auras whose `SpellInfo` has `SPELL_EFFECT_ATTACK_ME`.
- The rest of the `RemoveAurasWithMechanic` behavior (effect/mechanic handling and target updates) remains unchanged.

### Testing
- No automated tests were run on this change.
- Code changes were committed; no further validation executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a1d822208327a9b2a7814a056e27)