### PR TITLE
Validate restriction codes in SendChatRestrictedNotice and log invalid values

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -916,6 +916,18 @@ void WorldSession::SendWrongFactionNotice()
 
 void WorldSession::SendChatRestrictedNotice(ChatRestrictionType restriction)
 {
+    switch (restriction)
+    {
+        case ERR_CHAT_RESTRICTED:
+        case ERR_CHAT_THROTTLED:
+        case ERR_USER_SQUELCHED:
+        case ERR_YELL_RESTRICTED:
+            break;
+        default:
+            TC_LOG_ERROR("network", "WorldSession::SendChatRestrictedNotice received invalid restriction {} for account {}", uint32(restriction), GetAccountId());
+            return;
+    }
+
     WorldPacket data(SMSG_CHAT_RESTRICTED, 1);
     data << uint8(restriction);
     SendPacket(&data);


### PR DESCRIPTION
### Motivation
- Prevent sending malformed chat restriction packets by validating the `restriction` parameter in `SendChatRestrictedNotice` and log unexpected values tied to the account ID.

### Description
- Add a `switch` in `SendChatRestrictedNotice` to accept only `ERR_CHAT_RESTRICTED`, `ERR_CHAT_THROTTLED`, `ERR_USER_SQUELCHED`, and `ERR_YELL_RESTRICTED` and early-return with a `TC_LOG_ERROR` if an invalid code is provided.

### Testing
- Project builds successfully (`make`) and existing automated tests were executed (`make test` / `ctest`) with no failures recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad9181c7483279d9e317fd001dc03)