### PR TITLE
Support Chromi whispers with realm-stripped target, forward user message, and create hidden Chromi session

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -54,75 +54,59 @@ std::array<std::string_view, 2> const CHROMI_WHISPER_NAMES = { "Chromi", "Chromi
 bool IsChromiWhisperTarget(std::string const& targetName)
 {
     std::string normalizedTarget = targetName;
+    if (std::string::size_type realmSeparator = normalizedTarget.find('-'); realmSeparator != std::string::npos)
+        normalizedTarget.erase(realmSeparator);
+
     if (!normalizePlayerName(normalizedTarget))
         return false;
 
     return std::find(CHROMI_WHISPER_NAMES.begin(), CHROMI_WHISPER_NAMES.end(), normalizedTarget) != CHROMI_WHISPER_NAMES.end();
 }
 
-Player* FindConnectedChromiPlayer()
-{
-    for (std::string_view chromiName : CHROMI_WHISPER_NAMES)
-        if (Player* chromi = ObjectAccessor::FindConnectedPlayerByName(chromiName))
-            return chromi;
-
-    return nullptr;
-}
-
-
-Player* EnsureHiddenChromiPlayer()
+Player* GetOrCreateChromiWhisperPlayer()
 {
     static std::unique_ptr<WorldSession> hiddenSession;
     static std::unique_ptr<Player> hiddenChromi;
 
-    if (hiddenChromi)
-        return hiddenChromi.get();
+    for (std::string_view chromiName : CHROMI_WHISPER_NAMES)
+        if (Player* chromi = ObjectAccessor::FindConnectedPlayerByName(chromiName))
+            return chromi;
 
-    hiddenSession = std::make_unique<WorldSession>(0, "chromie_hidden", std::shared_ptr<WorldSocket>(), SEC_GAMEMASTER, EXPANSION_WRATH_OF_THE_LICH_KING,
-        0, Minutes(0), DEFAULT_LOCALE, 0, false);
-
-    hiddenChromi = std::make_unique<Player>(hiddenSession.get());
-    hiddenChromi->GetMotionMaster()->Initialize();
-
-    CharacterCreateInfo createInfo;
-    createInfo.SetName("Chromie")
-        .SetRace(RACE_GNOME)
-        .SetClass(CLASS_MAGE)
-        .SetGender(GENDER_FEMALE)
-        .SetSkin(0)
-        .SetFace(0)
-        .SetHairStyle(0)
-        .SetHairColor(0)
-        .SetFacialHair(0)
-        .SetOutfitId(0);
-
-    if (!hiddenChromi->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
+    if (!hiddenChromi)
     {
-        hiddenChromi.reset();
-        hiddenSession.reset();
-        return nullptr;
+        hiddenSession = std::make_unique<WorldSession>(0, "chromie_hidden", std::shared_ptr<WorldSocket>(), SEC_GAMEMASTER, EXPANSION_WRATH_OF_THE_LICH_KING,
+            0, Minutes(0), DEFAULT_LOCALE, 0, false);
+
+        hiddenChromi = std::make_unique<Player>(hiddenSession.get());
+        hiddenChromi->GetMotionMaster()->Initialize();
+
+        CharacterCreateInfo createInfo;
+        createInfo.SetName("Chromie")
+            .SetRace(RACE_GNOME)
+            .SetClass(CLASS_MAGE)
+            .SetGender(GENDER_FEMALE)
+            .SetSkin(0)
+            .SetFace(0)
+            .SetHairStyle(0)
+            .SetHairColor(0)
+            .SetFacialHair(0)
+            .SetOutfitId(0);
+
+        if (!hiddenChromi->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
+        {
+            hiddenChromi.reset();
+            hiddenSession.reset();
+            return nullptr;
+        }
+
+        hiddenChromi->SetGameMaster(true);
+        hiddenChromi->SetAcceptWhispers(true);
+        hiddenChromi->SetGMVisible(false);
+        hiddenSession->SetPlayer(hiddenChromi.get());
+        ObjectAccessor::AddObject(hiddenChromi.get());
     }
 
-    hiddenChromi->SetGameMaster(true);
-    hiddenChromi->SetAcceptWhispers(true);
-    hiddenChromi->SetGMVisible(false);
-    hiddenSession->SetPlayer(hiddenChromi.get());
     return hiddenChromi.get();
-}
-
-void WhisperFromChromi(Player* receiver, std::string_view message)
-{
-    if (!receiver)
-        return;
-
-    if (Player* chromi = FindConnectedChromiPlayer())
-    {
-        chromi->Whisper(message, LANG_UNIVERSAL, receiver);
-        return;
-    }
-
-    if (Player* hiddenChromi = EnsureHiddenChromiPlayer())
-        hiddenChromi->Whisper(message, LANG_UNIVERSAL, receiver);
 }
 
 std::string_view GetRandomChromiCatFact()
@@ -423,7 +407,14 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
         {
             if (IsChromiWhisperTarget(to))
             {
-                WhisperFromChromi(sender, GetRandomChromiCatFact());
+                if (Player* chromi = GetOrCreateChromiWhisperPlayer())
+                {
+                    sender->Whisper(msg, Language(lang), chromi);
+                    chromi->Whisper(GetRandomChromiCatFact(), LANG_UNIVERSAL, sender);
+                }
+                else
+                    SendPlayerNotFoundNotice(to);
+
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Ensure whispers addressed to the NPC/character named Chromi/Chromie are correctly recognized even when a realm suffix is included and that a reply is produced reliably whether a real Chromi is connected or not.

### Description
- Strip any realm suffix after `-` in `IsChromiWhisperTarget` before normalizing the player name to allow targets like `Chromi-Realm` to match. 
- Replace the separate `FindConnectedChromiPlayer`/`EnsureHiddenChromiPlayer`/`WhisperFromChromi` helpers with a single `GetOrCreateChromiWhisperPlayer` that first returns a connected Chromi if present or creates/registers a hidden `Player` and `WorldSession` fallback. 
- Change whisper handling so the sender's message is forwarded to Chromi (`sender->Whisper(...)`) and then Chromi replies with a random cat fact, and return a player-not-found notice if Chromi couldn't be obtained. 
- Register created hidden Chromi with `ObjectAccessor::AddObject` so it can be found and addressed like a normal player.

### Testing
- Built the project successfully using the normal build (`cmake` / `make`) pipeline. 
- Ran the chat handler unit/regression tests (`ChatHandlerTest`) and they passed. 
- Executed automated regression suite covering whisper handling and the relevant tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c7205a748327b3646c79a3b3c0e5)