### PR TITLE
Trigger Deadly Shot interrupt proc when interrupting casts (spell 89159)

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -69,7 +69,8 @@ enum RogueSpells
     SPELL_ROGUE_RUTHLESSNESS_BONUS              = 81407,
     SPELL_ROGUE_IMPROVED_EVASION_TRIGGER        = 81403,
     SPELL_ROGUE_IMPROVED_EVASION_AURA           = 81404,
-    SPELL_ROGUE_GOUGE_DOT_REMOVAL_AURA          = 81410
+    SPELL_ROGUE_GOUGE_DOT_REMOVAL_AURA          = 81410,
+    SPELL_ROGUE_DEADLY_SHOT_INTERRUPT_TRIGGER   = 89159
 };
 
 // 13877, 33735, (check 51211, 65956) - Blade Flurry
@@ -1310,6 +1311,9 @@ class spell_rog_deadly_shot : public SpellScript
 
         // Lock out the school of the *interrupted* spell, not Deadly Shot's school
         target->GetSpellHistory()->LockSpellSchool(schoolMask, lockMs);
+
+        if (caster->HasAura(SPELL_ROGUE_IMPROVED_EVASION_AURA))
+            caster->CastSpell(caster, SPELL_ROGUE_DEADLY_SHOT_INTERRUPT_TRIGGER, true);
     }
 
 


### PR DESCRIPTION
### Motivation
- When Deadly Shot interrupts a target's spell, the rogue should receive a follow-up trigger if they have the Improved Evasion aura (81404). 
- This ensures the interrupt interaction can drive additional effects (spell 89159) used by class/item/talent mechanics.

### Description
- Added `SPELL_ROGUE_DEADLY_SHOT_INTERRUPT_TRIGGER = 89159` to the `RogueSpells` enum in `src/server/scripts/Spells/spell_rogue.cpp`.
- After calling `target->InterruptNonMeleeSpells(false)` the code now checks `caster->HasAura(SPELL_ROGUE_IMPROVED_EVASION_AURA)` and calls `caster->CastSpell(caster, SPELL_ROGUE_DEADLY_SHOT_INTERRUPT_TRIGGER, true)` when present.
- The change was applied in the `spell_rog_deadly_shot` spell script handling the `OnHit` logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695715f816088327b71ea590eb0097a9)