### PR TITLE
Update group status when a player picks up/drops Warsong Gulch flags

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -19,6 +19,7 @@
 #include "BattlegroundMgr.h"
 #include "DBCStores.h"
 #include "GameObject.h"
+#include "Group.h"
 #include "Log.h"
 #include "Map.h"
 #include "Object.h"
@@ -294,6 +295,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
         SetHordeFlagPicker(ObjectGuid::Empty);              // must be before aura remove to prevent 2 events (drop+capture) at the same time
                                                             // horde flag in base (but not respawned yet)
         _flagState[TEAM_HORDE] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
+        player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
                                                             // Drop Horde Flag from Player
         player->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
         if (_flagDebuffState == 1)
@@ -313,6 +315,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
         SetAllianceFlagPicker(ObjectGuid::Empty);           // must be before aura remove to prevent 2 events (drop+capture) at the same time
                                                             // alliance flag in base (but not respawned yet)
         _flagState[TEAM_ALLIANCE] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
+        player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
                                                             // Drop Alliance Flag from Player
         player->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
         if (_flagDebuffState == 1)
@@ -391,6 +394,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             if (GetFlagPickerGUID(TEAM_HORDE) == player->GetGUID())
             {
                 SetHordeFlagPicker(ObjectGuid::Empty);
+                player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
                 player->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
             }
         }
@@ -402,6 +406,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             if (GetFlagPickerGUID(TEAM_ALLIANCE) == player->GetGUID())
             {
                 SetAllianceFlagPicker(ObjectGuid::Empty);
+                player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
                 player->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
             }
         }
@@ -417,6 +422,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
         if (GetFlagPickerGUID(TEAM_HORDE) == player->GetGUID())
         {
             SetHordeFlagPicker(ObjectGuid::Empty);
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             player->RemoveAurasDueToSpell(BG_WS_SPELL_WARSONG_FLAG);
             if (_flagDebuffState == 1)
               player->RemoveAurasDueToSpell(WS_SPELL_FOCUSED_ASSAULT);
@@ -434,6 +440,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
         if (GetFlagPickerGUID(TEAM_ALLIANCE) == player->GetGUID())
         {
             SetAllianceFlagPicker(ObjectGuid::Empty);
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             player->RemoveAurasDueToSpell(BG_WS_SPELL_SILVERWING_FLAG);
             if (_flagDebuffState == 1)
               player->RemoveAurasDueToSpell(WS_SPELL_FOCUSED_ASSAULT);
@@ -480,6 +487,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
         PlaySoundToAll(BG_WS_SOUND_ALLIANCE_FLAG_PICKED_UP);
         SpawnBGObject(BG_WS_OBJECT_A_FLAG, RESPAWN_ONE_DAY);
         SetAllianceFlagPicker(player->GetGUID());
+        player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
         _flagState[TEAM_ALLIANCE] = BG_WS_FLAG_STATE_ON_PLAYER;
         //update world state to show correct flag carrier
         UpdateFlagState(HORDE, BG_WS_FLAG_STATE_ON_PLAYER);
@@ -503,6 +511,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
         PlaySoundToAll(BG_WS_SOUND_HORDE_FLAG_PICKED_UP);
         SpawnBGObject(BG_WS_OBJECT_H_FLAG, RESPAWN_ONE_DAY);
         SetHordeFlagPicker(player->GetGUID());
+        player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
         _flagState[TEAM_HORDE] = BG_WS_FLAG_STATE_ON_PLAYER;
         //update world state to show correct flag carrier
         UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_ON_PLAYER);
@@ -530,6 +539,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             SpawnBGObject(BG_WS_OBJECT_A_FLAG, RESPAWN_IMMEDIATELY);
             PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
             UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             _bothFlagsKept = false;
             HandleFlagRoomCapturePoint(TEAM_HORDE); // Check Horde flag if it is in capture zone; if so, capture it
         }
