### PR TITLE
Restrict all chat commands to GM accounts

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -155,6 +155,10 @@ void ChatHandler::SendSysMessage(uint32 entry)
 
 bool ChatHandler::_ParseCommands(std::string_view text)
 {
+    // Prevent regular player accounts from executing any chat command.
+    if (m_session && AccountMgr::IsPlayerAccount(m_session->GetSecurity()))
+        return false;
+
     if (Trinity::ChatCommands::TryExecuteCommand(*this, text))
         return true;
 


### PR DESCRIPTION
### Motivation
- Prevent non-GM player accounts from executing any chat-driven commands by blocking command parsing at the central entrypoint.

### Description
- Add a guard in `ChatHandler::_ParseCommands` that returns false when `m_session` exists and `AccountMgr::IsPlayerAccount(m_session->GetSecurity())` is true, preventing further command dispatch for regular player accounts.

### Testing
- No automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fd00d1bc83278ac5e12ac8cc51ab)