### PR TITLE
Fix Gurubashi battle ring exit punishment direction

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -435,8 +435,7 @@ public:
         float const distance2d = tracked.HasPosition ? tracked.Position.GetExactDist2d(currentPosition) : std::numeric_limits<float>::max();
         bool const isTeleportTransition = player->IsBeingTeleported() || tracked.MapId != player->GetMapId() || distance2d > 15.0f;
         bool const crossedBattleRingBoundary =
-            (tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing) ||
-            (tracked.AreaState == GurubashiAreaState::NonRing && currentState == GurubashiAreaState::BattleRing);
+            tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing;
 
         if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
         {


### PR DESCRIPTION
### Motivation
- The Gurubashi arena script was punishing players both when entering and when leaving the FFA battle ring; the intended behavior is to only apply the death/punishment when leaving the battle ring to safety, not when entering it.

### Description
- Change the boundary check in `OnUpdateZone` in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` so the punishment triggers only when `tracked.AreaState == GurubashiAreaState::BattleRing` and `currentState == GurubashiAreaState::NonRing` (i.e. exiting the ring).

### Testing
- Ran `git -C /workspace/TrinityCore112 diff --check` and `git -C /workspace/TrinityCore112 status --short`, both checks succeeded and the intended single-file change was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09c0f90288327b5454860148db400)