### PR TITLE
Add Gurubashi arena exit enforcer with Chromi whispering and helper utilities

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -17,6 +17,7 @@
 
 #include "Chat.h"
 #include "Creature.h"
+#include "DBCStores.h"
 #include "GameObject.h"
 #include "GameObjectAI.h"
 #include "GameTime.h"
@@ -29,10 +30,14 @@
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "TaskScheduler.h"
+#include "TemporarySummon.h"
 #include "Util.h"
 
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <shared_mutex>
+#include <unordered_map>
 #include <unordered_set>
 
 using namespace std::chrono_literals;
@@ -44,9 +49,13 @@ constexpr uint32 STRANGLETHORN_VALE_ZONE_ID = 33;
 constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
+constexpr uint32 MOONFIRE_SPELL_ID = 8921;
+constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
+char const* const CHROMI_NAME = "Chromi";
+char const* const GURUBASHI_EXIT_WHISPER = "The only way out of the arena is death.";
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
 
@@ -65,6 +74,71 @@ bool IsPlayerEligible(Player* player)
         return false;
 
     return player->GetZoneId() == STRANGLETHORN_VALE_ZONE_ID;
+}
+
+enum class GurubashiAreaState
+{
+    Outside,
+    BattleRing,
+    NonRing
+};
+
+GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 /*areaId*/)
+{
+    if (!player || player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
+        return GurubashiAreaState::Outside;
+
+    if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
+        return GurubashiAreaState::Outside;
+
+    return player->IsFFAPvP() ? GurubashiAreaState::BattleRing : GurubashiAreaState::NonRing;
+}
+
+
+Creature* GetChromiCasterForPlayer(Player* player)
+{
+    if (!player)
+        return nullptr;
+
+    Map* map = player->GetMap();
+    if (!map)
+        return nullptr;
+
+    Creature* nearestChromi = nullptr;
+    float nearestDistance = std::numeric_limits<float>::max();
+
+    for (auto const& spawnPair : map->GetCreatureBySpawnIdStore())
+    {
+        Creature* creature = spawnPair.second;
+        if (!creature || !creature->IsAlive() || creature->GetEntry() != CHROMIE_ENTRY)
+            continue;
+
+        float const distance = player->GetExactDist2d(creature);
+        if (distance < nearestDistance)
+        {
+            nearestDistance = distance;
+            nearestChromi = creature;
+        }
+    }
+
+    if (nearestChromi && nearestDistance <= 40.0f)
+        return nearestChromi;
+
+    Position summonPosition = player->GetPosition();
+    summonPosition.m_positionX += std::cos(summonPosition.GetOrientation()) * 2.0f;
+    summonPosition.m_positionY += std::sin(summonPosition.GetOrientation()) * 2.0f;
+
+    return player->SummonCreature(CHROMIE_ENTRY, summonPosition, TEMPSUMMON_TIMED_DESPAWN, 5s);
+}
+
+void WhisperFromChromi(Player* player, Creature* chromi, std::string_view message)
+{
+    WorldPacket data;
+    ObjectGuid chromiGuid = chromi ? chromi->GetGUID() : ObjectGuid::Create<HighGuid::Unit>(CHROMIE_ENTRY, 1);
+    std::string speakerName = chromi ? chromi->GetName() : CHROMI_NAME;
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_WHISPER, LANG_UNIVERSAL, chromiGuid, player->GetGUID(), message,
+        0, speakerName.c_str(), player->GetName());
+    player->SendDirectMessage(&data);
 }
 
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)
@@ -310,6 +384,88 @@ private:
 
 gurubashi_arena_hourly_event* gurubashi_arena_hourly_event::s_Instance = nullptr;
 
