### PR TITLE
Send Chromie whispers via direct chat packet instead of hidden Player/WorldSession

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -24,19 +24,15 @@
 #include "Item.h"
 #include "Map.h"
 #include "MapManager.h"
-#include "MotionMaster.h"
 #include "ObjectAccessor.h"
-#include "ObjectMgr.h"
 #include "Player.h"
 #include "RBAC.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "TaskScheduler.h"
 #include "Util.h"
-#include "WorldSession.h"
 
 #include <chrono>
-#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -57,7 +53,6 @@ constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
-char const* const CHROMI_NAME = "Chromi";
 char const* const GURUBASHI_EXIT_WHISPER = "The only way out of the arena is death.";
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
@@ -114,68 +109,15 @@ GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, ui
 }
 
 
-Player* FindConnectedChromiPlayer()
-{
-    if (Player* chromi = ObjectAccessor::FindConnectedPlayerByName(CHROMI_NAME))
-        return chromi;
-
-    return ObjectAccessor::FindConnectedPlayerByName("Chromie");
-}
-
-
-Player* EnsureHiddenChromiPlayer()
-{
-    static std::unique_ptr<WorldSession> hiddenSession;
-    static std::unique_ptr<Player> hiddenChromi;
-
-    if (hiddenChromi)
-        return hiddenChromi.get();
-
-    hiddenSession = std::make_unique<WorldSession>(0, "chromie_hidden", std::shared_ptr<WorldSocket>(), SEC_GAMEMASTER, EXPANSION_WRATH_OF_THE_LICH_KING,
-        0, Minutes(0), DEFAULT_LOCALE, 0, false);
-
-    hiddenChromi = std::make_unique<Player>(hiddenSession.get());
-    hiddenChromi->GetMotionMaster()->Initialize();
-
-    CharacterCreateInfo createInfo;
-    createInfo.SetName("Chromie")
-        .SetRace(RACE_GNOME)
-        .SetClass(CLASS_MAGE)
-        .SetGender(GENDER_FEMALE)
-        .SetSkin(0)
-        .SetFace(0)
-        .SetHairStyle(0)
-        .SetHairColor(0)
-        .SetFacialHair(0)
-        .SetOutfitId(0);
-
-    if (!hiddenChromi->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
-    {
-        hiddenChromi.reset();
-        hiddenSession.reset();
-        return nullptr;
-    }
-
-    hiddenChromi->SetGameMaster(true);
-    hiddenChromi->SetAcceptWhispers(true);
-    hiddenChromi->SetGMVisible(false);
-    hiddenSession->SetPlayer(hiddenChromi.get());
-    return hiddenChromi.get();
-}
-
 void WhisperFromChromi(Player* player, std::string_view message)
 {
     if (!player)
         return;
 
-    if (Player* chromiPlayer = FindConnectedChromiPlayer())
-    {
-        chromiPlayer->Whisper(message, LANG_UNIVERSAL, player);
-        return;
-    }
-
-    if (Player* hiddenChromi = EnsureHiddenChromiPlayer())
-        hiddenChromi->Whisper(message, LANG_UNIVERSAL, player);
+    ObjectGuid chromieGuid = ObjectGuid::Create<HighGuid::Player>(1);
+    WorldPacket data;
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER_FOREIGN, LANG_UNIVERSAL, chromieGuid, player->GetGUID(), message, 0, "Chromie");
+    player->SendDirectMessage(&data);
 }
 
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)

--- a/src/server/scripts/Custom/custom_zone_group_rules.cpp
+++ b/src/server/scripts/Custom/custom_zone_group_rules.cpp
@@ -18,16 +18,12 @@
 #include "ScriptMgr.h"
 #include "Player.h"
 #include "Group.h"
-#include "MotionMaster.h"
 #include "ObjectAccessor.h"
-#include "ObjectMgr.h"
 #include "ObjectGuid.h"
 #include "DatabaseEnv.h"
+#include "Chat.h"
 #include "Log.h"
 #include "StringFormat.h"
-#include "WorldSession.h"
-
-#include <memory>
 #include <string_view>
 
 #include <unordered_map>
