### PR TITLE
Make talent respecs always free

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3981,12 +3981,7 @@ void Player::RemoveArenaSpellCooldowns(bool removeActivePetCooldowns)
 
 uint32 Player::ResetTalentsCost() const
 {
-    //first time is free
-    if (m_resetTalentsTime == 0)
-    {
-        return 0;
-    }
-    return 1 * GOLD;
+    return 0;
 }
 
 bool Player::ResetTalents(bool no_cost)


### PR DESCRIPTION
### Motivation
- Make talent respecs always free by removing the previous first-time-free / subsequent cost behavior so players can reset talents at no cost every time.

### Description
- Changed `Player::ResetTalentsCost()` in `src/server/game/Entities/Player/Player.cpp` to unconditionally return `0`, with no other gameplay logic modified.

### Testing
- Located relevant reset logic with `rg` and verified repository state with `git diff --check` and `git status --short`, then committed the change, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c82c12092c8327b48f6ea0d1f4cd7b)