### PR TITLE
Add initial playerbot PvP role-selection scaffold

### DIFF
--- a/doc/Playerbots/pvp-port-plan.md
+++ b/doc/Playerbots/pvp-port-plan.md
@@ -1,0 +1,40 @@
+# Playerbot PvP port plan for this custom TrinityCore
+
+This repository now includes a **starter PvP role-selection scaffold** under `src/server/game/AI/Playerbots/Pvp`.
+
+## Reference inputs used
+
+- `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/BattleGroundTactics.cpp`
+- `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/BattleGroundTactics.h`
+- `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/BattleGroundJoinAction.*`
+- `playerbot reference/mod-playerbots-master/src/Ai/Base/Values/BGStatusValue.*`
+
+## What was ported in this commit
+
+- Added `playerbot::BattlegroundPvpRole` and `playerbot::BattlegroundPvpStateSnapshot`.
+- Added `playerbot::PlayerbotPvpRoleSelector` with deterministic role selection based on:
+  - flag-carrier pressure,
+  - objective proximity,
+  - low-health fallback,
+  - team-size disadvantage.
+
+This is intentionally small and compile-safe so you can iterate in your custom core without importing the full AzerothCore playerbot stack in one step.
+
+## Next porting steps (recommended order)
+
+1. Add a `PlayerbotPvpContext` adapter that reads real battleground state from TrinityCore APIs.
+2. Add battleground objective providers per map (WSG/AB/EotS/AV/IoC).
+3. Add movement driver actions (follow objective, defend objective, escort carrier).
+4. Add queue/join/leave battleground state machine.
+5. Add SQL/config knobs for bot PvP participation rates and role weights.
+6. Add debug commands (`.playerbot pvp role`, `.playerbot pvp state`) for live tuning.
+
+## Why this approach
+
+Directly copying `mod-playerbots` PvP code is high-risk because the original module depends on:
+
+- AzerothCore-specific hooks,
+- module lifecycle wiring,
+- broader playerbot AI contexts and value stores.
+
+By introducing a local scaffold first, you can port behavior incrementally while keeping your core build stable.

--- a/src/server/game/AI/Playerbots/Pvp/PlayerbotPvpRoleSelector.cpp
+++ b/src/server/game/AI/Playerbots/Pvp/PlayerbotPvpRoleSelector.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PlayerbotPvpRoleSelector.h"
+
+namespace playerbot
+{
+    BattlegroundPvpRole PlayerbotPvpRoleSelector::SelectRole(BattlegroundPvpStateSnapshot const& snapshot, std::uint32_t randomSeed) const
+    {
+        if (snapshot.EnemyHasFlagCarrier && snapshot.IsNearFriendlyObjective)
+            return BattlegroundPvpRole::Defender;
+
+        if (snapshot.TeamHasFlagCarrier && snapshot.IsNearEnemyObjective)
+            return BattlegroundPvpRole::ObjectiveRunner;
+
+        if (snapshot.IsHealthLow)
+            return BattlegroundPvpRole::Support;
+
+        if (snapshot.TeamSize + 2 < snapshot.EnemyTeamSize)
+            return BattlegroundPvpRole::Support;
+
+        return Roles[randomSeed % Roles.size()];
+    }
+}

--- a/src/server/game/AI/Playerbots/Pvp/PlayerbotPvpRoleSelector.h
+++ b/src/server/game/AI/Playerbots/Pvp/PlayerbotPvpRoleSelector.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_PLAYERBOT_PVP_ROLE_SELECTOR_H
+#define TRINITY_PLAYERBOT_PVP_ROLE_SELECTOR_H
+
+#include <array>
+#include <cstdint>
+
+namespace playerbot
+{
+    enum class BattlegroundPvpRole : std::uint8_t
+    {
+        Frontline = 0,
+        Defender = 1,
+        ObjectiveRunner = 2,
+        Support = 3
+    };
+
+    struct BattlegroundPvpStateSnapshot
+    {
+        std::uint8_t TeamSize = 0;
+        std::uint8_t EnemyTeamSize = 0;
+        bool TeamHasFlagCarrier = false;
+        bool EnemyHasFlagCarrier = false;
+        bool IsNearFriendlyObjective = false;
+        bool IsNearEnemyObjective = false;
+        bool IsHealthLow = false;
+    };
+
+    class PlayerbotPvpRoleSelector
+    {
+    public:
+        BattlegroundPvpRole SelectRole(BattlegroundPvpStateSnapshot const& snapshot, std::uint32_t randomSeed) const;
+
+    private:
+        static constexpr std::array<BattlegroundPvpRole, 4> Roles = {
+            BattlegroundPvpRole::Frontline,
+            BattlegroundPvpRole::Defender,
+            BattlegroundPvpRole::ObjectiveRunner,
+            BattlegroundPvpRole::Support};
+    };
+}
+
+#endif


### PR DESCRIPTION
### Motivation

- Provide a minimal, compile-safe foundation to port mod-playerbots PvP behavior into the custom TrinityCore incrementally.  
- Avoid importing the full AzerothCore playerbot module at once by isolating role-selection logic and a small battleground state snapshot for later wiring.

### Description

- Add `playerbot::BattlegroundPvpRole` and `playerbot::BattlegroundPvpStateSnapshot` in `src/server/game/AI/Playerbots/Pvp/PlayerbotPvpRoleSelector.h` to represent role types and a compact battleground state.  
- Implement deterministic role selection logic in `src/server/game/AI/Playerbots/Pvp/PlayerbotPvpRoleSelector.cpp` that prioritizes defending flag pressure, objective-running for carriers, low-health support, and team-size fallback with a seeded random choice.  
- Include a porting plan and next-step recommendations in `doc/Playerbots/pvp-port-plan.md` that lists referenced files and an ordered migration path (state adapter, objectives, movement/actions, lifecycle, config/debug hooks).  
- Keep the scaffold intentionally small and dependency-light so it can be integrated and iterated on within the custom core before adding full playerbot AI contexts.

### Testing

- Ran configure with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTOOLS=0 -DSERVERS=1` to validate basic integration and the configure step reached dependency checks.  
- Configure failed due to missing Boost development components (`system`, `filesystem`, `program_options`, `iostreams`, `regex`, `locale`) in the environment, so no full build was performed.  
- No unit tests or runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdab4659c48327a16e4e947be41db7)