### PR TITLE
Fix absorbed periodic damage to trigger taken-damage procs

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5382,7 +5382,7 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     uint32 procAttacker = PROC_FLAG_DONE_PERIODIC;
     uint32 procVictim   = PROC_FLAG_TAKEN_PERIODIC;
     uint32 hitMask = damageInfo.GetHitMask();
-    if (damage)
+    if (damage || absorb)
     {
         hitMask |= crit ? PROC_HIT_CRITICAL : PROC_HIT_NORMAL;
         procVictim |= PROC_FLAG_TAKEN_DAMAGE;
@@ -5469,7 +5469,7 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
     uint32 procAttacker = PROC_FLAG_DONE_PERIODIC;
     uint32 procVictim   = PROC_FLAG_TAKEN_PERIODIC;
     uint32 hitMask = damageInfo.GetHitMask();
-    if (damage)
+    if (damage || absorb)
     {
         hitMask |= crit ? PROC_HIT_CRITICAL : PROC_HIT_NORMAL;
         procVictim |= PROC_FLAG_TAKEN_DAMAGE;


### PR DESCRIPTION
### Motivation
- Fully absorbed periodic damage (DoT / health-leech ticks) was not treated as "damage taken" for proc/interrupt logic, causing effects like stealth not to break under shields such as `Power Word: Shield`.

### Description
- In `src/server/game/Spells/Auras/SpellAuraEffects.cpp` updated two checks in `AuraEffect::HandlePeriodicDamageAurasTick` and `AuraEffect::HandlePeriodicHealthLeechAuraTick` from `if (damage)` to `if (damage || absorb)` so ticks that are fully absorbed still set `PROC_FLAG_TAKEN_DAMAGE` and the appropriate `hitMask`.

### Testing
- Ran `git diff --check` which returned clean results and committed the change; commit recorded locally.  
- No `build/` directory is present in this environment, so a compile/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d3bdda348327af02bf27258bc85c)