### PR TITLE
Add GM `bgqueue` command to list battleground/arena queue members

### DIFF
--- a/src/server/scripts/Commands/cs_bgqueue.cpp
+++ b/src/server/scripts/Commands/cs_bgqueue.cpp
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ScriptMgr.h"
+#include "BattlegroundMgr.h"
+#include "CharacterCache.h"
+#include "Chat.h"
+#include "ObjectAccessor.h"
+#include "Player.h"
+#include "RBAC.h"
+
+using namespace Trinity::ChatCommands;
+
+class bgqueue_commandscript : public CommandScript
+{
+public:
+    bgqueue_commandscript() : CommandScript("bgqueue_commandscript") { }
+
+    ChatCommandTable GetCommands() const override
+    {
+        static ChatCommandTable commandTable =
+        {
+            { "bgqueue", HandleBgQueueCommand, rbac::RBAC_PERM_COMMAND_LFG_QUEUE, Console::Yes },
+        };
+
+        return commandTable;
+    }
+
+    static bool HandleBgQueueCommand(ChatHandler* handler)
+    {
+        bool hasQueuedPlayers = false;
+
+        for (uint32 queueTypeId = BATTLEGROUND_QUEUE_AV; queueTypeId < MAX_BATTLEGROUND_QUEUE_TYPES; ++queueTypeId)
+        {
+            BattlegroundQueueTypeId bgQueueTypeId = BattlegroundQueueTypeId(queueTypeId);
+            BattlegroundQueue& queue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
+            if (queue.m_QueuedPlayers.empty())
+                continue;
+
+            hasQueuedPlayers = true;
+
+            std::string queueName;
+            if (uint8 arenaType = BattlegroundMgr::BGArenaType(bgQueueTypeId))
+                queueName = Trinity::StringFormat("Arena %uv%u", arenaType, arenaType);
+            else
+            {
+                BattlegroundTypeId bgTypeId = BattlegroundMgr::BGTemplateId(bgQueueTypeId);
+                if (Battleground* bgTemplate = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId))
+                    queueName = bgTemplate->GetName();
+                else
+                    queueName = Trinity::StringFormat("Battleground type %u", bgTypeId);
+            }
+
+            handler->PSendSysMessage("%s queue (%zu players):", queueName.c_str(), queue.m_QueuedPlayers.size());
+
+            for (BattlegroundQueue::QueuedPlayersMap::value_type const& queuedPlayer : queue.m_QueuedPlayers)
+            {
+                std::string playerName;
+
+                if (Player const* player = ObjectAccessor::FindConnectedPlayer(queuedPlayer.first))
+                    playerName = player->GetName();
+                else if (!sCharacterCache->GetCharacterNameByGuid(queuedPlayer.first, playerName))
+                    playerName = "<unknown>";
+
+                char const* factionName = "Unknown";
+                char const* queueMode = "Unrated";
+
+                if (GroupQueueInfo const* groupInfo = queuedPlayer.second.GroupInfo)
+                {
+                    factionName = groupInfo->Team == HORDE ? "Horde" : "Alliance";
+                    queueMode = groupInfo->IsRated ? "Rated" : "Unrated";
+                }
+
+                handler->PSendSysMessage(" - %s (%s, %s)", playerName.c_str(), factionName, queueMode);
+            }
+        }
+
+        if (!hasQueuedPlayers)
+            handler->SendSysMessage("No players are currently queued for battlegrounds or arenas.");
+
+        return true;
+    }
+};
+
+void AddSC_bgqueue_commandscript()
+{
+    new bgqueue_commandscript();
+}

--- a/src/server/scripts/Commands/cs_script_loader.cpp
+++ b/src/server/scripts/Commands/cs_script_loader.cpp
@@ -20,6 +20,7 @@ void AddSC_account_commandscript();
 void AddSC_achievement_commandscript();
 void AddSC_ahbot_commandscript();
 void AddSC_arena_commandscript();
+void AddSC_bgqueue_commandscript();
 void AddSC_ban_commandscript();
 void AddSC_bf_commandscript();
 void AddSC_cast_commandscript();
@@ -65,6 +66,7 @@ void AddCommandsScripts()
     AddSC_achievement_commandscript();
     AddSC_ahbot_commandscript();
     AddSC_arena_commandscript();
+    AddSC_bgqueue_commandscript();
     AddSC_ban_commandscript();
     AddSC_bf_commandscript();
     AddSC_cast_commandscript();


### PR DESCRIPTION
### Motivation
- Provide GMs a convenient command to see who is currently queued for battlegrounds and arenas so they can inspect queues and debug matchmaking/queue-related issues.

### Description
- Add a new command script `cs_bgqueue.cpp` that registers a `bgqueue` GM command and iterates all battleground/arena queue types to collect queue data. 
- The command prints the queue name, queued player count, and each queued player with resolved name, faction (Alliance/Horde), and `Rated`/`Unrated` mode. 
- Online players are resolved via `ObjectAccessor::FindConnectedPlayer` and offline names fall back to `sCharacterCache->GetCharacterNameByGuid`. 
- Wire the new script into startup by adding `AddSC_bgqueue_commandscript()` to `cs_script_loader.cpp`. 
- The command uses the existing permission `RBAC_PERM_COMMAND_LFG_QUEUE` to avoid introducing new RBAC IDs.

### Testing
- Attempted to configure the project (`cmake -S . -B build -DSCRIPTS=static -DTOOLS=0 -DNOJEM=1`) to validate integration, but configuration failed in this environment due to missing Boost development components (`system filesystem program_options iostreams regex locale`).
- No additional automated unit tests were run in this environment; the new script is self-contained and registered with the script loader for runtime verification on a properly configured build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990bb0d19483278fcb90131d8a249f)