### PR TITLE
Remove map ID check from Gurubashi area state detection

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -86,7 +86,7 @@ enum class GurubashiAreaState
 
 GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 areaId)
 {
-    if (!player || player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
+    if (!player)
         return GurubashiAreaState::Outside;
 
     if (zoneId != STRANGLETHORN_VALE_ZONE_ID)


### PR DESCRIPTION
### Motivation
- `GetGurubashiAreaState` was hard-gated by a `player->GetMapId() != GURUBASHI_ARENA_MAP_ID` check which prevented area-state resolution when the player's map id did not match, so the check was removed to allow zone/area-based detection to proceed when `player` is valid.

### Description
- Removed the `player->GetMapId()` comparison from `GetGurubashiAreaState`, keeping only the null-player guard and the `zoneId` check while preserving the parent-area arena-flag lookup.

### Testing
- No automated runtime tests were executed; only repository diffs and commit verification commands were run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b099f6022083278e1358f7ab96d8a6)