### PR TITLE
Gurubashi: summon trigger to cast Moonfire when exiting battle ring (with fallback damage)

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -50,6 +50,7 @@ constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +477,24 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    if (Creature* moonfireCaster = player->SummonTrigger(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetOrientation(), 6s))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                        CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
+                        args.AddSpellMod(SPELLVALUE_BASE_POINT0, int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+
+                        SpellCastResult const castResult = moonfireCaster->CastSpell(CastSpellTargetArg(player), MOONFIRE_SPELL_ID, args);
+                        if (castResult != SPELL_CAST_OK)
+                        {
+                            SpellNonMeleeDamage damageInfo(moonfireCaster, player, MOONFIRE_SPELL_ID, SPELL_SCHOOL_MASK_NATURE);
+                            damageInfo.damage = GURUBASHI_EXIT_PUNISH_DAMAGE;
+                            Unit::DealDamageMods(player, damageInfo.damage, &damageInfo.absorb);
+                            player->DealSpellDamage(&damageInfo, true);
+                            player->SendSpellNonMeleeDamageLog(&damageInfo);
+                        }
+                    }
+
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation
- Make the exit punishment apply as a proper spell cast from a summoned hostile trigger so it respects spell casting flow and related game mechanics.
- Replace a previous raw direct-damage call with a caster-based approach while ensuring a deterministic damage fallback if the spell cast fails.

### Description
- Added `HOSTILE_FACTION_ID` constant and summon-based cast logic that creates a trigger via `SummonTrigger` to act as the caster for `MOONFIRE_SPELL_ID`.
- The summoned trigger has its faction set to `HOSTILE_FACTION_ID` and uses `CastSpellExtraArgs` to set `SPELLVALUE_BASE_POINT0` to `GURUBASHI_EXIT_PUNISH_DAMAGE` before calling `CastSpell` on the target player.
- If the spell cast returns an error, a manual damage fallback is applied using `SpellNonMeleeDamage` and `Unit::DealDamageMods`/`DealSpellDamage` to ensure the player still takes `GURUBASHI_EXIT_PUNISH_DAMAGE`.
- Removed the prior `Unit::DealDamage` direct call and retained the Chromie whisper via `WhisperFromChromi`.

### Testing
- Project built successfully with the modified source (local compile/smoke build succeeded). 
- Performed a local runtime smoke check to confirm the summon is created and the fallback damage path triggers when the cast does not succeed.
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)