### PR TITLE
Mage: Cast Arcane Implosion when Mana Shield breaks

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1065,7 +1065,7 @@ class spell_mage_mana_shield : public spell_mage_incanters_absorbtion_base_AuraS
 
     bool Validate(SpellInfo const* spellInfo) override
     {
-        return ValidateSpellInfo({ SPELL_MAGE_ARCANE_SURGE }) &&
+        return ValidateSpellInfo({ SPELL_MAGE_ARCANE_SURGE, SPELL_MAGE_IMPLOSION, SPELL_MAGE_RECALIBRATING }) &&
             spell_mage_incanters_absorbtion_base_AuraScript::Validate(spellInfo);
     }
 
@@ -1091,7 +1091,7 @@ class spell_mage_mana_shield : public spell_mage_incanters_absorbtion_base_AuraS
             && !GetCaster()->HasAura(SPELL_MAGE_RECALIBRATING)
             )
         {
-            GetCaster()->AddAura(SPELL_MAGE_BROKEN_MANA_SHIELD, GetCaster());
+            GetCaster()->CastSpell(GetCaster(), SPELL_MAGE_IMPLOSION, true);
             GetCaster()->AddAura(SPELL_MAGE_RECALIBRATING, GetCaster());
         }
     }


### PR DESCRIPTION
### Motivation
- Ensure that when Mana Shield is removed by enemy damage the mage triggers an active `SPELL_MAGE_IMPLOSION` cast instead of only adding the broken-shield aura.
- Prevent missing spell references by validating `SPELL_MAGE_IMPLOSION` and `SPELL_MAGE_RECALIBRATING` in the Mana Shield script.

### Description
- Added `SPELL_MAGE_IMPLOSION` and `SPELL_MAGE_RECALIBRATING` to the `ValidateSpellInfo` list in the `spell_mage_mana_shield` validator.
- Replaced `GetCaster()->AddAura(SPELL_MAGE_BROKEN_MANA_SHIELD, ...)` with an explicit cast: `GetCaster()->CastSpell(GetCaster(), SPELL_MAGE_IMPLOSION, true)` inside `OnRemove` when the aura is removed by enemy spell damage.
- Left the existing `SPELL_MAGE_RECALIBRATING` aura application in place to preserve the recalibration behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69571e141aa48327a62f9259fd131bb4)