### PR TITLE
Fix WSG cross-faction team handling for flags, caps, and graveyards

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -221,7 +221,7 @@ void BattlegroundWS::AddPlayer(Player* player)
     if (!isInBattleground)
     {
         BattlegroundWGScore* scoreEntry = new BattlegroundWGScore(player->GetGUID());
-        if (player->GetTeam() == HORDE)
+        if (player->GetBGTeam() == HORDE)
         {
             scoreEntry->BonusHonor = 1;
         }
@@ -284,9 +284,10 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
         return;
 
     uint32 winner = 0;
+    uint32 const team = GetPlayerTeam(player->GetGUID());
 
     player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
-    if (player->GetTeam() == ALLIANCE)
+    if (team == ALLIANCE)
     {
         if (!IsHordeFlagPickedup())
             return;
@@ -326,23 +327,23 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
     }
     uint32 flag_honor = sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP);
 
-    RewardHonorToTeam(flag_honor, player->GetTeam());
+    RewardHonorToTeam(flag_honor, team);
 
     SpawnBGObject(BG_WS_OBJECT_H_FLAG, BG_WS_FLAG_RESPAWN_TIME);
     SpawnBGObject(BG_WS_OBJECT_A_FLAG, BG_WS_FLAG_RESPAWN_TIME);
 
-    if (player->GetTeam() == ALLIANCE)
+    if (team == ALLIANCE)
         SendBroadcastText(BG_WS_TEXT_CAPTURED_HORDE_FLAG, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
     else
         SendBroadcastText(BG_WS_TEXT_CAPTURED_ALLIANCE_FLAG, CHAT_MSG_BG_SYSTEM_HORDE, player);
 
-    UpdateFlagState(player->GetTeam(), 1);                  // flag state none
-    UpdateTeamScore(player->GetTeamId());
+    UpdateFlagState(team, 1);                  // flag state none
+    UpdateTeamScore(GetTeamIndexByTeamId(team));
     // only flag capture should be updated
     UpdatePlayerScore(player, SCORE_FLAG_CAPTURES, 1);      // +1 flag captures
 
     // update last flag capture to be used if teamscore is equal
-    SetLastFlagCapture(player->GetTeam());
+    SetLastFlagCapture(team);
 
     if (GetTeamScore(TEAM_ALLIANCE) == BG_WS_MAX_TEAM_SCORE)
         winner = ALLIANCE;
@@ -363,7 +364,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
     }
     else
     {
-        _flagsTimer[GetTeamIndexByTeamId(player->GetTeam()) ? 0 : 1] = BG_WS_FLAG_RESPAWN_TIME;
+        _flagsTimer[GetTeamIndexByTeamId(team) ? 0 : 1] = BG_WS_FLAG_RESPAWN_TIME;
     }
 }
 void BattlegroundWS::HandleFlagRoomCapturePoint(int32 team)
