### PR TITLE
Filter deleted characters from weekly honor selection

### DIFF
--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -521,8 +521,8 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_DEL_CHAR_SKILLS, "DELETE FROM character_skills WHERE guid = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_UPD_CHAR_HONOR_POINTS, "UPDATE characters SET totalHonorPoints = ? WHERE guid = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_INS_WEEKLY_HONOR_POINTS, "INSERT INTO character_honor_weekly (guid, weekly_honor) VALUES (?, ?) ON DUPLICATE KEY UPDATE weekly_honor = weekly_honor + VALUES(weekly_honor)", CONNECTION_ASYNC);
-    PrepareStatement(CHAR_SEL_WEEKLY_HONOR_TOP, "SELECT guid, weekly_honor FROM character_honor_weekly ORDER BY weekly_honor DESC, guid ASC LIMIT 1", CONNECTION_SYNCH);
-    PrepareStatement(CHAR_SEL_WEEKLY_HONOR_TOP_TWO, "SELECT guid, weekly_honor FROM character_honor_weekly ORDER BY weekly_honor DESC, guid ASC LIMIT 2", CONNECTION_SYNCH);
+    PrepareStatement(CHAR_SEL_WEEKLY_HONOR_TOP, "SELECT chw.guid, chw.weekly_honor FROM character_honor_weekly chw INNER JOIN characters c ON chw.guid = c.guid ORDER BY chw.weekly_honor DESC, chw.guid ASC LIMIT 1", CONNECTION_SYNCH);
+    PrepareStatement(CHAR_SEL_WEEKLY_HONOR_TOP_TWO, "SELECT chw.guid, chw.weekly_honor FROM character_honor_weekly chw INNER JOIN characters c ON chw.guid = c.guid ORDER BY chw.weekly_honor DESC, chw.guid ASC LIMIT 2", CONNECTION_SYNCH);
     PrepareStatement(CHAR_UPD_WEEKLY_HONOR_RESET, "UPDATE character_honor_weekly SET weekly_honor = 0", CONNECTION_ASYNC);
     PrepareStatement(CHAR_SEL_WARCHIEF_HONOR, "SELECT current_warchief_guid, current_warchief_name FROM warchief_honor WHERE id = 1", CONNECTION_SYNCH);
     PrepareStatement(CHAR_UPD_WARCHIEF_HONOR, "INSERT INTO warchief_honor (id, current_warchief_guid, current_warchief_name, last_warchief_guid, last_warchief_name) VALUES (1, ?, ?, ?, ?) "


### PR DESCRIPTION
### Motivation
- Prevent deleted character GUIDs stored in `character_honor_weekly` from being selected as the weekly warchief.
- Ensure weekly honor winner selection only considers players that still exist in the `characters` table.

### Description
- Change prepared statements `CHAR_SEL_WEEKLY_HONOR_TOP` and `CHAR_SEL_WEEKLY_HONOR_TOP_TWO` to use `character_honor_weekly chw INNER JOIN characters c ON chw.guid = c.guid` so deleted characters are excluded.
- Keep existing ordering and limits while restricting the result set to existing characters only.

### Testing
- No automated tests were executed for this change.
- The change is limited to SQL prepared statement strings and does not modify runtime logic beyond the query filters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695543fa5a80832786236cff761ac4d8)