### PR TITLE
Kill players who leave Gurubashi battle ring instead of casting moonfire

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -48,8 +48,6 @@ constexpr uint32 STRANGLETHORN_VALE_ZONE_ID = 33;
 constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
-constexpr uint32 MOONFIRE_SPELL_ID = 8921;
-constexpr uint32 GURUBASHI_EXIT_PUNISH_DAMAGE = 1000000;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -476,9 +474,8 @@ public:
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
                 {
-                    player->CastSpell(player, MOONFIRE_SPELL_ID, true);
+                    Unit::Kill(player, player);
 
-                    Unit::DealDamage(player, player, GURUBASHI_EXIT_PUNISH_DAMAGE, nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NATURE, nullptr, false);
                     WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
                 }
             }


### PR DESCRIPTION
### Motivation

- Remove reliance on a hard-coded spell and a large damage constant and enforce a deterministic death when a player illegitimately leaves the Gurubashi battle ring.  
- Simplify exit-punishment logic to avoid edge cases where damage/spell interactions might not guarantee player death.

### Description

- Removed unused constants `MOONFIRE_SPELL_ID` and `GURUBASHI_EXIT_PUNISH_DAMAGE`.  
- Replaced the previous `CastSpell` + `Unit::DealDamage` punishment with a direct `Unit::Kill(player, player)` call when a non-GM alive player crosses the battle ring boundary.  
- Preserved the Chromie whisper (`WhisperFromChromi`) behavior after the kill.

### Testing

- Built the project using the repository's build system (`make` / `cmake --build`) and the build completed successfully.  
- Ran the repository's automated unit/integration test suite (`make test` / CI test target) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1117cc1c4832786dfb5b8473cd069)