### PR TITLE
Add Gurubashi arena exit enforcer and area-state tracking

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -17,6 +17,7 @@
 
 #include "Chat.h"
 #include "Creature.h"
+#include "DBCStores.h"
 #include "GameObject.h"
 #include "GameObjectAI.h"
 #include "GameTime.h"
@@ -33,6 +34,7 @@
 
 #include <chrono>
 #include <shared_mutex>
+#include <unordered_map>
 #include <unordered_set>
 
 using namespace std::chrono_literals;
@@ -44,9 +46,13 @@ constexpr uint32 STRANGLETHORN_VALE_ZONE_ID = 33;
 constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
+constexpr uint32 MOONFIRE_SPELL_ID = 8921;
+constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
+char const* const CHROMI_NAME = "Chromi";
+char const* const GURUBASHI_EXIT_WHISPER = "The only way out of the arena is death.";
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
 
@@ -65,6 +71,37 @@ bool IsPlayerEligible(Player* player)
         return false;
 
     return player->GetZoneId() == STRANGLETHORN_VALE_ZONE_ID;
+}
+
+enum class GurubashiAreaState
+{
+    Other,
+    BattleRing,
+    Sanctuary
+};
+
+GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 areaId)
+{
+    if (!player || player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
+        return GurubashiAreaState::Other;
+
+    if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
+        return GurubashiAreaState::Other;
+
+    if (AreaTableEntry const* areaEntry = sAreaTableStore.LookupEntry(areaId))
+        if (areaEntry->IsSanctuary())
+            return GurubashiAreaState::Sanctuary;
+
+    return player->IsFFAPvP() ? GurubashiAreaState::BattleRing : GurubashiAreaState::Other;
+}
+
+void WhisperFromChromi(Player* player, std::string_view message)
+{
+    WorldPacket data;
+    ObjectGuid chromiGuid = ObjectGuid::Create<HighGuid::Unit>(CHROMIE_ENTRY, 1);
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_WHISPER, LANG_UNIVERSAL, chromiGuid, player->GetGUID(), message,
+        0, CHROMI_NAME, player->GetName());
+    player->SendDirectMessage(&data);
 }
 
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)
@@ -310,6 +347,103 @@ private:
 
 gurubashi_arena_hourly_event* gurubashi_arena_hourly_event::s_Instance = nullptr;
 
+
+class gurubashi_arena_exit_enforcer : public PlayerScript
+{
+public:
+    gurubashi_arena_exit_enforcer() : PlayerScript("gurubashi_arena_exit_enforcer") { }
+
+    void OnLogin(Player* player, bool /*firstLogin*/) override
+    {
+        MarkTeleportTransition(player);
+        UpdateArenaState(player);
+    }
+
+    void OnLogout(Player* player) override
+    {
+        if (!player)
+            return;
+
+        ObjectGuid const guid = player->GetGUID();
+        _playerAreaState.erase(guid);
+        _ignoreUntilMs.erase(guid);
+    }
+
+    void OnMapChanged(Player* player) override
+    {
+        MarkTeleportTransition(player);
+        UpdateArenaState(player);
+    }
+
+    void OnUpdateZone(Player* player, uint32 newZone, uint32 newArea) override
+    {
+        if (!player)
+            return;
+
+        ObjectGuid const guid = player->GetGUID();
+
+        if (player->IsBeingTeleported())
+        {
+            MarkTeleportTransition(player);
+            _playerAreaState[guid] = GetGurubashiAreaState(player, newZone, newArea);
+            return;
+        }
+
+        GurubashiAreaState const previousState = _playerAreaState[guid];
+        GurubashiAreaState const currentState = GetGurubashiAreaState(player, newZone, newArea);
+
+        if (previousState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::Sanctuary &&
+            !player->IsGameMaster() && player->IsAlive() && !IsTeleportRelatedUpdate(guid))
+        {
+            player->CastSpell(player, MOONFIRE_SPELL_ID, TRIGGERED_FULL_MASK);
+            Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+            WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
+        }
+
+        _playerAreaState[guid] = currentState;
+    }
+
+private:
+    static uint32 GetTeleportGraceUntilMs()
+    {
+        return GameTime::GetGameTimeMS() + 3000;
+    }
+
+    void MarkTeleportTransition(Player* player)
+    {
+        if (!player)
+            return;
+
+        _ignoreUntilMs[player->GetGUID()] = GetTeleportGraceUntilMs();
+    }
+
+    bool IsTeleportRelatedUpdate(ObjectGuid guid)
+    {
+        auto const itr = _ignoreUntilMs.find(guid);
+        if (itr == _ignoreUntilMs.end())
+            return false;
+
+        uint32 const now = GameTime::GetGameTimeMS();
+        if (now <= itr->second)
+            return true;
+
+        _ignoreUntilMs.erase(itr);
+        return false;
+    }
+
+    void UpdateArenaState(Player* player)
+    {
+        if (!player)
+            return;
+
+        _playerAreaState[player->GetGUID()] = GetGurubashiAreaState(player, player->GetZoneId(), player->GetAreaId());
+    }
+
+    std::unordered_map<ObjectGuid, GurubashiAreaState> _playerAreaState;
+    std::unordered_map<ObjectGuid, uint32> _ignoreUntilMs;
+};
+
+
 namespace
 {
 using namespace Trinity::ChatCommands;
@@ -409,5 +543,6 @@ void AddSC_custom_gurubashi_arena()
 {
     new go_custom_gurubashi_hourly_chest();
     new gurubashi_arena_hourly_event();
+    new gurubashi_arena_exit_enforcer();
     new gurubashi_arena_commands();
 }


### PR DESCRIPTION
### Motivation
- Prevent players from escaping the Gurubashi Battle Ring by entering the sanctuary area and enforce server-side punishment for illicit exits.
- Track arena area state per-player to reliably detect valid transitions and avoid false positives during teleports.

### Description
- Add `GurubashiAreaState` enum and `GetGurubashiAreaState` helper to classify player location as `BattleRing`, `Sanctuary`, or `Other` using `sAreaTableStore` and zone checks.
- Introduce `gurubashi_arena_exit_enforcer` `PlayerScript` that updates per-player area state on `OnLogin`, `OnLogout`, `OnMapChanged`, and `OnUpdateZone`, and applies punishment (spell cast and high damage) plus a whisper from Chromi when a non-GM player illegally moves from the battle ring into the sanctuary.
- Add `WhisperFromChromi` helper to build and send a monster whisper packet and new constants `MOONFIRE_SPELL_ID`, `GURUBASHI_EXIT_PUNISH_DAMAGE`, and `GURUBASHI_EXIT_WHISPER` for behavior configuration.
- Add includes for `DBCStores` and `unordered_map`, and register the new script in `AddSC_custom_gurubashi_arena` by instantiating `gurubashi_arena_exit_enforcer`.

### Testing
- Built the project using the usual build (`cmake`/`make`) and the build completed successfully.
- Ran automated smoke/integration checks simulating player zone updates to verify `OnUpdateZone` transitions and the teleport-grace handling, which passed.
- Verified the new script is registered at startup by loading server scripts automatically, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07671b57c832780dfdfa744c06ffa)