### PR TITLE
Play Starfire visual when forcing player deaths in Gurubashi Arena

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -53,6 +53,7 @@ constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 TELEPORT_VISUAL_SPELL = 64446;
+constexpr uint32 FORCED_DEATH_STARFIRE_SPELL_ID = 48465;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -139,6 +140,18 @@ void WhisperRandomExitKillLineFromChromie(Player* player)
         return;
 
     WhisperFromChromi(player, GURUBASHI_EXIT_KILL_WHISPERS[urand(0, 3)]);
+}
+
+void PlayForcedDeathStarfireVisual(Player* player)
+{
+    if (!player || !player->IsInWorld())
+        return;
+
+    SpellInfo const* starfireInfo = sSpellMgr->GetSpellInfo(FORCED_DEATH_STARFIRE_SPELL_ID);
+    if (!starfireInfo || !starfireInfo->SpellVisual[0])
+        return;
+
+    player->SendPlaySpellVisual(starfireInfo->SpellVisual[0]);
 }
 
 bool HasLivingHostileInGurubashiBattleRing(Player const* player)
@@ -672,6 +685,7 @@ public:
             bool const chestActive = event && event->IsChestActive();
             if (chestActive && IsChestDeathLockoutActive(guid) && currentState == GurubashiAreaState::BattleRing && player->IsAlive() && !player->IsGameMaster())
             {
+                PlayForcedDeathStarfireVisual(player);
                 Unit::Kill(player, player);
                 WhisperFromChromi(player, GURUBASHI_REENTRY_RULE_WHISPER);
             }
@@ -686,6 +700,7 @@ public:
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive() &&
                     HasLivingHostileInGurubashiBattleRing(player))
                 {
+                    PlayForcedDeathStarfireVisual(player);
                     Unit::Kill(player, player);
 
                     WhisperRandomExitKillLineFromChromie(player);


### PR DESCRIPTION
### Motivation
- Improve player feedback when players are force-killed for Gurubashi Arena rules by showing a spell visual before death.

### Description
- Add `FORCED_DEATH_STARFIRE_SPELL_ID` constant and implement `PlayForcedDeathStarfireVisual` to send the spell visual to a player.
- Invoke `PlayForcedDeathStarfireVisual` immediately before `Unit::Kill(player, player)` in both the chest death-lockout enforcement and the battle ring exit enforcement code paths.

### Testing
- Performed a full project build with `cmake --build` to ensure the changes compile successfully. 
- Ran automated test suite with `ctest` which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7798ab21c8327a8b8bf067445a694)