### PR TITLE
Prevent Mind Vision from triggering combat or interrupting auras

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2471,7 +2471,7 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
     else if (MissCondition == SPELL_MISS_REFLECT && ReflectResult == SPELL_MISS_NONE)
         _spellHitTarget = spell->m_caster->ToUnit();
 
-    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()))
+    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()) && !spell->m_spellInfo->IsMindVision())
     {
         if(spell->m_spellInfo->Id != 14309 && spell->m_spellInfo->Id != 14308 && spell->m_spellInfo->Id != 3355 && spell->m_spellInfo->Id != 13810 && spell->m_spellInfo->Id != 63487 && spell->m_spellInfo->Id != 67035
             && spell->m_spellInfo->Id != 72216 && spell->m_spellInfo->Id != 19185 && spell->m_spellInfo->Id != 3600 && spell->m_spellInfo->Id != 6474) //freezing/frost traps and Earthbind Totem don't put you in combat
@@ -2893,7 +2893,7 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
         if (m_spellInfo->Speed > 0.0f && unit->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE) && unit->GetCharmerOrOwnerGUID() != m_caster->GetGUID())
             return SPELL_MISS_EVADE;
 
-        if (m_caster->IsValidAttackTarget(unit, m_spellInfo))
+        if (m_caster->IsValidAttackTarget(unit, m_spellInfo) && !m_spellInfo->IsMindVision())
             unit->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_HITBYSPELL);
         else if (m_caster->IsFriendlyTo(unit))
         {
@@ -8079,7 +8079,7 @@ void Spell::PreprocessSpellLaunch(TargetInfo& targetInfo)
         return;
 
     // This will only cause combat - the target will engage once the projectile hits (in Spell::TargetInfo::PreprocessTarget)
-    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged())
+    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()) && !m_spellInfo->IsMindVision()
         && (m_spellInfo->Id != 14309 && m_spellInfo->Id != 14308 && m_spellInfo->Id != 3355 && m_spellInfo->Id != 13810 && m_spellInfo->Id != 63487 && m_spellInfo->Id != 67035 && m_spellInfo->Id != 72216 && m_spellInfo->Id != 19185
             && m_spellInfo->Id != 3600 && m_spellInfo->Id != 6474)) //freezing/frost traps and Earthbind Totem don't put you in combat
         m_originalCaster->SetInCombatWith(targetUnit, true);

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1251,6 +1251,11 @@ bool SpellInfo::IsStarfire() const
     return SpellFamilyName == SPELLFAMILY_DRUID && (SpellFamilyFlags[0] & 0x00000004);
 }
 
+bool SpellInfo::IsMindVision() const
+{
+    return Id == 2096 || Id == 10909;
+}
+
 float SpellInfo::GetStarfireSnareSpeedRate() const
 {
     switch (Id)

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -418,6 +418,7 @@ class TC_GAME_API SpellInfo
         bool IsChanneled() const;
         bool IsMoveAllowedChannel() const;
         bool IsStarfire() const;
+        bool IsMindVision() const;
         float GetStarfireSnareSpeedRate() const;
         bool NeedsComboPoints() const;
         bool IsNextMeleeSwingSpell() const;


### PR DESCRIPTION
### Motivation
- Mind Vision (ranks `2096` / `10909`) should be a passive observation effect that does not force targets into combat or interrupt actions like eating/drinking.
- Current spell processing treats Mind Vision like other hostile/aggro spells and may set combat or remove interruptible auras.

### Description
- Add a helper `SpellInfo::IsMindVision()` in `src/server/game/Spells/SpellInfo.{h,cpp}` that identifies Mind Vision ranks.
- Skip setting combat state for Mind Vision by checking `!m_spellInfo->IsMindVision()` in `Spell::TargetInfo::PreprocessTarget` and `Spell::PreprocessSpellLaunch` (`src/server/game/Spells/Spell.cpp`).
- Prevent Mind Vision from removing hit-based interrupt flags by gating the `RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_HITBYSPELL)` call with `!m_spellInfo->IsMindVision()` in `Spell::PreprocessSpellHit` (`src/server/game/Spells/Spell.cpp`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973326942dc832782f58e6815c91f99)