### PR TITLE
Fix playerbot BG bootstrap insert call signature

### DIFF
--- a/src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp
+++ b/src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp
@@ -173,7 +173,7 @@ namespace
         uint32 enqueued = 0;
         for (uint32 i = 0; i < requestedCount; ++i)
         {
-            CharacterDatabase.Execute("INSERT INTO playerbot_bg_bootstrap_queue "
+            CharacterDatabase.PExecute("INSERT INTO playerbot_bg_bootstrap_queue "
                 "(requested_at, team_id, battleground_type_id, bot_name_prefix, state) "
                 "VALUES (NOW(), {}, {}, '{}', 'queued')", uint32(team), uint32(bgTypeId), botNamePrefix);
             ++enqueued;


### PR DESCRIPTION
### Motivation
- Fix a compile error caused by calling `CharacterDatabase.Execute` with multiple arguments where only single-argument overloads exist, by using the variadic formatting API.

### Description
- Replace `CharacterDatabase.Execute(...)` with `CharacterDatabase.PExecute(...)` in `EnqueueSqlBootstrapRequests` in `src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp` so the SQL insert uses the variadic formatted-argument API.

### Testing
- Verified the change with `rg` to confirm the call site was updated and inspected the file region with `nl -ba src/server/scripts/Custom/Playerbots/playerbot_bg_integration.cpp | sed -n '168,186p'`, both showing the `PExecute` usage; no full build was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc90838b6083279c7ab82552528d8d)