### PR TITLE
Fix attack power modifier field updates

### DIFF
--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -506,19 +506,15 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
     if (ranged)
     {
         SetRangedAttackPower(int32(base_attPower));
-        if (attPowerMod >= 0)
-            SetRangedAttackPowerModPos(int32(attPowerMod));
-        if (attPowerMod <= 0)
-            SetRangedAttackPowerModNeg(int32(attPowerMod));
+        SetRangedAttackPowerModPos(attPowerMod > 0.0f ? int32(attPowerMod) : 0);
+        SetRangedAttackPowerModNeg(attPowerMod < 0.0f ? int32(attPowerMod) : 0);
         SetRangedAttackPowerMultiplier(attPowerMultiplier);
     }
     else
     {
         SetAttackPower(int32(base_attPower));
-        if (attPowerMod >= 0)
-            SetAttackPowerModPos(int32(attPowerMod));
-        if (attPowerMod <= 0)
-            SetAttackPowerModNeg(int32(attPowerMod));
+        SetAttackPowerModPos(attPowerMod > 0.0f ? int32(attPowerMod) : 0);
+        SetAttackPowerModNeg(attPowerMod < 0.0f ? int32(attPowerMod) : 0);
         SetAttackPowerMultiplier(attPowerMultiplier);
     }
 
@@ -1102,19 +1098,15 @@ void Creature::UpdateAttackPowerAndDamage(bool ranged)
     if (ranged)
     {
         SetRangedAttackPower(int32(baseAttackPower));
-        if (attackPowerMod >= 0)
-            SetRangedAttackPowerModPos(int32(attackPowerMod));
-        if (attackPowerMod <= 0)
-            SetRangedAttackPowerModNeg(int32(attackPowerMod));
+        SetRangedAttackPowerModPos(attackPowerMod > 0.0f ? int32(attackPowerMod) : 0);
+        SetRangedAttackPowerModNeg(attackPowerMod < 0.0f ? int32(attackPowerMod) : 0);
         SetRangedAttackPowerMultiplier(attackPowerMultiplier);
     }
     else
     {
         SetAttackPower(int32(baseAttackPower));
-        if (attackPowerMod >= 0)
-            SetAttackPowerModPos(int32(attackPowerMod));
-        if (attackPowerMod <= 0)
-            SetAttackPowerModNeg(int32(attackPowerMod));
+        SetAttackPowerModPos(attackPowerMod > 0.0f ? int32(attackPowerMod) : 0);
+        SetAttackPowerModNeg(attackPowerMod < 0.0f ? int32(attackPowerMod) : 0);
         SetAttackPowerMultiplier(attackPowerMultiplier);
     }
 
@@ -1490,7 +1482,8 @@ void Guardian::UpdateAttackPowerAndDamage(bool ranged)
     float attPowerMultiplier = GetPctModifierValue(unitMod, TOTAL_PCT) - 1.0f;
 
     SetAttackPower(int32(base_attPower));
-    SetAttackPowerModPos(int32(attPowerMod));
+    SetAttackPowerModPos(attPowerMod > 0.0f ? int32(attPowerMod) : 0);
+    SetAttackPowerModNeg(attPowerMod < 0.0f ? int32(attPowerMod) : 0);
     SetAttackPowerMultiplier(attPowerMultiplier);
 
     //automatically update weapon damage after attack power modification


### PR DESCRIPTION
### Motivation
- Attack power calculations could show incorrect totals when flat AP debuffs (e.g. Demoralizing Roar/Shout) were applied or removed because positive/negative modifier fields could remain stale or not be cleared.
- The intent is to ensure the client-facing AP modifier fields are always set explicitly so dependent stats and damage calculations stay in sync.

### Description
- Replace conditional writes with explicit assignments so both positive and negative AP modifier fields are always updated in `Player::UpdateAttackPowerAndDamage`, `Creature::UpdateAttackPowerAndDamage`, and `Guardian::UpdateAttackPowerAndDamage` in `src/server/game/Entities/Unit/StatSystem.cpp`.
- Use sign checks to set `SetAttackPowerModPos(...)` and `SetAttackPowerModNeg(...)` (and their ranged equivalents) to a value or `0` to avoid leaving stale values when the modifier flips sign or is removed.
- Preserve existing multiplier and base AP calculations while ensuring the unit fields used by `GetTotalAttackPowerValue` reflect the current state.

### Testing
- No automated tests were executed for this change.
- Code was compiled and committed as part of the change set (no CI results included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69675548c11c8327ad8e34b0d98c47d4)