### PR TITLE
Plainsrunning (89153): special-case right-click auto-attack behavior

### DIFF
--- a/src/server/game/Handlers/CombatHandler.cpp
+++ b/src/server/game/Handlers/CombatHandler.cpp
@@ -59,6 +59,25 @@ void WorldSession::HandleAttackSwingOpcode(WorldPackets::Combat::AttackSwing& pa
     }
 
     _player->ClearAttackStopRequestAfterTaunt();
+
+    // Plainsrunning (89153): mimic real mount behavior for right-click auto attack.
+    // If in melee range -> dismount and start attack.
+    // If NOT in melee range -> do NOT dismount, do NOT queue attack, send "not in range".
+    if (_player->IsMounted() && _player->HasAura(89153))
+    {
+        if (!_player->IsWithinMeleeRange(enemy))
+        {
+            _player->SendAttackSwingNotInRange();
+
+            // Ensure client does not think it is in an attack state
+            SendAttackStop(enemy);
+            return;
+        }
+
+        _player->Dismount();
+        _player->RemoveAurasByType(SPELL_AURA_MOUNTED);
+    }
+
     _player->Attack(enemy, true);
 }
 


### PR DESCRIPTION
### Motivation

- Implement mount-specific behavior to match the real client for Plainsrunning (`89153`) so the client/game feel matches expected mount rules.
- Ensure right-click auto-attack does not dismount or queue a chase/attack when the target is out of melee range.
- Provide immediate dismount and start the attack only when the target is within melee range.
- Send the proper "not in range" feedback to the client when out of range.

### Description

- Added a Plainsrunning-specific check inside `WorldSession::HandleAttackSwingOpcode` in `src/server/game/Handlers/CombatHandler.cpp` to detect `HasAura(89153)` while mounted.  
- If the player is mounted with aura `89153` and the target is out of melee range the handler now calls `_player->SendAttackSwingNotInRange()` and `SendAttackStop(enemy)` and returns without queuing an attack.  
- If the player is within melee range the handler dismounts via `_player->Dismount()` and removes mounted auras with `_player->RemoveAurasByType(SPELL_AURA_MOUNTED)` before proceeding to `_player->Attack(enemy, true)`.  
- This change is scoped only to aura `89153` and leaves normal mounts and other attack flow unchanged.

### Testing

- No automated tests were run for this change.
- The change was applied to `src/server/game/Handlers/CombatHandler.cpp` and committed to the work branch.
- Manual runtime verification was not recorded as part of the automated test report.
- No unit/integration test failures were reported because none were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ba8fe9b4832793b0680378b6fb1d)