### PR TITLE
Treat non-raid players in Gurubashi ring as hostile and randomize Chromie exit whispers

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -159,7 +159,10 @@ bool HasLivingHostileInGurubashiBattleRing(Player const* player)
         if (GetGurubashiAreaState(other, other->GetZoneId(), other->GetAreaId()) != GurubashiAreaState::BattleRing)
             continue;
 
-        if (player->IsValidAttackTarget(other))
+        // Evaluate hostility without relying on transient FFA flags.
+        // When a player steps out of the ring, FFA can drop before this check runs,
+        // but the exit rule should still treat non-group/raid players in the ring as hostile.
+        if (!player->IsInSameRaidWith(other))
             return true;
     }
 
@@ -685,7 +688,7 @@ public:
                 {
                     Unit::Kill(player, player);
 
-                    WhisperFromChromi(player, GURUBASHI_REENTRY_RULE_WHISPER);
+                    WhisperRandomExitKillLineFromChromie(player);
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Ensure the Gurubashi re-entry/exit kill rule treats players who are not in the same raid as hostile even if transient FFA flags have already dropped.
- Improve the player experience by randomizing Chromie whisper lines when the re-entry/exit kill is applied.

### Description
- Replace the `IsValidAttackTarget` check in `HasLivingHostileInGurubashiBattleRing` with `!player->IsInSameRaidWith(other)` and add a comment explaining the rationale to avoid reliance on transient FFA flags.
- Use `WhisperRandomExitKillLineFromChromie(player)` instead of the single `GURUBASHI_REENTRY_RULE_WHISPER` message when killing a player for leaving the battle ring to pick a random message from Chromie.
- No other changes to the tracked-player or area-state logic were made.

### Testing
- No new automated tests were added for this change.
- Existing automated test suite and build were executed and completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b776a2136c832796b2727afb961638)