### PR TITLE
Reply to whispers addressed to "Chromie" via connected or hidden player with fallback synthetic packets

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -18,6 +18,7 @@
 #include "WorldSession.h"
 #include "AccountMgr.h"
 #include "CellImpl.h"
+#include "CharacterCache.h"
 #include "Common.h"
 #include "Channel.h"
 #include "ChannelMgr.h"
@@ -50,79 +51,69 @@
 namespace
 {
 std::array<std::string_view, 2> const CHROMI_WHISPER_NAMES = { "Chromi", "Chromie" };
+ObjectGuid::LowType constexpr CHROMIE_FAKE_GUID = 1;
+char const* const CHROMIE_WHISPER_NAME = "Chromie";
 
 bool IsChromiWhisperTarget(std::string const& targetName)
 {
     std::string normalizedTarget = targetName;
+    if (std::string::size_type realmSeparator = normalizedTarget.find('-'); realmSeparator != std::string::npos)
+        normalizedTarget.erase(realmSeparator);
+
     if (!normalizePlayerName(normalizedTarget))
         return false;
 
     return std::find(CHROMI_WHISPER_NAMES.begin(), CHROMI_WHISPER_NAMES.end(), normalizedTarget) != CHROMI_WHISPER_NAMES.end();
 }
 
-Player* FindConnectedChromiPlayer()
-{
-    for (std::string_view chromiName : CHROMI_WHISPER_NAMES)
-        if (Player* chromi = ObjectAccessor::FindConnectedPlayerByName(chromiName))
-            return chromi;
-
-    return nullptr;
-}
-
-
-Player* EnsureHiddenChromiPlayer()
+Player* GetOrCreateChromiWhisperPlayer()
 {
     static std::unique_ptr<WorldSession> hiddenSession;
     static std::unique_ptr<Player> hiddenChromi;
 
-    if (hiddenChromi)
-        return hiddenChromi.get();
+    for (std::string_view chromiName : CHROMI_WHISPER_NAMES)
+        if (Player* chromi = ObjectAccessor::FindConnectedPlayerByName(chromiName))
+            return chromi;
 
-    hiddenSession = std::make_unique<WorldSession>(0, "chromie_hidden", std::shared_ptr<WorldSocket>(), SEC_GAMEMASTER, EXPANSION_WRATH_OF_THE_LICH_KING,
-        0, Minutes(0), DEFAULT_LOCALE, 0, false);
-
-    hiddenChromi = std::make_unique<Player>(hiddenSession.get());
-    hiddenChromi->GetMotionMaster()->Initialize();
-
-    CharacterCreateInfo createInfo;
-    createInfo.SetName("Chromie")
-        .SetRace(RACE_GNOME)
-        .SetClass(CLASS_MAGE)
-        .SetGender(GENDER_FEMALE)
-        .SetSkin(0)
-        .SetFace(0)
-        .SetHairStyle(0)
-        .SetHairColor(0)
-        .SetFacialHair(0)
-        .SetOutfitId(0);
-
-    if (!hiddenChromi->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
+    if (!hiddenChromi)
     {
-        hiddenChromi.reset();
-        hiddenSession.reset();
-        return nullptr;
+        hiddenSession = std::make_unique<WorldSession>(0, "chromie_hidden", std::shared_ptr<WorldSocket>(), SEC_GAMEMASTER, EXPANSION_WRATH_OF_THE_LICH_KING,
+            0, Minutes(0), DEFAULT_LOCALE, 0, false);
+
+        hiddenChromi = std::make_unique<Player>(hiddenSession.get());
+        hiddenChromi->GetMotionMaster()->Initialize();
+
+        CharacterCreateInfo createInfo;
+        createInfo.SetName("Chromie")
+            .SetRace(RACE_GNOME)
+            .SetClass(CLASS_MAGE)
+            .SetGender(GENDER_FEMALE)
+            .SetSkin(0)
+            .SetFace(0)
+            .SetHairStyle(0)
+            .SetHairColor(0)
+            .SetFacialHair(0)
+            .SetOutfitId(0);
+
+        if (!hiddenChromi->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
+        {
+            hiddenChromi.reset();
+            hiddenSession.reset();
+            return nullptr;
+        }
+
+        if (!sCharacterCache->HasCharacterCacheEntry(hiddenChromi->GetGUID()))
+            sCharacterCache->AddCharacterCacheEntry(hiddenChromi->GetGUID(), hiddenSession->GetAccountId(), hiddenChromi->GetName(),
+                hiddenChromi->GetNativeGender(), hiddenChromi->GetRace(), hiddenChromi->GetClass(), hiddenChromi->GetLevel());
+
+        hiddenChromi->SetGameMaster(true);
+        hiddenChromi->SetAcceptWhispers(true);
+        hiddenChromi->SetGMVisible(false);
+        hiddenSession->SetPlayer(hiddenChromi.get());
+        ObjectAccessor::AddObject(hiddenChromi.get());
     }
 
-    hiddenChromi->SetGameMaster(true);
-    hiddenChromi->SetAcceptWhispers(true);
-    hiddenChromi->SetGMVisible(false);
-    hiddenSession->SetPlayer(hiddenChromi.get());
     return hiddenChromi.get();
-}
-
-void WhisperFromChromi(Player* receiver, std::string_view message)
-{
-    if (!receiver)
-        return;
-
-    if (Player* chromi = FindConnectedChromiPlayer())
-    {
-        chromi->Whisper(message, LANG_UNIVERSAL, receiver);
-        return;
-    }
-
-    if (Player* hiddenChromi = EnsureHiddenChromiPlayer())
-        hiddenChromi->Whisper(message, LANG_UNIVERSAL, receiver);
 }
 
 std::string_view GetRandomChromiCatFact()
@@ -423,7 +414,23 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
         {
             if (IsChromiWhisperTarget(to))
             {
-                WhisperFromChromi(sender, GetRandomChromiCatFact());
+                if (Player* chromi = GetOrCreateChromiWhisperPlayer())
+                {
+                    sender->Whisper(msg, Language(lang), chromi);
+                    chromi->Whisper(GetRandomChromiCatFact(), LANG_UNIVERSAL, sender);
+                }
+                else
+                {
+                    ObjectGuid chromieGuid = ObjectGuid::Create<HighGuid::Player>(CHROMIE_FAKE_GUID);
+
+                    WorldPacket data;
+                    ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER_INFORM, LANG_UNIVERSAL, chromieGuid, chromieGuid, msg, 0);
+                    sender->SendDirectMessage(&data);
+
+                    ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER_FOREIGN, LANG_UNIVERSAL, chromieGuid, sender->GetGUID(), GetRandomChromiCatFact(), 0, CHROMIE_WHISPER_NAME);
+                    sender->SendDirectMessage(&data);
+                }
+
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Allow players who whisper to the names "Chromi" or "Chromie" to receive an automated cat-fact reply even when no Chromie player is logged in.
- Ensure a hidden GM player can be created and registered so the reply appears as a normal in-game whisper from a player and is present in the character cache.
- Normalize realm-qualified targets (strip `-Realm`) before name validation for whisper targeting.

### Description
- Added `CharacterCache.h` and a `CHROMIE_FAKE_GUID`/`CHROMIE_WHISPER_NAME` constant for fallback behavior.
- Updated `IsChromiWhisperTarget` to strip realm suffixes before name normalization.
- Replaced earlier helper logic with `GetOrCreateChromiWhisperPlayer` which first returns any connected Chromie player and otherwise creates a hidden `WorldSession`/`Player`, initializes it, registers it in `CharacterCache`, and adds it to `ObjectAccessor`.
- Changed whisper handling so that when the target is Chromie the server either relays the message to a connected/hidden Chromie and sends back a cat fact, or, if creation failed, synthesizes `CHAT_MSG_WHISPER` packets using a fake GUID and the display name `Chromie` and sends them directly to the sender.

### Testing
- Project rebuilt successfully with the existing build system (`cmake --build` / `make`).
- No additional automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c7205a748327b3646c79a3b3c0e5)