### PR TITLE
Add fluent CharacterCreateInfo setters and update hidden Chromi initialization; include MotionMaster/ObjectMgr

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -34,6 +34,7 @@
 #include "Log.h"
 #include "ObjectAccessor.h"
 #include "ObjectMgr.h"
+#include "MotionMaster.h"
 #include "Opcodes.h"
 #include "Player.h"
 #include "ScriptMgr.h"
@@ -68,6 +69,7 @@ Player* FindConnectedChromiPlayer()
     return nullptr;
 }
 
+
 Player* EnsureHiddenChromiPlayer()
 {
     static std::unique_ptr<WorldSession> hiddenSession;
@@ -83,16 +85,16 @@ Player* EnsureHiddenChromiPlayer()
     hiddenChromi->GetMotionMaster()->Initialize();
 
     CharacterCreateInfo createInfo;
-    createInfo.Name = "Chromie";
-    createInfo.Race = RACE_GNOME;
-    createInfo.Class = CLASS_MAGE;
-    createInfo.Gender = GENDER_FEMALE;
-    createInfo.Skin = 0;
-    createInfo.Face = 0;
-    createInfo.HairStyle = 0;
-    createInfo.HairColor = 0;
-    createInfo.FacialHair = 0;
-    createInfo.OutfitId = 0;
+    createInfo.SetName("Chromie")
+        .SetRace(RACE_GNOME)
+        .SetClass(CLASS_MAGE)
+        .SetGender(GENDER_FEMALE)
+        .SetSkin(0)
+        .SetFace(0)
+        .SetHairStyle(0)
+        .SetHairColor(0)
+        .SetFacialHair(0)
+        .SetOutfitId(0);
 
     if (!hiddenChromi->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
     {

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -361,6 +361,18 @@ class CharacterCreateInfo
     friend class WorldSession;
     friend class Player;
 
+    public:
+        CharacterCreateInfo& SetName(std::string name) { Name = std::move(name); return *this; }
+        CharacterCreateInfo& SetRace(uint8 race) { Race = race; return *this; }
+        CharacterCreateInfo& SetClass(uint8 playerClass) { Class = playerClass; return *this; }
+        CharacterCreateInfo& SetGender(uint8 gender) { Gender = gender; return *this; }
+        CharacterCreateInfo& SetSkin(uint8 skin) { Skin = skin; return *this; }
+        CharacterCreateInfo& SetFace(uint8 face) { Face = face; return *this; }
+        CharacterCreateInfo& SetHairStyle(uint8 hairStyle) { HairStyle = hairStyle; return *this; }
+        CharacterCreateInfo& SetHairColor(uint8 hairColor) { HairColor = hairColor; return *this; }
+        CharacterCreateInfo& SetFacialHair(uint8 facialHair) { FacialHair = facialHair; return *this; }
+        CharacterCreateInfo& SetOutfitId(uint8 outfitId) { OutfitId = outfitId; return *this; }
+
     protected:
         /// User specified variables
         std::string Name;

--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -24,7 +24,9 @@
 #include "Item.h"
 #include "Map.h"
 #include "MapManager.h"
+#include "MotionMaster.h"
 #include "ObjectAccessor.h"
+#include "ObjectMgr.h"
 #include "Player.h"
 #include "RBAC.h"
 #include "ScriptMgr.h"
@@ -159,6 +161,7 @@ Player* FindConnectedChromiPlayer()
     return ObjectAccessor::FindConnectedPlayerByName("Chromie");
 }
 
+
 Player* EnsureHiddenChromiPlayer()
 {
     static std::unique_ptr<WorldSession> hiddenSession;
@@ -174,16 +177,16 @@ Player* EnsureHiddenChromiPlayer()
     hiddenChromi->GetMotionMaster()->Initialize();
 
     CharacterCreateInfo createInfo;
-    createInfo.Name = "Chromie";
-    createInfo.Race = RACE_GNOME;
-    createInfo.Class = CLASS_MAGE;
-    createInfo.Gender = GENDER_FEMALE;
-    createInfo.Skin = 0;
-    createInfo.Face = 0;
-    createInfo.HairStyle = 0;
-    createInfo.HairColor = 0;
-    createInfo.FacialHair = 0;
-    createInfo.OutfitId = 0;
+    createInfo.SetName("Chromie")
+        .SetRace(RACE_GNOME)
+        .SetClass(CLASS_MAGE)
+        .SetGender(GENDER_FEMALE)
+        .SetSkin(0)
+        .SetFace(0)
+        .SetHairStyle(0)
+        .SetHairColor(0)
+        .SetFacialHair(0)
+        .SetOutfitId(0);
 
     if (!hiddenChromi->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
     {


### PR DESCRIPTION
### Motivation

- Provide a clearer, safer API for constructing temporary/hidden characters by exposing chainable setters on `CharacterCreateInfo` instead of writing to protected members directly.
- Ensure hidden Chromie/Chromi initialization properly initializes motion and has required headers included where used.

### Description

- Added chainable setter methods to `CharacterCreateInfo` in `WorldSession.h` (`SetName`, `SetRace`, `SetClass`, `SetGender`, `SetSkin`, `SetFace`, `SetHairStyle`, `SetHairColor`, `SetFacialHair`, `SetOutfitId`).
- Replaced direct field assignments with chained `Set...` calls when creating the hidden Chromie player in `ChatHandler.cpp` and `custom_gurubashi_arena.cpp`.
- Included `MotionMaster.h` in both `ChatHandler.cpp` and `custom_gurubashi_arena.cpp` and added `ObjectMgr.h` include in `custom_gurubashi_arena.cpp` to satisfy usages; kept `GetMotionMaster()->Initialize()` call for the hidden player initialization.

### Testing

- Performed a full project build with the usual build commands (`cmake`/`make`) and compilation succeeded. 
- Executed the project's automated test runner (`ctest` / `make test`) and the existing test suite completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c2d3e6748327b7631ecfe3be3259)