### PR TITLE
Add audit logging for `.npc add item` vendor updates

### DIFF
--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -198,6 +198,15 @@ public:
 
         sObjectMgr->AddVendorItem(vendor_entry, itemId, maxcount, incrtime, extendedcost);
 
+        if (WorldSession* session = handler->GetSession())
+        {
+            Player* player = session->GetPlayer();
+            TC_LOG_INFO("entities.player.character", "Account: {} (IP: {}) Character:[{}] {} added vendor item {} to vendor entry {} (maxcount: {}, incrtime: {}, extendedcost: {})",
+                session->GetAccountId(), session->GetRemoteAddress(),
+                player ? player->GetName() : "<none>", player ? player->GetGUID().ToString() : "<none>",
+                itemId, vendor_entry, maxcount, incrtime, extendedcost);
+        }
+
         handler->PSendSysMessage(LANG_ITEM_ADDED_TO_LIST, itemId, item->Name1.c_str(), maxcount, incrtime, extendedcost);
         return true;
     }


### PR DESCRIPTION
### Motivation
- Provide an audit trail when a vendor item is added so server logs record who performed the action and when.

### Description
- Add a `TC_LOG_INFO` entry in `HandleNpcAddVendorItemCommand` immediately after `sObjectMgr->AddVendorItem` to record `account id`, `remote IP`, `character name`/GUID (if present), `item id`, `vendor entry`, and the vendor item parameters (`maxcount`, `incrtime`, `extendedcost`).
- Use the existing `entities.player.character` log channel so the timestamp is provided by the standard server log prefix.

### Testing
- Patch applied cleanly to `src/server/scripts/Commands/cs_npc.cpp` using the repo tooling and the change was visible in the file.
- Ran repository checks with `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68ebb76ec832786be17f67c01c330)