### PR TITLE
WSG: emit FULL addon snapshots from flag identity with normalized coords

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -28,6 +28,9 @@
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
 #include "World.h"
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
 #include <string>
 
 // these variables aren't used outside of this file, so declare them only here
@@ -96,6 +99,99 @@ char const* BattlegroundWS::GetWSGFlagStateToken(uint8 flagState)
     }
 }
 
+float BattlegroundWS::NormalizeWSGCoord(float value, float min, float max)
+{
+    if (max <= min)
+        return 0.0f;
+
+    float normalized = (value - min) / (max - min);
+    return std::clamp(normalized, 0.0f, 1.0f);
+}
+
+std::string BattlegroundWS::FormatWSGCoord(float value)
+{
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(4) << value;
+    return stream.str();
+}
+
+bool BattlegroundWS::GetWSGFlagWorldPositionByIdentity(uint32 flagTeam, float& x, float& y) const
+{
+    int32 const flagTeamIndex = GetTeamIndexByTeamId(flagTeam);
+    if (flagTeamIndex != TEAM_ALLIANCE && flagTeamIndex != TEAM_HORDE)
+        return false;
+
+    if (_flagState[flagTeamIndex] == BG_WS_FLAG_STATE_ON_PLAYER)
+    {
+        if (Player* carrier = ObjectAccessor::FindPlayer(m_FlagKeepers[flagTeamIndex]))
+        {
+            x = carrier->GetPositionX();
+            y = carrier->GetPositionY();
+            return true;
+        }
+    }
+    else if (_flagState[flagTeamIndex] == BG_WS_FLAG_STATE_ON_GROUND)
+    {
+        if (Map* map = GetBgMap())
+        {
+            if (GameObject* droppedFlag = map->GetGameObject(GetDroppedFlagGUID(flagTeam)))
+            {
+                x = droppedFlag->GetPositionX();
+                y = droppedFlag->GetPositionY();
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+std::string BattlegroundWS::BuildWSGFlagFullPayload() const
+{
+    // WSG worldspace extents used to map world coordinates to 0..1 minimap-like coordinates.
+    // We keep these constants local to the WSG sync layer so gameplay behavior remains unchanged.
+    constexpr float WSG_MIN_X = 850.0f;
+    constexpr float WSG_MAX_X = 1600.0f;
+    constexpr float WSG_MIN_Y = 1300.0f;
+    constexpr float WSG_MAX_Y = 1750.0f;
+
+    std::string allianceCarrier;
+    std::string hordeCarrier;
+    std::string allianceX;
+    std::string allianceY;
+    std::string hordeX;
+    std::string hordeY;
+
+    if (_flagState[TEAM_ALLIANCE] == BG_WS_FLAG_STATE_ON_PLAYER)
+    {
+        if (Player* carrier = ObjectAccessor::FindPlayer(m_FlagKeepers[TEAM_ALLIANCE]))
+            allianceCarrier = carrier->GetName();
+    }
+
+    if (_flagState[TEAM_HORDE] == BG_WS_FLAG_STATE_ON_PLAYER)
+    {
+        if (Player* carrier = ObjectAccessor::FindPlayer(m_FlagKeepers[TEAM_HORDE]))
+            hordeCarrier = carrier->GetName();
+    }
+
+    float x = 0.0f;
+    float y = 0.0f;
+    if (GetWSGFlagWorldPositionByIdentity(ALLIANCE, x, y))
+    {
+        allianceX = FormatWSGCoord(NormalizeWSGCoord(x, WSG_MIN_X, WSG_MAX_X));
+        allianceY = FormatWSGCoord(NormalizeWSGCoord(y, WSG_MIN_Y, WSG_MAX_Y));
+    }
+
+    if (GetWSGFlagWorldPositionByIdentity(HORDE, x, y))
+    {
+        hordeX = FormatWSGCoord(NormalizeWSGCoord(x, WSG_MIN_X, WSG_MAX_X));
+        hordeY = FormatWSGCoord(NormalizeWSGCoord(y, WSG_MIN_Y, WSG_MAX_Y));
+    }
+
+    return std::string("FULL:") + allianceCarrier + ":" + hordeCarrier + ":" + GetWSGFlagStateToken(_flagState[TEAM_ALLIANCE]) + ":" +
+        GetWSGFlagStateToken(_flagState[TEAM_HORDE]) + ":" + allianceX + ":" + allianceY + ":" + hordeX + ":" + hordeY;
+}
+
 void BattlegroundWS::SendWSGFlagAddonMessage(std::string const& payload)
 {
     // Crossfaction WSG UI patch uses this addon channel payload as authoritative flag-color state.
@@ -108,16 +204,7 @@ void BattlegroundWS::SendWSGFlagAddonMessage(std::string const& payload)
 
 void BattlegroundWS::BroadcastWSGFlagFullState()
 {
-    std::string allianceCarrier;
-    std::string hordeCarrier;
-
-    if (Player* player = ObjectAccessor::FindPlayer(m_FlagKeepers[TEAM_ALLIANCE]))
-        allianceCarrier = player->GetName();
-
-    if (Player* player = ObjectAccessor::FindPlayer(m_FlagKeepers[TEAM_HORDE]))
-        hordeCarrier = player->GetName();
-
-    std::string payload = std::string("FULL:") + allianceCarrier + ":" + hordeCarrier + ":" + GetWSGFlagStateToken(_flagState[TEAM_ALLIANCE]) + ":" + GetWSGFlagStateToken(_flagState[TEAM_HORDE]);
+    std::string payload = BuildWSGFlagFullPayload();
     std::string message = "CWSG\t" + payload;
     WorldPacket data;
     ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER, LANG_ADDON, ObjectGuid::Empty, ObjectGuid::Empty, message, 0);
@@ -129,16 +216,7 @@ void BattlegroundWS::SendWSGFlagFullStateTo(Player* player)
     if (!player || !player->GetSession())
         return;
 
-    std::string allianceCarrier;
-    std::string hordeCarrier;
-
-    if (Player* carrier = ObjectAccessor::FindPlayer(m_FlagKeepers[TEAM_ALLIANCE]))
-        allianceCarrier = carrier->GetName();
-
-    if (Player* carrier = ObjectAccessor::FindPlayer(m_FlagKeepers[TEAM_HORDE]))
-        hordeCarrier = carrier->GetName();
-
-    std::string payload = std::string("FULL:") + allianceCarrier + ":" + hordeCarrier + ":" + GetWSGFlagStateToken(_flagState[TEAM_ALLIANCE]) + ":" + GetWSGFlagStateToken(_flagState[TEAM_HORDE]);
+    std::string payload = BuildWSGFlagFullPayload();
     std::string message = "CWSG\t" + payload;
     WorldPacket data;
     ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER, LANG_ADDON, ObjectGuid::Empty, ObjectGuid::Empty, message, 0);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -238,6 +238,7 @@ class BattlegroundWS : public Battleground
         void SendWSGFlagAddonMessage(std::string const& payload);
         void BroadcastWSGFlagFullState();
         void SendWSGFlagFullStateTo(Player* player);
+        std::string BuildWSGFlagFullPayload() const;
 
         void RemovePlayer(Player* player, ObjectGuid guid, uint32 team) override;
         void HandleAreaTrigger(Player* player, uint32 trigger) override;
@@ -257,7 +258,7 @@ class BattlegroundWS : public Battleground
                 m_DroppedFlagGUID[team] = guid;
         }
 
-        ObjectGuid GetDroppedFlagGUID(uint32 TeamID)             { return m_DroppedFlagGUID[GetTeamIndexByTeamId(TeamID)]; }
+        ObjectGuid GetDroppedFlagGUID(uint32 TeamID) const       { return m_DroppedFlagGUID[GetTeamIndexByTeamId(TeamID)]; }
         void FillInitialWorldStates(WorldPackets::WorldState::InitWorldStates& packet) override;
 
         /* Scorekeeping */
@@ -292,5 +293,8 @@ class BattlegroundWS : public Battleground
 
         void PostUpdateImpl(uint32 diff) override;
         static char const* GetWSGFlagStateToken(uint8 flagState);
+        bool GetWSGFlagWorldPositionByIdentity(uint32 flagTeam, float& x, float& y) const;
+        static float NormalizeWSGCoord(float value, float min, float max);
+        static std::string FormatWSGCoord(float value);
 };
 #endif


### PR DESCRIPTION
### Motivation
- The server-side WSG addon payload mixed team-side semantics with flag identity which caused incorrect A/H meanings for clients on join and on flag DROP; the snapshot must represent flags (Alliance/Horde) only. 
- Clients require an authoritative `FULL` format that always describes the two flag identities (A/H), their state, carrier name, and normalized map coordinates to support crossfaction UIs.

### Description
- Added a dedicated builder `BuildWSGFlagFullPayload()` that produces `FULL:<aCarrier>:<hCarrier>:<aState>:<hState>:<ax>:<ay>:<hx>:<hy>` where `aCarrier`/`hCarrier` are set only when the respective flag is `PLAYER`, `ax/ay` or `hx/hy` come from the carrier position when `PLAYER` or from the dropped flag gameobject when `GROUND`, and are left empty for `BASE`/`WAIT` states. Files changed: `src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp` and `src/server/game/Battlegrounds/Zones/BattlegroundWS.h`.
- Added helpers `GetWSGFlagWorldPositionByIdentity()`, `NormalizeWSGCoord()` and `FormatWSGCoord()` to source coordinates from the actual flag identity slots and map them to 0..1 normalized values (local WSG extents constants), and formatted to four decimal places.
- Rewired `BroadcastWSGFlagFullState()` and `SendWSGFlagFullStateTo()` to use the new builder so broadcasts and join-in-progress syncs are identical and authoritative; kept all changes localized to WSG battleground code and did not alter gameplay logic.
- Minor header adjustments: `GetDroppedFlagGUID()` made `const` and new member declarations added to `BattlegroundWS` for the helpers.
- Explicit semantics: A/H in `FULL` now represent FLAG IDENTITY only (Alliance flag vs Horde flag) and not the carrier/team side; if a Horde player carries the Alliance flag the `aCarrier` will contain that Horde player name and `aState=PLAYER`.

### Testing
- No automated build or unit tests were executed in this environment; only static repository inspections (`diff`/`show`) and edits were performed to validate the change set applied cleanly.  
- Note: please run a full build and integration tests on your CI or local environment to confirm compilation and runtime behavior before production deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12e9ab1e083278ae4bd140e5b6ea5)