### PR TITLE
Add logging for account bans and GameObject additions

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2932,6 +2932,12 @@ BanReturn World::BanAccount(BanMode mode, std::string const& nameOrIP, uint32 du
 
     LoginDatabase.CommitTransaction(trans);
 
+    if (mode == BAN_ACCOUNT)
+    {
+        TC_LOG_ERROR("server", "Account ban applied: account '{}' by '{}' for {} seconds. Reason: {}.",
+            nameOrIP, author, duration_secs, reason);
+    }
+
     return BAN_SUCCESS;
 }
 

--- a/src/server/scripts/Commands/cs_gobject.cpp
+++ b/src/server/scripts/Commands/cs_gobject.cpp
@@ -159,6 +159,10 @@ public:
         /// @todo is it really necessary to add both the real and DB table guid here ?
         sObjectMgr->AddGameobjectToGrid(guidLow, sObjectMgr->GetGameObjectData(guidLow));
 
+        TC_LOG_ERROR("commands.gobject", "GameObject added by account {} (player: {}): entry {} ({}) spawnId {} at map {} ({}, {}, {}), spawnTimeSecs {}.",
+            handler->GetSession()->GetAccountId(), player->GetName(), objectId, objectInfo->name, guidLow, map->GetId(),
+            player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), spawnTimeSecs.value_or(0));
+
         handler->PSendSysMessage(LANG_GAMEOBJECT_ADD, objectId, objectInfo->name.c_str(), guidLow, player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
         return true;
     }


### PR DESCRIPTION
### Motivation
- Improve observability by emitting explicit logs when an account ban is applied and when a GameObject is added via commands so admins can audit actions and debug issues.

### Description
- Add an error-level log in `World::BanAccount` that records account/IP, author, duration, and reason when `mode == BAN_ACCOUNT`.
- Add an error-level log in command handling (`cs_gobject.cpp`) that records the account id, player name, GameObject entry and name, spawnId, map id, position, and spawn time when a GameObject is added.
- These changes only introduce logging and do not alter existing behavior or database interactions.

### Testing
- Built the server with `cmake --build .` and the build completed successfully.
- Ran the existing automated test suite with `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fef89c808327afd3a82cee9b33d5)