### PR TITLE
Play Starfire visual when forcibly killing players in Gurubashi arena

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -30,6 +30,7 @@
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "SpellMgr.h"
+#include "SpellInfo.h"
 #include "TaskScheduler.h"
 #include "TemporarySummon.h"
 #include "Util.h"
@@ -53,6 +54,7 @@ constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 TELEPORT_VISUAL_SPELL = 64446;
+constexpr uint32 FORCED_DEATH_STARFIRE_SPELL_ID = 48465;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
@@ -139,6 +141,18 @@ void WhisperRandomExitKillLineFromChromie(Player* player)
         return;
 
     WhisperFromChromi(player, GURUBASHI_EXIT_KILL_WHISPERS[urand(0, 3)]);
+}
+
+void PlayForcedDeathStarfireVisual(Player* player)
+{
+    if (!player || !player->IsInWorld())
+        return;
+
+    SpellInfo const* starfireInfo = sSpellMgr->GetSpellInfo(FORCED_DEATH_STARFIRE_SPELL_ID);
+    if (!starfireInfo || !starfireInfo->SpellVisual[0])
+        return;
+
+    player->SendPlaySpellVisual(starfireInfo->SpellVisual[0]);
 }
 
 bool HasLivingHostileInGurubashiBattleRing(Player const* player)
@@ -672,6 +686,7 @@ public:
             bool const chestActive = event && event->IsChestActive();
             if (chestActive && IsChestDeathLockoutActive(guid) && currentState == GurubashiAreaState::BattleRing && player->IsAlive() && !player->IsGameMaster())
             {
+                PlayForcedDeathStarfireVisual(player);
                 Unit::Kill(player, player);
                 WhisperFromChromi(player, GURUBASHI_REENTRY_RULE_WHISPER);
             }
@@ -686,6 +701,7 @@ public:
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive() &&
                     HasLivingHostileInGurubashiBattleRing(player))
                 {
+                    PlayForcedDeathStarfireVisual(player);
                     Unit::Kill(player, player);
 
                     WhisperRandomExitKillLineFromChromie(player);


### PR DESCRIPTION
### Motivation

- Make enforced kills in the Gurubashi Battle Ring visually clear by playing a Starfire spell visual before the player is killed.

### Description

- Add `#include "SpellInfo.h"` and a new constant `FORCED_DEATH_STARFIRE_SPELL_ID` for the visual spell ID.  
- Implement `PlayForcedDeathStarfireVisual(Player*)` which looks up the spell via `sSpellMgr->GetSpellInfo` and sends the visual with `SendPlaySpellVisual` when available.  
- Invoke `PlayForcedDeathStarfireVisual` immediately before `Unit::Kill(player, player)` in both the chest re-entry lockout enforcement and the exit-kill enforcement code paths.

### Testing

- Project was built with `cmake && make` and the build completed without errors.  
- Ran automated integration smoke checks that exercise the Gurubashi re-entry and exit-kill enforcement paths and observed the visual packet being sent and the enforced kills occurring as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7798ab21c8327a8b8bf067445a694)