### PR TITLE
Plainsrunning: dismount only when melee in range and block out-of-range auto-attacks

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -87,6 +87,14 @@
 namespace
 {
 static uint32 constexpr SPELL_SHAMAN_GHOST_WOLF = 2645;
+
+static inline bool IsPlainsrunningRunMount(Unit* unit)
+{
+    return unit
+        && unit->GetTypeId() == TYPEID_PLAYER
+        && unit->IsMounted()
+        && unit->HasAura(89153); // Plainsrunning
+}
 }
 
 float baseMoveSpeed[MAX_MOVE_TYPE] =
@@ -5746,9 +5754,27 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     if (!IsAlive() || !victim->IsInWorld() || !victim->IsAlive())
         return false;
 
-    // player cannot attack in mount state
+    // player cannot attack in mount state (except Plainsrunning run-mount)
     if (GetTypeId() == TYPEID_PLAYER && IsMounted())
-        return false;
+    {
+        if (!IsPlainsrunningRunMount(this))
+            return false;
+
+        if (meleeAttack)
+        {
+            if (IsWithinMeleeRange(victim))
+            {
+                Dismount();
+                RemoveAurasByType(SPELL_AURA_MOUNTED);
+            }
+            else
+            {
+                if (Player* player = ToPlayer())
+                    player->SendAttackSwingNotInRange();
+                return false;
+            }
+        }
+    }
 
     Creature* creature = ToCreature();
     // creatures cannot attack while evading


### PR DESCRIPTION
### Motivation
- Fix Plainsrunning mount (`89153`) auto-attack behavior so it matches other mounts by dismounting only when a melee swing will actually fire.
- Prevent auto-attack from starting or being queued while mounted and out of melee range, and ensure the client receives a not-in-range message.
- Centralize dismount behavior at attack start instead of deferring dismount to the `Player::Update` loop.

### Description
- Add `IsPlainsrunningRunMount` helper in `Unit.cpp` and use it to detect players mounted on the Plainsrunning mount.  
- Update `Unit::Attack` to allow melee attack start while on Plainsrunning, call `Dismount()` and `RemoveAurasByType(SPELL_AURA_MOUNTED)` when `IsWithinMeleeRange(victim)`, and otherwise send `SendAttackSwingNotInRange()` and return without queuing the attack.  
- Remove the duplicate helper from `Player.cpp` and remove the deferred dismount logic that previously executed before `AttackerStateUpdate` for base and offhand swings.  

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954b4c4153883278d1019953ed2c396)