### PR TITLE
Detect Gurubashi battle ring using server FFA PvP state

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -60,6 +60,19 @@ char const* const GURUBASHI_EXIT_WHISPER = "The only way out of the arena is dea
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
 
+bool IsInGurubashiBattleRingByPvpState(Player const* player, uint32 zoneId)
+{
+    if (!player)
+        return false;
+
+    if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
+        return false;
+
+    // The server already maintains authoritative FFA arena membership.
+    // In Gurubashi, entering/leaving the battle ring toggles this state.
+    return player->pvpInfo.IsInFFAPvPArea && player->HasPvpFlag(UNIT_BYTE2_FLAG_FFA_PVP);
+}
+
 bool IsPlayerEligible(Player* player)
 {
     if (!player || !player->IsInWorld())
@@ -84,7 +97,7 @@ enum class GurubashiAreaState
     NonRing
 };
 
-GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 areaId)
+GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, uint32 /*areaId*/)
 {
     if (!player)
         return GurubashiAreaState::Outside;
@@ -92,17 +105,8 @@ GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, ui
     if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
         return GurubashiAreaState::Outside;
 
-    // Match Player::UpdateArea() behavior: the arena flag can be defined on a parent area.
-    for (AreaTableEntry const* areaEntry = sAreaTableStore.LookupEntry(areaId); areaEntry;)
-    {
-        if (areaEntry->Flags & AREA_FLAG_ARENA)
-            return GurubashiAreaState::BattleRing;
-
-        if (!areaEntry->ParentAreaID)
-            break;
-
-        areaEntry = sAreaTableStore.LookupEntry(areaEntry->ParentAreaID);
-    }
+    if (IsInGurubashiBattleRingByPvpState(player, zoneId))
+        return GurubashiAreaState::BattleRing;
 
     return GurubashiAreaState::NonRing;
 }


### PR DESCRIPTION
### Motivation

- Replace area-flag based detection with server-maintained PvP state because the server already tracks authoritative FFA arena membership and that state toggles when entering/leaving the Gurubashi battle ring.
- The previous logic walked the area table entries to find `AREA_FLAG_ARENA`, which could be out-of-sync with the server's FFA flag and required the `areaId` parameter.

### Description

- Add `IsInGurubashiBattleRingByPvpState(Player const*, uint32)` which returns true when the player is in Stranglethorn Vale and both `pvpInfo.IsInFFAPvPArea` and `HasPvpFlag(UNIT_BYTE2_FLAG_FFA_PVP)` are set.
- Change `GetGurubashiAreaState` to call the new PvP-state helper and remove the area table parent-walk that checked `AREA_FLAG_ARENA`, treating non-matching zone as `Outside` and otherwise returning `NonRing` when not in the PvP ring.
- Remove dependence on `areaId` in `GetGurubashiAreaState` (it's now an unused parameter) and simplify the region detection logic.

### Testing

- Built the server codebase successfully and ran the automated build checks with no failures reported.
- Executed the project's automated unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09e44fa608327a9ab05aff387423a)