### PR TITLE
Use temporary hostile summon to apply Gurubashi exit punishment and fix damage attribution

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -30,6 +30,7 @@
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "TaskScheduler.h"
+#include "TemporarySummon.h"
 #include "Util.h"
 
 #include <chrono>
@@ -50,6 +51,7 @@ constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +478,21 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    Unit* damageDealer = player;
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                    if (Creature* moonfireCaster = player->SummonCreature(WORLD_TRIGGER, player->GetPosition(), TEMPSUMMON_TIMED_DESPAWN, 5s))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
+                        moonfireCaster->CastSpell(player, MOONFIRE_SPELL_ID, false);
+                        damageDealer = moonfireCaster;
+                    }
+
+                    SpellNonMeleeDamage damageInfo(damageDealer, player, MOONFIRE_SPELL_ID, SPELL_SCHOOL_MASK_NATURE);
+                    damageInfo.damage = GURUBASHI_EXIT_PUNISH_DAMAGE;
+                    Unit::DealDamageMods(player, damageInfo.damage, &damageInfo.absorb);
+                    player->DealSpellDamage(&damageInfo, true);
+                    player->SendSpellNonMeleeDamageLog(&damageInfo);
+
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation

- Ensure the Gurubashi arena exit punishment is attributed to a hostile NPC rather than the player to avoid self-cast semantics and ensure correct combat logging and faction behavior.

### Description

- Added `TemporarySummon.h` include and a `HOSTILE_FACTION_ID` constant.
- When a player illegally exits the battle ring, summon a timed `WORLD_TRIGGER`, set its faction hostile, and have it cast the moonfire spell on the player so the damage is attributed to the summon.
- Construct and apply `SpellNonMeleeDamage` with `Unit::DealDamageMods`, `DealSpellDamage`, and `SendSpellNonMeleeDamageLog` instead of the previous self-cast and `Unit::DealDamage` call.

### Testing

- Built the server with `make` and the build completed successfully.
- Executed the automated unit test suite and all tests passed.
- Ran an automated integration test that simulates a player crossing the Gurubashi boundary and confirmed the summon-cast, damage application, and whisper behavior succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)