### PR TITLE
Fix Gurubashi arena exit kill logic for walking vs teleport transitions

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -84,7 +84,7 @@ enum class GurubashiAreaState
     NonRing
 };
 
-GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 /*areaId*/)
+GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 areaId)
 {
     if (!player || player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
         return GurubashiAreaState::Outside;
@@ -92,7 +92,11 @@ GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, ui
     if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
         return GurubashiAreaState::Outside;
 
-    return player->IsFFAPvP() ? GurubashiAreaState::BattleRing : GurubashiAreaState::NonRing;
+    AreaTableEntry const* areaEntry = sAreaTableStore.LookupEntry(areaId);
+    if (areaEntry && (areaEntry->Flags & AREA_FLAG_ARENA))
+        return GurubashiAreaState::BattleRing;
+
+    return GurubashiAreaState::NonRing;
 }
 
 
@@ -420,8 +424,7 @@ public:
         Position const currentPosition = player->GetPosition();
         GurubashiAreaState const currentState = GetGurubashiAreaState(player, newZone, newArea);
 
-        bool const isTeleportTransition = player->IsBeingTeleported() || tracked.MapId != player->GetMapId() ||
-            (tracked.HasPosition && tracked.Position.GetExactDist2d(currentPosition) > 80.0f);
+        bool const isTeleportTransition = player->IsBeingTeleported() || tracked.MapId != player->GetMapId();
 
         if (tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing &&
             !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())


### PR DESCRIPTION
### Motivation
- The exit-enforcement was misclassifying transitions and was killing players when they teleported but not when they actually walked in/out of the Gurubashi battle ring.
- The intent is to punish only on walking-based area transitions out of the arena ring, and ignore legitimate teleports.

### Description
- Changed `GetGurubashiAreaState` to use the `newArea` id and `AREA_FLAG_ARENA` from the area table (`sAreaTableStore.LookupEntry(areaId)`) instead of relying on `IsFFAPvP()`, making ring vs non-ring detection area-based and immediate. (`src/server/scripts/Custom/custom_gurubashi_arena.cpp`)
- Simplified teleport detection in `OnUpdateZone` by removing the distance-based heuristic and only treating `IsBeingTeleported()` or a map id change as a teleport transition, so large client-side position jumps no longer suppress normal walk-based enforcement. (`src/server/scripts/Custom/custom_gurubashi_arena.cpp`)

### Testing
- Ran `git diff` to inspect the changes to `src/server/scripts/Custom/custom_gurubashi_arena.cpp` and confirmed the intended edits were applied. (succeeded)
- Created a commit with the updated file via `git commit` to record the change. (succeeded)
- Attempted a local scripts build with `cmake --build`, but no `build/` directory exists in this environment, so a compile/run test could not be performed here. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08e7ac7588327869d880c50c37de7)