### PR TITLE
Auto-reply to whispers addressed to 'Chromi' with cat facts and add reserved-name migration

### DIFF
--- a/sql/custom/characters/.gitignore
+++ b/sql/custom/characters/.gitignore
@@ -1,2 +1,3 @@
 *.sql
 !2024_05_04_00_characters_arena_4v4.sql
+!2026_03_10_00_characters_reserved_name_chromi.sql

--- a/sql/custom/characters/2026_03_10_00_characters_reserved_name_chromi.sql
+++ b/sql/custom/characters/2026_03_10_00_characters_reserved_name_chromi.sql
@@ -1,0 +1,2 @@
+DELETE FROM `reserved_name` WHERE `name` = 'Chromi';
+INSERT INTO `reserved_name` (`name`) VALUES ('Chromi');

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -43,6 +43,31 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include <algorithm>
+#include <array>
+
+namespace
+{
+char const* const CHROMI_WHISPER_NAME = "Chromi";
+bool IsChromiWhisperTarget(std::string const& targetName)
+{
+    std::string normalizedTarget = targetName;
+    return normalizePlayerName(normalizedTarget) && normalizedTarget == CHROMI_WHISPER_NAME;
+}
+
+std::string_view GetRandomChromiCatFact()
+{
+    static constexpr std::array catFacts =
+    {
+        "Cats can rotate their ears 180 degrees to pinpoint sounds.",
+        "A cat's purr can vibrate between 25 and 150 Hz, a range associated with tissue healing.",
+        "Cats have a special righting reflex that helps them twist midair and land on their feet.",
+        "A cat's nose print is unique, much like a human fingerprint.",
+        "Cats can make over 100 different vocal sounds, far more than dogs."
+    };
+
+    return catFacts[urand(0, catFacts.size() - 1)];
+}
+}
 
 inline bool isNasty(uint8 c)
 {
@@ -325,6 +350,17 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
         }
         case CHAT_MSG_WHISPER:
         {
+            if (IsChromiWhisperTarget(to))
+            {
+                if (Player* chromi = ObjectAccessor::FindConnectedPlayerByName(CHROMI_WHISPER_NAME))
+                {
+                    WorldPacket data;
+                    ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER, LANG_UNIVERSAL, chromi, sender, GetRandomChromiCatFact());
+                    sender->SendDirectMessage(&data);
+                    break;
+                }
+            }
+
             if (!normalizePlayerName(to))
             {
                 SendPlayerNotFoundNotice(to);


### PR DESCRIPTION
### Motivation
- Provide a special-case behavior for whispers sent to the reserved name `Chromi` so senders receive an entertaining automated reply when `Chromi` is online.
- Ensure the `Chromi` name is present in the `reserved_name` table via a migration so the special behavior applies consistently across servers.

### Description
- Added a new SQL migration `sql/custom/characters/2026_03_10_00_characters_reserved_name_chromi.sql` which recreates the `Chromi` entry in the `reserved_name` table and updated `.gitignore` to include the migration file.
- Implemented `IsChromiWhisperTarget` and `GetRandomChromiCatFact` helpers in `ChatHandler.cpp`, added `CHROMI_WHISPER_NAME` constant, and included `<array>` for storing static cat facts.
- In `WorldSession::HandleMessagechatOpcode` the `CHAT_MSG_WHISPER` path now intercepts whispers targeted at `Chromi`, and if a player named `Chromi` is connected it sends a randomized cat-fact whisper back to the sender instead of the normal whisper routing.

### Testing
- Project was compiled successfully with the updated `ChatHandler.cpp` changes using the normal build (`make`/build system) and there were no compilation errors.
- Automated test suite was executed (`make test`/`ctest`) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a4ad2ce08327963b10ae89d60b23)