### PR TITLE
Log gameobject additions and account bans for server-side auditing

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2932,6 +2932,12 @@ BanReturn World::BanAccount(BanMode mode, std::string const& nameOrIP, uint32 du
 
     LoginDatabase.CommitTransaction(trans);
 
+    if (mode == BAN_ACCOUNT)
+    {
+        TC_LOG_INFO("server", "Account ban applied: account '{}' by '{}' for {} seconds. Reason: {}.",
+            nameOrIP, author, duration_secs, reason);
+    }
+
     return BAN_SUCCESS;
 }
 

--- a/src/server/scripts/Commands/cs_gobject.cpp
+++ b/src/server/scripts/Commands/cs_gobject.cpp
@@ -159,6 +159,10 @@ public:
         /// @todo is it really necessary to add both the real and DB table guid here ?
         sObjectMgr->AddGameobjectToGrid(guidLow, sObjectMgr->GetGameObjectData(guidLow));
 
+        TC_LOG_INFO("commands.gobject", "GameObject added by account {} (player: {}): entry {} ({}) spawnId {} at map {} ({}, {}, {}), spawnTimeSecs {}.",
+            handler->GetSession()->GetAccountId(), player->GetName(), objectId, objectInfo->name, guidLow, map->GetId(),
+            player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), spawnTimeSecs.value_or(0));
+
         handler->PSendSysMessage(LANG_GAMEOBJECT_ADD, objectId, objectInfo->name.c_str(), guidLow, player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
         return true;
     }


### PR DESCRIPTION
### Motivation
- Provide server-side audit logs for administrative actions so operators can trace when GMs add gameobjects and when accounts are banned.

### Description
- Added an info log in `HandleGameObjectAddCommand` (file `src/server/scripts/Commands/cs_gobject.cpp`) that logs account id, player name, gameobject entry and name, spawnId, map id, coordinates, and spawn time using `TC_LOG_INFO("commands.gobject", ...)`.
- Added an info log in `World::BanAccount` (file `src/server/game/World/World.cpp`) that logs the account name, banning author, duration in seconds, and reason using `TC_LOG_INFO("server", ...)` after the DB transaction commit.
- The change touches two files: `src/server/scripts/Commands/cs_gobject.cpp` and `src/server/game/World/World.cpp` and uses existing logging infrastructure without changing behavior.

### Testing
- Attempted an automated build with `cmake --build build --target worldserver -j2`, which failed in this environment because the `build` directory does not exist. No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fef89c808327afd3a82cee9b33d5)