### PR TITLE
Add Gurubashi arena exit enforcer to punish leaving the battle ring and whisper Chromi

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -33,6 +33,7 @@
 
 #include <chrono>
 #include <shared_mutex>
+#include <unordered_map>
 #include <unordered_set>
 
 using namespace std::chrono_literals;
@@ -44,9 +45,13 @@ constexpr uint32 STRANGLETHORN_VALE_ZONE_ID = 33;
 constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
+constexpr uint32 MOONFIRE_SPELL_ID = 8921;
+constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
+char const* const CHROMI_NAME = "Chromi";
+char const* const GURUBASHI_EXIT_WHISPER = "The only way out of the arena is death.";
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
 
@@ -65,6 +70,27 @@ bool IsPlayerEligible(Player* player)
         return false;
 
     return player->GetZoneId() == STRANGLETHORN_VALE_ZONE_ID;
+}
+
+bool IsInGurubashiBattleRing(Player const* player, uint32 zoneId)
+{
+    if (!player || player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
+        return false;
+
+    if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
+        return false;
+
+    // Gurubashi battle ring uses FFA PvP; the surrounding spectator/safe area does not.
+    return player->IsFFAPvP();
+}
+
+void WhisperFromChromi(Player* player, std::string_view message)
+{
+    WorldPacket data;
+    ObjectGuid chromiGuid = ObjectGuid::Create<HighGuid::Unit>(CHROMIE_ENTRY, 1);
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_WHISPER, LANG_UNIVERSAL, chromiGuid, player->GetGUID(), message,
+        0, CHROMI_NAME, player->GetName());
+    player->SendDirectMessage(&data);
 }
 
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)
@@ -310,6 +336,76 @@ private:
 
 gurubashi_arena_hourly_event* gurubashi_arena_hourly_event::s_Instance = nullptr;
 
+
+class gurubashi_arena_exit_enforcer : public PlayerScript
+{
+public:
+    gurubashi_arena_exit_enforcer() : PlayerScript("gurubashi_arena_exit_enforcer") { }
+
+    void OnLogin(Player* player, bool /*firstLogin*/) override
+    {
+        if (!player)
+            return;
+
+        _ignoreNextZoneUpdate.insert(player->GetGUID());
+        UpdateArenaState(player);
+    }
+
+    void OnLogout(Player* player) override
+    {
+        if (!player)
+            return;
+
+        ObjectGuid const guid = player->GetGUID();
+        _playerInBattleRing.erase(guid);
+        _ignoreNextZoneUpdate.erase(guid);
+    }
+
+    void OnMapChanged(Player* player) override
+    {
+        if (!player)
+            return;
+
+        _ignoreNextZoneUpdate.insert(player->GetGUID());
+        UpdateArenaState(player);
+    }
+
+    void OnUpdateZone(Player* player, uint32 newZone, uint32 /*newArea*/) override
+    {
+        if (!player || !player->IsAlive() || player->IsBeingTeleported() || player->IsGameMaster())
+        {
+            UpdateArenaState(player);
+            return;
+        }
+
+        ObjectGuid const guid = player->GetGUID();
+        bool const wasInBattleRing = _playerInBattleRing[guid];
+        bool const isInBattleRing = IsInGurubashiBattleRing(player, newZone);
+        bool const isTeleportRelatedUpdate = player->IsBeingTeleported() || (_ignoreNextZoneUpdate.erase(guid) > 0);
+
+        if (wasInBattleRing && !isInBattleRing && !isTeleportRelatedUpdate)
+        {
+            player->CastSpell(player, MOONFIRE_SPELL_ID, TRIGGERED_FULL_MASK);
+            Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+            WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
+        }
+
+        _playerInBattleRing[guid] = isInBattleRing;
+    }
+
+private:
+    void UpdateArenaState(Player* player)
+    {
+        if (!player)
+            return;
+
+        _playerInBattleRing[player->GetGUID()] = IsInGurubashiBattleRing(player, player->GetZoneId());
+    }
+
+    std::unordered_map<ObjectGuid, bool> _playerInBattleRing;
+    std::unordered_set<ObjectGuid> _ignoreNextZoneUpdate;
+};
+
 namespace
 {
 using namespace Trinity::ChatCommands;
@@ -409,5 +505,6 @@ void AddSC_custom_gurubashi_arena()
 {
     new go_custom_gurubashi_hourly_chest();
     new gurubashi_arena_hourly_event();
+    new gurubashi_arena_exit_enforcer();
     new gurubashi_arena_commands();
 }


### PR DESCRIPTION
### Motivation

- Prevent players from leaving the Gurubashi battle ring area to escape combat by automatically punishing unauthorized exits and notifying them via an NPC whisper.

### Description

- Add `gurubashi_arena_exit_enforcer` `PlayerScript` that tracks players in the arena, ignores teleport-related zone updates, and enforces exit penalties on unauthorized zone changes.  
- Implement helper functions `IsInGurubashiBattleRing` and `WhisperFromChromi`, add constants `MOONFIRE_SPELL_ID`, `GURUBASHI_EXIT_PUNISH_DAMAGE`, `CHROMI_NAME`, and `GURUBASHI_EXIT_WHISPER`, and include necessary headers.  
- Apply the punishment by casting the configured spell and dealing configurable damage, and send a whisper from the Chromi persona when the player leaves the battle ring.  
- Register the new script in `AddSC_custom_gurubashi_arena()` so the enforcer is loaded with the other Gurubashi arena scripts.

### Testing

- Performed an automated build of the server sources (`cmake`/`make`) which completed successfully.  
- Executed the project's automated unit test suite (`ctest`/`make test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07671b57c832780dfdfa744c06ffa)