### PR TITLE
Spells/Hunter: make Viper Sting break damage-sensitive CC

### DIFF
--- a/sql/updates/world/3.3.5/2026_03_28_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_03_28_00_world.sql
@@ -1,0 +1,4 @@
+-- Attach Viper Sting spell script so its periodic mana leech breaks crowd control effects that break on damage.
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_hun_viper_sting';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(-3034, 'spell_hun_viper_sting');

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1357,6 +1357,23 @@ class spell_hun_viper_attack_speed : public AuraScript
     }
 };
 
+// -3034 - Viper Sting
+class spell_hun_viper_sting : public AuraScript
+{
+    PrepareAuraScript(spell_hun_viper_sting);
+
+    void HandlePeriodic(AuraEffect const* /*aurEff*/)
+    {
+        // Viper Sting is expected to break crowd control effects that break on damage.
+        GetTarget()->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TAKE_DAMAGE, GetId());
+    }
+
+    void Register() override
+    {
+        OnEffectPeriodic += AuraEffectPeriodicFn(spell_hun_viper_sting::HandlePeriodic, EFFECT_0, SPELL_AURA_PERIODIC_MANA_LEECH);
+    }
+};
+
 // -19386 - Wyvern Sting
 class spell_hun_wyvern_sting : public AuraScript
 {
@@ -1842,6 +1859,7 @@ void AddSC_hunter_spell_scripts()
     RegisterSpellScript(spell_hun_thrill_of_the_hunt);
     RegisterSpellScript(spell_hun_t9_4p_bonus);
     RegisterSpellScript(spell_hun_viper_attack_speed);
+    RegisterSpellScript(spell_hun_viper_sting);
     RegisterSpellScript(spell_hun_wyvern_sting);
     RegisterSpellScript(spell_hun_hunters_mark);
     RegisterSpellScript(spell_hun_mongoose_bite);


### PR DESCRIPTION
### Motivation
- Viper Sting's periodic mana-leech ticks should break crowd-control effects that are removed by taking damage, but the script wasn't removing those auras on tick.

### Description
- Add a new AuraScript `spell_hun_viper_sting` that runs on Viper Sting periodic ticks and calls `RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TAKE_DAMAGE, GetId())` to clear damage-sensitive CCs.
- Register the new script in `AddSC_hunter_spell_scripts()` so the scripting system loads it at startup.
- Add an SQL update `sql/updates/world/3.3.5/2026_03_28_00_world.sql` to attach the script to the Viper Sting rank chain via `spell_script_names` using the `-3034` entry.

### Testing
- Ran `git diff --check` which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84adf0c6c8327805ee9f50d2e3eea)