### PR TITLE
Restrict Ignite spread to humanoid creature type

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -937,7 +937,7 @@ class spell_mage_ignite_tick : public AuraScript
             if (!caster->IsValidAttackTarget(spreadTarget))
                 continue;
 
-            if (spreadTarget->GetTypeId() != TYPEID_PLAYER && spreadTarget->GetCreatureType() != CREATURE_TYPE_HUMANOID)
+            if (spreadTarget->GetCreatureType() != CREATURE_TYPE_HUMANOID)
                 continue;
 
             if (spreadTarget->HasAura(SPELL_MAGE_IGNITE))


### PR DESCRIPTION
### Motivation
- Fix a bug where `spell_mage_ignite_tick` could spread Ignite to druids in cat/bear/travel forms because the previous check allowed `TYPEID_PLAYER` regardless of creature type. 
- The spread should only affect humanoid targets, not beasts or shapeshifted forms.

### Description
- Changed the target filter in `spell_mage_ignite_tick::HandleRemove` (file `src/server/scripts/Spells/spell_mage.cpp`) to require `spreadTarget->GetCreatureType() == CREATURE_TYPE_HUMANOID` instead of the prior `TYPEID_PLAYER`/humanoid combined check. 
- This removes the special-case that permitted player units to receive Ignite regardless of their current creature type, preventing spread to beast forms.

### Testing
- No automated tests were executed for this change.
- The change was validated by static inspection of the modified logic and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697372238dc48327b28bcd6dab7b0976)