### PR TITLE
Enforce Gurubashi arena exit behavior with Chromi interaction and player tracking

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -17,6 +17,7 @@
 
 #include "Chat.h"
 #include "Creature.h"
+#include "DBCStores.h"
 #include "GameObject.h"
 #include "GameObjectAI.h"
 #include "GameTime.h"
@@ -32,7 +33,10 @@
 #include "Util.h"
 
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <shared_mutex>
+#include <unordered_map>
 #include <unordered_set>
 
 using namespace std::chrono_literals;
@@ -44,9 +48,13 @@ constexpr uint32 STRANGLETHORN_VALE_ZONE_ID = 33;
 constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
+constexpr uint32 MOONFIRE_SPELL_ID = 8921;
+constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
+char const* const CHROMI_NAME = "Chromi";
+char const* const GURUBASHI_EXIT_WHISPER = "The only way out of the arena is death.";
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
 
@@ -65,6 +73,75 @@ bool IsPlayerEligible(Player* player)
         return false;
 
     return player->GetZoneId() == STRANGLETHORN_VALE_ZONE_ID;
+}
+
+enum class GurubashiAreaState
+{
+    Other,
+    BattleRing,
+    Sanctuary
+};
+
+GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 areaId)
+{
+    if (!player || player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
+        return GurubashiAreaState::Other;
+
+    if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
+        return GurubashiAreaState::Other;
+
+    if (AreaTableEntry const* areaEntry = sAreaTableStore.LookupEntry(areaId))
+        if (areaEntry->IsSanctuary())
+            return GurubashiAreaState::Sanctuary;
+
+    return player->IsFFAPvP() ? GurubashiAreaState::BattleRing : GurubashiAreaState::Other;
+}
+
+
+Creature* GetChromiCasterForPlayer(Player* player)
+{
+    if (!player)
+        return nullptr;
+
+    Map* map = player->GetMap();
+    if (!map)
+        return nullptr;
+
+    Creature* nearestChromi = nullptr;
+    float nearestDistance = std::numeric_limits<float>::max();
+
+    for (auto const& spawnPair : map->GetCreatureBySpawnIdStore())
+    {
+        Creature* creature = spawnPair.second;
+        if (!creature || !creature->IsAlive() || creature->GetEntry() != CHROMIE_ENTRY)
+            continue;
+
+        float const distance = player->GetExactDist2d(creature);
+        if (distance < nearestDistance)
+        {
+            nearestDistance = distance;
+            nearestChromi = creature;
+        }
+    }
+
+    if (nearestChromi && nearestDistance <= 40.0f)
+        return nearestChromi;
+
+    Position summonPosition = player->GetPosition();
+    summonPosition.m_positionX += std::cos(summonPosition.GetOrientation()) * 2.0f;
+    summonPosition.m_positionY += std::sin(summonPosition.GetOrientation()) * 2.0f;
+
+    return player->SummonCreature(CHROMIE_ENTRY, summonPosition, TEMPSUMMON_TIMED_DESPAWN, 5s);
+}
+
+void WhisperFromChromi(Player* player, Creature* chromi, std::string_view message)
+{
+    WorldPacket data;
+    ObjectGuid chromiGuid = chromi ? chromi->GetGUID() : ObjectGuid::Create<HighGuid::Unit>(CHROMIE_ENTRY, 1);
+    std::string speakerName = chromi ? chromi->GetName() : CHROMI_NAME;
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_WHISPER, LANG_UNIVERSAL, chromiGuid, player->GetGUID(), message,
+        0, speakerName.c_str(), player->GetName());
+    player->SendDirectMessage(&data);
 }
 
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)
@@ -310,6 +387,84 @@ private:
 
 gurubashi_arena_hourly_event* gurubashi_arena_hourly_event::s_Instance = nullptr;
 
