### PR TITLE
Adjust Gurubashi chest teleport recovery and exit-death checks

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -183,6 +183,10 @@ bool HasLivingHostileInGurubashiBattleRing(Player const* player)
         if (GetGurubashiAreaState(other, other->GetZoneId(), other->GetAreaId()) != GurubashiAreaState::BattleRing)
             continue;
 
+        // Stealthed/invisible players should not block non-lethal exits from the ring.
+        if (other->HasStealthAura() || other->HasInvisibilityAura())
+            continue;
+
         // Evaluate hostility without relying on transient FFA flags.
         // When a player steps out of the ring, FFA can drop before this check runs,
         // but the exit rule should still treat non-group/raid players in the ring as hostile.
@@ -307,6 +311,11 @@ void TeleportStranglethornPlayersToBattleRing()
         player->CastSpell(player, TELEPORT_VISUAL_SPELL, TRIGGERED_FULL_MASK);
         Position const destination = BuildRandomBattleRingPosition(player);
         player->NearTeleportTo(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), destination.GetOrientation(), true);
+        player->SetFullHealth();
+        for (Powers powerType = POWER_MANA; powerType < MAX_POWERS; powerType = Powers(powerType + 1))
+            if (int32 maxPower = player->GetMaxPower(powerType); maxPower > 0)
+                player->SetPower(powerType, maxPower);
+        player->RemoveArenaSpellCooldowns(true);
         player->CastSpell(player, TELEPORT_VISUAL_SPELL, TRIGGERED_FULL_MASK);
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure players ported into the Gurubashi Battle Ring for the chest event are fully restored so they enter at full health/power and with cooldowns cleared. 
- Prevent stealthed/invisible players from blocking safe exits from the ring so non-visible players (e.g., stealth rogues) do not trigger the forced-death exit rule.

### Description
- In `src/server/scripts/Custom/custom_gurubashi_arena.cpp` changed `HasLivingHostileInGurubashiBattleRing` to ignore players with `HasStealthAura()` or `HasInvisibilityAura()` when deciding whether a hostile remains in the ring. 
- In `TeleportStranglethornPlayersToBattleRing()` added a post-teleport recovery: call `SetFullHealth()`, refill all power types via `SetPower(...)` for each `Powers`, and call `RemoveArenaSpellCooldowns(true)` before playing the exit visual. 
- Kept existing teleport visuals and tracking logic unchanged; only added recovery and visibility checks.

### Testing
- Ran `git diff --check` which succeeded. 
- Ran `cmake -S . -B build -G Ninja -DTOOLS=0 -DSCRIPTS=1` which failed because `SCRIPTS=1` is not a valid CMake option for this repository. 
- Ran `cmake -S . -B build -G Ninja -DTOOLS=0 -DSCRIPTS=static` which progressed but failed in this environment due to missing Boost development libraries/headers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a5ec58a883279222954a224e43cc)