### PR TITLE
Attribute Gurubashi exit punishment to hostile summon and use spell info

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -29,7 +29,9 @@
 #include "RBAC.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
+#include "SpellMgr.h"
 #include "TaskScheduler.h"
+#include "TemporarySummon.h"
 #include "Util.h"
 
 #include <chrono>
@@ -50,6 +52,7 @@ constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +479,17 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    SpellInfo const* moonfireSpell = sSpellMgr->GetSpellInfo(MOONFIRE_SPELL_ID);
+                    Unit* damageDealer = player;
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                    if (Creature* moonfireCaster = player->SummonCreature(WORLD_TRIGGER, player->GetPosition(), TEMPSUMMON_TIMED_DESPAWN, 5s))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
+                        moonfireCaster->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                        damageDealer = moonfireCaster;
+                    }
+
+                    Unit::DealDamage(damageDealer, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, moonfireSpell, false);
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation
- Ensure the Gurubashi arena exit punishment is applied with correct damage attribution and spell behavior by using a hostile temporary summon as the damage source and supplying the `SpellInfo` to damage calculation.

### Description
- Added `SpellMgr.h` and `TemporarySummon.h` includes and introduced `HOSTILE_FACTION_ID` constant.
- Replaced the direct self-cast and self-damage logic with a temporary `WORLD_TRIGGER` summon that is set to the hostile faction and casts `MOONFIRE_SPELL_ID` on the player.
- Retrieved the `SpellInfo` via `sSpellMgr->GetSpellInfo` and passed it to `Unit::DealDamage`, using the summon as the damage dealer so damage attribution and spell-specific handling are correct.
- Kept the Chromie whisper and set the summon to despawn after `5s`.

### Testing
- Built the server with `cmake`/`make` successfully. 
- Ran the automated server unit test suite and it passed. 
- Executed an automated integration scenario that simulates a player crossing the Gurubashi ring boundary and verified the summon spawn, spell cast, and damage application; the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)