### PR TITLE
Add GM command to skip battleground/arena start countdown

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -453,66 +453,7 @@ inline void Battleground::_ProcessJoin(uint32 diff)
     }
     // Delay expired (after 2 or 1 minute)
     else if (GetStartDelayTime() <= 0 && !(m_Events & BG_STARTING_EVENT_4))
-    {
-        m_Events |= BG_STARTING_EVENT_4;
-
-        StartingEventOpenDoors();
-
-        if (StartMessageIds[BG_STARTING_EVENT_FOURTH])
-            SendBroadcastText(StartMessageIds[BG_STARTING_EVENT_FOURTH], CHAT_MSG_BG_SYSTEM_NEUTRAL);
-        SetStatus(STATUS_IN_PROGRESS);
-        SetStartDelayTime(StartDelayTimes[BG_STARTING_EVENT_FOURTH]);
-
-        // Remove preparation
-        if (isArena())
-        {
-            /// @todo add arena sound PlaySoundToAll(SOUND_ARENA_START);
-            for (BattlegroundPlayerMap::const_iterator itr = GetPlayers().begin(); itr != GetPlayers().end(); ++itr)
-                if (Player* player = ObjectAccessor::FindPlayer(itr->first))
-                {
-                    // BG Status packet
-                    WorldPacket status;
-                    BattlegroundQueueTypeId bgQueueTypeId = sBattlegroundMgr->BGQueueTypeId(m_TypeID, GetArenaType());
-                    uint32 queueSlot = player->GetBattlegroundQueueIndex(bgQueueTypeId);
-                    sBattlegroundMgr->BuildBattlegroundStatusPacket(&status, this, queueSlot, STATUS_IN_PROGRESS, 0, GetStartTime(), GetArenaType(), player->GetBGTeam());
-                    player->SendDirectMessage(&status);
-
-                    player->RemoveAurasDueToSpell(SPELL_ARENA_PREPARATION);
-                    player->RemoveAurasDueToSpell(SPELL_INSTANT_CAST);
-                    player->ResetAllPowers();
-                    if (!player->IsGameMaster())
-                    {
-                        // remove auras with duration lower than 30s
-                        player->RemoveAppliedAuras([](AuraApplication const* aurApp)
-                        {
-                            Aura* aura = aurApp->GetBase();
-                            return !aura->IsPermanent()
-                                && aura->GetDuration() <= 30 * IN_MILLISECONDS
-                                && aurApp->IsPositive()
-                                && !aura->GetSpellInfo()->HasAttribute(SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY)
-                                && !aura->HasEffectType(SPELL_AURA_MOD_INVISIBILITY);
-                        });
-                    }
-                }
-
-            CheckWinConditions();
-        }
-        else
-        {
-            PlaySoundToAll(SOUND_BG_START);
-
-            for (BattlegroundPlayerMap::const_iterator itr = GetPlayers().begin(); itr != GetPlayers().end(); ++itr)
-                if (Player* player = ObjectAccessor::FindPlayer(itr->first))
-                {
-                    player->RemoveAurasDueToSpell(SPELL_PREPARATION);
-                    player->RemoveAurasDueToSpell(SPELL_INSTANT_CAST);
-                    player->ResetAllPowers();
-                }
-            // Announce BG starting
-            if (sWorld->getBoolConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_ENABLE))
-                sWorld->SendWorldText(LANG_BG_STARTED_ANNOUNCE_WORLD, GetName().c_str(), GetMinLevel(), GetMaxLevel());
-        }
-    }
+        SkipStartDelay();
 }
 
 inline void Battleground::_ProcessLeave(uint32 diff)
@@ -1051,6 +992,97 @@ void Battleground::StartBattleground()
 
     if (m_IsRated)
         TC_LOG_DEBUG("bg.arena", "Arena match type: {} for Team1Id: {} - Team2Id: {} started.", m_ArenaType, m_ArenaTeamIds[TEAM_ALLIANCE], m_ArenaTeamIds[TEAM_HORDE]);
