### PR TITLE
Summon hostile caster for Gurubashi exit Moonfire and apply damage via spell damage path

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -35,6 +35,7 @@
 #include <chrono>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -49,7 +50,10 @@ constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
+constexpr uint32 GURUBASHI_MOONFIRE_CASTER_ENTRY = 1;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
+constexpr bool ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS = true;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +480,31 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    Unit* damageCaster = player;
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                    if (Creature* moonfireCaster = player->GetMap()->SummonCreature(GURUBASHI_MOONFIRE_CASTER_ENTRY, player->GetPosition(), nullptr, 6 * IN_MILLISECONDS, nullptr))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
+                        damageCaster = moonfireCaster;
+
+                        SpellCastResult castResult = moonfireCaster->CastSpell(CastSpellTargetArg(player), MOONFIRE_SPELL_ID, CastSpellExtraArgs());
+                        if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                            WhisperFromChromi(player, "[Gurubashi Debug] Moonfire visual cast result: " + std::to_string(static_cast<uint32>(castResult)) + (castResult == SPELL_FAILED_BAD_TARGETS ? " (SPELL_FAILED_BAD_TARGETS)" : ""));
+                    }
+                    else if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                    {
+                        WhisperFromChromi(player, "[Gurubashi Debug] Failed to summon Moonfire caster entry 1; using player as damage caster.");
+                    }
+
+                    SpellNonMeleeDamage damageInfo(damageCaster, player, MOONFIRE_SPELL_ID, SPELL_SCHOOL_MASK_NATURE);
+                    damageInfo.damage = GURUBASHI_EXIT_PUNISH_DAMAGE;
+                    Unit::DealDamageMods(player, damageInfo.damage, &damageInfo.absorb);
+                    player->DealSpellDamage(&damageInfo, true);
+                    player->SendSpellNonMeleeDamageLog(&damageInfo);
+
+                    if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                        WhisperFromChromi(player, "[Gurubashi Debug] Applied immediate Moonfire punish damage: " + std::to_string(GURUBASHI_EXIT_PUNISH_DAMAGE));
+
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation

- Ensure the Moonfire exit punishment uses a proper caster entity for visual/scripting correctness and to avoid bad-targets/attribution issues.
- Provide clearer debug feedback for Moonfire cast and summon failures to aid troubleshooting.

### Description

- Added `#include <string>` and new constants `GURUBASHI_MOONFIRE_CASTER_ENTRY`, `HOSTILE_FACTION_ID`, and `ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS` to configure the summoned caster and debug behavior.
- On boundary exit, attempt to summon a creature at the player's position and set it as the damage caster with a hostile faction and trigger a visual Moonfire cast from that creature, falling back to the player when summon fails.
- Replace the previous direct `Unit::DealDamage` and `CastSpell` calls with creation of a `SpellNonMeleeDamage` instance, applying `DealSpellDamage` and sending the non-melee damage log to correctly attribute and log the spell damage.
- Emit optional whisper debug messages (`WhisperFromChromi`) about summon/cast results and applied damage when `ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS` is enabled.

### Testing

- Performed a full build of the server (`cmake --build .`) which completed successfully.
- Executed the automated test suite (`ctest`) after the build and all tests passed.
- Ran the automated integration test that simulates a player crossing the Gurubashi battle ring boundary and verified the Moonfire cast and damage application path completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)