### PR TITLE
WSG: use Map2ZoneCoordinates for FULL payload flag positions

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -28,7 +28,6 @@
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
 #include "World.h"
-#include <algorithm>
 #include <iomanip>
 #include <sstream>
 #include <string>
@@ -99,15 +98,6 @@ char const* BattlegroundWS::GetWSGFlagStateToken(uint8 flagState)
     }
 }
 
-float BattlegroundWS::NormalizeWSGCoord(float value, float min, float max)
-{
-    if (max <= min)
-        return 0.0f;
-
-    float normalized = (value - min) / (max - min);
-    return std::clamp(normalized, 0.0f, 1.0f);
-}
-
 std::string BattlegroundWS::FormatWSGCoord(float value)
 {
     std::ostringstream stream;
@@ -148,13 +138,6 @@ bool BattlegroundWS::GetWSGFlagWorldPositionByIdentity(uint32 flagTeam, float& x
 
 std::string BattlegroundWS::BuildWSGFlagFullPayload() const
 {
-    // WSG worldspace extents used to map world coordinates to 0..1 minimap-like coordinates.
-    // We keep these constants local to the WSG sync layer so gameplay behavior remains unchanged.
-    constexpr float WSG_MIN_X = 850.0f;
-    constexpr float WSG_MAX_X = 1600.0f;
-    constexpr float WSG_MIN_Y = 1300.0f;
-    constexpr float WSG_MAX_Y = 1750.0f;
-
     std::string allianceCarrier;
     std::string hordeCarrier;
     std::string allianceX;
@@ -178,14 +161,16 @@ std::string BattlegroundWS::BuildWSGFlagFullPayload() const
     float y = 0.0f;
     if (GetWSGFlagWorldPositionByIdentity(ALLIANCE, x, y))
     {
-        allianceX = FormatWSGCoord(NormalizeWSGCoord(x, WSG_MIN_X, WSG_MAX_X));
-        allianceY = FormatWSGCoord(NormalizeWSGCoord(y, WSG_MIN_Y, WSG_MAX_Y));
+        Map2ZoneCoordinates(x, y, 3277);
+        allianceX = FormatWSGCoord(x / 100.0f);
+        allianceY = FormatWSGCoord(y / 100.0f);
     }
 
     if (GetWSGFlagWorldPositionByIdentity(HORDE, x, y))
     {
-        hordeX = FormatWSGCoord(NormalizeWSGCoord(x, WSG_MIN_X, WSG_MAX_X));
-        hordeY = FormatWSGCoord(NormalizeWSGCoord(y, WSG_MIN_Y, WSG_MAX_Y));
+        Map2ZoneCoordinates(x, y, 3277);
+        hordeX = FormatWSGCoord(x / 100.0f);
+        hordeY = FormatWSGCoord(y / 100.0f);
     }
 
     return std::string("FULL:") + allianceCarrier + ":" + hordeCarrier + ":" + GetWSGFlagStateToken(_flagState[TEAM_ALLIANCE]) + ":" +

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -296,7 +296,6 @@ class BattlegroundWS : public Battleground
         void PostUpdateImpl(uint32 diff) override;
         static char const* GetWSGFlagStateToken(uint8 flagState);
         bool GetWSGFlagWorldPositionByIdentity(uint32 flagTeam, float& x, float& y) const;
-        static float NormalizeWSGCoord(float value, float min, float max);
         static std::string FormatWSGCoord(float value);
 };
 #endif


### PR DESCRIPTION
### Motivation
- Dropped-flag markers were placed incorrectly because `BuildWSGFlagFullPayload()` converted world coordinates using guessed hardcoded bounds and linear normalization that do not match the client map projection. 
- The client expects zone/map-projected coordinates with a specific axis handling that the hardcoded min/max approach did not provide. 
- TrinityCore already exposes the authoritative conversion `Map2ZoneCoordinates(float& x, float& y, uint32 zone)`, which uses `WorldMapArea.dbc` and matches the client map coordinate system.

### Description
- Replaced the WSG min/max normalization in `BuildWSGFlagFullPayload()` with a call to `Map2ZoneCoordinates(x, y, 3277)` and serialize `x / 100.0f` and `y / 100.0f` as the FULL payload coordinates. 
- Removed the unused helper `NormalizeWSGCoord` (declaration and definition) and removed the now-unneeded `#include <algorithm>`. 
- Kept the FULL payload wire format exactly as `FULL:<aCarrier>:<hCarrier>:<aState>:<hState>:<ax>:<ay>:<hx>:<hy>`. 
- Files changed: `src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp` and `src/server/game/Battlegrounds/Zones/BattlegroundWS.h`.

### Testing
- Ran `rg -n "NormalizeWSGCoord|WSG_MIN_X|WSG_MAX_X|WSG_MIN_Y|WSG_MAX_Y"` to confirm the old symbols/constants are no longer referenced, and the search returned no hits (success). 
- Inspected the changes with `git diff -- src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp src/server/game/Battlegrounds/Zones/BattlegroundWS.h` to verify the coordinate conversion and removal of the helper (success). 
- Committed the changes locally with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c22e0039d483279fcc00f4669752a0)