### PR TITLE
Fix GCC 11 build failure in TransmogMgr::GetTransmogSetItems

### DIFF
--- a/src/server/game/Transmog/TransmogMgr.cpp
+++ b/src/server/game/Transmog/TransmogMgr.cpp
@@ -261,7 +261,10 @@ std::span<TransmogSetEntry const* const> TransmogMgr::GetTransmogSetsForItemModi
 
 std::span<TransmogSetItemEntry const* const> TransmogMgr::GetTransmogSetItems(uint32 transmogSetId)
 {
-    return std::ranges::equal_range(TransmogSetItemsByTransmogSet, transmogSetId, {}, &TransmogSetItemEntry::TransmogSetID);
+    auto const lowerBound = std::ranges::lower_bound(TransmogSetItemsByTransmogSet, transmogSetId, {}, &TransmogSetItemEntry::TransmogSetID);
+    auto const upperBound = std::ranges::upper_bound(lowerBound, TransmogSetItemsByTransmogSet.end(), transmogSetId, {}, &TransmogSetItemEntry::TransmogSetID);
+
+    return { lowerBound, upperBound };
 }
 
 std::span<TransmogOutfitEntryEntry const* const> TransmogMgr::GetAutomaticallyUnlockedOutfits()


### PR DESCRIPTION
### Motivation
- Avoid instantiating `std::ranges::equal_range` which caused a GCC 11 ranges/subrange compilation failure in CI by using an equivalent, simpler lookup approach.

### Description
- Replace `std::ranges::equal_range` with `std::ranges::lower_bound` and `std::ranges::upper_bound` and return the iterator pair as a `std::span` in `src/server/game/Transmog/TransmogMgr.cpp`.

### Testing
- No automated build or unit tests were executed in this environment; the change was verified locally as a minimal source edit and committed so CI can run the full build and tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc8f5bbdc08327a7e23c72cfbd63f4)