### PR TITLE
Stop Auto Shot/autorepeat when clearing target

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -483,6 +483,9 @@ void WorldSession::HandleSetSelectionOpcode(WorldPacket& recvData)
     }
 
     _player->SetSelection(guid);
+
+    if (guid.IsEmpty())
+        _player->InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
 }
 
 void WorldSession::HandleStandStateChangeOpcode(WorldPacket& recvData)


### PR DESCRIPTION
### Motivation
- Prevent Auto Shot/autorepeat from continuing after the player clears their target so ranged autorepeat cannot fire at an untargeted target (fixes behavior during spells like `Aimed Shot`).

### Description
- Add a check in `WorldSession::HandleSetSelectionOpcode` (file `src/server/game/Handlers/MiscHandler.cpp`) that calls `InterruptSpell(CURRENT_AUTOREPEAT_SPELL)` when the received `guid` is empty. 

### Testing
- Ran `git diff --check` and inspected the last change with `git show --stat --oneline -1`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2b74c1588327a6ef43dc1f1c0de4)