### PR TITLE
Simplify Chromie whisper logic, send synthetic chat packet, and add cat facts

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -45,69 +45,23 @@
 #include "WorldPacket.h"
 #include <algorithm>
 #include <array>
-#include <memory>
 
 namespace
 {
 std::array<std::string_view, 2> const CHROMI_WHISPER_NAMES = { "Chromi", "Chromie" };
+uint32 constexpr CHROMIE_PLAYER_GUID = 1;
+char const* const CHROMIE_NAME = "Chromie";
 
 bool IsChromiWhisperTarget(std::string const& targetName)
 {
     std::string normalizedTarget = targetName;
+    if (std::string::size_type realmSeparator = normalizedTarget.find('-'); realmSeparator != std::string::npos)
+        normalizedTarget.erase(realmSeparator);
+
     if (!normalizePlayerName(normalizedTarget))
         return false;
 
     return std::find(CHROMI_WHISPER_NAMES.begin(), CHROMI_WHISPER_NAMES.end(), normalizedTarget) != CHROMI_WHISPER_NAMES.end();
-}
-
-Player* FindConnectedChromiPlayer()
-{
-    for (std::string_view chromiName : CHROMI_WHISPER_NAMES)
-        if (Player* chromi = ObjectAccessor::FindConnectedPlayerByName(chromiName))
-            return chromi;
-
-    return nullptr;
-}
-
-
-Player* EnsureHiddenChromiPlayer()
-{
-    static std::unique_ptr<WorldSession> hiddenSession;
-    static std::unique_ptr<Player> hiddenChromi;
-
-    if (hiddenChromi)
-        return hiddenChromi.get();
-
-    hiddenSession = std::make_unique<WorldSession>(0, "chromie_hidden", std::shared_ptr<WorldSocket>(), SEC_GAMEMASTER, EXPANSION_WRATH_OF_THE_LICH_KING,
-        0, Minutes(0), DEFAULT_LOCALE, 0, false);
-
-    hiddenChromi = std::make_unique<Player>(hiddenSession.get());
-    hiddenChromi->GetMotionMaster()->Initialize();
-
-    CharacterCreateInfo createInfo;
-    createInfo.SetName("Chromie")
-        .SetRace(RACE_GNOME)
-        .SetClass(CLASS_MAGE)
-        .SetGender(GENDER_FEMALE)
-        .SetSkin(0)
-        .SetFace(0)
-        .SetHairStyle(0)
-        .SetHairColor(0)
-        .SetFacialHair(0)
-        .SetOutfitId(0);
-
-    if (!hiddenChromi->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
-    {
-        hiddenChromi.reset();
-        hiddenSession.reset();
-        return nullptr;
-    }
-
-    hiddenChromi->SetGameMaster(true);
-    hiddenChromi->SetAcceptWhispers(true);
-    hiddenChromi->SetGMVisible(false);
-    hiddenSession->SetPlayer(hiddenChromi.get());
-    return hiddenChromi.get();
 }
 
 void WhisperFromChromi(Player* receiver, std::string_view message)
@@ -115,14 +69,11 @@ void WhisperFromChromi(Player* receiver, std::string_view message)
     if (!receiver)
         return;
 
-    if (Player* chromi = FindConnectedChromiPlayer())
-    {
-        chromi->Whisper(message, LANG_UNIVERSAL, receiver);
-        return;
-    }
-
-    if (Player* hiddenChromi = EnsureHiddenChromiPlayer())
-        hiddenChromi->Whisper(message, LANG_UNIVERSAL, receiver);
+    WorldPacket data;
+    ObjectGuid chromieGuid = ObjectGuid::Create<HighGuid::Player>(CHROMIE_PLAYER_GUID);
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER_FOREIGN, LANG_UNIVERSAL, chromieGuid, receiver->GetGUID(), message,
+        0, CHROMIE_NAME);
+    receiver->SendDirectMessage(&data);
 }
 
 std::string_view GetRandomChromiCatFact()


### PR DESCRIPTION
### Motivation

- Avoid creating and managing a hidden `Player`/`WorldSession` for Chromie whispers and make whisper delivery robust across realms.

### Description

- Strip realm suffix from whisper target names in `IsChromiWhisperTarget` so `Name-Realm` matches Chromie aliases. 
- Remove hidden `WorldSession`/`Player` creation and lookup helpers and instead send a synthetic whisper by building a chat packet with a fixed player GUID and name (`CHROMIE_PLAYER_GUID` / `CHROMIE_NAME`) in `WhisperFromChromi`.
- Add a small set of cat facts in `GetRandomChromiCatFact` and use `ChatHandler::BuildChatPacket` + `SendDirectMessage` to deliver the message, and remove the now-unused `<memory>` include.

### Testing

- Built the project (`make`) successfully after the changes. 
- Ran the automated test suite (`ctest`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c7205a748327b3646c79a3b3c0e5)