### PR TITLE
Spawn Gurubashi chest at 8 PM regardless of STV population

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -37,6 +37,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <ctime>
 #include <mutex>
 #include <shared_mutex>
 #include <string>
@@ -471,6 +472,18 @@ private:
         return std::chrono::milliseconds(secondsUntilNextHour * IN_MILLISECONDS);
     }
 
+    static bool IsEightPmServerTime()
+    {
+        time_t const now = GameTime::GetGameTime();
+        tm localTime {};
+#ifdef _WIN32
+        localtime_s(&localTime, &now);
+#else
+        localtime_r(&now, &localTime);
+#endif
+        return localTime.tm_hour == 20;
+    }
+
     void ScheduleNextCheck(std::chrono::milliseconds delay)
     {
         _nextCheckTimeMs = GameTime::GetGameTimeMS() + static_cast<uint32>(delay.count());
@@ -487,7 +500,8 @@ private:
         uint32 const playerCount = CountEligiblePlayers(&summonerGuid);
         _lastEligibleCount = playerCount;
 
-        if (!force && playerCount < REQUIRED_PLAYER_COUNT)
+        bool const bypassPlayerRequirement = !force && IsEightPmServerTime();
+        if (!force && !bypassPlayerRequirement && playerCount < REQUIRED_PLAYER_COUNT)
             return SpawnResult::NotEnoughPlayers;
 
         Player* summoner = FindEligibleSummoner(summonerGuid);


### PR DESCRIPTION
### Motivation
- Ensure the Gurubashi Arena hourly chest appears at 20:00 server local time even when fewer than the configured `REQUIRED_PLAYER_COUNT` eligible players are present, while leaving normal hourly behavior unchanged.

### Description
- Add `#include <ctime>` and a thread-safe helper `IsEightPmServerTime()` that consults `GameTime::GetGameTime()` and the local hour via `localtime_r`/`localtime_s`.
- Compute a `bypassPlayerRequirement` flag and use it inside `AttemptSpawn()` so the `REQUIRED_PLAYER_COUNT` check is skipped during the 8 PM server-time hourly check.
- Preserve all existing safeguards including forced spawns (`force`), chest active/duplicate checks, map availability checks, and death-lockout handling.

### Testing
- Verified the patch was applied successfully with `apply_patch` and file contents were inspected using `sed` and `nl` (file view commands completed successfully). 
- Confirmed repository state with `git status --short` and created a commit with `git commit` (commands ran and returned success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c577bf87d08327a0eaa39d1944162b)