### PR TITLE
Gurubashi: summon caster to apply Moonfire punish and add fallback handling

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -35,6 +35,7 @@
 #include <chrono>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -49,7 +50,10 @@ constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
+constexpr uint32 GURUBASHI_MOONFIRE_CASTER_ENTRY = 1;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
+constexpr bool ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS = true;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +480,63 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    Unit* damageCaster = player;
+                    SpellCastResult moonfireCastResult = SPELL_FAILED_ERROR;
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                    if (Creature* moonfireCaster = player->GetMap()->SummonCreature(GURUBASHI_MOONFIRE_CASTER_ENTRY, player->GetPosition(), nullptr, 6 * IN_MILLISECONDS, nullptr))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
+                        moonfireCaster->SetLevel(player->GetLevel());
+                        damageCaster = moonfireCaster;
+
+                        TriggerCastFlags const moonfireCastFlags = TriggerCastFlags(TRIGGERED_IGNORE_POWER_AND_REAGENT_COST
+                            | TRIGGERED_IGNORE_GCD
+                            | TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD
+                            | TRIGGERED_IGNORE_CAST_IN_PROGRESS
+                            | TRIGGERED_IGNORE_CASTER_AURAS
+                            | TRIGGERED_IGNORE_CASTER_AURASTATE
+                            | TRIGGERED_IGNORE_SHAPESHIFT
+                            | TRIGGERED_IGNORE_CASTER_MOUNTED_OR_ON_VEHICLE);
+
+                        CastSpellExtraArgs castArgs(moonfireCastFlags);
+                        castArgs.AddSpellMod(SPELLVALUE_BASE_POINT0, int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                        moonfireCastResult = moonfireCaster->CastSpell(CastSpellTargetArg(player), MOONFIRE_SPELL_ID, castArgs);
+                        if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                            WhisperFromChromi(player, "[Gurubashi Debug] Moonfire cast result: " + std::to_string(static_cast<uint32>(moonfireCastResult))
+                                + (moonfireCastResult == SPELL_FAILED_BAD_TARGETS ? " (SPELL_FAILED_BAD_TARGETS)" : "")
+                                + (moonfireCastResult == SPELL_FAILED_NO_POWER ? " (SPELL_FAILED_NO_POWER)" : ""));
+                    }
+                    else if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                    {
+                        WhisperFromChromi(player, "[Gurubashi Debug] Failed to summon Moonfire caster entry 1; using player as damage caster.");
+                    }
+
+                    if (moonfireCastResult != SPELL_CAST_OK)
+                    {
+                        ObjectGuid const punishedPlayerGuid = player->GetGUID();
+                        ObjectGuid const damageCasterGuid = damageCaster->GetGUID();
+                        player->m_Events.AddEventAtOffset([punishedPlayerGuid, damageCasterGuid]()
+                        {
+                            Player* punishedPlayer = ObjectAccessor::FindPlayer(punishedPlayerGuid);
+                            if (!punishedPlayer || !punishedPlayer->IsInWorld() || !punishedPlayer->IsAlive())
+                                return;
+
+                            Unit* resolvedDamageCaster = punishedPlayer;
+                            if (damageCasterGuid)
+                                if (Unit* caster = ObjectAccessor::GetUnit(*punishedPlayer, damageCasterGuid))
+                                    resolvedDamageCaster = caster;
+
+                            SpellNonMeleeDamage damageInfo(resolvedDamageCaster, punishedPlayer, MOONFIRE_SPELL_ID, SPELL_SCHOOL_MASK_ARCANE);
+                            damageInfo.damage = GURUBASHI_EXIT_PUNISH_DAMAGE;
+                            Unit::DealDamageMods(punishedPlayer, damageInfo.damage, &damageInfo.absorb);
+                            punishedPlayer->DealSpellDamage(&damageInfo, true);
+                            punishedPlayer->SendSpellNonMeleeDamageLog(&damageInfo);
+
+                            if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                                WhisperFromChromi(punishedPlayer, "[Gurubashi Debug] Applied guaranteed fallback Moonfire punish damage: " + std::to_string(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                        }, 50ms);
+                    }
+
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation

- Ensure the Gurubashi arena exit punishment is applied reliably and attributed properly by casting Moonfire from a summoned hostile caster instead of forcing a self-cast on the player.
- Provide a robust fallback to apply guaranteed damage if the summoned caster creation or spell cast fails, and add debug whispers to aid troubleshooting.

### Description

- Added constants and includes (`GURUBASHI_MOONFIRE_CASTER_ENTRY`, `HOSTILE_FACTION_ID`, `ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS`, and `<string>`) and enabled summoning a caster when players leave the battle ring boundary.
- Summons a creature at the player's location, sets its faction and level, then triggers `MOONFIRE_SPELL_ID` using `CastSpellExtraArgs` with `SPELLVALUE_BASE_POINT0` set to `GURUBASHI_EXIT_PUNISH_DAMAGE` and `TriggerCastFlags` that ignore usual cast restrictions.
- If summoning or the cast does not succeed, schedules a guaranteed fallback damage application via `SpellNonMeleeDamage` dispatched shortly after detection, and sends optional debug whispers with cast results via `WhisperFromChromi`.
- Removed the previous direct `Unit::DealDamage`/self-cast approach and updated tracking code to keep the same boundary checks and whisper message on exit.

### Testing

- Built the project (`cmake --build` / `make`) with the updated script and the build succeeded.
- No new automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)