### PR TITLE
Always cast 5-CP Slice and Dice (no aura refresh)

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -45,6 +45,7 @@ enum RogueSpells
     SPELL_ROGUE_KILLING_SPREE_DMG_BUFF          = 61851,
     SPELL_ROGUE_PREY_ON_THE_WEAK                = 58670,
     SPELL_ROGUE_SHIV_TRIGGERED                  =  5940,
+    SPELL_ROGUE_SLICE_AND_DICE_R1               =  5171,
     SPELL_ROGUE_TRICKS_OF_THE_TRADE             = 57934,
     SPELL_ROGUE_TRICKS_OF_THE_TRADE_DMG_BOOST   = 57933,
     SPELL_ROGUE_TRICKS_OF_THE_TRADE_PROC        = 59628,
@@ -264,6 +265,35 @@ class spell_rog_cut_to_the_chase : public AuraScript
     void Register() override
     {
         OnEffectProc += AuraEffectProcFn(spell_rog_cut_to_the_chase::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+    }
+};
+
+// Slice and Dice (5 combo points, no combo point cost)
+class spell_rog_slice_and_dice_5cp : public SpellScript
+{
+    PrepareSpellScript(spell_rog_slice_and_dice_5cp);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_ROGUE_SLICE_AND_DICE_R1 });
+    }
+
+    void HandleAfterCast()
+    {
+        Unit* caster = GetCaster();
+        if (!caster)
+            return;
+
+        uint32 sliceAndDiceId = SPELL_ROGUE_SLICE_AND_DICE_R1;
+        if (uint8 rank = sSpellMgr->GetSpellRank(GetSpellInfo()->Id))
+            sliceAndDiceId = sSpellMgr->GetSpellWithRank(SPELL_ROGUE_SLICE_AND_DICE_R1, rank);
+
+        caster->CastSpell(caster, sliceAndDiceId, CastSpellExtraArgs(TRIGGERED_IGNORE_COMBO_POINTS));
+    }
+
+    void Register() override
+    {
+        AfterCast += SpellCastFn(spell_rog_slice_and_dice_5cp::HandleAfterCast);
     }
 };
 
@@ -1289,6 +1319,7 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellScript(spell_rog_cheat_death);
     RegisterSpellScript(spell_rog_cut_to_the_chase);
     RegisterSpellScript(spell_rog_deadly_poison);
+    RegisterSpellScript(spell_rog_slice_and_dice_5cp);
     RegisterSpellScript(spell_rog_garrote);
     RegisterSpellScript(spell_rog_ruthlessness_bonus);
     new spell_rog_killing_spree();


### PR DESCRIPTION
### Motivation
- Ensure the helper spell always applies a fresh 5-combo-point `Slice and Dice` aura rather than refreshing an existing aura.
- Make the helper spell cast the appropriate rank of `Slice and Dice` while ignoring combo point consumption.
- Preserve rank-aware behavior so higher ranks of the helper spell trigger the matching `Slice and Dice` rank.
- Simplify the behavior to always reapply the aura on cast.

### Description
- Remove the previous aura-refresh logic and instead call `caster->CastSpell(caster, sliceAndDiceId, CastSpellExtraArgs(TRIGGERED_IGNORE_COMBO_POINTS))` unconditionally.
- Implement `spell_rog_slice_and_dice_5cp` `SpellScript` that validates `SPELL_ROGUE_SLICE_AND_DICE_R1` and resolves the specific rank via `sSpellMgr->GetSpellRank` and `sSpellMgr->GetSpellWithRank`.
- Register the new script in `AddSC_rogue_spell_scripts` with `RegisterSpellScript(spell_rog_slice_and_dice_5cp)`.
- Maintain use of `TRIGGERED_IGNORE_COMBO_POINTS` so the cast does not consume combo points.

### Testing
- No automated unit or integration tests were executed for this change.
- No build or compilation check was performed as part of this PR run.
- Manual runtime verification was not reported.
- Recommend running CI/build and relevant unit tests before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956fb4d061083279bd3c98c51c8c0fc)