### PR TITLE
Handle GameObject respawn time and visibility in Battlegrounds

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1406,7 +1406,7 @@ void Battleground::RelocateDeadPlayers(ObjectGuid guideGuid)
     }
 }
 
-bool Battleground::AddObject(uint32 type, uint32 entry, float x, float y, float z, float o, float rotation0, float rotation1, float rotation2, float rotation3, uint32 /*respawnTime*/, GOState goState)
+bool Battleground::AddObject(uint32 type, uint32 entry, float x, float y, float z, float o, float rotation0, float rotation1, float rotation2, float rotation3, uint32 respawnTime, GOState goState)
 {
     // If the assert is called, means that BgObjects must be resized!
     ASSERT(type < BgObjects.size());
@@ -1435,6 +1435,12 @@ bool Battleground::AddObject(uint32 type, uint32 entry, float x, float y, float 
                 entry, m_MapId, m_InstanceID);
         delete go;
         return false;
+    }
+
+    if (respawnTime)
+    {
+        go->SetLootState(GO_JUST_DEACTIVATED);
+        go->SetRespawnTime(respawnTime);
     }
 /*
     uint32 guid = go->GetGUID().GetCounter();
@@ -1558,7 +1564,7 @@ void Battleground::SpawnBGObject(uint32 type, uint32 respawntime)
             obj->SetRespawnTime(respawntime);
             if (!obj->IsInWorld())
                 map->AddToMap(obj);
-            else if (!respawntime)
+            else
                 obj->UpdateObjectVisibility(true);
         }
 }


### PR DESCRIPTION
### Motivation
- Ensure battleground `GameObject`s created with a non-zero respawn time are initialized in a deactivated state and have their respawn time recorded.
- Fix visibility updates for spawned battleground objects so objects already in-world always refresh visibility after spawn handling.

### Description
- Named the `respawnTime` parameter in `Battleground::AddObject` and set `GO_JUST_DEACTIVATED` and `SetRespawnTime(respawnTime)` when `respawnTime` is non-zero.
- Modified `SpawnBGObject` to always call `UpdateObjectVisibility(true)` for objects already in-world, removing the prior `!respawntime` conditional branch.
- Kept the legacy `GameObjectData` persistence block commented out and retained the zero-rotation safety handling in `AddObject`.

### Testing
- Performed a full server build which completed successfully.
- Executed available automated tests covering battleground object spawning and core `GameObject` behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf3095fe908327af9369c7700db730)