### PR TITLE
Align shaman STR->AP scaling with 1.12 (2 AP per Strength)

### DIFF
--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -393,7 +393,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
                 val2 = level * 2.0f + GetStat(STAT_STRENGTH) + GetStat(STAT_AGILITY) - 20.0f;
                 break;
             case CLASS_SHAMAN:
-                val2 = level * 2.0f + GetStat(STAT_STRENGTH) + GetStat(STAT_AGILITY) - 20.0f;
+                val2 = level * 2.0f + GetStat(STAT_STRENGTH) * 2.0f + GetStat(STAT_AGILITY) - 20.0f;
                 break;
             case CLASS_DRUID:
             {


### PR DESCRIPTION
### Motivation
- Make shaman melee attack power scaling match 1.12-era behavior where Strength grants 2 attack power each.
- Correct an inconsistency where shamans used the same 1 AP per Strength term as some other classes in the melee branch.
- Ensure weapon damage and related dependent calculations use the intended AP conversion for shamans.

### Description
- Change made in `src/server/game/Entities/Unit/StatSystem.cpp` inside `Player::UpdateAttackPowerAndDamage` for the melee (non-ranged) `CLASS_SHAMAN` case. 
- The Strength contribution was changed from `GetStat(STAT_STRENGTH)` to `GetStat(STAT_STRENGTH) * 2.0f` so Strength now counts as 2 AP per point. 
- This only affects melee attack power computation path and thus downstream damage/weapon calculations that read AP.

### Testing
- No automated tests were run against this change.
- No unit or integration test suites were executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695780cf87088327880145dc7f9b056a)