### PR TITLE
database: restore Execute(format, args...) compatibility overload

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.h
+++ b/src/server/database/Database/DatabaseWorkerPool.h
@@ -23,6 +23,7 @@
 #include "StringFormat.h"
 #include <array>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 template <typename T>
@@ -69,6 +70,14 @@ class DatabaseWorkerPool
         //! Enqueues a one-way SQL operation in string format that will be executed asynchronously.
         //! This method should only be used for queries that are only executed once, e.g during startup.
         void Execute(char const* sql);
+
+        //! Compatibility overload for callers still using Execute(format, args...).
+        //! Prefer PExecute() for new code.
+        template<typename... Args, std::enable_if_t<(sizeof...(Args) > 0), int> = 0>
+        void Execute(Trinity::FormatString<Args...> sql, Args&&... args)
+        {
+            this->PExecute(sql, std::forward<Args>(args)...);
+        }
 
         //! Enqueues a one-way SQL operation in string format -with variable args- that will be executed asynchronously.
         //! This method should only be used for queries that are only executed once, e.g during startup.


### PR DESCRIPTION
### Motivation
- Restore source compatibility for legacy call sites that used `CharacterDatabase.Execute(format, args...)` which stopped compiling due to overload resolution ambiguity.

### Description
- Added `#include <type_traits>` to support SFINAE constraints used by the new overload.
- Added a template overload `void Execute(Trinity::FormatString<Args...> sql, Args&&... args)` constrained with `std::enable_if_t<(sizeof...(Args) > 0), int> = 0` that forwards to `PExecute` to preserve behavior for formatted calls.
- Kept existing `Execute(char const*)` and `Execute(PreparedStatement<T>*)` overloads unchanged so runtime behavior and unformatted calls remain unambiguous.

### Testing
- Ran `git status --short` and `git diff -- src/server/database/Database/DatabaseWorkerPool.h` to verify the patch output, which succeeded.
- Committed the change with `git commit -m "database: add formatted Execute overload compatibility"`, which succeeded.
- No build or CI compilation was executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc8d64a1fc8327b16528848e98aeb6)