### PR TITLE
Allow Mangle on partial blocks for Claw

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2192,16 +2192,19 @@ class spell_dru_claw : public SpellScript
 {
     PrepareSpellScript(spell_dru_claw);
 
-    bool _shouldMangle = false;
+    SpellMissInfo _missInfo = SPELL_MISS_NONE;
 
     void HandleBeforeHit(SpellMissInfo missInfo)
     {
-        _shouldMangle = missInfo == SPELL_MISS_NONE;
+        _missInfo = missInfo;
     }
 
     void HandleAfterHit()
     {
-        if (!_shouldMangle)
+        bool shouldMangle = _missInfo == SPELL_MISS_NONE ||
+            (_missInfo == SPELL_MISS_BLOCK && GetHitDamage() > 0);
+
+        if (!shouldMangle)
             return;
 
         if (GetCaster()->IsPlayer())


### PR DESCRIPTION
### Motivation
- Fix a bug where a partially blocked `Claw` hit would not trigger the `Mangle` debuff when it should. 
- Ensure `Mangle` applies for any hit that deals damage, including block-with-damage cases. 

### Description
- Replace the boolean hit flag with a stored `SpellMissInfo` (`_missInfo`) in `spell_dru_claw` to retain the miss state from `BeforeHit` to `AfterHit`.
- Compute `shouldMangle` in `AfterHit` as `(_missInfo == SPELL_MISS_NONE) || (_missInfo == SPELL_MISS_BLOCK && GetHitDamage() > 0)` and only return early when it is false.
- Preserve existing behavior for non-hit and full-miss cases while enabling Mangle on partial blocks that still dealt damage.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955410390bc8327b3c332ee68912872)