### PR TITLE
Avoid Deadly Shot self lockout when resolving target

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -1281,8 +1281,10 @@ class spell_rog_deadly_shot : public SpellScript
     void HandleOnHit()
     {
         Unit* caster = GetCaster();
-        Unit* target = GetHitUnit();
-        if (!caster || !target)
+        Unit* target = GetExplTargetUnit();
+        if (!target || target == caster)
+            target = GetHitUnit();
+        if (!caster || !target || target == caster)
             return;
 
         if (!_comboPoints)


### PR DESCRIPTION
### Motivation
- Prevent Deadly Shot from locking the caster out when reflections or missing explicit targets cause the caster to be treated as the hit unit.

### Description
- In `spell_rog_deadly_shot::HandleOnHit` prefer `GetExplTargetUnit()` and only fall back to `GetHitUnit()` if the explicit target is null or equals the caster, and early-return if the resolved target is the caster.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf2723fe08327acf3684d2849952a)