### PR TITLE
Guard against null-owned auras/gameobjects and null caster in aura stacking logic

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3001,17 +3001,32 @@ void Unit::_UpdateSpells(uint32 time)
     // m_auraUpdateIterator can be updated in indirect called code at aura remove to skip next planned to update but removed auras
     for (m_auraUpdateIterator = m_ownedAuras.begin(); m_auraUpdateIterator != m_ownedAuras.end();)
     {
-        Aura* i_aura = m_auraUpdateIterator->second;
+        AuraMap::iterator current = m_auraUpdateIterator;
+        Aura* i_aura = current->second;
         ++m_auraUpdateIterator;                            // need shift to next for allow update if need into aura update
+
+        if (!i_aura)
+        {
+            TC_LOG_ERROR("entities.unit", "Unit::_UpdateSpells: removing null owned aura entry on {}", GetGUID().ToString());
+            m_ownedAuras.erase(current);
+            continue;
+        }
+
         i_aura->UpdateOwner(time, this);
     }
 
     // remove expired auras - do that after updates(used in scripts?)
     for (AuraMap::iterator i = m_ownedAuras.begin(); i != m_ownedAuras.end();)
     {
-        if (i->second->IsExpired())
+        Aura* aura = i->second;
+        if (!aura)
+        {
+            TC_LOG_ERROR("entities.unit", "Unit::_UpdateSpells: removing null owned aura entry during expire pass on {}", GetGUID().ToString());
+            i = m_ownedAuras.erase(i);
+        }
+        else if (aura->IsExpired())
             RemoveOwnedAura(i, AURA_REMOVE_BY_EXPIRE);
-        else if (i->second->GetSpellInfo()->IsChanneled() && i->second->GetCasterGUID() != GetGUID() && !ObjectAccessor::GetWorldObject(*this, i->second->GetCasterGUID()))
+        else if (aura->GetSpellInfo()->IsChanneled() && aura->GetCasterGUID() != GetGUID() && !ObjectAccessor::GetWorldObject(*this, aura->GetCasterGUID()))
             RemoveOwnedAura(i, AURA_REMOVE_BY_CANCEL); // remove channeled auras when caster is not on the same map
         else
             ++i;
@@ -3028,11 +3043,19 @@ void Unit::_UpdateSpells(uint32 time)
         GameObjectList::iterator itr;
         for (itr = m_gameObj.begin(); itr != m_gameObj.end();)
         {
-            if (!(*itr)->isSpawned())
+            GameObject* gameObject = *itr;
+            if (!gameObject)
             {
-                (*itr)->SetOwnerGUID(ObjectGuid::Empty);
-                (*itr)->SetRespawnTime(0);
-                (*itr)->Delete();
+                TC_LOG_ERROR("entities.unit", "Unit::_UpdateSpells: removing null owned gameobject entry on {}", GetGUID().ToString());
+                itr = m_gameObj.erase(itr);
+                continue;
+            }
+
+            if (!gameObject->isSpawned())
+            {
+                gameObject->SetOwnerGUID(ObjectGuid::Empty);
+                gameObject->SetRespawnTime(0);
+                gameObject->Delete();
                 m_gameObj.erase(itr++);
             }
             else

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1909,8 +1909,9 @@ bool Aura::CanStackWith(Aura const* existingAura) const
     if (m_spellInfo->HasAura(SPELL_AURA_TRACK_RESOURCES) && existingSpellInfo->HasAura(SPELL_AURA_TRACK_RESOURCES))
         return sWorld->getBoolConfig(CONFIG_ALLOW_TRACK_BOTH_RESOURCES);
 
-    bool ignoreJustice = (m_spellInfo->Id == 20164 || existingSpellInfo->Id == 20164) && GetCaster()->HasAura(81474); // lancelot's justice
-    bool ignoreJudgementJustice = (m_spellInfo->Id == 20184 || existingSpellInfo->Id == 20184) && GetCaster()->HasAura(81474); // lancelot's justice
+    Unit* caster = GetCaster();
+    bool ignoreJustice = caster && (m_spellInfo->Id == 20164 || existingSpellInfo->Id == 20164) && caster->HasAura(81474); // lancelot's justice
+    bool ignoreJudgementJustice = caster && (m_spellInfo->Id == 20184 || existingSpellInfo->Id == 20184) && caster->HasAura(81474); // lancelot's justice
 
     // check spell specific stack rules
     if (m_spellInfo->IsAuraExclusiveBySpecificWith(existingSpellInfo)


### PR DESCRIPTION
### Motivation

- Prevent crashes and undefined behavior when null pointers are present in owned aura and gameobject containers during spell/auras update and expiration passes.  
- Avoid dereferencing a null caster when evaluating special-case aura stacking rules.

### Description

- In `Unit::_UpdateSpells` iterate using a copied iterator (`current`) and check for null `Aura*` entries, log an error, erase the map entry, and continue before calling `UpdateOwner`.
- In the aura-expire pass extract `Aura* aura` and check for null entries, log and erase them, and otherwise handle expiration and channeled-removal using the local pointer.
- In the gameobject cleanup loop check for null `GameObject*`, log and erase the vector entry, and otherwise operate on a local `gameObject` variable when clearing owner/respawn and deleting.
- In `Aura::CanStackWith` introduce a `Unit* caster = GetCaster();` and guard `HasAura(81474)` checks with the caster pointer to avoid null dereference.

### Testing

- Built the project using the normal build system with `make` and the build completed successfully.  
- Ran the automated test suite using `ctest`/`make test` and all executed tests passed without failures.  
- Exercised spell/auras update paths to verify no null-pointer crashes and observed the new error logs for previously-broken states.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96ac6c6e483279c9db4435a23c206)