### PR TITLE
Start battleground playerbot integration bootstrap

### DIFF
--- a/doc/playerbot_bg_integration.md
+++ b/doc/playerbot_bg_integration.md
@@ -47,3 +47,24 @@ Place your module in:
 3. BG start/end callbacks are hit (add temporary logs).
 4. Teams receive bot backfill symmetrically.
 5. No crash on BG shutdown / teleport out.
+
+
+## Current status (started in this tree)
+
+- ✅ Core hook bridge is in place (`BGScript`, `OnBattlegroundStart`, `OnBattlegroundEnd`).
+- 🚧 BG-only module bootstrapping has started under `src/server/scripts/Custom/Playerbots/` with a first Trinity-side `BGScript` that tracks battleground lifecycle events and logs start/end transitions.
+
+## Remaining work (in order)
+
+1. **Port `PlayerBotsBGScript` decision logic**
+   - Replace lifecycle-only tracking with actual per-BG strategy management (composition, role policies, map-specific behavior).
+2. **Port queue participation / fill behavior**
+   - Bring over the subset of `RandomPlayerbotMgr` logic needed for auto-join and symmetric team backfill.
+3. **Port required BG strategy/action classes**
+   - Only port classes referenced by steps 1 and 2 to keep scope minimal.
+4. **Add config keys (`Playerbot.BG.*`)**
+   - Define enable toggles, bracket limits, queue cadence, and fill/balance thresholds in `worldserver.conf.dist`.
+5. **Add SQL persistence (if needed by selected queue logic)**
+   - Introduce minimal tables only if your chosen queue/backfill implementation requires persistent state.
+6. **Validation pass**
+   - Verify queueing, callback hit rates, symmetric backfill, and clean BG teardown with no crash/teleport regressions.

--- a/src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp
+++ b/src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Battleground.h"
+#include "Log.h"
+#include "ScriptMgr.h"
+
+#include <unordered_set>
+
+namespace
+{
+    class PlayerbotBGStateTracker : public BGScript
+    {
+        public:
+            PlayerbotBGStateTracker() : BGScript("playerbot_bg_state_tracker") { }
+
+            void OnBattlegroundStart(Battleground* bg) override
+            {
+                if (!bg)
+                    return;
+
+                uint32 instanceId = bg->GetInstanceID();
+                _activeBattlegrounds.insert(instanceId);
+
+                TC_LOG_INFO("bg.playerbot", "Playerbot BG tracker: started battleground '{}' (type {}, instance {})",
+                    bg->GetName(), uint32(bg->GetTypeID()), instanceId);
+            }
+
+            void OnBattlegroundEnd(Battleground* bg, TeamId winnerTeam) override
+            {
+                if (!bg)
+                    return;
+
+                uint32 instanceId = bg->GetInstanceID();
+                _activeBattlegrounds.erase(instanceId);
+
+                TC_LOG_INFO("bg.playerbot", "Playerbot BG tracker: ended battleground '{}' (type {}, instance {}, winnerTeam {})",
+                    bg->GetName(), uint32(bg->GetTypeID()), instanceId, uint32(winnerTeam));
+            }
+
+        private:
+            std::unordered_set<uint32> _activeBattlegrounds;
+    };
+}
+
+void AddSC_playerbot_bg_integration()
+{
+    new PlayerbotBGStateTracker();
+}

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -19,6 +19,10 @@
 
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
+// Custom / playerbot experiments
+void AddSC_playerbot_bg_integration();
+
 void AddCustomScripts()
 {
+    AddSC_playerbot_bg_integration();
 }


### PR DESCRIPTION
### Motivation

- Provide a minimal Trinity-side bootstrap for integrating AzerothCore `Playerbot` battleground behavior so further porting can proceed incrementally.
- Establish an observable lifecycle hook and baseline logging to validate BG start/end events before porting decision/queue logic and strategy classes.

### Description

- Add `src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp` which registers a `BGScript` (`PlayerbotBGStateTracker`) that tracks active battleground instance IDs and logs BG start/end transitions with name, type, instance, and winner team.
- Wire the script into the custom script loader by declaring and invoking `AddSC_playerbot_bg_integration()` from `src/server/scripts/Custom/custom_script_loader.cpp` so the script is registered at startup.
- Update `doc/playerbot_bg_integration.md` with a `Current status` section and an ordered `Remaining work` checklist that lists porting `PlayerBotsBGScript` decision logic, queue participation/fill behavior, strategy/action classes, config keys, optional SQL persistence, and a validation pass.

### Testing

- Ran CMake configuration with `-DSCRIPTS=static -DTOOLS=0 -DBUILD_TESTING=0` to validate integration paths, which failed due to missing Boost package CMake files (`BoostConfig.cmake` / `boost-config.cmake`) in this environment.
- No unit tests were executed in this run and no binary build was completed due to the configuration failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc5b89e2488327af18cb476aaa71d8)