### PR TITLE
Add Playerbot BG config, directives, and queue-fill scaffolding

### DIFF
--- a/doc/playerbot_bg_integration.md
+++ b/doc/playerbot_bg_integration.md
@@ -69,11 +69,19 @@ Place your module in:
      - one-player max team imbalance window,
      - available free slots per team.
    - Added transition-only logging for queue-fill request snapshots (`initialized`, `updated`, `final snapshot`).
-3. **Port required BG strategy/action classes**
-   - Only port classes referenced by steps 1 and 2 to keep scope minimal.
-4. **Add config keys (`Playerbot.BG.*`)**
-   - Define enable toggles, bracket limits, queue cadence, and fill/balance thresholds in `worldserver.conf.dist`.
-5. **Add SQL persistence (if needed by selected queue logic)**
-   - Introduce minimal tables only if your chosen queue/backfill implementation requires persistent state.
+3. ✅ **Port required BG strategy/action classes**
+   - Added Trinity-side minimal directive/action classes for BG squads:
+     - `PlayerbotBGAction`
+     - `PlayerbotBGSquadDirective`
+   - Added map-profile-to-action translation (`BuildSquadDirectives`) and directive logging on BG start.
+4. ✅ **Add config keys (`Playerbot.BG.*`)**
+   - Added settings to `worldserver.conf.dist`:
+     - `Playerbot.BG.Enable`
+     - `Playerbot.BG.QueueUpdateMs`
+     - `Playerbot.BG.MaxTeamImbalance`
+     - `Playerbot.BG.MaxBackfillPerUpdate`
+   - Wired settings into runtime behavior (enable gate, queue cadence, imbalance limit, per-tick cap).
+5. ✅ **Add SQL persistence (if needed by selected queue logic)**
+   - Not required for current implementation: queue/backfill state is computed from live battleground populations + invite counts and kept in-memory per active instance.
 6. **Validation pass**
    - Verify queueing, callback hit rates, symmetric backfill, and clean BG teardown with no crash/teleport regressions.

--- a/src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp
+++ b/src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp
@@ -17,11 +17,14 @@
 
 #include "Battleground.h"
 #include "BattlegroundMgr.h"
+#include "Config.h"
 #include "Log.h"
 #include "ScriptMgr.h"
 
+#include <algorithm>
 #include <array>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 
 namespace
@@ -75,6 +78,72 @@ namespace
         uint32 InstanceId = 0;
         BackfillRequest LastRequest;
     };
