### PR TITLE
Fix run-mount display id access and defer auto-dismount in Spell::CheckCast

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5339,6 +5339,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
 {
     GameObject const* trapCaster = GetTrapGameObject();
     bool trapSuccessDebugPending = sWorld->getBoolConfig(CONFIG_TRAP_DEBUG_WHISPER_ON_SUCCESS) && IsTrapGameObject(trapCaster);
+    bool deferAutoDismountForRunMount = false;
 
     // check death state
     if (m_caster->ToUnit() && !m_caster->ToUnit()->IsAlive() && !m_spellInfo->IsPassive() && !(m_spellInfo->HasAttribute(SPELL_ATTR0_CASTABLE_WHILE_DEAD) || (IsTriggered() && !m_triggeredByAuraSpell)))
@@ -5649,6 +5650,8 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
         {
             if (m_caster->ToPlayer()->IsInFlight())
                 return SPELL_FAILED_NOT_ON_TAXI;
+            else if (m_caster->ToUnit()->GetMountDisplayId() == 0 && m_caster->ToPlayer()->HasAura(89153))
+                deferAutoDismountForRunMount = true;
             else
                 return SPELL_FAILED_NOT_MOUNTED;
         }
@@ -6466,6 +6469,15 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
     }
 
     // all ok
+    if (deferAutoDismountForRunMount)
+    {
+        Player* playerCaster = m_caster->ToPlayer();
+        if (playerCaster && playerCaster->IsMounted())
+        {
+            playerCaster->Dismount();
+            playerCaster->RemoveAurasByType(SPELL_AURA_MOUNTED);
+        }
+    }
     return SPELL_CAST_OK;
 }
 


### PR DESCRIPTION
### Motivation
- Preserve retail-like behavior for "run mount" spells by deferring auto-dismount until the cast is about to succeed so casts aren't rejected prematurely.
- The code introduced a defer flag and dismount behavior for run-mount cases inside `Spell::CheckCast` to implement the above behavior.
- A compile error occurred because `GetMountDisplayId()` was accessed on the wrong base type (`WorldObject`), which does not expose that member.
- The intent is to both implement deferred dismount and fix the incorrect call site to avoid the compilation failure.

### Description
- Added a local flag `deferAutoDismountForRunMount` in `Spell::CheckCast` to mark run-mount cases without immediately failing the cast.
- When the flag is set, perform `Dismount()` and `RemoveAurasByType(SPELL_AURA_MOUNTED)` just before returning `SPELL_CAST_OK` so the cast proceeds while preserving expected client behavior.
- Fixed the mount display id access by changing the check to use `m_caster->ToUnit()->GetMountDisplayId()` instead of calling `GetMountDisplayId()` on `m_caster` directly.
- Kept existing taxi/in-flight behavior unchanged and only applied the defer logic for players with the run-mount aura (`89153`).

### Testing
- No automated tests were run.
- No CI test results are included in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954af77f99483278c1f7aaddf1c8cfb)