### PR TITLE
Fix playerbot config compilation and add <charconv> include

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -56,6 +56,7 @@
 #include "WorldSession.h"
 #include "WorldStateMgr.h"
 #include "WowTime.h"
+#include <charconv>
 #include <random>
 
 char const* const ConditionMgr::StaticSourceTypeData[CONDITION_SOURCE_TYPE_MAX_DB_ALLOWED] =

--- a/src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp
+++ b/src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp
@@ -108,20 +108,20 @@ namespace
     PlayerbotBGConfig LoadPlayerbotBGConfig()
     {
         PlayerbotBGConfig config;
-        config.Enabled = sConfigMgr->GetOption<bool>("Playerbot.BG.Enable", true);
-        config.QueueUpdateIntervalMs = std::max<uint32>(1000, sConfigMgr->GetOption<uint32>("Playerbot.BG.QueueUpdateMs", 5000));
-        config.MaxTeamImbalance = std::min<uint32>(5, sConfigMgr->GetOption<uint32>("Playerbot.BG.MaxTeamImbalance", 1));
-        config.MaxBackfillPerUpdate = std::max<uint32>(1, sConfigMgr->GetOption<uint32>("Playerbot.BG.MaxBackfillPerUpdate", 3));
-        config.AutoQueueBots = sConfigMgr->GetOption<bool>("Playerbot.BG.AutoQueueBots", false);
-        config.AutoQueueBgType = BattlegroundTypeId(sConfigMgr->GetOption<uint32>("Playerbot.BG.AutoQueueBgType", uint32(BATTLEGROUND_RB)));
-        config.BotNamePrefix = sConfigMgr->GetOption<std::string>("Playerbot.BG.BotNamePrefix", "bot");
-        config.PreferRealPlayers = sConfigMgr->GetOption<bool>("Playerbot.BG.PreferRealPlayers", true);
-        config.AutoGenerateBots = sConfigMgr->GetOption<bool>("Playerbot.BG.AutoGenerateBots", false);
-        config.AutoGenerateTargetAlliance = sConfigMgr->GetOption<uint32>("Playerbot.BG.AutoGenerateTargetAlliance", 10);
-        config.AutoGenerateTargetHorde = sConfigMgr->GetOption<uint32>("Playerbot.BG.AutoGenerateTargetHorde", 10);
-        config.AutoGenerateMaxCreatePerTick = std::max<uint32>(1, sConfigMgr->GetOption<uint32>("Playerbot.BG.AutoGenerateMaxCreatePerTick", 2));
-        config.AutoGenerateNamePrefix = sConfigMgr->GetOption<std::string>("Playerbot.BG.AutoGenerateNamePrefix", "pbbot");
-        config.RuntimeBootstrapProvider = sConfigMgr->GetOption<std::string>("Playerbot.BG.RuntimeBootstrapProvider", "none");
+        config.Enabled = sConfigMgr->GetBoolDefault("Playerbot.BG.Enable", true);
+        config.QueueUpdateIntervalMs = std::max<uint32>(1000, uint32(sConfigMgr->GetIntDefault("Playerbot.BG.QueueUpdateMs", 5000)));
+        config.MaxTeamImbalance = std::min<uint32>(5, uint32(sConfigMgr->GetIntDefault("Playerbot.BG.MaxTeamImbalance", 1)));
+        config.MaxBackfillPerUpdate = std::max<uint32>(1, uint32(sConfigMgr->GetIntDefault("Playerbot.BG.MaxBackfillPerUpdate", 3)));
+        config.AutoQueueBots = sConfigMgr->GetBoolDefault("Playerbot.BG.AutoQueueBots", false);
+        config.AutoQueueBgType = BattlegroundTypeId(uint32(sConfigMgr->GetIntDefault("Playerbot.BG.AutoQueueBgType", int32(BATTLEGROUND_RB))));
+        config.BotNamePrefix = sConfigMgr->GetStringDefault("Playerbot.BG.BotNamePrefix", "bot");
+        config.PreferRealPlayers = sConfigMgr->GetBoolDefault("Playerbot.BG.PreferRealPlayers", true);
+        config.AutoGenerateBots = sConfigMgr->GetBoolDefault("Playerbot.BG.AutoGenerateBots", false);
+        config.AutoGenerateTargetAlliance = uint32(sConfigMgr->GetIntDefault("Playerbot.BG.AutoGenerateTargetAlliance", 10));
+        config.AutoGenerateTargetHorde = uint32(sConfigMgr->GetIntDefault("Playerbot.BG.AutoGenerateTargetHorde", 10));
+        config.AutoGenerateMaxCreatePerTick = std::max<uint32>(1, uint32(sConfigMgr->GetIntDefault("Playerbot.BG.AutoGenerateMaxCreatePerTick", 2)));
+        config.AutoGenerateNamePrefix = sConfigMgr->GetStringDefault("Playerbot.BG.AutoGenerateNamePrefix", "pbbot");
+        config.RuntimeBootstrapProvider = sConfigMgr->GetStringDefault("Playerbot.BG.RuntimeBootstrapProvider", "none");
         return config;
     }
 


### PR DESCRIPTION
### Motivation
- Fix compilation failures caused by unsupported `ConfigMgr::GetOption<T>` calls in the playerbot battleground integration and a missing header for `std::to_chars` usage in `ConditionMgr`.

### Description
- Replace `sConfigMgr->GetOption<T>(...)` usages in `src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp` with TrinityCore-compatible accessors: `GetBoolDefault`, `GetIntDefault`, and `GetStringDefault`, preserving clamping logic and adding explicit casts where appropriate.
- Add the missing `#include <charconv>` to `src/server/game/Conditions/ConditionMgr.cpp` so `std::to_chars` resolves during compilation.
- Changes are limited to `LoadPlayerbotBGConfig()` adjustments and the include addition; existing bounds checks (`std::max`/`std::min`) and semantics were retained.

### Testing
- Ran a code search with `rg` to verify `GetOption<T>` usages in the targeted files were replaced, which succeeded.
- Attempted to build the `scripts` target with `cmake --build build --target scripts -j4` but no `build/` directory exists in this environment so a local compile could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc88b6616c83279b579045c92f6cec)