### PR TITLE
Remove world-scoped `reserved_name` custom SQL (Chromi)

### DIFF
--- a/sql/custom/world/2026_03_10_00_world_reserved_name_chromi.sql
+++ b/sql/custom/world/2026_03_10_00_world_reserved_name_chromi.sql
@@ -1,2 +1,0 @@
-DELETE FROM `reserved_name` WHERE `name` = 'Chromi';
-INSERT INTO `reserved_name` (`name`) VALUES ('Chromi');


### PR DESCRIPTION
### Motivation
- The `reserved_name` table belongs to the characters database, so a duplicate custom migration under `sql/custom/world` caused updater failures with `ERROR 1146` when run against the `world` DB.

### Description
- Delete the erroneous file `sql/custom/world/2026_03_10_00_world_reserved_name_chromi.sql` and keep the characters-scoped migration `sql/custom/characters/2026_03_10_00_characters_reserved_name_chromi.sql` as the single source of truth.

### Testing
- Ran `rg -n "reserved_name" sql` to confirm locations, inspected `sql/base/characters_database.sql` to verify the table lives in characters DB, used `ls sql/custom/world` to confirm removal, and ran `git commit` to record the change; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a7cd041c8327a8eb0386dee48fc8)