### PR TITLE
Add BGScript hooks and battleground lifecycle events for Playerbot BG integration

### DIFF
--- a/doc/playerbot_bg_integration.md
+++ b/doc/playerbot_bg_integration.md
@@ -1,0 +1,49 @@
+# Integrating `azerothcore-wotlk-Playerbot` (Battleground-focused) into this TrinityCore tree
+
+This repository is TrinityCore-based, while `mod-playerbots` targets an AzerothCore fork that already carries Playerbot core patches.
+
+Because of that, full drop-in integration is **not** possible without a compatibility layer. This commit adds the first required compatibility hook: a new script type named `BGScript` with battleground start/end callbacks.
+
+## What was added in core
+
+- `BGScript` script type in `ScriptMgr`.
+- New callbacks:
+  - `ScriptMgr::OnBattlegroundStart(Battleground* bg)`
+  - `ScriptMgr::OnBattlegroundEnd(Battleground* bg, TeamId winnerTeam)`
+- Battleground lifecycle bridge calls from Trinity core:
+  - `Battleground::StartBattleground()` now emits `OnBattlegroundStart`.
+  - `Battleground::EndBattleground()` now emits `OnBattlegroundEnd`.
+
+This mirrors the hook pattern used by AzerothCore modules that register a `BGScript` for battleground bot tactics.
+
+## Recommended module layout in this repo
+
+Place your module in:
+
+- `src/server/scripts/Custom/Playerbots/` for gradual Trinity-ported files, or
+- keep your imported source in `azerothcore-wotlk-Playerbot/` and copy/port only BG-relevant code into Trinity script files.
+
+## BG-only porting order (minimal path)
+
+1. Port `PlayerBotsBGScript` logic first (BG start/end strategy management).
+2. Port queue participation logic from `RandomPlayerbotMgr` (auto-join/fill behavior).
+3. Port only BG strategy/action classes actually referenced by step 1 and 2.
+4. Add config keys in `worldserver.conf.dist` under a dedicated section (e.g. `Playerbot.BG.*`).
+5. Add SQL tables required by bot queue state, if your selected logic depends on persistent state.
+
+## Practical caveats
+
+- AzerothCore Playerbot uses APIs and helper managers that do not exist in TrinityCore as-is.
+- Expect symbol mismatches around:
+  - bot account/session managers,
+  - queue/invite helper wrappers,
+  - script registration macros and naming.
+- Keep the scope BG-only until queue filling and match behavior are stable.
+
+## Quick validation checklist after porting module files
+
+1. Build succeeds.
+2. Bots can queue into at least one BG bracket.
+3. BG start/end callbacks are hit (add temporary logs).
+4. Teams receive bot backfill symmetrically.
+5. No crash on BG shutdown / teleport out.

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -42,6 +42,7 @@
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ReputationMgr.h"
+#include "ScriptMgr.h"
 #include "SpellAuras.h"
 #include "TemporarySummon.h"
 #include "Transport.h"
@@ -635,6 +636,14 @@ void Battleground::EndBattleground(Team winner)
         SetWinner(PVP_TEAM_NEUTRAL);
     }
 
+    TeamId winnerTeam = TEAM_NEUTRAL;
+    if (winner == ALLIANCE)
+        winnerTeam = TEAM_ALLIANCE;
+    else if (winner == HORDE)
+        winnerTeam = TEAM_HORDE;
+
+    sScriptMgr->OnBattlegroundEnd(this, winnerTeam);
+
     CharacterDatabasePreparedStatement* stmt = nullptr;
     uint64 battlegroundId = 1;
     if (isBattleground() && sWorld->getBoolConfig(CONFIG_BATTLEGROUND_STORE_STATISTICS_ENABLE))
@@ -957,6 +966,8 @@ void Battleground::StartBattleground()
 
     if (m_IsRated)
         TC_LOG_DEBUG("bg.arena", "Arena match type: {} started.", m_ArenaType);
+
+    sScriptMgr->OnBattlegroundStart(this);
 }
 
 void Battleground::TeleportPlayerToExploitLocation(Player* player)

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1972,6 +1972,16 @@ void ScriptMgr::OnShutdown()
     FOREACH_SCRIPT(WorldScript)->OnShutdown();
 }
 
