### PR TITLE
Use summoned caster for Gurubashi exit punish Moonfire, add fallback damage and debug whispers

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -35,6 +35,7 @@
 #include <chrono>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -49,7 +50,10 @@ constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 MOONFIRE_SPELL_ID = 8921;
+constexpr uint32 GURUBASHI_MOONFIRE_CASTER_ENTRY = 1;
 constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
+constexpr uint32 HOSTILE_FACTION_ID = 14;
+constexpr bool ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS = true;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +480,65 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    Unit* damageCaster = player;
+                    SpellCastResult moonfireCastResult = SPELL_FAILED_ERROR;
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
+                    if (Creature* moonfireCaster = player->GetMap()->SummonCreature(GURUBASHI_MOONFIRE_CASTER_ENTRY, player->GetPosition(), nullptr, 6 * IN_MILLISECONDS, nullptr))
+                    {
+                        moonfireCaster->SetFaction(HOSTILE_FACTION_ID);
+                        moonfireCaster->SetLevel(player->GetLevel());
+                        damageCaster = moonfireCaster;
+
+                        TriggerCastFlags const moonfireCastFlags = TriggerCastFlags(TRIGGERED_IGNORE_POWER_AND_REAGENT_COST
+                            | TRIGGERED_IGNORE_GCD
+                            | TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD
+                            | TRIGGERED_IGNORE_CAST_IN_PROGRESS
+                            | TRIGGERED_IGNORE_CASTER_AURAS
+                            | TRIGGERED_IGNORE_CASTER_AURASTATE
+                            | TRIGGERED_IGNORE_SHAPESHIFT
+                            | TRIGGERED_IGNORE_CASTER_MOUNTED_OR_ON_VEHICLE);
+
+                        CastSpellExtraArgs castArgs(moonfireCastFlags);
+                        castArgs.AddSpellBP0(int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                        castArgs.AddSpellBP1(int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                        castArgs.AddSpellBP2(int32(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                        moonfireCastResult = moonfireCaster->CastSpell(CastSpellTargetArg(player), MOONFIRE_SPELL_ID, castArgs);
+                        if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                            WhisperFromChromi(player, "[Gurubashi Debug] Moonfire cast result: " + std::to_string(static_cast<uint32>(moonfireCastResult))
+                                + (moonfireCastResult == SPELL_FAILED_BAD_TARGETS ? " (SPELL_FAILED_BAD_TARGETS)" : "")
+                                + (moonfireCastResult == SPELL_FAILED_NO_POWER ? " (SPELL_FAILED_NO_POWER)" : ""));
+                    }
+                    else if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                    {
+                        WhisperFromChromi(player, "[Gurubashi Debug] Failed to summon Moonfire caster entry 1; using player as damage caster.");
+                    }
+
+                    if (moonfireCastResult != SPELL_CAST_OK)
+                    {
+                        ObjectGuid const punishedPlayerGuid = player->GetGUID();
+                        ObjectGuid const damageCasterGuid = damageCaster->GetGUID();
+                        player->m_Events.AddEventAtOffset([punishedPlayerGuid, damageCasterGuid]()
+                        {
+                            Player* punishedPlayer = ObjectAccessor::FindPlayer(punishedPlayerGuid);
+                            if (!punishedPlayer || !punishedPlayer->IsInWorld() || !punishedPlayer->IsAlive())
+                                return;
+
+                            Unit* resolvedDamageCaster = punishedPlayer;
+                            if (damageCasterGuid)
+                                if (Unit* caster = ObjectAccessor::GetUnit(*punishedPlayer, damageCasterGuid))
+                                    resolvedDamageCaster = caster;
+
+                            SpellNonMeleeDamage damageInfo(resolvedDamageCaster, punishedPlayer, MOONFIRE_SPELL_ID, SPELL_SCHOOL_MASK_ARCANE);
+                            damageInfo.damage = GURUBASHI_EXIT_PUNISH_DAMAGE;
+                            Unit::DealDamageMods(punishedPlayer, damageInfo.damage, &damageInfo.absorb);
+                            punishedPlayer->DealSpellDamage(&damageInfo, true);
+                            punishedPlayer->SendSpellNonMeleeDamageLog(&damageInfo);
+
+                            if (ENABLE_GURUBASHI_EXIT_DEBUG_WHISPERS)
+                                WhisperFromChromi(punishedPlayer, "[Gurubashi Debug] Applied guaranteed fallback Moonfire punish damage: " + std::to_string(GURUBASHI_EXIT_PUNISH_DAMAGE));
+                        }, 50ms);
+                    }
+
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation
- Ensure exit-punish Moonfire is attributed to a hostile caster and reliably kills players who illegally leave the Gurubashi battle ring while providing better diagnostics for debugging.

### Description
- Add constants for the Moonfire caster entry, hostile faction, and a debug-whispers toggle, and include `<string>` for debug message composition.
- Instead of directly damaging the player, summon a temporary creature at the player's position, set its faction/level, and have it cast `MOONFIRE_SPELL_ID` with `CastSpellExtraArgs` and explicit `TriggerCastFlags` to force the cast and convey custom BP values for damage.
- If the summoned-caster cast does not succeed, schedule a guaranteed fallback damage application via `SpellNonMeleeDamage` in a delayed event, and send optional debug whispers describing cast result and fallback application.
- Preserve the chromie whisper `GURUBASHI_EXIT_WHISPER` to notify the player when punished.

### Testing
- Performed an automated CI build of the project which completed successfully with no compile errors.
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)