### PR TITLE
scripts/gurubashi: only punish ring exits when hostiles are still alive

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -56,9 +56,10 @@ constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
 char const* const GURUBASHI_EXIT_KILL_WHISPERS[] =
 {
-    "You left the Battle Ring with enemies still inside.",
-    "No escape while foes yet stand in the Battle Ring.",
-    "Coward."
+    "The only way out of the arena is death.",
+    "One does not simply walk out of the Battle Ring.",
+    "Coward.",
+    "Enemy players impede the exit from the Battle Ring."
 };
 
 Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
@@ -131,7 +132,7 @@ void WhisperRandomExitKillLineFromChromie(Player* player)
     if (!player)
         return;
 
-    WhisperFromChromi(player, GURUBASHI_EXIT_KILL_WHISPERS[urand(0, 2)]);
+    WhisperFromChromi(player, GURUBASHI_EXIT_KILL_WHISPERS[urand(0, 3)]);
 }
 
 bool HasLivingHostileInGurubashiBattleRing(Player const* player)

--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -56,8 +56,8 @@ constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
 char const* const GURUBASHI_EXIT_KILL_WHISPERS[] =
 {
-    "The only way out of the arena is death.",
-    "One does not simply walk out of the Battle Ring.",
+    "You left the Battle Ring with enemies still inside.",
+    "No escape while foes yet stand in the Battle Ring.",
     "Coward."
 };
 

--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -134,6 +134,31 @@ void WhisperRandomExitKillLineFromChromie(Player* player)
     WhisperFromChromi(player, GURUBASHI_EXIT_KILL_WHISPERS[urand(0, 2)]);
 }
 
+bool HasLivingHostileInGurubashiBattleRing(Player const* player)
+{
+    if (!player)
+        return false;
+
+    std::shared_lock<std::shared_mutex> guard(*HashMapHolder<Player>::GetLock());
+    for (auto const& playerPair : ObjectAccessor::GetPlayers())
+    {
+        Player* other = playerPair.second;
+        if (!other || other == player || !other->IsAlive())
+            continue;
+
+        if (other->GetMapId() != player->GetMapId() || other->GetZoneId() != STRANGLETHORN_VALE_ZONE_ID)
+            continue;
+
+        if (GetGurubashiAreaState(other, other->GetZoneId(), other->GetAreaId()) != GurubashiAreaState::BattleRing)
+            continue;
+
+        if (player->IsValidAttackTarget(other))
+            return true;
+    }
+
+    return false;
+}
+
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)
 {
     uint32 playerCount = 0;
@@ -488,7 +513,8 @@ public:
                 bool const crossedBattleRingBoundary =
                     tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing;
 
-                if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive())
+                if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive() &&
+                    HasLivingHostileInGurubashiBattleRing(player))
                 {
                     Unit::Kill(player, player);
 


### PR DESCRIPTION
### Motivation
- Prevent players from being killed when leaving the Gurubashi battle ring after combat has effectively ended because no living hostiles remain in the ring.

### Description
- Added a new helper `HasLivingHostileInGurubashiBattleRing(Player const*)` that scans online players for living, attackable hostiles in the same map/zone and in the battle ring.
- Integrated that helper into the exit-enforcement check so the death penalty is only applied when the player crosses from BattleRing to NonRing and at least one living hostile remains in the ring.
- Preserved existing safeguards including teleport-transition detection, GM immunity, and alive-state checks.
- Changes are implemented in `src/server/scripts/Custom/custom_gurubashi_arena.cpp`.

### Testing
- Performed automated code inspection of the modified file using `git diff` and file excerpts to verify the new function and updated condition were added as intended and the commit succeeded.
- Ran repository search commands (`rg`) to ensure no other references needed modification and that the behavior change is scoped to the Gurubashi exit enforcement.
- No unit tests exist for this script, and no automated test failures were observed during these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b76a7484b48327935c5a304f5bb979)