### PR TITLE
Block casts under attack-me fear unless spell grants charm immunity

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6687,9 +6687,43 @@ bool Spell::CheckSpellCancelsAuraEffect(AuraType auraType, uint32* param1) const
 
 bool Spell::CheckSpellCancelsCharm(uint32* param1) const
 {
-    return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_CHARM, param1) &&
-        CheckSpellCancelsAuraEffect(SPELL_AURA_AOE_CHARM, param1) &&
-        CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_POSSESS, param1);
+    if (!CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_CHARM, param1) ||
+        !CheckSpellCancelsAuraEffect(SPELL_AURA_AOE_CHARM, param1) ||
+        !CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_POSSESS, param1))
+        return false;
+
+    Unit* unitCaster = (m_originalCaster ? m_originalCaster : m_caster->ToUnit());
+    if (!unitCaster)
+        return false;
+
+    if (!unitCaster->HasAttackMeFearAura())
+        return true;
+
+    for (SpellEffectInfo const& effect : m_spellInfo->GetEffects())
+    {
+        if (!effect.IsEffect(SPELL_EFFECT_APPLY_AURA))
+            continue;
+
+        uint32 const miscValue = static_cast<uint32>(effect.MiscValue);
+        switch (effect.ApplyAuraName)
+        {
+            case SPELL_AURA_MECHANIC_IMMUNITY:
+                if (miscValue == MECHANIC_CHARM)
+                    return true;
+                break;
+            case SPELL_AURA_STATE_IMMUNITY:
+                if (miscValue == SPELL_AURA_MOD_CHARM || miscValue == SPELL_AURA_AOE_CHARM || miscValue == SPELL_AURA_MOD_POSSESS)
+                    return true;
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (param1)
+        *param1 = MECHANIC_CHARM;
+
+    return false;
 }
 
 bool Spell::CheckSpellCancelsTaunt(uint32* param1) const


### PR DESCRIPTION
### Motivation
- Item spells that were blocked by fear+`SPELL_EFFECT_ATTACK_ME` were treated like normal fear but should behave like a charm when preventing item casts.
- The intent is to prevent items that only remove fear (but not charm) from being used while under an attack-me fear effect.
- Ensure the server requires explicit charm immunity from the spell (or state/mechanic immunity) before allowing casts under attack-me fear. 

### Description
- Modified `Spell::CheckSpellCancelsCharm` in `src/server/game/Spells/Spell.cpp` to preserve existing charm-aura checks and then perform additional checks for `HasAttackMeFearAura`. 
- When an `attack_me` fear aura is present, the code now requires the casting spell to provide charm immunity via `SPELL_AURA_MECHANIC_IMMUNITY` with `MECHANIC_CHARM` or `SPELL_AURA_STATE_IMMUNITY` for charm/possess states. 
- If the spell does not grant the required charm immunity the check sets the mechanic hint (`param1`) to `MECHANIC_CHARM` and blocks the cast. 

### Testing
- No automated tests were executed for this change.
- Manual verification steps are recommended for items like the Classic Mage PvP trinket that remove fear/polymorph but not charm to confirm behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954bb0ea80c8327a203bbac5025a943)