### PR TITLE
Prevent player accounts from using GM command permissions

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1356,6 +1356,14 @@ bool WorldSession::HasPermission(uint32 permission)
         LoadPermissions();
 
     bool hasPermission = _RBACData->HasPermission(permission);
+
+    // Non-GM accounts must never execute GM-only commands, even if those command permissions
+    // were granted directly by mistake.
+    if (hasPermission && AccountMgr::IsPlayerAccount(GetSecurity()) && permission >= rbac::RBAC_PERM_COMMAND_RBAC)
+    {
+        hasPermission = sAccountMgr->GetRBACPermission(rbac::RBAC_ROLE_PLAYER)->GetLinkedPermissions().count(permission);
+    }
+
     TC_LOG_DEBUG("rbac", "WorldSession::HasPermission [AccountId: {}, Name: {}, realmId: {}]",
                    _RBACData->GetId(), _RBACData->GetName(), realm.Id.Realm);
 


### PR DESCRIPTION
### Motivation
- Fix a privilege escalation where non-GM (player-security) accounts could run GM-only commands (e.g. `.npc delete`) when command permissions were granted directly by mistake.

### Description
- Hardened `WorldSession::HasPermission` so that when an account is a player account (`AccountMgr::IsPlayerAccount(GetSecurity())`) and the checked permission is a command permission (`permission >= rbac::RBAC_PERM_COMMAND_RBAC`), the permission is only allowed if it appears in the `RBAC_ROLE_PLAYER` linked permissions via `sAccountMgr->GetRBACPermission(rbac::RBAC_ROLE_PLAYER)->GetLinkedPermissions().count(permission)`.

### Testing
- Ran `git diff --check` which produced no errors and passed.  
- Attempted a build with `cmake --build build --target worldserver -j2` but the build failed in this environment because the `build/` directory is not present (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68dc4f62483279019ad819232f155)