### PR TITLE
WSG: defer FULL flag sync until dropped GO is registered

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -192,14 +192,15 @@ std::string BattlegroundWS::BuildWSGFlagFullPayload() const
         GetWSGFlagStateToken(_flagState[TEAM_HORDE]) + ":" + allianceX + ":" + allianceY + ":" + hordeX + ":" + hordeY;
 }
 
-void BattlegroundWS::SendWSGFlagAddonMessage(std::string const& payload)
+void BattlegroundWS::SendWSGFlagAddonMessage(std::string const& payload, bool broadcastFullState /*= true*/)
 {
     // Crossfaction WSG UI patch uses this addon channel payload as authoritative flag-color state.
     std::string message = "CWSG\t" + payload;
     WorldPacket data;
     ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER, LANG_ADDON, ObjectGuid::Empty, ObjectGuid::Empty, message, 0);
     SendPacketToAll(&data);
-    BroadcastWSGFlagFullState();
+    if (broadcastFullState)
+        BroadcastWSGFlagFullState();
 }
 
 void BattlegroundWS::BroadcastWSGFlagFullState()
@@ -608,13 +609,13 @@ void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
         if (droppedFlagIdentity == TEAM_HORDE)
         {
             SendBroadcastText(BG_WS_TEXT_HORDE_FLAG_DROPPED, CHAT_MSG_BG_SYSTEM_HORDE, player);
-            SendWSGFlagAddonMessage("H:DROP");
+            SendWSGFlagAddonMessage("H:DROP", false);
             UpdateWorldState(BG_WS_FLAG_UNK_HORDE, uint32(-1));
         }
         else
         {
             SendBroadcastText(BG_WS_TEXT_ALLIANCE_FLAG_DROPPED, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
-            SendWSGFlagAddonMessage("A:DROP");
+            SendWSGFlagAddonMessage("A:DROP", false);
             UpdateWorldState(BG_WS_FLAG_UNK_ALLIANCE, uint32(-1));
         }
 

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -237,7 +237,7 @@ class BattlegroundWS : public Battleground
         void EventPlayerClickedOnFlag(Player* player, GameObject* target_obj) override;
         void EventPlayerCapturedFlag(Player* player);
         void HandleFlagRoomCapturePoint(int32 team);
-        void SendWSGFlagAddonMessage(std::string const& payload);
+        void SendWSGFlagAddonMessage(std::string const& payload, bool broadcastFullState = true);
         void BroadcastWSGFlagFullState();
         void SendWSGFlagFullStateTo(Player* player);
         std::string BuildWSGFlagFullPayload() const;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3876,7 +3876,11 @@ void Spell::EffectSummonObjectWild()
                     droppedFlagTeam = player->GetTeam() == ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE;
 
                 if (droppedFlagTeam == TEAM_ALLIANCE || droppedFlagTeam == TEAM_HORDE)
+                {
                     bg->SetDroppedFlagGUID(pGameObj->GetGUID(), droppedFlagTeam);
+                    if (bg->GetTypeID() == BATTLEGROUND_WS)
+                        static_cast<BattlegroundWS*>(bg)->BroadcastWSGFlagFullState();
+                }
             }
 
     if (GameObject* linkedTrap = pGameObj->GetLinkedTrap())


### PR DESCRIPTION
### Motivation
- Prevent clients from receiving a FULL WSG snapshot that reports a ground flag state before the dropped flag gameobject GUID is registered, which caused blank ax/ay or hx/hy and made dropped flags disappear on the map.

### Description
- Added an optional `broadcastFullState` parameter to `BattlegroundWS::SendWSGFlagAddonMessage` (default true) and stopped forcing an immediate FULL broadcast for `A:DROP`/`H:DROP` by passing `false` in `EventPlayerDroppedFlag`.
- After a dropped-flag gameobject is created and `SetDroppedFlagGUID(...)` is called in `Spell::EffectSummonObjectWild`, trigger `BattlegroundWS::BroadcastWSGFlagFullState()` for WSG to emit the authoritative FULL snapshot once the dropped GUID is populated.
- Kept flag identity tokens unchanged (`A` = Alliance/blue, `H` = Horde/red) and kept the change minimal and localized to WSG drop handling.

### Testing
- No automated tests were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c223e060748327aa7d6f09adbb5ad8)