### PR TITLE
Fix Gurubashi exit Moonfire to trigger visual and combat log

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -29,6 +29,7 @@
 #include "RBAC.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
+#include "SpellMgr.h"
 #include "TaskScheduler.h"
 #include "Util.h"
 
@@ -476,9 +477,10 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    SpellInfo const* moonfireSpell = sSpellMgr->GetSpellInfo(MOONFIRE_SPELL_ID);
+                    player->CastSpell(player, MOONFIRE_SPELL_ID, false);
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, moonfireSpell, false);
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation
- Players exiting the Gurubashi battle ring were being killed without the Moonfire visual or combat-log entry, indicating the Moonfire application was treated as a triggered/internal effect rather than a normal spell attribution. 
- The change ensures the kill is attributed to Moonfire so the client shows the animation and the combat log records the spell.

### Description
- Fetch `SpellInfo` for Moonfire with `sSpellMgr->GetSpellInfo(MOONFIRE_SPELL_ID)` and pass it to `Unit::DealDamage` so the damage/kill is attributed to that spell. 
- Change the Moonfire cast to be non-triggered by calling `player->CastSpell(player, MOONFIRE_SPELL_ID, false)` so the client displays the visual and logs the spell. 
- Add `#include "SpellMgr.h"` to support `sSpellMgr` usage in the file.

### Testing
- Ran a project configuration attempt with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which failed due to missing Boost development components (`system`, `filesystem`, `program_options`, `iostreams`, `regex`, `locale`).
- Performed source checks (`rg`/line inspections) to verify the updated lines are present and `SpellMgr` include was added, and these inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)