### PR TITLE
Fix WSG crossfaction team resolution for dropped flags

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -897,7 +897,16 @@ bool BattlegroundWS::CheckAchievementCriteriaMeet(uint32 criteriaId, Player cons
         case BG_CRITERIA_CHECK_SAVE_THE_DAY:
             if (target)
                 if (Player const* playerTarget = target->ToPlayer())
-                    return GetFlagState(playerTarget->GetTeam()) == BG_WS_FLAG_STATE_ON_BASE;
+                {
+                    // Use battleground team, not native faction, so crossfaction assignments stay consistent.
+                    uint32 team = GetPlayerTeam(playerTarget->GetGUID());
+                    if (!team)
+                        team = playerTarget->GetBGTeam();
+                    if (!team)
+                        team = playerTarget->GetTeam();
+
+                    return GetFlagState(team) == BG_WS_FLAG_STATE_ON_BASE;
+                }
             return false;
     }
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3860,7 +3860,16 @@ void Spell::EffectSummonObjectWild()
     if (pGameObj->GetGoType() == GAMEOBJECT_TYPE_FLAGDROP)
         if (Player* player = m_caster->ToPlayer())
             if (Battleground* bg = player->GetBattleground())
-                bg->SetDroppedFlagGUID(pGameObj->GetGUID(), player->GetTeam() == ALLIANCE ? TEAM_HORDE: TEAM_ALLIANCE);
+            {
+                // Crossfaction BGs can spoof native faction; resolve team by battleground assignment first.
+                uint32 team = bg->GetPlayerTeam(player->GetGUID());
+                if (!team)
+                    team = player->GetBGTeam();
+                if (!team)
+                    team = player->GetTeam();
+
+                bg->SetDroppedFlagGUID(pGameObj->GetGUID(), team == ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE);
+            }
 
     if (GameObject* linkedTrap = pGameObj->GetLinkedTrap())
     {


### PR DESCRIPTION
### Motivation
- Warsong Gulch flag state and map markers could become desynced in crossfaction battlegrounds because some code used a player’s native faction via `GetTeam()` instead of the battleground-assigned team.
- The change ensures battleground-side team resolution is authoritative where flag ownership/state is being recorded or queried so crossfaction/spoofed-faction setups behave correctly while preserving normal behavior for non-crossfaction BGs.

### Description
- Updated `Spell::EffectSummonObjectWild` in `src/server/game/Spells/SpellEffects.cpp` so `GAMEOBJECT_TYPE_FLAGDROP` resolves the team with battleground semantics using `bg->GetPlayerTeam(player->GetGUID())` then `player->GetBGTeam()` then `player->GetTeam()` before calling `SetDroppedFlagGUID` and added a short explanatory comment.
- Updated the WSG achievement check `BG_CRITERIA_CHECK_SAVE_THE_DAY` in `src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp` to resolve the player team using `GetPlayerTeam` / `GetBGTeam` / `GetTeam` in the same order before calling `GetFlagState`, with a short comment explaining the rationale.
- Changes are minimal and localized to flag-related logic in WSG and use fallbacks so non-crossfaction battlegrounds keep existing behavior.
- Notable remaining suspicious `GetTeam()` usages were identified (examples: some references in `BattlegroundEY.cpp` and `BattlegroundIC.cpp`) but were not changed to avoid broad/sweeping replacements.

### Testing
- Ran repository searches to verify occurrences with `rg -n` and inspected the modified contexts, which showed the two targeted locations were updated successfully.
- Ran `git diff --check` with no issues reported and `git status --short` to confirm staged changes.
- Committed the changes with `git commit`, which completed successfully.
- No automated unit/integration BG tests were executed in this patch; the updates are intentionally minimal to reduce risk and rely on the fallback order to preserve legacy behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf915b6af483278a2de11af7b8b966)