### PR TITLE
scripts/gurubashi: grant 3 Marks of Honor from 8 PM chest

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -72,6 +72,17 @@ char const* const GURUBASHI_REENTRY_RULE_WHISPER = "You died while the chest is 
 
 void ClearChestDeathLockouts();
 
+uint32 GetChestMarkRewardCount()
+{
+    time_t const now = GameTime::GetGameTime();
+    tm localTime {};
+#ifdef _WIN32
+    localtime_s(&localTime, &now);
+#else
+    localtime_r(&now, &localTime);
+#endif
+    return localTime.tm_hour == 20 ? 3u : 1u;
+}
 
 bool IsInGurubashiBattleRingByPvpState(Player const* player, uint32 zoneId)
 {
@@ -360,8 +371,9 @@ public:
             if (!player)
                 return;
 
+            uint32 const rewardCount = GetChestMarkRewardCount();
             ItemPosCountVec dest;
-            if (player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, LEGIONNAIRE_MARK_OF_HONOR, 1) != EQUIP_ERR_OK)
+            if (player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, LEGIONNAIRE_MARK_OF_HONOR, rewardCount) != EQUIP_ERR_OK)
             {
                 player->SendEquipError(EQUIP_ERR_INVENTORY_FULL, nullptr, nullptr);
                 me->SetLootState(GO_READY);
@@ -369,7 +381,7 @@ public:
             }
 
             if (Item* item = player->StoreNewItem(dest, LEGIONNAIRE_MARK_OF_HONOR, true))
-                player->SendNewItem(item, 1, true, false);
+                player->SendNewItem(item, rewardCount, true, false);
 
             _rewardGranted = true;
             ClearChestDeathLockouts();


### PR DESCRIPTION
### Motivation
- Make the Gurubashi hourly treasure chest give a larger reward at the 8 PM server hour so the 20:00 chest awards `3` Marks of Honor instead of the default `1`.

### Description
- Added `GetChestMarkRewardCount()` which samples server local time (`tm_hour`) and returns `3` when `tm_hour == 20` and `1` otherwise.
- Wired the computed reward count into the chest loot flow in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` so both the inventory capacity check (`CanStoreNewItem`) and the awarded/new-item notification (`SendNewItem`) use the same `rewardCount`.

### Testing
- Applied the patch with `apply_patch` and it reported success (file updated: `src/server/scripts/Custom/custom_gurubashi_arena.cpp`).
- Verified changes with `git diff -- src/server/scripts/Custom/custom_gurubashi_arena.cpp` and committed the change with `git add`/`git commit`, both commands completed successfully.
- Inspected the modified lines with `nl -ba ...` to confirm the helper and the usage were added; the inspection completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8689bd7cc8327bc561e4e132cf054)