### PR TITLE
Call CleanupsBeforeDelete before deletion and add defensive Unit aura cleanup

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -416,6 +416,16 @@ Unit::~Unit()
 
     m_Events.KillAllEvents(true);
 
+    // Cleanup should normally happen in CleanupsBeforeDelete. Keep a defensive
+    // fallback here so a partially cleaned unit does not crash during
+    // destruction (for example in exceptional shutdown paths).
+    if (!m_appliedAuras.empty() || !m_ownedAuras.empty() || !m_removedAuras.empty())
+    {
+        TC_LOG_ERROR("entities.unit", "Unit::~Unit: forcing late aura cleanup for {} (applied: {}, owned: {}, removed: {})",
+            GetGUID().ToString(), m_appliedAuras.size(), m_ownedAuras.size(), m_removedAuras.size());
+        RemoveAllAuras();
+    }
+
     _DeleteRemovedAuras();
 
     delete i_motionMaster;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -470,6 +470,8 @@ void Map::SwitchGridContainers(GameObject* obj, bool on)
 template<class T>
 void Map::DeleteFromWorld(T* obj)
 {
+    obj->CleanupsBeforeDelete();
+
     // Note: In case resurrectable corpse and pet its removed from global lists in own destructor
     delete obj;
 }
@@ -477,6 +479,8 @@ void Map::DeleteFromWorld(T* obj)
 template<>
 void Map::DeleteFromWorld(Player* player)
 {
+    player->CleanupsBeforeDelete();
+
     ObjectAccessor::RemoveObject(player);
     RemoveUpdateObject(player); /// @todo I do not know why we need this, it should be removed in ~Object anyway
     delete player;
@@ -485,6 +489,8 @@ void Map::DeleteFromWorld(Player* player)
 template<>
 void Map::DeleteFromWorld(Transport* transport)
 {
+    transport->CleanupsBeforeDelete();
+
     ObjectAccessor::RemoveObject(transport);
     delete transport;
 }


### PR DESCRIPTION
### Motivation

- Ensure objects run their `CleanupsBeforeDelete()` logic prior to destruction to avoid resource leaks and invalid state during deletion.  
- Defend against partial cleanup paths where a `Unit` might still have auras during destructor run, which can crash in exceptional shutdowns.

### Description

- Call `CleanupsBeforeDelete()` for generic objects in `Map::DeleteFromWorld(T* obj)` before `delete`.  
- Call `CleanupsBeforeDelete()` for `Player` and `Transport` specializations in `Map::DeleteFromWorld` before `delete`.  
- Add a defensive check in `Unit::~Unit()` that logs an error when aura containers are not empty and forces cleanup via `RemoveAllAuras()` so partially cleaned units do not crash during destruction.  
- Left existing `_DeleteRemovedAuras()` and assertions in place to ensure normal cleanup remains validated.

### Testing

- Built the project using `make` (debug build) and the build completed successfully.  
- Started a development server and exercised unit/player/transport deletion paths by loading and unloading maps; no crashes were observed.  
- Ran the repository's automated unit tests and integration checks; they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6914aa1dc832796fe15b358e4b678)