### PR TITLE
Enable instant logout in sanctuary areas

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -356,11 +356,13 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPackets::Character::LogoutRequ
     if (ObjectGuid lguid = GetPlayer()->GetLootGUID())
         DoLootRelease(lguid);
 
-    bool instantLogout = (GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) && !GetPlayer()->IsInCombat()) ||
+    bool canUseRestLogout = GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) || GetPlayer()->IsInSanctuary();
+
+    bool instantLogout = (canUseRestLogout && !GetPlayer()->IsInCombat()) ||
                          GetPlayer()->IsInFlight() || HasPermission(rbac::RBAC_PERM_INSTANT_LOGOUT);
 
     /// TODO: Possibly add RBAC permission to log out in combat
-    bool canLogoutInCombat = GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING);
+    bool canLogoutInCombat = canUseRestLogout;
 
     uint32 reason = 0;
     if (GetPlayer()->IsInCombat() && !canLogoutInCombat)
@@ -381,7 +383,7 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPackets::Character::LogoutRequ
         return;
     }
 
-    // instant logout in taverns/cities or on taxi or for admins, gm's, mod's if its enabled in worldserver.conf
+    // instant logout in taverns/sanctuary cities, on taxi, or for admins/gm's/mod's if enabled in worldserver.conf
     if (instantLogout)
     {
         LogoutPlayer(true);


### PR DESCRIPTION
### Motivation
- Treat sanctuary areas like resting/tavern zones so players in sanctuary cities can use instant logout behavior without waiting for the normal logout timer.

### Description
- In `HandleLogoutRequestOpcode` introduced `canUseRestLogout = GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) || GetPlayer()->IsInSanctuary()` and used it for `instantLogout` and `canLogoutInCombat`, and updated the inline comment to mention sanctuary cities.

### Testing
- Attempted to build with `cmake --build build --target worldserver -j2`, which failed in this environment because the `/workspace/TrinityCore112/build` directory does not exist (no further automated tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a6b5373c8327ac973e7658df2c2b)