### PR TITLE
Use CastSpellExtraArgs for Gurubashi exit punishment and remove direct DealDamage

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -476,9 +476,10 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
+                    args.AddSpellMod(SPELLVALUE_BASE_POINT0, int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                    player->CastSpell(player, MOONFIRE_SPELL_ID, args);
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation
- Apply the Gurubashi exit punishment as a properly triggered spell effect using spell parameters rather than an explicit damage call to ensure the damage is delivered through the spell system and respects spell handling rules.

### Description
- Replace the previous `player->CastSpell(player, MOONFIRE_SPELL_ID, true)` plus `Unit::DealDamage(...)` with a single `CastSpellExtraArgs` invocation using `TRIGGERED_FULL_MASK`.
- Add `args.AddSpellMod(SPELLVALUE_BASE_POINT0, int32(GURUBASHI_EXIT_PUNISH_DAMAGE))` so the punishment damage is passed via the spell's base point and then call `player->CastSpell(player, MOONFIRE_SPELL_ID, args)`.
- Remove the direct `Unit::DealDamage` call and keep the existing `WhisperFromChromi` notification unchanged.

### Testing
- Project built successfully with `make` after the change.
- Automated test suite executed with `ctest` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)