### PR TITLE
Defer dismount for run-mount casts (aura 89153)

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5339,6 +5339,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
 {
     GameObject const* trapCaster = GetTrapGameObject();
     bool trapSuccessDebugPending = sWorld->getBoolConfig(CONFIG_TRAP_DEBUG_WHISPER_ON_SUCCESS) && IsTrapGameObject(trapCaster);
+    bool deferAutoDismountForRunMount = false;
 
     // check death state
     if (m_caster->ToUnit() && !m_caster->ToUnit()->IsAlive() && !m_spellInfo->IsPassive() && !(m_spellInfo->HasAttribute(SPELL_ATTR0_CASTABLE_WHILE_DEAD) || (IsTriggered() && !m_triggeredByAuraSpell)))
@@ -5649,6 +5650,8 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
         {
             if (m_caster->ToPlayer()->IsInFlight())
                 return SPELL_FAILED_NOT_ON_TAXI;
+            else if (m_caster->GetMountDisplayId() == 0 && m_caster->ToPlayer()->HasAura(89153))
+                deferAutoDismountForRunMount = true;
             else
                 return SPELL_FAILED_NOT_MOUNTED;
         }
@@ -6466,6 +6469,15 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
     }
 
     // all ok
+    if (deferAutoDismountForRunMount)
+    {
+        Player* playerCaster = m_caster->ToPlayer();
+        if (playerCaster && playerCaster->IsMounted())
+        {
+            playerCaster->Dismount();
+            playerCaster->RemoveAurasByType(SPELL_AURA_MOUNTED);
+        }
+    }
     return SPELL_CAST_OK;
 }
 


### PR DESCRIPTION
### Motivation
- The server blocks most casting while mounted in `Spell::CheckCast`, which breaks retail-like auto-dismount behavior for “run mount” spells that use `MiscValueA = 0` and show no mount model.  
- The client usually does pre-dismount for normal mounts but often does not for run-mounts, causing casts to be rejected with `SPELL_FAILED_NOT_MOUNTED`.  
- The goal is to preserve the retail-like behavior where the player only dismounts when the cast would actually succeed (in-range), not when the cast is first attempted.  

### Description
- Added a local flag `deferAutoDismountForRunMount` in `Spell::CheckCast` to mark run-mount cases without immediately failing.  
- Changed the mounted-block to set the flag when `GetMountDisplayId() == 0` and the player `HasAura(89153)`, while keeping taxi/in-flight behavior unchanged.  
- When the check completes and the cast is about to return `SPELL_CAST_OK`, the code now performs `Dismount()` and `RemoveAurasByType(SPELL_AURA_MOUNTED)` for flagged run-mount players so the cast proceeds.  

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954af77f99483278c1f7aaddf1c8cfb)