### PR TITLE
Stockades: grant +10 death honor token bonus only once per run

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <charconv>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -321,6 +322,20 @@ namespace
     }
 
     GuidSet s_RecentDeathChests;
+    std::unordered_map<uint32, GuidSet> s_DeathBonusRecipientsByInstance;
+
+    bool ShouldGrantDeathHonorBonus(Player* victim)
+    {
+        if (!victim)
+            return false;
+
+        uint32 const instanceId = victim->GetInstanceId();
+        if (!instanceId)
+            return false;
+
+        GuidSet& recipients = s_DeathBonusRecipientsByInstance[instanceId];
+        return recipients.insert(victim->GetGUID()).second;
+    }
 
     void DropDeathChest(Player* victim)
     {
@@ -348,8 +363,8 @@ namespace
         if (beadCount)
             chest.AddStackableItem(beadItemId, beadCount);
 
-        chest.AddStackableItem(StockadesPvPvE::HonorTokenItemId,
-            honorTokenCount + StockadesPvPvE::HonorTokenKillBonus);
+        uint32 const deathBonus = ShouldGrantDeathHonorBonus(victim) ? StockadesPvPvE::HonorTokenKillBonus : 0;
+        chest.AddStackableItem(StockadesPvPvE::HonorTokenItemId, honorTokenCount + deathBonus);
 
         if (bossKeyCount)
             chest.AddStackableItem(StockadesPvPvE::BossKeyItemId, bossKeyCount);


### PR DESCRIPTION
### Motivation

- Prevent the +10 death honor-token bonus in Stockades PvPvE from being granted multiple times to the same player during a single run to avoid repeated bonus exploitation. 
- Track recipients per instance so the bonus still resets between separate Stockades runs.

### Description

- Added `#include <unordered_map>` and a `std::unordered_map<uint32, GuidSet> s_DeathBonusRecipientsByInstance` to track which players have received the death bonus per instance. 
- Implemented `ShouldGrantDeathHonorBonus(Player* victim)` which returns true only the first time a given player GUID is seen for the instance ID. 
- Modified `DropDeathChest` to compute a `deathBonus` from `ShouldGrantDeathHonorBonus` and add `honorTokenCount + deathBonus` to the chest instead of always adding `HonorTokenKillBonus`.

### Testing

- Ran `git diff --check` to validate the working tree and the change produces no whitespace or diff-check issues, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c693a8fb208327b231e255078f924d)