+
+    struct PlayerbotBGConfig
+    {
+        bool Enabled = true;
+        uint32 QueueUpdateIntervalMs = 5000;
+        uint32 MaxTeamImbalance = 1;
+        uint32 MaxBackfillPerUpdate = 3;
+    };
+
+    PlayerbotBGConfig LoadPlayerbotBGConfig()
+    {
+        PlayerbotBGConfig config;
+        config.Enabled = sConfigMgr->GetOption<bool>("Playerbot.BG.Enable", true);
+        config.QueueUpdateIntervalMs = std::max<uint32>(1000, sConfigMgr->GetOption<uint32>("Playerbot.BG.QueueUpdateMs", 5000));
+        config.MaxTeamImbalance = std::min<uint32>(5, sConfigMgr->GetOption<uint32>("Playerbot.BG.MaxTeamImbalance", 1));
+        config.MaxBackfillPerUpdate = std::max<uint32>(1, sConfigMgr->GetOption<uint32>("Playerbot.BG.MaxBackfillPerUpdate", 3));
+        return config;
+    }
+
+    enum class PlayerbotBGAction : uint8
+    {
+        HoldObjectives,
+        CaptureObjectives,
+        EscortCarrier,
+        DefendCarrierRoute,
+        PressureFrontline
+    };
+
+    struct PlayerbotBGSquadDirective
+    {
+        char const* SquadName = "main";
+        PlayerbotBGAction Action = PlayerbotBGAction::HoldObjectives;
+        uint8 Priority = 1;
+    };
+
+    char const* ToString(PlayerbotBGAction action)
+    {
+        switch (action)
+        {
+            case PlayerbotBGAction::HoldObjectives: return "HoldObjectives";
+            case PlayerbotBGAction::CaptureObjectives: return "CaptureObjectives";
+            case PlayerbotBGAction::EscortCarrier: return "EscortCarrier";
+            case PlayerbotBGAction::DefendCarrierRoute: return "DefendCarrierRoute";
+            case PlayerbotBGAction::PressureFrontline: return "PressureFrontline";
+            default: return "Unknown";
+        }
+    }
+
+    std::array<PlayerbotBGSquadDirective, 3> BuildSquadDirectives(PlayerbotMapPolicy const& policy)
+    {
+        std::array<PlayerbotBGSquadDirective, 3> directives{ };
+        for (uint8 i = 0; i < policy.SquadCount; ++i)
+        {
+            directives[i].SquadName = policy.Squads[i].Name;
+            directives[i].Priority = uint8(i + 1);
+
+            if (policy.ProfileName == std::string_view("ctf_split"))
+                directives[i].Action = i == 0 ? PlayerbotBGAction::CaptureObjectives : (i == 1 ? PlayerbotBGAction::EscortCarrier : PlayerbotBGAction::DefendCarrierRoute);
+            else if (policy.ProfileName == std::string_view("lane_pressure"))
+                directives[i].Action = i == 0 ? PlayerbotBGAction::PressureFrontline : PlayerbotBGAction::HoldObjectives;
+            else
+                directives[i].Action = i == 2 ? PlayerbotBGAction::CaptureObjectives : PlayerbotBGAction::HoldObjectives;
+        }
+
+        return directives;
+    }
 
     PlayerbotRoleTargets BuildRoleTargets(uint32 maxPlayersPerTeam)
     {
@@ -176,6 +245,10 @@ namespace
         if (!bg || bg->isArena())
             return { };
 
+        PlayerbotBGConfig const config = LoadPlayerbotBGConfig();
+        if (!config.Enabled)
+            return { };
+
         uint32 maxPlayersPerTeam = bg->GetMaxPlayersPerTeam();
         uint32 minPlayersPerTeam = bg->GetMinPlayersPerTeam();
         uint32 allianceOccupied = bg->GetPlayersCountByTeam(ALLIANCE) + bg->GetInvitedCount(ALLIANCE);
@@ -183,20 +256,20 @@ namespace
         uint32 allianceFreeSlots = bg->GetFreeSlotsForTeam(ALLIANCE);
         uint32 hordeFreeSlots = bg->GetFreeSlotsForTeam(HORDE);
 
-        uint32 constexpr MaxTeamImbalance = 1;
-
         uint32 allianceNeed = allianceOccupied < minPlayersPerTeam ? minPlayersPerTeam - allianceOccupied : 0;
         uint32 hordeNeed = hordeOccupied < minPlayersPerTeam ? minPlayersPerTeam - hordeOccupied : 0;
 
-        if (allianceOccupied > hordeOccupied + MaxTeamImbalance)
-            hordeNeed += allianceOccupied - (hordeOccupied + MaxTeamImbalance);
-        else if (hordeOccupied > allianceOccupied + MaxTeamImbalance)
-            allianceNeed += hordeOccupied - (allianceOccupied + MaxTeamImbalance);
+        if (allianceOccupied > hordeOccupied + config.MaxTeamImbalance)
+            hordeNeed += allianceOccupied - (hordeOccupied + config.MaxTeamImbalance);
+        else if (hordeOccupied > allianceOccupied + config.MaxTeamImbalance)
+            allianceNeed += hordeOccupied - (allianceOccupied + config.MaxTeamImbalance);
 
         allianceNeed = std::min(allianceNeed, allianceFreeSlots);
         hordeNeed = std::min(hordeNeed, hordeFreeSlots);
         allianceNeed = std::min(allianceNeed, maxPlayersPerTeam);
         hordeNeed = std::min(hordeNeed, maxPlayersPerTeam);
+        allianceNeed = std::min(allianceNeed, config.MaxBackfillPerUpdate);
+        hordeNeed = std::min(hordeNeed, config.MaxBackfillPerUpdate);
 
         return { uint8(allianceNeed), uint8(hordeNeed) };
     }
@@ -213,6 +286,8 @@ namespace
             void StartTracking(Battleground* bg)
             {
                 if (!bg || bg->isArena())
+                    return;
+                if (!LoadPlayerbotBGConfig().Enabled)
                     return;
 
                 ActiveQueueFillState& fillState = _activeQueueFill[bg->GetInstanceID()];
@@ -271,7 +346,7 @@ namespace
             }
 
             std::unordered_map<uint32, ActiveQueueFillState> _activeQueueFill;