+}
+
+bool Battleground::SkipStartDelay()
+{
+    if (GetStatus() != STATUS_WAIT_JOIN || (m_Events & BG_STARTING_EVENT_4))
+        return false;
+
+    // Ensure setup is complete if this is forced very early, before the first regular countdown update.
+    if (!(m_Events & BG_STARTING_EVENT_1))
+    {
+        m_Events |= BG_STARTING_EVENT_1;
+
+        if (!FindBgMap())
+        {
+            TC_LOG_ERROR("bg.battleground", "Battleground::SkipStartDelay: map (map id: {}, instance id: {}) is not created!", m_MapId, m_InstanceID);
+            EndNow();
+            return false;
+        }
+
+        if (!SetupBattleground())
+        {
+            EndNow();
+            return false;
+        }
+
+        StartingEventCloseDoors();
+    }
+
+    // Skip remaining countdown warnings.
+    m_Events |= BG_STARTING_EVENT_2;
+    m_Events |= BG_STARTING_EVENT_3;
+    m_Events |= BG_STARTING_EVENT_4;
+
+    StartingEventOpenDoors();
+
+    if (StartMessageIds[BG_STARTING_EVENT_FOURTH])
+        SendBroadcastText(StartMessageIds[BG_STARTING_EVENT_FOURTH], CHAT_MSG_BG_SYSTEM_NEUTRAL);
+    SetStatus(STATUS_IN_PROGRESS);
+    SetStartDelayTime(StartDelayTimes[BG_STARTING_EVENT_FOURTH]);
+
+    // Remove preparation
+    if (isArena())
+    {
+        /// @todo add arena sound PlaySoundToAll(SOUND_ARENA_START);
+        for (BattlegroundPlayerMap::const_iterator itr = GetPlayers().begin(); itr != GetPlayers().end(); ++itr)
+            if (Player* player = ObjectAccessor::FindPlayer(itr->first))
+            {
+                // BG Status packet
+                WorldPacket status;
+                BattlegroundQueueTypeId bgQueueTypeId = sBattlegroundMgr->BGQueueTypeId(m_TypeID, GetArenaType());
+                uint32 queueSlot = player->GetBattlegroundQueueIndex(bgQueueTypeId);
+                sBattlegroundMgr->BuildBattlegroundStatusPacket(&status, this, queueSlot, STATUS_IN_PROGRESS, 0, GetStartTime(), GetArenaType(), player->GetBGTeam());
+                player->SendDirectMessage(&status);
+
+                player->RemoveAurasDueToSpell(SPELL_ARENA_PREPARATION);
+                player->RemoveAurasDueToSpell(SPELL_INSTANT_CAST);
+                player->ResetAllPowers();
+                if (!player->IsGameMaster())
+                {
+                    // remove auras with duration lower than 30s
+                    player->RemoveAppliedAuras([](AuraApplication const* aurApp)
+                    {
+                        Aura* aura = aurApp->GetBase();
+                        return !aura->IsPermanent()
+                            && aura->GetDuration() <= 30 * IN_MILLISECONDS
+                            && aurApp->IsPositive()
+                            && !aura->GetSpellInfo()->HasAttribute(SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY)
+                            && !aura->HasEffectType(SPELL_AURA_MOD_INVISIBILITY);
+                    });
+                }
+            }
+
+        CheckWinConditions();
+    }
+    else
+    {
+        PlaySoundToAll(SOUND_BG_START);
+
+        for (BattlegroundPlayerMap::const_iterator itr = GetPlayers().begin(); itr != GetPlayers().end(); ++itr)
+            if (Player* player = ObjectAccessor::FindPlayer(itr->first))
+            {
+                player->RemoveAurasDueToSpell(SPELL_PREPARATION);
+                player->RemoveAurasDueToSpell(SPELL_INSTANT_CAST);
+                player->ResetAllPowers();
+            }
+        // Announce BG starting
+        if (sWorld->getBoolConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_ENABLE))
+            sWorld->SendWorldText(LANG_BG_STARTED_ANNOUNCE_WORLD, GetName().c_str(), GetMinLevel(), GetMaxLevel());
+    }
+
+    return true;
 }
 
 void Battleground::AddPlayer(Player* player)

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -325,6 +325,7 @@ class TC_GAME_API Battleground
 
         void ModifyStartDelayTime(int diff) { m_StartDelayTime -= diff; }
         void SetStartDelayTime(int Time)    { m_StartDelayTime = Time; }
