### PR TITLE
Fix hidden itemset learned spell cleanup

### DIFF
--- a/src/server/scripts/Custom/custom_hidden_itemset_bonus.cpp
+++ b/src/server/scripts/Custom/custom_hidden_itemset_bonus.cpp
@@ -65,6 +65,33 @@ struct LearnedSpellRefState
 
 using PlayerLearnedSpellRefMap = std::unordered_map<uint32, LearnedSpellRefState>;
 std::unordered_map<uint64, PlayerLearnedSpellRefMap> s_PlayerLearnedSpellRefs;
+
+void CollectLearnedSpellsFromSpell(uint32 spellId, std::unordered_set<uint32>& learnedSpellSet, std::unordered_set<uint32>& visitedSpells)
+{
+    if (!spellId)
+        return;
+
+    if (!visitedSpells.insert(spellId).second)
+        return;
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!spellInfo)
+        return;
+
+    SpellLearnSpellMapBounds learnBounds = sSpellMgr->GetSpellLearnSpellMapBounds(spellId);
+    for (auto itr = learnBounds.first; itr != learnBounds.second; ++itr)
+        learnedSpellSet.insert(itr->second.spell);
+
+    for (SpellEffectInfo const& effectInfo : spellInfo->GetEffects())
+    {
+        if ((effectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL) || effectInfo.IsEffect(SPELL_EFFECT_SCRIPT_EFFECT)) && effectInfo.TriggerSpell)
+            learnedSpellSet.insert(effectInfo.TriggerSpell);
+
+        if (effectInfo.TriggerSpell)
+            CollectLearnedSpellsFromSpell(effectInfo.TriggerSpell, learnedSpellSet, visitedSpells);
+    }
+}
+
 bool IsHiddenBonusActive(Player* player, uint32 itemsetId)
 {
     if (!player)
@@ -461,16 +488,11 @@ void LoadHiddenItemsetBonuses()
         }
 
         std::unordered_set<uint32> learnedSpellSet;
-
-        SpellLearnSpellMapBounds learnBounds = sSpellMgr->GetSpellLearnSpellMapBounds(b.spellId);
-        for (auto itr = learnBounds.first; itr != learnBounds.second; ++itr)
-            learnedSpellSet.insert(itr->second.spell);
+        std::unordered_set<uint32> visitedSpells;
+        CollectLearnedSpellsFromSpell(b.spellId, learnedSpellSet, visitedSpells);
 
         for (SpellEffectInfo const& effectInfo : spellInfo->GetEffects())
         {
-            if ((effectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL) || effectInfo.IsEffect(SPELL_EFFECT_SCRIPT_EFFECT)) && effectInfo.TriggerSpell)
-                learnedSpellSet.insert(effectInfo.TriggerSpell);
-
             if ((effectInfo.IsEffect(SPELL_EFFECT_SUMMON) || effectInfo.IsEffect(SPELL_EFFECT_SUMMON_PET)) && effectInfo.MiscValue > 0)
                 b.summonedEntries.push_back(effectInfo.MiscValue);
         }


### PR DESCRIPTION
### Motivation
- Hidden itemset bonuses that teach spells via triggers (for example basic campfire) were not fully tracked, causing taught spells to remain known after unequip instead of being cleaned up.

### Description
- Add a recursive collector `CollectLearnedSpellsFromSpell` that traverses spell-learn maps and triggered teach spells to build a complete set of learned spells. 
- Update `LoadHiddenItemsetBonuses` to use the recursive collector and continue to record summon entries, and store the discovered learns in the hidden-bonus maps (`s_KnownHiddenItemsetBonusLearns`, `s_KnownHiddenItemsetSpellIds`, `s_KnownHiddenItemsetBonusSummons`).
- Changes are implemented in `src/server/scripts/Custom/custom_hidden_itemset_bonus.cpp` and populate `s_PlayerLearnedSpellRefs` correctly so cleanup on unequip can remove trigger-taught spells.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ce26f97088327a28bd304ac6c9365)