### PR TITLE
Fix TeamId enum forward declaration mismatch

### DIFF
--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -1278,7 +1278,7 @@ enum Language
     LANG_TONGUES_OF_SANCTUARY = 308,
 };
 
-enum TeamId
+enum TeamId : uint32
 {
     TEAM_ALLIANCE = 0,
     TEAM_HORDE,


### PR DESCRIPTION
### Motivation
- Resolve compilation failures caused by a mismatch between the forward declaration `enum TeamId : uint32;` in `src/server/game/Scripting/ScriptMgr.h` and the untyped `enum TeamId` definition in `src/server/game/Miscellaneous/SharedDefines.h`, which made `TEAM_ALLIANCE`, `TEAM_HORDE`, and `TEAM_NEUTRAL` appear undeclared.

### Description
- Change `enum TeamId` in `src/server/game/Miscellaneous/SharedDefines.h` to `enum TeamId : uint32` so the definition matches the forward declaration in `ScriptMgr.h`.

### Testing
- Verified the modification with `git diff`, `rg -n "enum TeamId"` across the two headers, and inspected the updated source with `nl -ba`, and all checks confirm the forward declaration and definition now match.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc8122837883278997821697e91e49)