### PR TITLE
scripts: include ObjectMgr in zone group rules

### DIFF
--- a/src/server/scripts/Custom/custom_zone_group_rules.cpp
+++ b/src/server/scripts/Custom/custom_zone_group_rules.cpp
@@ -20,6 +20,7 @@
 #include "Group.h"
 #include "MotionMaster.h"
 #include "ObjectAccessor.h"
+#include "ObjectMgr.h"
 #include "ObjectGuid.h"
 #include "DatabaseEnv.h"
 #include "Log.h"


### PR DESCRIPTION
### Motivation
- `custom_zone_group_rules.cpp` used `sObjectMgr->GetGenerator<HighGuid::Player>()` but did not include `ObjectMgr.h`, causing dependent-template/undeclared identifier compile errors; the intent is to make `sObjectMgr` and its templates visible to this translation unit to fix those errors.

### Description
- Added `#include "ObjectMgr.h"` to `src/server/scripts/Custom/custom_zone_group_rules.cpp` so `sObjectMgr` and `GetGenerator<HighGuid::Player>()` are declared in this file.

### Testing
- Verified the include is present and the `GetGenerator<HighGuid::Player>` usage is reachable using a code search (`rg -n "#include \"ObjectMgr.h\"|GetGenerator<HighGuid::Player>" src/server/scripts/Custom/custom_zone_group_rules.cpp`); no full build was run in this environment due to missing build configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b107e9013483278159daca1e750721)