### PR TITLE
Plainsrunning mount behavior and Player mount display lookup fix

### DIFF
--- a/src/server/game/Handlers/CombatHandler.cpp
+++ b/src/server/game/Handlers/CombatHandler.cpp
@@ -59,6 +59,25 @@ void WorldSession::HandleAttackSwingOpcode(WorldPackets::Combat::AttackSwing& pa
     }
 
     _player->ClearAttackStopRequestAfterTaunt();
+
+    // Plainsrunning (89153): mimic real mount behavior for right-click auto attack.
+    // If in melee range -> dismount and start attack.
+    // If NOT in melee range -> do NOT dismount, do NOT queue attack, send "not in range".
+    if (_player->IsMounted() && _player->HasAura(89153))
+    {
+        if (!_player->IsWithinMeleeRange(enemy))
+        {
+            _player->SendAttackSwingNotInRange();
+
+            // Ensure client does not think it is in an attack state
+            SendAttackStop(enemy);
+            return;
+        }
+
+        _player->Dismount();
+        _player->RemoveAurasByType(SPELL_AURA_MOUNTED);
+    }
+
     _player->Attack(enemy, true);
 }
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5650,7 +5650,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
         {
             if (m_caster->ToPlayer()->IsInFlight())
                 return SPELL_FAILED_NOT_ON_TAXI;
-            else if (m_caster->GetMountDisplayId() == 0 && m_caster->ToPlayer()->HasAura(89153))
+            else if (m_caster->ToPlayer()->GetMountDisplayId() == 0 && m_caster->ToPlayer()->HasAura(89153))
                 deferAutoDismountForRunMount = true;
             else
                 return SPELL_FAILED_NOT_MOUNTED;


### PR DESCRIPTION
### Motivation
- Implement Plainsrunning aura (`89153`) mount behavior so right-click auto-attack does not dismount or queue an attack when the target is out of melee range.
- Ensure the server mirrors the real client behavior by dismounting only when the target is within melee range.
- Fix a build error caused by calling `GetMountDisplayId` on a `WorldObject` instead of using the `Player` API.

### Description
- Added a Plainsrunning-specific check in `WorldSession::HandleAttackSwingOpcode` (`src/server/game/Handlers/CombatHandler.cpp`) that, when `_player->IsMounted()` and `_player->HasAura(89153)`, calls `_player->SendAttackSwingNotInRange()` and `SendAttackStop(enemy)` if out of melee range, or calls `_player->Dismount()` and `_player->RemoveAurasByType(SPELL_AURA_MOUNTED)` before attacking if in range.
- Fixed the mount display lookup in `Spell::CheckCast` (`src/server/game/Spells/Spell.cpp`) by changing `m_caster->GetMountDisplayId()` to `m_caster->ToPlayer()->GetMountDisplayId()` to use the correct `Player` API and resolve the compile error.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ba8fe9b4832793b0680378b6fb1d)