### PR TITLE
game: reduce Tauren mount cast time by 1 second

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2404,6 +2404,9 @@ void WorldObject::ModSpellCastTime(SpellInfo const* spellInfo, int32& castTime, 
         castTime = int32(float(castTime) * unitCaster->m_modAttackSpeedPct[RANGED_ATTACK]);
     else if (spellInfo->SpellVisual[0] == 3881 && unitCaster->HasAura(67556)) // cooking with Chef Hat.
         castTime = 500;
+
+    if (Player const* playerCaster = unitCaster->ToPlayer(); playerCaster && playerCaster->GetRace() == RACE_TAUREN && spellInfo->HasAura(SPELL_AURA_MOUNTED))
+        castTime = std::max(castTime - 1000, 0);
 }
 
 void WorldObject::ModSpellDurationTime(SpellInfo const* spellInfo, int32& duration, Spell* spell /*= nullptr*/) const


### PR DESCRIPTION
### Motivation
- Give Tauren players a 1 second faster mounting behaviour by applying a server-side cast-time reduction for mount spells.

### Description
- Add a Tauren-specific adjustment in `WorldObject::ModSpellCastTime` (`src/server/game/Entities/Object/Object.cpp`) that reduces `castTime` by `1000` ms for `Player` casters with `GetRace() == RACE_TAUREN` when the spell has `SPELL_AURA_MOUNTED`, and clamp the result to `0`.

### Testing
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo`, which failed in this environment due to missing Boost development components (`system filesystem program_options iostreams regex locale`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699daca5ad9c8327bad4366906bb73a8)