### PR TITLE
Use summoned hostile caster to apply Gurubashi exit punishment

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -30,6 +30,7 @@
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "TaskScheduler.h"
+#include "TemporarySummon.h"
 #include "Util.h"
 
 #include <chrono>
@@ -50,6 +51,7 @@ constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +478,15 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    if (Creature* moonfireCaster = player->SummonCreature(WORLD_TRIGGER, player->GetPosition(), TEMPSUMMON_TIMED_DESPAWN, 5s))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                        CastSpellExtraArgs args;
+                        args.AddSpellMod(SPELLVALUE_BASE_POINT0, int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                        moonfireCaster->CastSpell(player, MOONFIRE_SPELL_ID, args);
+                    }
+
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation

- Ensure exit punishment is attributed to a hostile NPC rather than self-inflicted damage so faction and spell mechanics behave correctly.
- Avoid applying raw `Unit::DealDamage` to a player which can bypass caster-based spell modifiers and logging.
- Provide a short-lived, visible source for the punishment spell to integrate with PvP/faction interactions.

### Description

- Added `#include "TemporarySummon.h"` and a `HOSTILE_FACTION_ID` constant set to `14`.
- Replaced direct `player->CastSpell(player, MOONFIRE_SPELL_ID, true)` and `Unit::DealDamage(...)` with summoning a timed `WORLD_TRIGGER` creature at the player using `TEMPSUMMON_TIMED_DESPAWN` for `5s`.
- Set the summoned caster's faction to `HOSTILE_FACTION_ID` and used `CastSpellExtraArgs` with `SPELLVALUE_BASE_POINT0` to pass `GURUBASHI_EXIT_PUNISH_DAMAGE` to the spell, then had the summoned caster cast `MOONFIRE_SPELL_ID` on the player.
- Kept the Chromie whisper (`WhisperFromChromi`) when the boundary is crossed.

### Testing

- Successfully compiled the server after the changes with no build errors related to the new include and calls.
- Ran a local server build and simulated a player crossing the Gurubashi battle ring boundary; observed a temporary `WORLD_TRIGGER` summon, the hostile-caster `MOONFIRE` application with the intended damage value, and the chromie whisper, and no crashes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)