### PR TITLE
Align shaman AP scaling with 1.12 (Strength = 2 AP, remove Agility AP)

### DIFF
--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -393,7 +393,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
                 val2 = level * 2.0f + GetStat(STAT_STRENGTH) + GetStat(STAT_AGILITY) - 20.0f;
                 break;
             case CLASS_SHAMAN:
-                val2 = level * 2.0f + GetStat(STAT_STRENGTH) + GetStat(STAT_AGILITY) - 20.0f;
+                val2 = level * 2.0f + GetStat(STAT_STRENGTH) * 2.0f - 20.0f;
                 break;
             case CLASS_DRUID:
             {


### PR DESCRIPTION
### Motivation
- Ensure shaman melee attack power scaling follows 1.12-era conversions where `Strength` yields 2 AP and `Agility` does not contribute to AP.
- Correct an inconsistency where shamans previously received an `Agility` AP contribution like some other classes.
- Make weapon damage and downstream calculations reflect the intended shaman AP conversion.

### Description
- Updated `src/server/game/Entities/Unit/StatSystem.cpp` in the `Player::UpdateAttackPowerAndDamage` melee (non-ranged) `CLASS_SHAMAN` path.
- Replaced the formula `level * 2.0f + GetStat(STAT_STRENGTH) + GetStat(STAT_AGILITY) - 20.0f` with `level * 2.0f + GetStat(STAT_STRENGTH) * 2.0f - 20.0f`.
- This removes the `GetStat(STAT_AGILITY)` contribution and makes `GetStat(STAT_STRENGTH)` provide 2 AP per Strength for shamans.
- No other class formulas were changed.

### Testing
- No automated tests were run for this change.
- No CI or unit test suite results are available for this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695780cf87088327880145dc7f9b056a)