### PR TITLE
WSG: handle CWSGREQ/FULL, fix dropped-flag identity, and make A/H authoritative

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -436,10 +436,13 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
     uint32 winner = 0;
 
     player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
+    uint32 capturedFlagIdentity = TEAM_ALLIANCE;
+
     if (player->GetTeam() == ALLIANCE)
     {
         if (!IsHordeFlagPickedup())
             return;
+        capturedFlagIdentity = TEAM_HORDE;
         SetHordeFlagPicker(ObjectGuid::Empty);              // must be before aura remove to prevent 2 events (drop+capture) at the same time
                                                             // horde flag in base (but not respawned yet)
         _flagState[TEAM_HORDE] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
@@ -459,6 +462,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
     {
         if (!IsAllianceFlagPickedup())
             return;
+        capturedFlagIdentity = TEAM_ALLIANCE;
         SetAllianceFlagPicker(ObjectGuid::Empty);           // must be before aura remove to prevent 2 events (drop+capture) at the same time
                                                             // alliance flag in base (but not respawned yet)
         _flagState[TEAM_ALLIANCE] = BG_WS_FLAG_STATE_WAIT_RESPAWN;
@@ -485,7 +489,7 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
         SendBroadcastText(BG_WS_TEXT_CAPTURED_HORDE_FLAG, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
     else
         SendBroadcastText(BG_WS_TEXT_CAPTURED_ALLIANCE_FLAG, CHAT_MSG_BG_SYSTEM_HORDE, player);
-    SendWSGFlagAddonMessage(player->GetTeam() == ALLIANCE ? "H:CAPTURE" : "A:CAPTURE");
+    SendWSGFlagAddonMessage(capturedFlagIdentity == TEAM_HORDE ? "H:CAPTURE" : "A:CAPTURE");
 
     UpdateFlagState(player->GetTeam(), 1);                  // flag state none
     UpdateTeamScore(player->GetTeamId());
@@ -557,6 +561,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
     }
 
     bool set = false;
+    int32 droppedFlagIdentity = -1;
 
     if (player->GetTeam() == ALLIANCE)
     {
@@ -573,6 +578,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             _flagState[TEAM_HORDE] = BG_WS_FLAG_STATE_ON_GROUND;
             player->CastSpell(player, BG_WS_SPELL_WARSONG_FLAG_DROPPED, true);
             set = true;
+            droppedFlagIdentity = TEAM_HORDE;
         }
     }
     else
@@ -590,15 +596,16 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             _flagState[TEAM_ALLIANCE] = BG_WS_FLAG_STATE_ON_GROUND;
             player->CastSpell(player, BG_WS_SPELL_SILVERWING_FLAG_DROPPED, true);
             set = true;
+            droppedFlagIdentity = TEAM_ALLIANCE;
         }
     }
 
-    if (set)
+    if (set && (droppedFlagIdentity == TEAM_ALLIANCE || droppedFlagIdentity == TEAM_HORDE))
     {
         //player->CastSpell(player, SPELL_RECENTLY_DROPPED_FLAG, true);
-        UpdateFlagState(player->GetTeam(), 1);
+        UpdateFlagState(droppedFlagIdentity == TEAM_HORDE ? ALLIANCE : HORDE, 1);
 
-        if (player->GetTeam() == ALLIANCE)
+        if (droppedFlagIdentity == TEAM_HORDE)
         {
             SendBroadcastText(BG_WS_TEXT_HORDE_FLAG_DROPPED, CHAT_MSG_BG_SYSTEM_HORDE, player);
             SendWSGFlagAddonMessage("H:DROP");
@@ -611,7 +618,7 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
             UpdateWorldState(BG_WS_FLAG_UNK_ALLIANCE, uint32(-1));
         }
 
-        _flagsDropTimer[GetTeamIndexByTeamId(player->GetTeam()) ? 0 : 1] = BG_WS_FLAG_DROP_TIME;
+        _flagsDropTimer[droppedFlagIdentity] = BG_WS_FLAG_DROP_TIME;
     }
 }
 

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -22,6 +22,7 @@
 #include "Common.h"
 #include "Channel.h"
 #include "ChannelMgr.h"
+#include "BattlegroundWS.h"
 #include "Chat.h"
 #include "ChatPackets.h"
 #include "DatabaseEnv.h"
@@ -191,6 +192,25 @@ std::string_view GetRandomChromiCatFact()
     };
 
     return catFacts[urand(0, catFacts.size() - 1)];
+}
+
+bool HandleWSGFlagSyncRequest(Player* sender, uint32 type, uint32 lang, std::string const& msg)
+{
+    if (!sender || lang != LANG_ADDON || type != CHAT_MSG_BATTLEGROUND)
+        return false;
+
+    std::size_t const separator = msg.find('\t');
+    if (separator == std::string::npos)
+        return false;
+
+    if (msg.compare(0, separator, "CWSGREQ") != 0 || msg.compare(separator + 1, std::string::npos, "FULL") != 0)
+        return false;
+
+    if (Battleground* battleground = sender->GetBattleground())
+        if (battleground->GetStatus() == STATUS_IN_PROGRESS && battleground->GetTypeID() == BATTLEGROUND_WS)
+            static_cast<BattlegroundWS*>(battleground)->SendWSGFlagFullStateTo(sender);
+
+    return true;
 }
 
 }
