### PR TITLE
Randomize client cache version packet value

### DIFF
--- a/src/server/game/Handlers/AuthHandler.cpp
+++ b/src/server/game/Handlers/AuthHandler.cpp
@@ -16,8 +16,11 @@
  */
 
 #include "Opcodes.h"
+#include "Random.h"
 #include "WorldSession.h"
 #include "WorldPacket.h"
+
+#include <limits>
 
 void WorldSession::SendAuthResponse(uint8 code, bool shortForm, uint32 queuePos)
 {
@@ -39,7 +42,9 @@ void WorldSession::SendAuthResponse(uint8 code, bool shortForm, uint32 queuePos)
 
 void WorldSession::SendClientCacheVersion(uint32 version)
 {
+    uint32 maxVersion = version > 0 ? version : std::numeric_limits<uint32>::max();
+    uint32 randomVersion = urand(1u, maxVersion);
     WorldPacket data(SMSG_CLIENTCACHE_VERSION, 4);
-    data << uint32(version);
+    data << uint32(randomVersion);
     SendPacket(&data);
 }


### PR DESCRIPTION
### Motivation
- Randomize the value sent in `SendClientCacheVersion` to avoid always sending a fixed configured version and provide a safe fallback when the configured value is zero.

### Description
- Added `#include "Random.h"` and `#include <limits>` and changed `WorldSession::SendClientCacheVersion` to compute `maxVersion = version > 0 ? version : std::numeric_limits<uint32>::max()` and send `urand(1u, maxVersion)` instead of the original configured `version`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678a2627788327b49c5e0be843278d)