### PR TITLE
Use hostile temporary summon as caster for Gurubashi exit punishment and apply proper spell damage handling

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -29,7 +29,9 @@
 #include "RBAC.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
+#include "SpellMgr.h"
 #include "TaskScheduler.h"
+#include "TemporarySummon.h"
 #include "Util.h"
 
 #include <chrono>
@@ -50,6 +52,7 @@ constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +479,22 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    SpellInfo const* moonfireSpell = sSpellMgr->GetSpellInfo(MOONFIRE_SPELL_ID);
+                    Unit* damageDealer = player;
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                    if (Creature* moonfireCaster = player->SummonCreature(WORLD_TRIGGER, player->GetPosition(), TEMPSUMMON_TIMED_DESPAWN, 5s))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
+                        moonfireCaster->CastSpell(player, MOONFIRE_SPELL_ID, false);
+                        damageDealer = moonfireCaster;
+                    }
+
+                    SpellNonMeleeDamage damageInfo(damageDealer, player, MOONFIRE_SPELL_ID, moonfireSpell ? moonfireSpell->GetSchoolMask() : SPELL_SCHOOL_MASK_NATURE);
+                    damageInfo.damage = GURUBASHI_EXIT_PUNISH_DAMAGE;
+                    Unit::DealDamageMods(player, damageInfo.damage, &damageInfo.absorb);
+                    player->DealSpellDamage(&damageInfo, true);
+                    player->SendSpellNonMeleeDamageLog(&damageInfo);
+
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation
- Ensure players who illegally exit the Gurubashi battle ring receive lethal punishment attributed to a hostile caster and that the spell/damage are applied and logged correctly.

### Description
- Include `SpellMgr.h` and `TemporarySummon.h` and add a `HOSTILE_FACTION_ID` constant.
- Replace the previous self-cast + `Unit::DealDamage` path with creation of a temporary `WORLD_TRIGGER` summon that is set to a hostile faction and casts Moonfire on the player.
- Retrieve `SpellInfo` via `sSpellMgr->GetSpellInfo` and build a `SpellNonMeleeDamage` object, apply damage modifiers via `Unit::DealDamageMods`, call `DealSpellDamage`, and send the non-melee damage log.

### Testing
- Full server build was executed and completed successfully with no compilation errors.
- Automated test suite (build/tests) was run and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)