@@ -384,6 +404,9 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
     {
         if (msg.empty())
             return;
+        if (HandleWSGFlagSyncRequest(sender, type, lang, msg))
+            return;
+
         if (lang == LANG_ADDON)
         {
             if (AddonChannelCommandHandler(this).ParseCommands(msg.c_str()))

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -18,6 +18,7 @@
 #include "Spell.h"
 #include "AccountMgr.h"
 #include "Battleground.h"
+#include "BattlegroundWS.h"
 #include "CellImpl.h"
 #include "Common.h"
 #include "Creature.h"
@@ -3860,7 +3861,21 @@ void Spell::EffectSummonObjectWild()
     if (pGameObj->GetGoType() == GAMEOBJECT_TYPE_FLAGDROP)
         if (Player* player = m_caster->ToPlayer())
             if (Battleground* bg = player->GetBattleground())
-                bg->SetDroppedFlagGUID(pGameObj->GetGUID(), player->GetTeam() == ALLIANCE ? TEAM_HORDE: TEAM_ALLIANCE);
+            {
+                int32 droppedFlagTeam = -1;
+                if (bg->GetTypeID() == BATTLEGROUND_WS)
+                {
+                    if (pGameObj->GetEntry() == BG_OBJECT_A_FLAG_GROUND_WS_ENTRY)
+                        droppedFlagTeam = TEAM_ALLIANCE;
+                    else if (pGameObj->GetEntry() == BG_OBJECT_H_FLAG_GROUND_WS_ENTRY)
+                        droppedFlagTeam = TEAM_HORDE;
+                }
+
+                if (droppedFlagTeam == -1)
+                    droppedFlagTeam = player->GetTeam() == ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE;
+
+                bg->SetDroppedFlagGUID(pGameObj->GetGUID(), droppedFlagTeam);
+            }
 
     if (GameObject* linkedTrap = pGameObj->GetLinkedTrap())
     {


### PR DESCRIPTION
### Motivation
- Fix missing server-side handling for the client addon request `CWSGREQ\tFULL` so clients can request authoritative WSG FULL state. 
- Eliminate fragile cross-faction behavior that assigned dropped-flag GUIDs by the dropping player's team. 
- Ensure addon messages use flag identity (Alliance/Horde flag) for `A:`/`H:` tags rather than deriving A/H from the carrier's team.

### Description
- Added a minimal WSG addon request handler `HandleWSGFlagSyncRequest` in `src/server/game/Handlers/ChatHandler.cpp` that matches `CWSGREQ\tFULL`, validates the sender is in an in-progress WSG, and replies only to that player via `SendWSGFlagFullStateTo(sender)` (consumes the request). 
- Changed dropped-flag GUID assignment in `src/server/game/Spells/SpellEffects.cpp` to detect WSG dropped-flag gameobject entries and populate the corresponding identity slot (`BG_OBJECT_A_FLAG_GROUND_WS_ENTRY` -> Alliance slot, `BG_OBJECT_H_FLAG_GROUND_WS_ENTRY` -> Horde slot), with original fallback preserved for non-WSG or unknown entries. 
- Audited and adjusted WSG delta emission in `src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp` so CAPTURE and DROP addon messages choose `A:`/`H:` based on explicit flag-identity variables (`capturedFlagIdentity`, `droppedFlagIdentity`) instead of deriving A/H from the player's team. 
- Left FULL payload construction unchanged where it already reads from identity-keyed sources (`_flagState[TEAM_ALLIANCE/HORDE]`, `m_FlagKeepers[...]`, and dropped GUIDs by identity) so FULL semantics follow flag identity (A = Alliance flag / blue, H = Horde flag / red).
- Files changed: `src/server/game/Handlers/ChatHandler.cpp`, `src/server/game/Spells/SpellEffects.cpp`, `src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp` (commit 2c7a73b6).

### Testing
- Ran `git diff --check` to ensure no obvious whitespace/index issues and it succeeded. 
- Performed repository-wide searches for new symbols and patterns (e.g. `HandleWSGFlagSyncRequest`, `CWSGREQ`, `capturedFlagIdentity`, `droppedFlagIdentity`, `BG_OBJECT_A_FLAG_GROUND_WS_ENTRY`) to verify the changes are present and referenced, and all inspections succeeded. 
- Committed the changes successfully; no build or runtime test was executed in this patch (recommend building and running an integration WSG session to validate client requests, dropped-flag GUID placement, and addon payload semantics in-game).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c134503e68832786fab4341f429f2d)