+        bool SkipStartDelay();
 
         void SetMaxPlayersPerTeam(uint32 MaxPlayers) { m_MaxPlayersPerTeam = MaxPlayers; }
         void SetMinPlayersPerTeam(uint32 MinPlayers) { m_MinPlayersPerTeam = MinPlayers; }

--- a/src/server/scripts/Commands/cs_gm.cpp
+++ b/src/server/scripts/Commands/cs_gm.cpp
@@ -24,6 +24,7 @@ EndScriptData */
 
 #include "ScriptMgr.h"
 #include "AccountMgr.h"
+#include "Battleground.h"
 #include "Chat.h"
 #include "DatabaseEnv.h"
 #include "Language.h"
@@ -50,6 +51,7 @@ public:
             { "ingame",     HandleGMListIngameCommand,  rbac::RBAC_PERM_COMMAND_GM_INGAME,      Console::Yes },
             { "list",       HandleGMListFullCommand,    rbac::RBAC_PERM_COMMAND_GM_LIST,        Console::Yes },
             { "visible",    HandleGMVisibleCommand,     rbac::RBAC_PERM_COMMAND_GM_VISIBLE,     Console::No },
+            { "bgstart",    HandleGMBgStartCommand,     rbac::RBAC_PERM_COMMAND_GM,             Console::No },
             { "on",         HandleGMOnCommand,          rbac::RBAC_PERM_COMMAND_GM,             Console::No },
             { "off",        HandleGMOffCommand,         rbac::RBAC_PERM_COMMAND_GM,             Console::No },
         };
@@ -226,6 +228,37 @@ public:
         handler->GetPlayer()->SetGameMaster(true);
         handler->GetPlayer()->UpdateTriggerVisibility();
         handler->GetSession()->SendNotification(LANG_GM_ON);
+        return true;
+    }
+
+    static bool HandleGMBgStartCommand(ChatHandler* handler)
+    {
+        Player* player = handler->GetPlayer();
+        if (!player)
+            return false;
+
+        Battleground* battleground = player->GetBattleground();
+        if (!battleground)
+        {
+            handler->SendSysMessage("You must be inside a battleground or arena to use this command.");
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (battleground->GetStatus() != STATUS_WAIT_JOIN)
+        {
+            handler->SendSysMessage("This battleground or arena has already started.");
+            return true;
+        }
+
+        if (!battleground->SkipStartDelay())
+        {
+            handler->SendSysMessage("Could not skip the battleground or arena start countdown.");
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        handler->SendSysMessage("Skipped the battleground or arena start countdown.");
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Provide GMs a quick in-instance way to force a battleground or arena to start immediately without waiting for the pre-match countdown.
- Centralize the forced-start behavior so both natural countdown completion and GM-forced starts share the same transition logic.

### Description
- Added a new GM command ` .gm bgstart` implemented in `cs_gm.cpp` that checks the caller is inside a battleground/arena and that its status is `STATUS_WAIT_JOIN` before attempting to skip the countdown.
- Introduced `Battleground::SkipStartDelay()` (declaration in `Battleground.h` and implementation in `Battleground.cpp`) which performs necessary setup, opens starting doors, advances `m_Events` to the finished state, sets `STATUS_IN_PROGRESS`, clears preparation auras and performs the same per-player and announcement behavior used when a battleground naturally starts.
- Reworked the countdown expiry branch in `Battleground::_ProcessJoin()` to call `SkipStartDelay()` so manual and automatic starts follow the same code path.
- Included the battleground header in the GM commands file (`#include "Battleground.h"`) and added user-facing success/error messages for the command.

### Testing
- Ran `git diff --check` to verify there are no whitespace/style issues and the check passed.
- No build/run tests were executed in this environment because no build artifacts were present (no `build` directory), so runtime validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2279e60e083279ef0ffb4947d9a30)