### PR TITLE
Enforce fear restrictions before other CC checks

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6611,7 +6611,19 @@ SpellCastResult Spell::CheckCasterAuras(uint32* param1) const
         return SPELL_CAST_OK;
     };
 
-    if (unitflag & UNIT_FLAG_STUNNED)
+    if (result == SPELL_CAST_OK && unitflag & UNIT_FLAG_FLEEING)
+    {
+        if (usableWhileFeared)
+        {
+            SpellCastResult mechanicResult = mechanicCheck(SPELL_AURA_MOD_FEAR);
+            if (mechanicResult != SPELL_CAST_OK)
+                result = mechanicResult;
+        }
+        else if (!CheckSpellCancelsFear(param1))
+            result = SPELL_FAILED_FLEEING;
+    }
+
+    if (result == SPELL_CAST_OK && unitflag & UNIT_FLAG_STUNNED)
     {
         if (usableWhileStunned)
         {
@@ -6624,24 +6636,14 @@ SpellCastResult Spell::CheckCasterAuras(uint32* param1) const
         else if ((m_spellInfo->Mechanic & MECHANIC_IMMUNE_SHIELD) && m_caster->ToUnit() && m_caster->ToUnit()->HasAuraWithMechanic(1 << MECHANIC_BANISH))
             result = SPELL_FAILED_STUNNED;
     }
-    else if (unitCaster->IsTaunted() && !CheckSpellCancelsCharm(param1))
+
+    if (result == SPELL_CAST_OK && unitCaster->IsTaunted() && !CheckSpellCancelsCharm(param1))
         result = SPELL_FAILED_CHARMED;
-    else if (unitflag & UNIT_FLAG_SILENCED && m_spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE && !CheckSpellCancelsSilence(param1))
+    if (result == SPELL_CAST_OK && unitflag & UNIT_FLAG_SILENCED && m_spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE && !CheckSpellCancelsSilence(param1))
         result = SPELL_FAILED_SILENCED;
-    else if (unitflag & UNIT_FLAG_PACIFIED && m_spellInfo->PreventionType == SPELL_PREVENTION_TYPE_PACIFY && !CheckSpellCancelsPacify(param1))
+    if (result == SPELL_CAST_OK && unitflag & UNIT_FLAG_PACIFIED && m_spellInfo->PreventionType == SPELL_PREVENTION_TYPE_PACIFY && !CheckSpellCancelsPacify(param1))
         result = SPELL_FAILED_PACIFIED;
-    else if (unitflag & UNIT_FLAG_FLEEING)
-    {
-        if (usableWhileFeared)
-        {
-            SpellCastResult mechanicResult = mechanicCheck(SPELL_AURA_MOD_FEAR);
-            if (mechanicResult != SPELL_CAST_OK)
-                result = mechanicResult;
-        }
-        else if (!CheckSpellCancelsFear(param1))
-            result = SPELL_FAILED_FLEEING;
-    }
-    else if ((unitflag & UNIT_FLAG_CONFUSED))
+    if (result == SPELL_CAST_OK && (unitflag & UNIT_FLAG_CONFUSED))
     {
         if (usableWhileConfused)
         {


### PR DESCRIPTION
### Motivation
- Prevent spells that are not usable while feared from being cast when the caster is feared even if other control flags (like stunned) are also set.
- Remove the earlier special-case that only blocked `Blink` (`Id == 1953`) while feared and replace it with a general, correct enforcement.

### Description
- Update `Spell::CheckCasterAuras` to evaluate `UNIT_FLAG_FLEEING` (fear) before other control flags and perform `mechanicCheck(SPELL_AURA_MOD_FEAR)` when appropriate.
- Change the control-flow so each CC check (fear, stun, charm/taunt, silence, pacify, confused) only runs when `result == SPELL_CAST_OK`, replacing `else if` chains with guarded `if` checks.
- Remove the hardcoded `Blink` (`m_spellInfo->Id == 1953`) special-case so fear restrictions apply broadly to all spells that do not have `SPELL_ATTR5_USABLE_WHILE_FEARED`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d9881c7a08327afe8082a42128b06)