### PR TITLE
Set flag-carrier bit in group status and force group updates on WSG flag transitions

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -294,6 +294,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
         SetHordeFlagPicker(ObjectGuid::Empty);              // must be before aura remove to prevent 2 events (drop+capture) at the same time
                                                             // horde flag in base (but not respawned yet)
         _flagState[TEAM_HORDE] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
+        player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
                                                             // Drop Horde Flag from Player
         player->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
         if (_flagDebuffState == 1)
@@ -313,6 +314,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
         SetAllianceFlagPicker(ObjectGuid::Empty);           // must be before aura remove to prevent 2 events (drop+capture) at the same time
                                                             // alliance flag in base (but not respawned yet)
         _flagState[TEAM_ALLIANCE] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
+        player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
                                                             // Drop Alliance Flag from Player
         player->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
         if (_flagDebuffState == 1)
@@ -391,6 +393,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             if (GetFlagPickerGUID(TEAM_HORDE) == player->GetGUID())
             {
                 SetHordeFlagPicker(ObjectGuid::Empty);
+                player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
                 player->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
             }
         }
@@ -402,6 +405,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             if (GetFlagPickerGUID(TEAM_ALLIANCE) == player->GetGUID())
             {
                 SetAllianceFlagPicker(ObjectGuid::Empty);
+                player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
                 player->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
             }
         }
@@ -417,6 +421,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
         if (GetFlagPickerGUID(TEAM_HORDE) == player->GetGUID())
         {
             SetHordeFlagPicker(ObjectGuid::Empty);
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             player->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
             if (_flagDebuffState == 1)
               player->RemoveAurasDueToSpell(WS_SPELL_FOCUSED_ASSAULT);
@@ -434,6 +439,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
         if (GetFlagPickerGUID(TEAM_ALLIANCE) == player->GetGUID())
         {
             SetAllianceFlagPicker(ObjectGuid::Empty);
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             player->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
             if (_flagDebuffState == 1)
               player->RemoveAurasDueToSpell(WS_SPELL_FOCUSED_ASSAULT);
@@ -480,6 +486,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
         PlaySoundToAll(BG_WS_SOUND_ALLIANCE_FLAG_PICKED_UP);
         SpawnBGObject(BG_WS_OBJECT_A_FLAG, RESPAWN_ONE_DAY);
         SetAllianceFlagPicker(player->GetGUID());
+        player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
         _flagState[TEAM_ALLIANCE] = BG_WS_FLAG_STATE_ON_PLAYER;
         //update world state to show correct flag carrier
         UpdateFlagState(HORDE, BG_WS_FLAG_STATE_ON_PLAYER);
@@ -503,6 +510,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
         PlaySoundToAll(BG_WS_SOUND_HORDE_FLAG_PICKED_UP);
         SpawnBGObject(BG_WS_OBJECT_H_FLAG, RESPAWN_ONE_DAY);
         SetHordeFlagPicker(player->GetGUID());
+        player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
         _flagState[TEAM_HORDE] = BG_WS_FLAG_STATE_ON_PLAYER;
         //update world state to show correct flag carrier
         UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_ON_PLAYER);
@@ -530,6 +538,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             SpawnBGObject(BG_WS_OBJECT_A_FLAG, RESPAWN_IMMEDIATELY);
             PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
             UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             _bothFlagsKept = false;
             HandleFlagRoomCapturePoint(TEAM_HORDE); // Check Horde flag if it is in capture zone; if so, capture it
         }
@@ -539,6 +548,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             PlaySoundToAll(BG_WS_SOUND_ALLIANCE_FLAG_PICKED_UP);
             SpawnBGObject(BG_WS_OBJECT_A_FLAG, RESPAWN_ONE_DAY);
             SetAllianceFlagPicker(player->GetGUID());
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             player->CastSpell(player, BG_WS_SPELL_SILVERWING_FLAG, true);
             _flagState[TEAM_ALLIANCE] = BG_WS_FLAG_STATE_ON_PLAYER;
             UpdateFlagState(HORDE, BG_WS_FLAG_STATE_ON_PLAYER);