@@ -376,11 +377,13 @@ void BattlegroundWS::HandleFlagRoomCapturePoint(int32 team)
 
 void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
 {
+    uint32 const team = GetPlayerTeam(player->GetGUID());
+
     if (GetStatus() != STATUS_IN_PROGRESS)
     {
         // if not running, do not cast things at the dropper player (prevent spawning the "dropped" flag), neither send unnecessary messages
         // just take off the aura
-        if (player->GetTeam() == ALLIANCE)
+        if (team == ALLIANCE)
         {
             if (!IsHordeFlagPickedup())
                 return;
@@ -407,7 +410,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
 
     bool set = false;
 
-    if (player->GetTeam() == ALLIANCE)
+    if (team == ALLIANCE)
     {
         if (!IsHordeFlagPickedup())
             return;
@@ -445,9 +448,9 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
     if (set)
     {
         //player->CastSpell(player, SPELL_RECENTLY_DROPPED_FLAG, true);
-        UpdateFlagState(player->GetTeam(), 1);
+        UpdateFlagState(team, 1);
 
-        if (player->GetTeam() == ALLIANCE)
+        if (team == ALLIANCE)
         {
             SendBroadcastText(BG_WS_TEXT_HORDE_FLAG_DROPPED, CHAT_MSG_BG_SYSTEM_HORDE, player);
             UpdateWorldState(BG_WS_FLAG_UNK_HORDE, uint32(-1));
@@ -458,7 +461,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             UpdateWorldState(BG_WS_FLAG_UNK_ALLIANCE, uint32(-1));
         }
 
-        _flagsDropTimer[GetTeamIndexByTeamId(player->GetTeam()) ? 0 : 1] = BG_WS_FLAG_DROP_TIME;
+        _flagsDropTimer[GetTeamIndexByTeamId(team) ? 0 : 1] = BG_WS_FLAG_DROP_TIME;
     }
 }
 
@@ -467,8 +470,10 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
     if (GetStatus() != STATUS_IN_PROGRESS)
         return;
 
+    uint32 const team = GetPlayerTeam(player->GetGUID());
+
     //alliance flag picked up from base
-    if (player->GetTeam() == HORDE && GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_BASE
+    if (team == HORDE && GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_BASE
         && BgObjects[BG_WS_OBJECT_A_FLAG] == target_obj->GetGUID())
     {
         SendBroadcastText(BG_WS_TEXT_ALLIANCE_FLAG_PICKED_UP, CHAT_MSG_BG_SYSTEM_HORDE, player);
@@ -491,7 +496,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
     }
 
     //horde flag picked up from base
-    if (player->GetTeam() == ALLIANCE && GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_BASE
+    if (team == ALLIANCE && GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_BASE
         && BgObjects[BG_WS_OBJECT_H_FLAG] == target_obj->GetGUID())
     {
         SendBroadcastText(BG_WS_TEXT_HORDE_FLAG_PICKED_UP, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
@@ -517,7 +522,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
     if (GetFlagState(ALLIANCE) == BG_WS_FLAG_STATE_ON_GROUND && player->IsWithinDistInMap(target_obj, 10)
         && target_obj->GetGOInfo()->entry == BG_OBJECT_A_FLAG_GROUND_WS_ENTRY)
     {
-        if (player->GetTeam() == ALLIANCE)
+        if (team == ALLIANCE)
         {
             SendBroadcastText(BG_WS_TEXT_ALLIANCE_FLAG_RETURNED, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
             UpdateFlagState(HORDE, BG_WS_FLAG_STATE_WAIT_RESPAWN);
@@ -551,7 +556,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
     if (GetFlagState(HORDE) == BG_WS_FLAG_STATE_ON_GROUND && player->IsWithinDistInMap(target_obj, 10)
         && target_obj->GetGOInfo()->entry == BG_OBJECT_H_FLAG_GROUND_WS_ENTRY)
     {
-        if (player->GetTeam() == HORDE)
+        if (team == HORDE)
         {
             SendBroadcastText(BG_WS_TEXT_HORDE_FLAG_RETURNED, CHAT_MSG_BG_SYSTEM_HORDE, player);
             UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_WAIT_RESPAWN);
@@ -632,6 +637,8 @@ void BattlegroundWS::HandleAreaTrigger(Player* player, uint32 trigger)
     if (GetStatus() != STATUS_IN_PROGRESS)
         return;
 
+    uint32 const team = GetPlayerTeam(player->GetGUID());
+
     //uint32 SpellId = 0;
     //uint64 buff_guid = 0;
     switch (trigger)
@@ -655,12 +662,12 @@ void BattlegroundWS::HandleAreaTrigger(Player* player, uint32 trigger)
             //buff_guid = BgObjects[BG_WS_OBJECT_BERSERKBUFF_2];
             break;
         case 3646:                                          // Alliance Flag spawn
-            if (_flagState[TEAM_HORDE] && !_flagState[TEAM_ALLIANCE])
+            if (team == ALLIANCE && _flagState[TEAM_HORDE] && !_flagState[TEAM_ALLIANCE])
                 if (GetFlagPickerGUID(TEAM_HORDE) == player->GetGUID())
                     EventPlayerCapturedFlag(player);
             break;
         case 3647:                                          // Horde Flag spawn
-            if (_flagState[TEAM_ALLIANCE] && !_flagState[TEAM_HORDE])
+            if (team == HORDE && _flagState[TEAM_ALLIANCE] && !_flagState[TEAM_HORDE])
                 if (GetFlagPickerGUID(TEAM_ALLIANCE) == player->GetGUID())
                     EventPlayerCapturedFlag(player);
             break;
@@ -810,12 +817,14 @@ bool BattlegroundWS::UpdatePlayerScore(Player* player, uint32 type, uint32 value
 
 WorldSafeLocsEntry const* BattlegroundWS::GetClosestGraveyard(Player* player)
 {
+    uint32 const team = GetPlayerTeam(player->GetGUID());
+
     //if status in progress, it returns main graveyards with spiritguides
     //else it will return the graveyard in the flagroom - this is especially good
     //if a player dies in preparation phase - then the player can't cheat
     //and teleport to the graveyard outside the flagroom
     //and start running around, while the doors are still closed
-    if (player->GetTeam() == ALLIANCE)
+    if (team == ALLIANCE)
     {
         if (GetStatus() == STATUS_IN_PROGRESS)
             return sWorldSafeLocsStore.LookupEntry(WS_GRAVEYARD_MAIN_ALLIANCE);


### PR DESCRIPTION
### Motivation
- Warsong Gulch flag logic used the player's native faction, which breaks flag colors/score/graveyard selection for cross-faction battleground teams; the change makes flag flows respect the battleground-assigned team. 
- The goal is to ensure pickups, drops, captures, area-trigger captures and graveyard selection use the BG team identity so UI/worldstate and scoring match the cross-BG implementation.

### Description
- Replaced faction checks in WSG flows to use the battleground team via `GetPlayerTeam(player->GetGUID())` in `EventPlayerClickedOnFlag`, `EventPlayerDroppedFlag`, `EventPlayerCapturedFlag`, `HandleAreaTrigger`, and `GetClosestGraveyard` in `src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp`. 
- Adjusted honor/score/worldstate updates and timers to use the resolved BG team (e.g. `RewardHonorToTeam`, `UpdateFlagState`, `UpdateTeamScore`, `_flagsTimer/_flagsDropTimer` index updates) so rewards and worldstates align with the BG team. 
- Aligned `AddPlayer` WSG bonus-honor initialization to use the battleground-assigned team (`GetBGTeam`) to avoid using the player's native faction for scoring setup.

### Testing
- Ran `git diff --check` which returned no problems and therefore passed. 
- Verified working tree via `git status --short` to ensure only the intended file changed. 
- Committed the change successfully (`git commit`) and created the PR metadata; no full build or unit test was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf4b1590448327b40595e96651fc09)