@@ -539,6 +549,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             PlaySoundToAll(BG_WS_SOUND_ALLIANCE_FLAG_PICKED_UP);
             SpawnBGObject(BG_WS_OBJECT_A_FLAG, RESPAWN_ONE_DAY);
             SetAllianceFlagPicker(player->GetGUID());
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             player->CastSpell(player, BG_WS_SPELL_SILVERWING_FLAG, true);
             _flagState[TEAM_ALLIANCE] = BG_WS_FLAG_STATE_ON_PLAYER;
             UpdateFlagState(HORDE, BG_WS_FLAG_STATE_ON_PLAYER);
@@ -564,6 +575,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             SpawnBGObject(BG_WS_OBJECT_H_FLAG, RESPAWN_IMMEDIATELY);
             PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
             UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             _bothFlagsKept = false;
             HandleFlagRoomCapturePoint(TEAM_ALLIANCE); // Check Alliance flag if it is in capture zone; if so, capture it
         }
@@ -573,6 +585,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             PlaySoundToAll(BG_WS_SOUND_HORDE_FLAG_PICKED_UP);
             SpawnBGObject(BG_WS_OBJECT_H_FLAG, RESPAWN_ONE_DAY);
             SetHordeFlagPicker(player->GetGUID());
+            player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS);
             player->CastSpell(player, BG_WS_SPELL_WARSONG_FLAG, true);
             _flagState[TEAM_HORDE] = BG_WS_FLAG_STATE_ON_PLAYER;
             UpdateFlagState(ALLIANCE, BG_WS_FLAG_STATE_ON_PLAYER);

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "WorldSession.h"
+#include "Battleground.h"
 #include "CharacterCache.h"
 #include "Common.h"
 #include "DatabaseEnv.h"
@@ -804,6 +805,13 @@ void WorldSession::BuildPartyMemberStatsChangedPacket(Player* player, WorldPacke
         if (player->IsFFAPvP())
             playerStatus |= MEMBER_STATUS_PVP_FFA;
 
+        if (Battleground* bg = player->GetBattleground())
+        {
+            ObjectGuid guid = player->GetGUID();
+            if (bg->GetFlagPickerGUID(TEAM_ALLIANCE) == guid || bg->GetFlagPickerGUID(TEAM_HORDE) == guid)
+                playerStatus |= MEMBER_STATUS_UNK3;
+        }
+
         if (player->isAFK())
             playerStatus |= MEMBER_STATUS_AFK;
 
@@ -1005,6 +1013,13 @@ void WorldSession::HandleRequestPartyMemberStatsOpcode(WorldPacket &recvData)
 
     if (player->IsFFAPvP())
         playerStatus |= MEMBER_STATUS_PVP_FFA;
+
+    if (Battleground* bg = player->GetBattleground())
+    {
+        ObjectGuid guid = player->GetGUID();
+        if (bg->GetFlagPickerGUID(TEAM_ALLIANCE) == guid || bg->GetFlagPickerGUID(TEAM_HORDE) == guid)
+            playerStatus |= MEMBER_STATUS_UNK3;
+    }
 
     if (player->isAFK())
         playerStatus |= MEMBER_STATUS_AFK;


### PR DESCRIPTION
### Motivation
- Ensure group/party UI and packets reflect when a member is carrying a Warsong Gulch flag so party frames show the flag-carrier status bit.

### Description
- Call `player->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_STATUS)` at flag pickup, drop, return and capture points in `BattlegroundWS.cpp` so the group's status mask is updated when flag-related events occur.
- Add `#include "Group.h"` to `BattlegroundWS.cpp` and `#include "Battleground.h"` to `GroupHandler.cpp` to access group update and battleground APIs.
- In `WorldSession::BuildPartyMemberStatsChangedPacket` and `HandleRequestPartyMemberStatsOpcode` set the `MEMBER_STATUS_UNK3` bit when the player is the battleground flag picker by checking `bg->GetFlagPickerGUID(TEAM_ALLIANCE)` and `bg->GetFlagPickerGUID(TEAM_HORDE)`.
- No changes to core flag mechanics or scoring were made; this only updates the group-status/packet behaviour.

### Testing
- Project built successfully using the standard `cmake`/`make` workflow and the changes compiled without errors.
- Automated test suite (`make test`) was executed and completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf95802bd08327a9ad04cc20682881)