### PR TITLE
Play Starfire visual on forced Gurubashi deaths

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -53,6 +53,7 @@ constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 TELEPORT_VISUAL_SPELL = 64446;
+constexpr uint32 FORCED_DEATH_STARFIRE_VISUAL_SPELL = 48465;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -139,6 +140,14 @@ void WhisperRandomExitKillLineFromChromie(Player* player)
         return;
 
     WhisperFromChromi(player, GURUBASHI_EXIT_KILL_WHISPERS[urand(0, 3)]);
+}
+
+void PlayForcedDeathStarfireVisual(Player* player)
+{
+    if (!player || !player->IsInWorld())
+        return;
+
+    player->CastSpell(player, FORCED_DEATH_STARFIRE_VISUAL_SPELL, true);
 }
 
 bool HasLivingHostileInGurubashiBattleRing(Player const* player)
@@ -672,6 +681,7 @@ public:
             bool const chestActive = event && event->IsChestActive();
             if (chestActive && IsChestDeathLockoutActive(guid) && currentState == GurubashiAreaState::BattleRing && player->IsAlive() && !player->IsGameMaster())
             {
+                PlayForcedDeathStarfireVisual(player);
                 Unit::Kill(player, player);
                 WhisperFromChromi(player, GURUBASHI_REENTRY_RULE_WHISPER);
             }
@@ -686,6 +696,7 @@ public:
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive() &&
                     HasLivingHostileInGurubashiBattleRing(player))
                 {
+                    PlayForcedDeathStarfireVisual(player);
                     Unit::Kill(player, player);
 
                     WhisperRandomExitKillLineFromChromie(player);


### PR DESCRIPTION
### Motivation
- Provide visual feedback when the script force-kills players for Gurubashi arena rules by playing the Starfire visual on the player immediately before `Unit::Kill(...)` is invoked.

### Description
- Added `FORCED_DEATH_STARFIRE_VISUAL_SPELL = 48465`, implemented `PlayForcedDeathStarfireVisual(Player*)` which casts that spell on the player, and invoked it in both forced-death paths in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` (chest re-entry lockout and crossing out of the battle ring while hostiles remain).

### Testing
- Verified changes with `rg`/source inspection, ran `git diff --check` which passed, and committed the updated file `src/server/scripts/Custom/custom_gurubashi_arena.cpp` (commit shown via `git show`), all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7798ab21c8327a8b8bf067445a694)