@@ -564,6 +574,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             SpawnBGObject(BG_WS_OBJECT_H_FLAG, RESPAWN_IMMEDIATELY);
             PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
             UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             _bothFlagsKept = false;
             HandleFlagRoomCapturePoint(TEAM_ALLIANCE); // Check Alliance flag if it is in capture zone; if so, capture it
         }
@@ -573,6 +584,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             PlaySoundToAll(BG_WS_SOUND_HORDE_FLAG_PICKED_UP);
             SpawnBGObject(BG_WS_OBJECT_H_FLAG, RESPAWN_ONE_DAY);
             SetHordeFlagPicker(player->GetGUID());
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             player->CastSpell(player, BG_WS_SPELL_WARSONG_FLAG, true);
             _flagState[TEAM_HORDE] = BG_WS_FLAG_STATE_ON_PLAYER;
             UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_ON_PLAYER);

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "WorldSession.h"
+#include "Battleground.h"
 #include "CharacterCache.h"
 #include "Common.h"
 #include "DatabaseEnv.h"
@@ -804,6 +805,13 @@ void WorldSession::BuildPartyMemberStatsChangedPacket(Player* player, WorldPacke
         if (player->IsFFAPvP())
             playerStatus |= MEMBER_STATUS_PVP_FFA;
 
+        if (Battleground* bg = player->GetBattleground())
+        {
+            ObjectGuid guid = player->GetGUID();
+            if (bg->GetFlagPickerGUID(TEAM_ALLIANCE) == guid || bg->GetFlagPickerGUID(TEAM_HORDE) == guid)
+                playerStatus |= MEMBER_STATUS_UNK3;
+        }
+
         if (player->isAFK())
             playerStatus |= MEMBER_STATUS_AFK;
 
@@ -1005,6 +1013,13 @@ void WorldSession::HandleRequestPartyMemberStatsOpcode(WorldPacket &recvData)
 
     if (player->IsFFAPvP())
         playerStatus |= MEMBER_STATUS_PVP_FFA;
+
+    if (Battleground* bg = player->GetBattleground())
+    {
+        ObjectGuid guid = player->GetGUID();
+        if (bg->GetFlagPickerGUID(TEAM_ALLIANCE) == guid || bg->GetFlagPickerGUID(TEAM_HORDE) == guid)
+            playerStatus |= MEMBER_STATUS_UNK3;
+    }
 
     if (player->isAFK())
         playerStatus |= MEMBER_STATUS_AFK;


### PR DESCRIPTION
### Motivation
- The Warsong Gulch cross-faction flag map icon can be out-of-sync because the group status packet path did not mark flag carriers, so the client lacked the signal used by `Lua_GetPlayerMapPosition`/`Lua_GetBattlefieldFlagPosition` to render the flag icon.
- The change aims to use the existing `MEMBER_STATUS_UNK3` bit as the server-side indicator for a flag carrier and to force immediate group status refreshes on flag state transitions so clients update map icons promptly.

### Description
- Added `#include "Battleground.h"` and set `MEMBER_STATUS_UNK3` when building member status in both incremental (`BuildPartyMemberStatsChangedPacket`) and full (`SMSG_PARTY_MEMBER_STATS_FULL` / `HandleRequestPartyMemberStatsOpcode`) group-member status packet paths using `player->GetBattleground()` + `GetFlagPickerGUID(TEAM_ALLIANCE/HORDE)`.
- On all Warsong Gulch flag transitions (pickup, drop, capture, return), called `player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS)` for affected player(s) so the server will resend the status packet immediately; ensured this is applied where appropriate for both new and old carriers.
- Kept the patch minimal and local: no changes to `SpellEffects.cpp` and no broad refactors were performed.
- Files changed: `src/server/game/Handlers/GroupHandler.cpp` and `src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp`.

### Testing
- Ran repository checks `git status --short`, `git diff --name-only`, and `git show --unified=3` for the modified files and confirmed the intended diffs were produced, all commands succeeded. 
- Created a commit for the change (`Fix WSG flag carrier group status updates`) and the commit operation succeeded. 
- No automated unit tests were present or executed for these codepaths in this rollout; runtime verification of client behavior should be performed in an integration test (in-game) to confirm the map-icon fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf95802bd08327a9ad04cc20682881)