### PR TITLE
Guard against null caster in Aura::CanStackWith to avoid null-deref

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1909,8 +1909,9 @@ bool Aura::CanStackWith(Aura const* existingAura) const
     if (m_spellInfo->HasAura(SPELL_AURA_TRACK_RESOURCES) && existingSpellInfo->HasAura(SPELL_AURA_TRACK_RESOURCES))
         return sWorld->getBoolConfig(CONFIG_ALLOW_TRACK_BOTH_RESOURCES);
 
-    bool ignoreJustice = (m_spellInfo->Id == 20164 || existingSpellInfo->Id == 20164) && GetCaster()->HasAura(81474); // lancelot's justice
-    bool ignoreJudgementJustice = (m_spellInfo->Id == 20184 || existingSpellInfo->Id == 20184) && GetCaster()->HasAura(81474); // lancelot's justice
+    Unit* caster = GetCaster();
+    bool ignoreJustice = caster && (m_spellInfo->Id == 20164 || existingSpellInfo->Id == 20164) && caster->HasAura(81474); // lancelot's justice
+    bool ignoreJudgementJustice = caster && (m_spellInfo->Id == 20184 || existingSpellInfo->Id == 20184) && caster->HasAura(81474); // lancelot's justice
 
     // check spell specific stack rules
     if (m_spellInfo->IsAuraExclusiveBySpecificWith(existingSpellInfo)


### PR DESCRIPTION
### Motivation
- Prevent a potential null pointer dereference in `Aura::CanStackWith` when `GetCaster()` can be null while checking caster auras for specific spell interactions.

### Description
- Cache `GetCaster()` into `Unit* caster` and protect calls to `HasAura(81474)` with `caster && ...` so the existing logic for spell IDs `20164` and `20184` remains but no longer dereferences a null pointer.

### Testing
- Rebuilt the project using `make` and ran the automated test suite; the build completed and tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96ac6c6e483279c9db4435a23c206)