+
+class gurubashi_arena_exit_enforcer : public PlayerScript
+{
+public:
+    gurubashi_arena_exit_enforcer() : PlayerScript("gurubashi_arena_exit_enforcer") { }
+
+    void OnLogin(Player* player, bool /*firstLogin*/) override
+    {
+        UpdateTrackedState(player);
+    }
+
+    void OnMapChanged(Player* player) override
+    {
+        UpdateTrackedState(player);
+    }
+
+    void OnLogout(Player* player) override
+    {
+        if (!player)
+            return;
+
+        _trackedPlayers.erase(player->GetGUID());
+    }
+
+    void OnUpdateZone(Player* player, uint32 newZone, uint32 newArea) override
+    {
+        if (!player)
+            return;
+
+        ObjectGuid const guid = player->GetGUID();
+        TrackedState& tracked = _trackedPlayers[guid];
+
+        Position const currentPosition = player->GetPosition();
+        GurubashiAreaState const currentState = GetGurubashiAreaState(player, newZone, newArea);
+
+        bool const isTeleportTransition = player->IsBeingTeleported() || tracked.MapId != player->GetMapId() ||
+            (tracked.HasPosition && tracked.Position.GetExactDist2d(currentPosition) > 80.0f);
+
+        if (tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing &&
+            !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
+        {
+            Creature* chromi = GetChromiCasterForPlayer(player);
+            if (chromi)
+                chromi->CastSpell(player, MOONFIRE_SPELL_ID, false);
+            else
+                player->CastSpell(player, MOONFIRE_SPELL_ID, false);
+
+            Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+            WhisperFromChromi(player, chromi, GURUBASHI_EXIT_WHISPER);
+        }
+
+        tracked.AreaState = currentState;
+        tracked.Position = currentPosition;
+        tracked.MapId = player->GetMapId();
+        tracked.HasPosition = true;
+    }
+
+private:
+    void UpdateTrackedState(Player* player)
+    {
+        if (!player)
+            return;
+
+        TrackedState& tracked = _trackedPlayers[player->GetGUID()];
+        tracked.AreaState = GetGurubashiAreaState(player, player->GetZoneId(), player->GetAreaId());
+        tracked.Position = player->GetPosition();
+        tracked.MapId = player->GetMapId();
+        tracked.HasPosition = true;
+    }
+
+    struct TrackedState
+    {
+        GurubashiAreaState AreaState = GurubashiAreaState::Outside;
+        Position Position;
+        uint32 MapId = 0;
+        bool HasPosition = false;
+    };
+
+    std::unordered_map<ObjectGuid, TrackedState> _trackedPlayers;
+};
+
+
 namespace
 {
 using namespace Trinity::ChatCommands;
@@ -409,5 +565,6 @@ void AddSC_custom_gurubashi_arena()
 {
     new go_custom_gurubashi_hourly_chest();
     new gurubashi_arena_hourly_event();
+    new gurubashi_arena_exit_enforcer();
     new gurubashi_arena_commands();
 }


### PR DESCRIPTION
### Motivation
- Prevent players from leaving the Gurubashi Battle Ring without penalty and provide in-world feedback via Chromi when they do.
- Add helper utilities to locate or summon a nearby Chromie caster and emit monster whisper messages from that NPC.
- Support area-state tracking for players so the server can detect transitions between the battle ring and non-ring zones.

### Description
- Added includes and constants for Chromie (`CHROMIE_ENTRY`), moonfire spell (`MOONFIRE_SPELL_ID`), exit damage (`GURUBASHI_EXIT_PUNISH_DAMAGE`), and the Chromi whisper message (`GURUBASHI_EXIT_WHISPER`).
- Implemented `GurubashiAreaState` and `GetGurubashiAreaState` to classify player area membership (Outside, BattleRing, NonRing).
- Implemented `GetChromiCasterForPlayer` to find a nearby Chromie or summon a temporary one and `WhisperFromChromi` to build and send a monster whisper packet.
- Added `gurubashi_arena_exit_enforcer` `PlayerScript` which tracks players' area state and, on transition from `BattleRing` to `NonRing` (with safeguards for teleports and GMs), casts `MOONFIRE_SPELL_ID`, deals `GURUBASHI_EXIT_PUNISH_DAMAGE`, and sends the Chromi whisper.
- Registered the new script in `AddSC_custom_gurubashi_arena` and added necessary includes and data structures to the file.

### Testing
- Performed an automated build of the server with the updated script and the build completed successfully.
- Executed automated server script checks and CI-style tests related to scripting; those checks passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07671b57c832780dfdfa744c06ffa)