-    }
+    };
 
     class PlayerbotBGStateTracker : public BGScript
     {
@@ -281,6 +356,8 @@ namespace
             void OnBattlegroundStart(Battleground* bg) override
             {
                 if (!bg)
+                    return;
+                if (!LoadPlayerbotBGConfig().Enabled)
                     return;
 
                 uint32 instanceId = bg->GetInstanceID();
@@ -292,6 +369,7 @@ namespace
                 plan.AllianceTargets = BuildRoleTargets(maxPlayersPerTeam);
                 plan.HordeTargets = BuildRoleTargets(maxPlayersPerTeam);
                 plan.Policy = BuildMapPolicy(typeId, maxPlayersPerTeam);
+                auto const directives = BuildSquadDirectives(plan.Policy);
                 PlayerbotBGQueueCoordinator::Instance().StartTracking(bg);
 
                 _activeStrategies[instanceId] = plan;
@@ -314,6 +392,9 @@ namespace
                         "Playerbot BG squad plan (instance {}, squad {}): '{}' size {} with T/H/R/M {}/{}/{}/{} -> {}",
                         instanceId, uint32(i), squad.Name, uint32(squad.DesiredSize),
                         uint32(squad.Tanks), uint32(squad.Healers), uint32(squad.RangedDps), uint32(squad.MeleeDps), squad.Objective);
+                    TC_LOG_INFO("bg.playerbot",
+                        "Playerbot BG directive (instance {}, squad '{}'): action {} priority {}",
+                        instanceId, directives[i].SquadName, ToString(directives[i].Action), uint32(directives[i].Priority));
                 }
             }
 
@@ -357,17 +438,21 @@ namespace
 
             void OnUpdate(uint32 diff) override
             {
+                PlayerbotBGConfig const config = LoadPlayerbotBGConfig();
+                if (!config.Enabled)
+                    return;
+
                 if (_updateTimer <= diff)
                 {
                     PlayerbotBGQueueCoordinator::Instance().Update();
-                    _updateTimer = 5000;
+                    _updateTimer = config.QueueUpdateIntervalMs;
                 }
                 else
                     _updateTimer -= diff;
             }
 
         private:
-            uint32 _updateTimer = 5000;
+            uint32 _updateTimer = LoadPlayerbotBGConfig().QueueUpdateIntervalMs;
     };
 }
 

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4348,6 +4348,44 @@ Pvp.FactionBalance.Pct20 = 0.8
 ###################################################################################################
 
 ###################################################################################################
+# PLAYERBOT BATTLEGROUND SETTINGS
+#
+#    Playerbot.BG.Enable
+#        Description: Globally enables battleground-focused Playerbot integration hooks and queue-fill planning.
+#        Default:     1 - (Enabled)
+#                     0 - (Disabled)
+#
+
+Playerbot.BG.Enable = 1
+
+#    Playerbot.BG.QueueUpdateMs
+#        Description: Update cadence for battleground queue-fill recomputation in milliseconds.
+#        Default:     5000
+#        Min value:   1000
+#
+
+Playerbot.BG.QueueUpdateMs = 5000
+
+#    Playerbot.BG.MaxTeamImbalance
+#        Description: Maximum allowed team-size gap before additional backfill is requested for the smaller team.
+#        Default:     1
+#        Max value:   5
+#
+
+Playerbot.BG.MaxTeamImbalance = 1
+
+#    Playerbot.BG.MaxBackfillPerUpdate
+#        Description: Hard cap for requested bot invites per team during one queue-fill update tick.
+#        Default:     3
+#        Min value:   1
+#
+
+Playerbot.BG.MaxBackfillPerUpdate = 3
+
+#
+###################################################################################################
+
+###################################################################################################
 # LOAD SETTINGS
 #
 # These settings control content loading


### PR DESCRIPTION
### Motivation
- Provide the remaining runtime scaffolding so the battleground-focused Playerbot integration can be enabled/controlled from config and produce actionable squad directives on BG start.
- Make queue-fill/backfill planning configurable and gated so operators can tune cadence, imbalance thresholds, and per-tick invite caps.
- Capture the completed work in documentation so the porting checklist is up-to-date.

### Description
- Added runtime config support and runtime options via a new `PlayerbotBGConfig` with loader `LoadPlayerbotBGConfig()` and consumed `Playerbot.BG.*` keys in the logic in `src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp`.
- Introduced minimal BG strategy/action scaffolding (`PlayerbotBGAction`, `PlayerbotBGSquadDirective`, `BuildSquadDirectives`, and `ToString`) and log the generated directives during BG start.
- Wired configuration into backfill computation and runtime flow: config gate for enabling the feature, `QueueUpdateMs` used for world updater cadence, `MaxTeamImbalance` applied to symmetric backfill math, and `MaxBackfillPerUpdate` applied as a per-tick cap.
- Added configuration entries and documentation in `src/server/worldserver/worldserver.conf.dist` for `Playerbot.BG.Enable`, `Playerbot.BG.QueueUpdateMs`, `Playerbot.BG.MaxTeamImbalance`, and `Playerbot.BG.MaxBackfillPerUpdate` and updated `doc/playerbot_bg_integration.md` to mark the strategy/action and config items as completed.

### Testing
- Ran `git diff --check` to verify no whitespace/hunk issues, which completed successfully.
- Verified repository changes with `git status --short` and committed the edits, commit succeeded.
- No build or runtime tests were executed in this pass; a full server build and in-game BG validation are still recommended as the final validation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc68fd5cb08327a42ab378b3b6b105)