### PR TITLE
Fix combo point consumption on partial blocks

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2738,14 +2738,19 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
         // set hitmask for finish procs
         spell->m_hitMask |= hitMask;
 
-        // Do not take combo points on dodge and miss
+        // Do not take combo points on dodge, miss, or full block
+        bool fullBlock = MissCondition == SPELL_MISS_BLOCK && spell->m_spellInfo->HasAttribute(SPELL_ATTR3_COMPLETELY_BLOCKED);
+        bool partialBlock = MissCondition == SPELL_MISS_BLOCK && !fullBlock;
         bool blockedFinisherWithDebuff = MissCondition == SPELL_MISS_BLOCK &&
             spell->m_spellInfo->NeedsComboPoints() &&
             spell->m_spellInfo->HasEffect(SPELL_EFFECT_APPLY_AURA) &&
             !spell->IsPositive();
 
-        if (MissCondition != SPELL_MISS_NONE && !blockedFinisherWithDebuff && spell->m_needComboPoints && spell->m_targets.GetUnitTargetGUID() == TargetGUID)
-            spell->m_needComboPoints = false;
+        if (MissCondition != SPELL_MISS_NONE && !partialBlock && spell->m_needComboPoints && spell->m_targets.GetUnitTargetGUID() == TargetGUID)
+        {
+            if (fullBlock || !blockedFinisherWithDebuff)
+                spell->m_needComboPoints = false;
+        }
 
         // _spellHitTarget can be null if spell is missed in DoSpellHitOnUnit
         if (MissCondition != SPELL_MISS_EVADE && _spellHitTarget && !spell->m_caster->IsFriendlyTo(unit) && (!spell->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)))


### PR DESCRIPTION
### Motivation
- Finishers that were partially blocked were incorrectly preserving combo points instead of consuming them, while full blocks should prevent combo point consumption.
- The intent is to only avoid clearing combo points on a fully blocked finisher and treat partial blocks as hits for combo-point consumption.

### Description
- Update logic in `Spell::TargetInfo::DoDamageAndTriggers` to distinguish full blocks and partial blocks via `fullBlock` and `partialBlock` flags.
- Change the `m_needComboPoints` clearing condition so partial blocks do not prevent combo-point consumption, while full blocks still do.
- Preserve existing `blockedFinisherWithDebuff` semantics but apply them only when appropriate alongside full-block handling.

### Testing
- No automated tests were run for this change.
- (Manual testing or unit tests can be added separately to validate finisher behavior under partial and full block cases.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695717d46da48327b8af5385fcca8ffc)