### PR TITLE
game: apply Tauren mount cast-time reduction in universal cast-time hook

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2404,6 +2404,11 @@ void WorldObject::ModSpellCastTime(SpellInfo const* spellInfo, int32& castTime, 
         castTime = int32(float(castTime) * unitCaster->m_modAttackSpeedPct[RANGED_ATTACK]);
     else if (spellInfo->SpellVisual[0] == 3881 && unitCaster->HasAura(67556)) // cooking with Chef Hat.
         castTime = 500;
+
+    if (Player const* playerCaster = unitCaster->ToPlayer(); playerCaster && playerCaster->GetRace() == RACE_TAUREN
+        && (spellInfo->HasAura(SPELL_AURA_MOUNTED) || spellInfo->Mechanic == MECHANIC_MOUNT))
+        castTime = std::max(castTime - 1000, 0);
+
 }
 
 void WorldObject::ModSpellDurationTime(SpellInfo const* spellInfo, int32& duration, Spell* spell /*= nullptr*/) const


### PR DESCRIPTION
### Motivation
- Ensure the Tauren 1s mount cast-time reduction is always applied at the point where cast time is computed by moving it to the universal cast-time hook used during cast-time calculation. 
- This guarantees the reduction is applied for normal mount spells rather than relying on a narrower spellmod post-processing path.

### Description
- Remove the Tauren-specific 1s reduction from `Player::ApplySpellMod` in `src/server/game/Entities/Player/Player.cpp`.
- Add the same Tauren reduction to `WorldObject::ModSpellCastTime` in `src/server/game/Entities/Object/Object.cpp` using the same mount identification (`SPELL_AURA_MOUNTED` or `MECHANIC_MOUNT`) and clamping the result to zero via `std::max`.
- This leverages the universal cast-time hook called from `SpellInfo::CalcCastTime` (via `spell->GetCaster()->ModSpellCastTime(...)`) so the code path is hit for regular mount spell cast-time calculation.

### Testing
- Ran configuration with `cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo`, which failed in this environment due to missing Boost development components (`system filesystem program_options iostreams regex locale`).
- No unit tests or successful builds completed in this environment due to the missing dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699daca5ad9c8327bad4366906bb73a8)