### PR TITLE
Randomize Chromie whisper when killing players who leave Gurubashi battle ring

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -54,7 +54,12 @@ constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
-char const* const GURUBASHI_EXIT_WHISPER = "The only way out of the arena is death.";
+char const* const GURUBASHI_EXIT_KILL_WHISPERS[] =
+{
+    "The only way out of the arena is death.",
+    "One does not simply walk out of the battle ring.",
+    "Coward."
+};
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
 
@@ -119,6 +124,14 @@ void WhisperFromChromi(Player* player, std::string_view message)
     WorldPacket data;
     ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER_FOREIGN, LANG_UNIVERSAL, chromieGuid, player->GetGUID(), message, 0, "Chromie");
     player->SendDirectMessage(&data);
+}
+
+void WhisperRandomExitKillLineFromChromie(Player* player)
+{
+    if (!player)
+        return;
+
+    WhisperFromChromi(player, GURUBASHI_EXIT_KILL_WHISPERS[urand(0, 2)]);
 }
 
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)
@@ -479,7 +492,7 @@ public:
                 {
                     Unit::Kill(player, player);
 
-                    WhisperFromChromi(player, GURUBASHI_EXIT_WHISPER);
+                    WhisperRandomExitKillLineFromChromie(player);
                 }
             }
 

--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -57,7 +57,7 @@ constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
 char const* const GURUBASHI_EXIT_KILL_WHISPERS[] =
 {
     "The only way out of the arena is death.",
-    "One does not simply walk out of the battle ring.",
+    "One does not simply walk out of the Battle Ring.",
     "Coward."
 };
 


### PR DESCRIPTION
### Motivation

- Add variety to the NPC whisper emitted when enforcing the Gurubashi battle ring exit kill to make the message less repetitive.

### Description

- Replace the single `GURUBASHI_EXIT_WHISPER` constant with an array `GURUBASHI_EXIT_KILL_WHISPERS`, add `WhisperRandomExitKillLineFromChromie` which selects a random line, and call it instead of `WhisperFromChromi` when killing a player for leaving the battle ring.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c9e3ef108327b53d869a24c25d6a)