+
+class gurubashi_arena_exit_enforcer : public PlayerScript
+{
+public:
+    gurubashi_arena_exit_enforcer() : PlayerScript("gurubashi_arena_exit_enforcer") { }
+
+    void OnLogin(Player* player, bool /*firstLogin*/) override
+    {
+        UpdateTrackedState(player);
+    }
+
+    void OnMapChanged(Player* player) override
+    {
+        UpdateTrackedState(player);
+    }
+
+    void OnLogout(Player* player) override
+    {
+        if (!player)
+            return;
+
+        _trackedPlayers.erase(player->GetGUID());
+    }
+
+    void OnUpdateZone(Player* player, uint32 newZone, uint32 newArea) override
+    {
+        if (!player)
+            return;
+
+        ObjectGuid const guid = player->GetGUID();
+        TrackedState& tracked = _trackedPlayers[guid];
+
+        Position const currentPosition = player->GetPosition();
+        GurubashiAreaState const currentState = GetGurubashiAreaState(player, newZone, newArea);
+
+        bool const isTeleportTransition = player->IsBeingTeleported() || !player->HasUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+
+        if (tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::Sanctuary &&
+            !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
+        {
+            Creature* chromi = GetChromiCasterForPlayer(player);
+            if (chromi)
+                chromi->CastSpell(player, MOONFIRE_SPELL_ID, false);
+            else
+                player->CastSpell(player, MOONFIRE_SPELL_ID, false);
+
+            Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+            WhisperFromChromi(player, chromi, GURUBASHI_EXIT_WHISPER);
+        }
+
+        tracked.AreaState = currentState;
+        tracked.Position = currentPosition;
+        tracked.HasPosition = true;
+    }
+
+private:
+    void UpdateTrackedState(Player* player)
+    {
+        if (!player)
+            return;
+
+        TrackedState& tracked = _trackedPlayers[player->GetGUID()];
+        tracked.AreaState = GetGurubashiAreaState(player, player->GetZoneId(), player->GetAreaId());
+        tracked.Position = player->GetPosition();
+        tracked.HasPosition = true;
+    }
+
+    struct TrackedState
+    {
+        GurubashiAreaState AreaState = GurubashiAreaState::Other;
+        Position Position;
+        bool HasPosition = false;
+    };
+
+    std::unordered_map<ObjectGuid, TrackedState> _trackedPlayers;
+};
+
+
 namespace
 {
 using namespace Trinity::ChatCommands;
@@ -409,5 +564,6 @@ void AddSC_custom_gurubashi_arena()
 {
     new go_custom_gurubashi_hourly_chest();
     new gurubashi_arena_hourly_event();
+    new gurubashi_arena_exit_enforcer();
     new gurubashi_arena_commands();
 }


### PR DESCRIPTION
### Motivation

- Prevent players from leaving the Gurubashi arena Battle Ring into Sanctuary without punishment and provide an in-world messenger for the enforcement.
- Add player tracking and helper utilities to reliably detect area transitions and locate or summon a nearby Chromi for messaging.

### Description

- Added new includes and constants (`MOONFIRE_SPELL_ID`, `GURUBASHI_EXIT_PUNISH_DAMAGE`, `CHROMI_NAME`, `GURUBASHI_EXIT_WHISPER`) and small utility functions to determine area state with `GurubashiAreaState` and `GetGurubashiAreaState`.
- Implemented `GetChromiCasterForPlayer` to find or summon a nearby Chromie NPC and `WhisperFromChromi` to send a whisper packet from Chromi to a player.
- Introduced `gurubashi_arena_exit_enforcer` PlayerScript that tracks players, updates state on login/map/zone changes, and enforces the exit rule by casting the configured spell, applying lethal damage, and sending a Chromi whisper when a player moves from the Battle Ring into Sanctuary unlawfully.
- Registered the new `gurubashi_arena_exit_enforcer` in `AddSC_custom_gurubashi_arena` and added supportive data structures (`TrackedState`) to maintain per-player tracking.

### Testing

- Built the project with `cmake --build .` and the build completed successfully.
- Executed the automated test suite with `ctest` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07671b57c832780dfdfa744c06ffa)