### PR TITLE
Fix Gurubashi exit hostility detection

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -159,7 +159,10 @@ bool HasLivingHostileInGurubashiBattleRing(Player const* player)
         if (GetGurubashiAreaState(other, other->GetZoneId(), other->GetAreaId()) != GurubashiAreaState::BattleRing)
             continue;
 
-        if (player->IsValidAttackTarget(other))
+        // Evaluate hostility without relying on transient FFA flags.
+        // When a player steps out of the ring, FFA can drop before this check runs,
+        // but the exit rule should still treat non-group/raid players in the ring as hostile.
+        if (!player->IsInSameRaidWith(other))
             return true;
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the Gurubashi exit enforcer still treats unrelated enemy players inside the Battle Ring as hostile even when transient FFA attackability flags can drop during the boundary transition.

### Description
- Replace the `IsValidAttackTarget` check with a raid/group relationship check using `!player->IsInSameRaidWith(other)` in `HasLivingHostileInGurubashiBattleRing` and add a comment explaining why transient FFA flags are not trusted for this rule.

### Testing
- Performed automated code inspection and searches with `rg` and reviewed the modified lines with `nl`/`sed` and `git diff`, and confirmed the change was committed; no full server build or runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b776a2136c832796b2727afb961638)