### PR TITLE
Enforce Gurubashi Arena exit penalties and add Chromie whisper utilities

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -17,6 +17,7 @@
 
 #include "Chat.h"
 #include "Creature.h"
+#include "DBCStores.h"
 #include "GameObject.h"
 #include "GameObjectAI.h"
 #include "GameTime.h"
@@ -32,7 +33,9 @@
 #include "Util.h"
 
 #include <chrono>
+#include <limits>
 #include <shared_mutex>
+#include <unordered_map>
 #include <unordered_set>
 
 using namespace std::chrono_literals;
@@ -44,9 +47,13 @@ constexpr uint32 STRANGLETHORN_VALE_ZONE_ID = 33;
 constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
+constexpr uint32 MOONFIRE_SPELL_ID = 8921;
+constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
+char const* const CHROMI_NAME = "Chromi";
+char const* const GURUBASHI_EXIT_WHISPER = "The only way out of the arena is death.";
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
 
@@ -65,6 +72,68 @@ bool IsPlayerEligible(Player* player)
         return false;
 
     return player->GetZoneId() == STRANGLETHORN_VALE_ZONE_ID;
+}
+
+enum class GurubashiAreaState
+{
+    Other,
+    BattleRing,
+    Sanctuary
+};
+
+GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 areaId)
+{
+    if (!player || player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
+        return GurubashiAreaState::Other;
+
+    if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
+        return GurubashiAreaState::Other;
+
+    if (AreaTableEntry const* areaEntry = sAreaTableStore.LookupEntry(areaId))
+        if (areaEntry->IsSanctuary())
+            return GurubashiAreaState::Sanctuary;
+
+    return player->IsFFAPvP() ? GurubashiAreaState::BattleRing : GurubashiAreaState::Other;
+}
+
+
+Creature* FindChromiForPlayer(Player* player)
+{
+    if (!player)
+        return nullptr;
+
+    Map* map = player->GetMap();
+    if (!map)
+        return nullptr;
+
+    Creature* nearestChromi = nullptr;
+    float nearestDistance = std::numeric_limits<float>::max();
+
+    for (auto const& spawnPair : map->GetCreatureBySpawnIdStore())
+    {
+        Creature* creature = spawnPair.second;
+        if (!creature || !creature->IsAlive() || creature->GetEntry() != CHROMIE_ENTRY)
+            continue;
+
+        float const distance = player->GetExactDist2d(creature);
+        if (distance < nearestDistance)
+        {
+            nearestDistance = distance;
+            nearestChromi = creature;
+        }
+    }
+
+    return nearestChromi;
+}
+
+void WhisperFromChromi(Player* player, Creature* chromi, std::string_view message)
+{
+    WorldPacket data;
+    ObjectGuid chromiGuid = chromi ? chromi->GetGUID() : ObjectGuid::Create<HighGuid::Unit>(CHROMIE_ENTRY, 1);
+    std::string speakerName = chromi ? chromi->GetName() : CHROMI_NAME;
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_WHISPER, LANG_UNIVERSAL, chromiGuid, player->GetGUID(), message,
+        0, speakerName.c_str(), player->GetName());
+    player->SendDirectMessage(&data);
 }
 
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)
@@ -310,6 +379,85 @@ private:
 
 gurubashi_arena_hourly_event* gurubashi_arena_hourly_event::s_Instance = nullptr;
 
+
+class gurubashi_arena_exit_enforcer : public PlayerScript
+{
+public:
+    gurubashi_arena_exit_enforcer() : PlayerScript("gurubashi_arena_exit_enforcer") { }
+
+    void OnLogin(Player* player, bool /*firstLogin*/) override
+    {
+        UpdateTrackedState(player);
+    }
+
+    void OnMapChanged(Player* player) override
+    {
+        UpdateTrackedState(player);
+    }
+
+    void OnLogout(Player* player) override
+    {
+        if (!player)
+            return;
+
+        _trackedPlayers.erase(player->GetGUID());
+    }
+
+    void OnUpdateZone(Player* player, uint32 newZone, uint32 newArea) override
+    {
+        if (!player)
+            return;
+
+        ObjectGuid const guid = player->GetGUID();
+        TrackedState& tracked = _trackedPlayers[guid];
+
+        Position const currentPosition = player->GetPosition();
+        GurubashiAreaState const currentState = GetGurubashiAreaState(player, newZone, newArea);
+
+        bool const isTeleportTransition = player->IsBeingTeleported() ||
+            (tracked.HasPosition && tracked.Position.GetExactDist2d(currentPosition) > 80.0f);
+
+        if (tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::Sanctuary &&
+            !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
+        {
+            Creature* chromi = FindChromiForPlayer(player);
+            if (chromi)
+                chromi->CastSpell(player, MOONFIRE_SPELL_ID, false);
+            else
+                player->CastSpell(player, MOONFIRE_SPELL_ID, false);
+
+            Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+            WhisperFromChromi(player, chromi, GURUBASHI_EXIT_WHISPER);
+        }
+
+        tracked.AreaState = currentState;
+        tracked.Position = currentPosition;
+        tracked.HasPosition = true;
+    }
+
+private:
+    void UpdateTrackedState(Player* player)
+    {
+        if (!player)
+            return;
+
+        TrackedState& tracked = _trackedPlayers[player->GetGUID()];
+        tracked.AreaState = GetGurubashiAreaState(player, player->GetZoneId(), player->GetAreaId());
+        tracked.Position = player->GetPosition();
+        tracked.HasPosition = true;
+    }
+
+    struct TrackedState
+    {
+        GurubashiAreaState AreaState = GurubashiAreaState::Other;
+        Position Position;
+        bool HasPosition = false;
+    };
+
+    std::unordered_map<ObjectGuid, TrackedState> _trackedPlayers;
+};
+
+
 namespace
 {
 using namespace Trinity::ChatCommands;
@@ -409,5 +557,6 @@ void AddSC_custom_gurubashi_arena()
 {
     new go_custom_gurubashi_hourly_chest();
     new gurubashi_arena_hourly_event();
+    new gurubashi_arena_exit_enforcer();
     new gurubashi_arena_commands();
 }


### PR DESCRIPTION
### Motivation

- Prevent players from escaping PvP in the Gurubashi Arena by moving from the Battle Ring area into the Sanctuary area and to provide a clear in-game feedback when this occurs. 
- Provide utilities to locate nearby Chromie NPCs and send contextual whispers to players for a more immersive enforcement message. 

### Description

- Add a new `PlayerScript` named `gurubashi_arena_exit_enforcer` that tracks player area state and punishes non-GM, non-teleporting, alive players who transition from the Battle Ring into the Sanctuary by casting `MOONFIRE` and dealing `GURUBASHI_EXIT_PUNISH_DAMAGE`, and sending a whisper via Chromie. 
- Introduce helper functions `GetGurubashiAreaState`, `FindChromiForPlayer`, and `WhisperFromChromi` to determine area state using `sAreaTableStore`, find the nearest Chromie NPC, and send a monster whisper respectively. 
- Add constants and configuration values such as `MOONFIRE_SPELL_ID`, `GURUBASHI_EXIT_PUNISH_DAMAGE`, `CHROMI_NAME`, and `GURUBASHI_EXIT_WHISPER`, and include required headers (`DBCStores.h`, `<limits>`, `<unordered_map>`). 
- Register the new script in `AddSC_custom_gurubashi_arena()` by instantiating `gurubashi_arena_exit_enforcer`. 

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07671b57c832780dfdfa744c06ffa)