### PR TITLE
Prevent non-GM accounts from executing GM-only RBAC command permissions

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1356,6 +1356,15 @@ bool WorldSession::HasPermission(uint32 permission)
         LoadPermissions();
 
     bool hasPermission = _RBACData->HasPermission(permission);
+
+    // Non-GM accounts must never execute GM-only commands, even if those command permissions
+    // were granted directly by mistake.
+    if (hasPermission && AccountMgr::IsPlayerAccount(GetSecurity()))
+    {
+        if (rbac::RBACPermission const* permissionData = sAccountMgr->GetRBACPermission(permission); permissionData && permissionData->GetName().rfind("Command:", 0) == 0)
+            hasPermission = sAccountMgr->GetRBACPermission(rbac::RBAC_ROLE_PLAYER)->GetLinkedPermissions().count(permission);
+    }
+
     TC_LOG_DEBUG("rbac", "WorldSession::HasPermission [AccountId: {}, Name: {}, realmId: {}]",
                    _RBACData->GetId(), _RBACData->GetName(), realm.Id.Realm);
 


### PR DESCRIPTION
### Motivation

- Ensure non-GM (player) accounts cannot use GM-only commands even if those command permissions were granted directly by mistake.
- Tighten RBAC permission checks in `WorldSession::HasPermission` to honor the intended separation between player and GM roles.

### Description

- Add a check in `WorldSession::HasPermission` that, when a permission is granted but the account is a player account (`AccountMgr::IsPlayerAccount(GetSecurity())`), verifies the permission is not a GM-only command by inspecting the permission name prefix `"Command:"`.
- For command permissions, require that the permission is explicitly linked from the `rbac::RBAC_ROLE_PLAYER` role via `GetLinkedPermissions()`; otherwise the permission is denied.
- Keeps existing RBAC loading and logging behavior intact while restricting accidental direct grants of command permissions to players.

### Testing

- Project was built successfully after the change with no compilation errors.
- Automated RBAC-related unit tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68dc4f62483279019ad819232f155)