### PR TITLE
Handle realm suffix in Chromie whisper target detection

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -54,6 +54,9 @@ std::array<std::string_view, 2> const CHROMI_WHISPER_NAMES = { "Chromi", "Chromi
 bool IsChromiWhisperTarget(std::string const& targetName)
 {
     std::string normalizedTarget = targetName;
+    if (std::string::size_type realmSeparator = normalizedTarget.find('-'); realmSeparator != std::string::npos)
+        normalizedTarget.erase(realmSeparator);
+
     if (!normalizePlayerName(normalizedTarget))
         return false;
 


### PR DESCRIPTION
### Motivation
- Clients can send cross-realm formatted whisper targets like `Chromie-Realm`, which prevented the Chromie auto-reply path from matching the target name.

### Description
- Strip any `-RealmName` suffix from the target before calling `normalizePlayerName` and comparing against `CHROMI_WHISPER_NAMES` in `IsChromiWhisperTarget` (changes in `src/server/game/Handlers/ChatHandler.cpp`).

### Testing
- No automated tests were executed for this change; validation was performed via code inspection of the `CHAT_MSG_WHISPER` handling path and the updated `IsChromiWhisperTarget` logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c7205a748327b3646c79a3b3c0e5)