### PR TITLE
Make Chromi whispers originate from a hidden online player and reply with random cat facts; reserve the name

### DIFF
--- a/sql/custom/world/.gitignore
+++ b/sql/custom/world/.gitignore
@@ -4,3 +4,4 @@
 !2024_07_05_01_world_starfire_snare_talent.sql
 !2024_07_05_02_world_party_damage_redirect.sql
 !2024_07_12_00_world_gurubashi_hourly_chest.sql
+!2026_03_10_00_world_reserved_name_chromi.sql

--- a/sql/custom/world/2026_03_10_00_world_reserved_name_chromi.sql
+++ b/sql/custom/world/2026_03_10_00_world_reserved_name_chromi.sql
@@ -1,0 +1,2 @@
+DELETE FROM `reserved_name` WHERE `name` = 'Chromi';
+INSERT INTO `reserved_name` (`name`) VALUES ('Chromi');

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -43,6 +43,31 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include <algorithm>
+#include <array>
+
+namespace
+{
+char const* const CHROMI_WHISPER_NAME = "Chromi";
+bool IsChromiWhisperTarget(std::string const& targetName)
+{
+    std::string normalizedTarget = targetName;
+    return normalizePlayerName(normalizedTarget) && normalizedTarget == CHROMI_WHISPER_NAME;
+}
+
+std::string_view GetRandomChromiCatFact()
+{
+    static constexpr std::array catFacts =
+    {
+        "Cats can rotate their ears 180 degrees to pinpoint sounds.",
+        "A cat's purr can vibrate between 25 and 150 Hz, a range associated with tissue healing.",
+        "Cats have a special righting reflex that helps them twist midair and land on their feet.",
+        "A cat's nose print is unique, much like a human fingerprint.",
+        "Cats can make over 100 different vocal sounds, far more than dogs."
+    };
+
+    return catFacts[urand(0, catFacts.size() - 1)];
+}
+}
 
 inline bool isNasty(uint8 c)
 {
@@ -325,6 +350,17 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
         }
         case CHAT_MSG_WHISPER:
         {
+            if (IsChromiWhisperTarget(to))
+            {
+                if (Player* chromi = ObjectAccessor::FindConnectedPlayerByName(CHROMI_WHISPER_NAME))
+                {
+                    WorldPacket data;
+                    ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER, LANG_UNIVERSAL, chromi, sender, GetRandomChromiCatFact());
+                    sender->SendDirectMessage(&data);
+                    break;
+                }
+            }
+
             if (!normalizePlayerName(to))
             {
                 SendPlayerNotFoundNotice(to);


### PR DESCRIPTION
### Motivation
- Provide Chromi whisper replies that come from a real online player object so replies appear as coming from an actual player instead of a synthetic NPC packet.
- Keep the Chromi name protected so no new characters can be created with that name.

### Description
- Intercept whispers to `Chromi` in `WorldSession::HandleMessagechatOpcode` and, if a connected player named `Chromi` exists, immediately send a whisper back to the sender containing a random cat fact sourced from that `Player` object using `ObjectAccessor::FindConnectedPlayerByName("Chromi")` and `ChatHandler::BuildChatPacket` (file changed: `src/server/game/Handlers/ChatHandler.cpp`).
- Added helper functions `IsChromiWhisperTarget` and `GetRandomChromiCatFact` and a small static cat-fact array used for the reply (in `ChatHandler.cpp`).
- Added a SQL migration `sql/custom/world/2026_03_10_00_world_reserved_name_chromi.sql` to insert `Chromi` into `reserved_name` so the name is reserved and updated `sql/custom/world/.gitignore` to track the new migration.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or diff-check issues and it completed with no errors.
- No full server build or integration test was executed in this environment, so compilation and runtime validation should be performed in CI or a local build before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a4ad2ce08327963b10ae89d60b23)