### PR TITLE
Use temporary hostile caster to apply Gurubashi exit punishment spell

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -30,6 +30,7 @@
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "TaskScheduler.h"
+#include "TemporarySummon.h"
 #include "Util.h"
 
 #include <chrono>
@@ -50,6 +51,7 @@ constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +478,22 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    if (Creature* moonfireCaster = player->SummonCreature(WORLD_TRIGGER, player->GetPosition(), TEMPSUMMON_TIMED_DESPAWN, 6s))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                        CastSpellExtraArgs args;
+                        args.AddSpellMod(SPELLVALUE_BASE_POINT0, int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+
+                        SpellCastResult const castResult = moonfireCaster->CastSpell(CastSpellTargetArg(player), MOONFIRE_SPELL_ID, args);
+                        if (castResult != SPELL_CAST_OK)
+                        {
+                            CastSpellExtraArgs fallbackArgs(TRIGGERED_FULL_MASK);
+                            fallbackArgs.AddSpellMod(SPELLVALUE_BASE_POINT0, int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                            moonfireCaster->CastSpell(player, MOONFIRE_SPELL_ID, fallbackArgs);
+                        }
+                    }
+
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation
- Replace direct damage application when leaving the Gurubashi arena with a spell cast from a temporary hostile entity so the punishment is applied as a spell and respects spell mechanics and resistances.
- Ensure the spell has the correct casting context and can be attributed to a hostile faction rather than using `Unit::DealDamage` or directly casting on the victim.

### Description
- Added `#include "TemporarySummon.h"` and a new constant `HOSTILE_FACTION_ID = 14` to support summoned caster behavior.
- When a player illegally leaves the Gurubashi battle ring, summon a `WORLD_TRIGGER` temporary creature at the player's position with `TEMPSUMMON_TIMED_DESPAWN, 6s` and set its faction to `HOSTILE_FACTION_ID` before casting the punishment spell.
- Use `CastSpellExtraArgs` to inject `SPELLVALUE_BASE_POINT0` with `GURUBASHI_EXIT_PUNISH_DAMAGE` and attempt `CastSpell` from the summoned caster, falling back to a triggered cast mask if the initial cast fails.
- Removed the direct `Unit::DealDamage` call and the previous direct self-cast, while preserving the `WhisperFromChromi` notification.

### Testing
- Built the server with `cmake --build .` which completed successfully. 
- Ran automated test suite with `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)