### PR TITLE
Fix indefinite healer combat when assisting training dummy attackers

### DIFF
--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -1585,6 +1585,19 @@ struct npc_training_dummy : NullCreatureAI
             else
                 ++itr;
         }
+
+        // Attackers are the only units that refresh the timer on training dummies.
+        // If no attacker has hit the dummy recently, drop all remaining PvE combat refs
+        // (such as healers that were pulled in by assist threat).
+        if (_combatTimer.empty())
+        {
+            std::vector<CombatReference*> combatRefs;
+            for (auto const& [_, combatRef] : me->GetCombatManager().GetPvECombatRefs())
+                combatRefs.push_back(combatRef);
+
+            for (CombatReference* combatRef : combatRefs)
+                combatRef->EndCombat();
+        }
     }
 private:
     std::unordered_map<ObjectGuid /*attackerGUID*/, Milliseconds /*combatTime*/> _combatTimer;


### PR DESCRIPTION
### Motivation
- Healers that cast on players attacking a `npc_training_dummy` could remain flagged in PvE combat indefinitely because only direct attackers refresh the dummy's internal attacker timer.
- The intent is to ensure passive assist combat references (for example healers pulled in by assist threat) are cleared when no attacker has hit the dummy recently.

### Description
- Add a cleanup step to `npc_training_dummy::UpdateAI` that, when the `_combatTimer` is empty, snapshots `me->GetCombatManager().GetPvECombatRefs()` and calls `EndCombat()` on each `CombatReference*` to drop remaining assist refs.
- Snapshotting the references into a `std::vector<CombatReference*>` is used to avoid iterator invalidation while mutating the combat reference container.
- The existing per-attacker timeout behavior is preserved and still ends combat for direct attackers once their timer expires.

### Testing
- Ran `git diff --check`, which produced no issues and succeeded. 
- Ran `cmake -S . -B build -G Ninja` to validate project configure, which failed in this environment due to missing Boost development components (`system filesystem program_options iostreams regex locale`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999267c375883278af10f482ea75090)