@@ -41,67 +37,15 @@ namespace
     float constexpr GurubashiArenaFallbackZ = 21.858f;
     float constexpr GurubashiArenaFallbackO = 1.022f;
 
-    Player* FindConnectedChromiePlayer()
-    {
-        if (Player* chromie = ObjectAccessor::FindConnectedPlayerByName("Chromi"))
-            return chromie;
-
-        return ObjectAccessor::FindConnectedPlayerByName("Chromie");
-    }
-
-    Player* EnsureHiddenChromiePlayer()
-    {
-        static std::unique_ptr<WorldSession> hiddenSession;
-        static std::unique_ptr<Player> hiddenChromie;
-
-        if (hiddenChromie)
-            return hiddenChromie.get();
-
-        hiddenSession = std::make_unique<WorldSession>(0, "chromie_hidden", std::shared_ptr<WorldSocket>(), SEC_GAMEMASTER, EXPANSION_WRATH_OF_THE_LICH_KING,
-            0, Minutes(0), DEFAULT_LOCALE, 0, false);
-
-        hiddenChromie = std::make_unique<Player>(hiddenSession.get());
-        hiddenChromie->GetMotionMaster()->Initialize();
-
-        CharacterCreateInfo createInfo;
-        createInfo.SetName("Chromie")
-            .SetRace(RACE_GNOME)
-            .SetClass(CLASS_MAGE)
-            .SetGender(GENDER_FEMALE)
-            .SetSkin(0)
-            .SetFace(0)
-            .SetHairStyle(0)
-            .SetHairColor(0)
-            .SetFacialHair(0)
-            .SetOutfitId(0);
-
-        if (!hiddenChromie->Create(sObjectMgr->GetGenerator<HighGuid::Player>().Generate(), &createInfo))
-        {
-            hiddenChromie.reset();
-            hiddenSession.reset();
-            return nullptr;
-        }
-
-        hiddenChromie->SetGameMaster(true);
-        hiddenChromie->SetAcceptWhispers(true);
-        hiddenChromie->SetGMVisible(false);
-        hiddenSession->SetPlayer(hiddenChromie.get());
-        return hiddenChromie.get();
-    }
-
     void WhisperFromChromie(Player* player, std::string_view message)
     {
         if (!player)
             return;
 
-        if (Player* chromiePlayer = FindConnectedChromiePlayer())
-        {
-            chromiePlayer->Whisper(message, LANG_UNIVERSAL, player);
-            return;
-        }
-
-        if (Player* hiddenChromie = EnsureHiddenChromiePlayer())
-            hiddenChromie->Whisper(message, LANG_UNIVERSAL, player);
+        ObjectGuid chromieGuid = ObjectGuid::Create<HighGuid::Player>(1);
+        WorldPacket data;
+        ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER_FOREIGN, LANG_UNIVERSAL, chromieGuid, player->GetGUID(), message, 0, "Chromie");
+        player->SendDirectMessage(&data);
     }
 
     struct ZoneAreaKey


### PR DESCRIPTION
### Motivation

- Remove complex hidden `Player`/`WorldSession` creation and reliance on a connected player to deliver Chromie-style whispers, simplifying message delivery and reducing coupling to player/session internals.

### Description

- Replace `FindConnectedChromiPlayer`/`FindConnectedChromiePlayer` and `EnsureHiddenChromiPlayer` logic with direct packet construction using `ChatHandler::BuildChatPacket` and `player->SendDirectMessage(&data)` in `WhisperFromChromi` functions. 
- Use a synthetic sender GUID created via `ObjectGuid::Create<HighGuid::Player>(1)` to represent "Chromie" instead of creating or looking up an actual `Player` instance. 
- Remove unused includes and headers related to `WorldSession`, `MotionMaster`, `ObjectMgr`, and `<memory>` and add `Chat.h` where needed. 
- Changes applied to `src/server/scripts/Custom/custom_gurubashi_arena.cpp` and `src/server/scripts/Custom/custom_zone_group_rules.cpp`.

### Testing

- Performed a full project build which completed successfully. 
- Ran automated build-time checks and available unit tests, and they passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10ceb60ac8327b02ec6be80fc93b5)