+void ScriptMgr::OnBattlegroundStart(Battleground* bg)
+{
+    FOREACH_SCRIPT(BGScript)->OnBattlegroundStart(bg);
+}
+
+void ScriptMgr::OnBattlegroundEnd(Battleground* bg, TeamId winnerTeam)
+{
+    FOREACH_SCRIPT(BGScript)->OnBattlegroundEnd(bg, winnerTeam);
+}
+
 // Achievement
 void ScriptMgr::OnAchievementCompleted(Player* player, AchievementEntry const* achievement)
 {
@@ -2474,6 +2484,22 @@ void WorldScript::OnStartup()
 }
 
 void WorldScript::OnShutdown()
+{
+}
+
+BGScript::BGScript(char const* name) noexcept
+    : ScriptObject(name)
+{
+    ScriptRegistry<BGScript>::Instance()->AddScript(this);
+}
+
+BGScript::~BGScript() = default;
+
+void BGScript::OnBattlegroundStart(Battleground* /*bg*/)
+{
+}
+
+void BGScript::OnBattlegroundEnd(Battleground* /*bg*/, TeamId /*winnerTeam*/)
 {
 }
 
@@ -3250,6 +3276,7 @@ void PlayerChoiceScript::OnResponse(WorldObject* /*object*/, Player* /*player*/,
 template class TC_GAME_API ScriptRegistry<SpellScriptLoader>;
 template class TC_GAME_API ScriptRegistry<ServerScript>;
 template class TC_GAME_API ScriptRegistry<WorldScript>;
+template class TC_GAME_API ScriptRegistry<BGScript>;
 template class TC_GAME_API ScriptRegistry<FormulaScript>;
 template class TC_GAME_API ScriptRegistry<WorldMapScript>;
 template class TC_GAME_API ScriptRegistry<InstanceMapScript>;

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -94,6 +94,7 @@ enum RemoveMethod : uint8;
 enum ShutdownExitCode : uint32;
 enum ShutdownMask : uint32;
 enum SpellEffIndex : uint8;
+enum TeamId : uint32;
 enum WeatherState : uint32;
 enum XPColorChar : uint8;
 
@@ -278,6 +279,20 @@ class TC_GAME_API WorldScript : public ScriptObject
 
         // Called when the world is actually shut down.
         virtual void OnShutdown();
+};
+
+class TC_GAME_API BGScript : public ScriptObject
+{
+    protected:
+
+        explicit BGScript(char const* name) noexcept;
+
+    public:
+
+        ~BGScript();
+
+        virtual void OnBattlegroundStart(Battleground* bg);
+        virtual void OnBattlegroundEnd(Battleground* bg, TeamId winnerTeam);
 };
 
 class TC_GAME_API FormulaScript : public ScriptObject
@@ -1105,6 +1120,11 @@ class TC_GAME_API ScriptMgr
         void OnWorldUpdate(uint32 diff);
         void OnStartup();
         void OnShutdown();
+
+    public: /* BGScript */
+
+        void OnBattlegroundStart(Battleground* bg);
+        void OnBattlegroundEnd(Battleground* bg, TeamId winnerTeam);
 
     public: /* FormulaScript */
 


### PR DESCRIPTION
### Motivation
- Provide a minimal compatibility seam so AzerothCore `mod-playerbots` BG logic can be incrementally ported to this TrinityCore tree by exposing battleground lifecycle hooks.

### Description
- Add a new `BGScript` script type to `ScriptMgr` with virtual `OnBattlegroundStart(Battleground*)` and `OnBattlegroundEnd(Battleground*, TeamId)` callbacks and register it in the script registry.
- Add `ScriptMgr::OnBattlegroundStart` and `ScriptMgr::OnBattlegroundEnd` dispatchors and default `BGScript` implementations in `ScriptMgr.cpp`.
- Emit the new hooks from `Battleground::StartBattleground()` and `Battleground::EndBattleground()` and map the internal `Team` winner to `TeamId` before dispatching.
- Add a document `doc/playerbot_bg_integration.md` describing a BG-focused porting plan and recommended module layout/port order for Playerbot code.

### Testing
- Ran CMake configure to validate the changes with: `cmake -S . -B build -DSERVERS=1 -DTOOLS=0 -DBUILD_TESTING=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0`; configuration failed due to a missing Boost CMake package (`BoostConfig.cmake` / `boost-config.cmake`).
- No further automated build or unit tests were executed in this environment due to the above configuration dependency failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc58d0f6c883279a4771c7752fda60)