### PR TITLE
Block fear-only cleanses and casting while attack-me (ghetto taunt) is active

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4228,6 +4228,8 @@ void Unit::RemoveMovementImpairingAuras(bool withRoot)
 
 void Unit::RemoveAurasWithMechanic(uint32 mechanicMaskToRemove, AuraRemoveMode removeMode, uint32 exceptSpellId, bool withEffectMechanics)
 {
+    bool const removingFear = (mechanicMaskToRemove & (1 << MECHANIC_FEAR)) != 0;
+    bool const removingCharm = (mechanicMaskToRemove & (1 << MECHANIC_CHARM)) != 0;
     std::vector<Aura*> aurasToUpdateTargets;
     RemoveAppliedAuras([=, &aurasToUpdateTargets](AuraApplication const* aurApp)
     {
@@ -4237,6 +4239,9 @@ void Unit::RemoveAurasWithMechanic(uint32 mechanicMaskToRemove, AuraRemoveMode r
 
         uint32 appliedMechanicMask = aura->GetSpellInfo()->GetSpellMechanicMaskByEffectMask(aurApp->GetEffectMask());
         if (!(appliedMechanicMask & mechanicMaskToRemove))
+            return false;
+
+        if (removingFear && !removingCharm && aura->GetSpellInfo()->HasEffect(SPELL_EFFECT_ATTACK_ME))
             return false;
 
         // spell mechanic matches required mask for removal

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6615,7 +6615,9 @@ SpellCastResult Spell::CheckCasterAuras(uint32* param1) const
         result = SPELL_FAILED_PACIFIED;
     else if (unitflag & UNIT_FLAG_FLEEING)
     {
-        if (usableWhileFeared)
+        if (unitCaster->HasAttackMeFearAura() && !CheckSpellCancelsCharm(param1))
+            result = SPELL_FAILED_CHARMED;
+        else if (usableWhileFeared)
         {
             SpellCastResult mechanicResult = mechanicCheck(SPELL_AURA_MOD_FEAR);
             if (mechanicResult != SPELL_CAST_OK)


### PR DESCRIPTION
### Motivation
- Some spells/effects use `SPELL_EFFECT_ATTACK_ME` (attack-me / ghetto taunt) which should behave like charm/taunt and not be removable by fear-only cleanses. 
- Trinkets or spells that only remove fear should not be usable to bypass attack-me effects because those are intended to persist unless charm removal is allowed. 

### Description
- In `Unit::RemoveAurasWithMechanic` added detection of `removingFear` and `removingCharm` and skip removal of auras whose `SpellInfo` has `SPELL_EFFECT_ATTACK_ME` when fear is being removed but charm is not. 
- In `Spell::CheckCasterAuras` updated `UNIT_FLAG_FLEEING` handling to surface `SPELL_FAILED_CHARMED` when `unitCaster->HasAttackMeFearAura()` and the spell does not `CheckSpellCancelsCharm(param1)`, before performing normal fear checks. 
- Preserved existing mechanic checks and target-update behavior for other aura removals and spell-cast conditions. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a1d822208327a9b2a7814a056e27)