### PR TITLE
Plainsrunning (89153): allow attack start while mounted and defer dismount to swing

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -117,6 +117,14 @@ namespace
     constexpr float MaxStarfireSnareSpeedRate = 1.0f;
     constexpr uint8 StarfireSnareRemovalGraceUpdates = 2;
     UnitMoveType const StarfireSnareMoveTypes[] = { MOVE_RUN, MOVE_RUN_BACK, MOVE_SWIM, MOVE_SWIM_BACK };
+
+    static inline bool IsPlainsrunningRunMount(Unit* unit)
+    {
+        return unit
+            && unit->GetTypeId() == TYPEID_PLAYER
+            && unit->IsMounted()
+            && unit->HasAura(89153); // Plainsrunning
+    }
 }
 #include "ArenaSpectator.h"
 
@@ -1198,6 +1206,12 @@ void Player::Update(uint32 p_time)
                             setAttackTimer(OFF_ATTACK, ATTACK_DISPLAY_DELAY);
 
                     // do attack
+                    // Plainsrunning: defer dismount until we actually swing (in range + facing + valid)
+                    if (IsPlainsrunningRunMount(this))
+                    {
+                        Dismount();
+                        RemoveAurasByType(SPELL_AURA_MOUNTED);
+                    }
                     AttackerStateUpdate(victim, BASE_ATTACK);
                     resetAttackTimer(BASE_ATTACK);
                 }
@@ -1216,6 +1230,12 @@ void Player::Update(uint32 p_time)
                         setAttackTimer(BASE_ATTACK, ATTACK_DISPLAY_DELAY);
 
                     // do attack
+                    // Plainsrunning: defer dismount until we actually swing (in range + facing + valid)
+                    if (IsPlainsrunningRunMount(this))
+                    {
+                        Dismount();
+                        RemoveAurasByType(SPELL_AURA_MOUNTED);
+                    }
                     AttackerStateUpdate(victim, OFF_ATTACK);
                     resetAttackTimer(OFF_ATTACK);
                 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -87,6 +87,14 @@
 namespace
 {
 static uint32 constexpr SPELL_SHAMAN_GHOST_WOLF = 2645;
+
+static inline bool IsPlainsrunningRunMount(Unit* unit)
+{
+    return unit
+        && unit->GetTypeId() == TYPEID_PLAYER
+        && unit->IsMounted()
+        && unit->HasAura(89153); // Plainsrunning
+}
 }
 
 float baseMoveSpeed[MAX_MOVE_TYPE] =
@@ -5746,8 +5754,8 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     if (!IsAlive() || !victim->IsInWorld() || !victim->IsAlive())
         return false;
 
-    // player cannot attack in mount state
-    if (GetTypeId() == TYPEID_PLAYER && IsMounted())
+    // player cannot attack in mount state (except Plainsrunning run-mount)
+    if (GetTypeId() == TYPEID_PLAYER && IsMounted() && !IsPlainsrunningRunMount(this))
         return false;
 
     Creature* creature = ToCreature();


### PR DESCRIPTION
### Motivation
- Fix right-click auto-attack for the Plainsrunning mount (spell `89153`) which currently blocks attack starts or causes "too far away" behavior while mounted.
- Make behavior match normal mounts by allowing the attack/chase to start while mounted and only dismount when a melee swing will actually fire.
- Ensure the server performs the dismount for MiscValueA=0 mounts where the client does not automatically dismount.

### Description
- Add a helper predicate `IsPlainsrunningRunMount` in the anonymous namespace of both `Unit.cpp` and `Player.cpp` to detect a player-mounted unit with aura `89153`.
- Update `Unit::Attack` to permit starting an attack when the player is mounted if `IsPlainsrunningRunMount(this)` is true, thereby allowing chase/click-to-move logic to proceed.
- Update `Player::Update` to call `Dismount()` and `RemoveAurasByType(SPELL_AURA_MOUNTED)` immediately before `AttackerStateUpdate(..., BASE_ATTACK)` and `AttackerStateUpdate(..., OFF_ATTACK)` so the server dismounts the player at the moment a valid base or offhand swing is executed.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954b4c4153883278d1019953ed2c396)