### PR TITLE
Playerbot: Phase 2B battleground tactical scaffold behind config gate

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -32,6 +32,7 @@ void PvpCore::LoadConfig()
 {
     g_PvpCoreConfig.moduleEnabled = sConfigMgr->GetBoolDefault("Playerbot.Enable", false);
     g_PvpCoreConfig.pvpCoreEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpCore.Enable", false);
+    g_PvpCoreConfig.pvpTacticsEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpTactics.Enable", false);
 }
 
 PvpCoreConfig const& PvpCore::GetConfig()
@@ -82,6 +83,20 @@ bool PvpCore::IsTriggerActive(PvpTrigger trigger, PvpValues const& values)
     return false;
 }
 
+BattlegroundTacticalContext PvpCore::BuildBattlegroundTacticalContext(Player const* player, PvpValues const& values)
+{
+    BattlegroundTacticalContext context;
+    context.tacticsEnabled = g_PvpCoreConfig.moduleEnabled && g_PvpCoreConfig.pvpCoreEnabled && g_PvpCoreConfig.pvpTacticsEnabled;
+    if (!context.tacticsEnabled || !player || !IsTriggerActive(PvpTrigger::BgActive, values))
+        return context;
+
+    context.shouldEvaluate = true;
+    context.objective = SelectObjectiveSkeleton(values);
+    context.movement = SelectMovementPrimitiveSkeleton(values, context.objective);
+    context.flagCarrierDirective = SelectFlagCarrierDirectiveSkeleton(values);
+    return context;
+}
+
 bool PvpCore::IsInBattlegroundQueue(Player const* player)
 {
     if (!player)
@@ -112,5 +127,49 @@ BattlegroundState PvpCore::DetectBattlegroundState(Player const* player, bool in
     }
 
     return BattlegroundState::None;
+}
+
+BattlegroundObjectiveSelection PvpCore::SelectObjectiveSkeleton(PvpValues const& values)
+{
+    BattlegroundObjectiveSelection objective;
+
+    if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierNear, values))
+        objective.type = BattlegroundObjectiveType::AttackFlagCarrier;
+    else if (IsTriggerActive(PvpTrigger::PlayerHasFlag, values) || IsTriggerActive(PvpTrigger::TeamFlagCarrierNear, values))
+        objective.type = BattlegroundObjectiveType::ProtectFlagCarrier;
+
+    return objective;
+}
+
+BattlegroundMovementPrimitive PvpCore::SelectMovementPrimitiveSkeleton(PvpValues const& values,
+    BattlegroundObjectiveSelection const& objective)
+{
+    if (!IsTriggerActive(PvpTrigger::BgActive, values))
+        return BattlegroundMovementPrimitive::None;
+
+    switch (objective.type)
+    {
+        case BattlegroundObjectiveType::AttackFlagCarrier:
+        case BattlegroundObjectiveType::ProtectFlagCarrier:
+            return BattlegroundMovementPrimitive::MoveToObjectiveUnit;
+        case BattlegroundObjectiveType::AssaultNode:
+        case BattlegroundObjectiveType::DefendNode:
+        case BattlegroundObjectiveType::CaptureFlag:
+            return BattlegroundMovementPrimitive::MoveToObjectivePosition;
+        case BattlegroundObjectiveType::None:
+        default:
+            return BattlegroundMovementPrimitive::None;
+    }
+}
+
+FlagCarrierDirective PvpCore::SelectFlagCarrierDirectiveSkeleton(PvpValues const& values)
+{
+    if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierNear, values))
+        return FlagCarrierDirective::AttackEnemyCarrier;
+
+    if (IsTriggerActive(PvpTrigger::PlayerHasFlag, values) || IsTriggerActive(PvpTrigger::TeamFlagCarrierNear, values))
+        return FlagCarrierDirective::ProtectTeamCarrier;
+
+    return FlagCarrierDirective::None;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -29,6 +29,7 @@ struct PvpCoreConfig
 {
     bool moduleEnabled = false;
     bool pvpCoreEnabled = false;
+    bool pvpTacticsEnabled = false;
 };
 
 enum class BattlegroundState : uint8
@@ -61,6 +62,46 @@ enum class PvpTrigger : uint8
     TeamFlagCarrierNear
 };
 
+enum class BattlegroundObjectiveType : uint8
+{
+    None = 0,
+    AssaultNode,
+    DefendNode,
+    CaptureFlag,
+    AttackFlagCarrier,
+    ProtectFlagCarrier
+};
+
+enum class BattlegroundMovementPrimitive : uint8
+{
+    None = 0,
+    MoveToObjectivePosition,
+    MoveToObjectiveUnit,
+    FollowFlagCarrier
+};
+
+enum class FlagCarrierDirective : uint8
+{
+    None = 0,
+    AttackEnemyCarrier,
+    ProtectTeamCarrier
+};
+
+struct BattlegroundObjectiveSelection
+{
+    BattlegroundObjectiveType type = BattlegroundObjectiveType::None;
+    uint32 objectiveId = 0;
+};
+
+struct BattlegroundTacticalContext
+{
+    bool tacticsEnabled = false;
+    bool shouldEvaluate = false;
+    BattlegroundObjectiveSelection objective;
+    BattlegroundMovementPrimitive movement = BattlegroundMovementPrimitive::None;
+    FlagCarrierDirective flagCarrierDirective = FlagCarrierDirective::None;
+};
+
 class PvpCore
 {
 public:
@@ -69,10 +110,15 @@ public:
 
     static PvpValues CollectValues(Player const* player);
     static bool IsTriggerActive(PvpTrigger trigger, PvpValues const& values);
+    static BattlegroundTacticalContext BuildBattlegroundTacticalContext(Player const* player, PvpValues const& values);
 
 private:
     static bool IsInBattlegroundQueue(Player const* player);
     static BattlegroundState DetectBattlegroundState(Player const* player, bool inQueue);
+    static BattlegroundObjectiveSelection SelectObjectiveSkeleton(PvpValues const& values);
+    static BattlegroundMovementPrimitive SelectMovementPrimitiveSkeleton(PvpValues const& values,
+        BattlegroundObjectiveSelection const& objective);
+    static FlagCarrierDirective SelectFlagCarrierDirectiveSkeleton(PvpValues const& values);
 };
 }
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -37,8 +37,9 @@ public:
         playerbot::PvpCore::LoadConfig();
         playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
 
-        TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}).",
-            config.moduleEnabled ? "true" : "false", config.pvpCoreEnabled ? "true" : "false");
+        TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}, pvp tactics: {}).",
+            config.moduleEnabled ? "true" : "false", config.pvpCoreEnabled ? "true" : "false",
+            config.pvpTacticsEnabled ? "true" : "false");
     }
 };
 }

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -33,3 +33,12 @@ Playerbot.Enable = 0
 #                     1 - (Enabled)
 
 Playerbot.PvpCore.Enable = 0
+
+#    Playerbot.PvpTactics.Enable
+#        Description: Enables battleground tactical scaffolding (objective selection, movement primitives,
+#                     and flag-carrier attack/protect placeholder decisions).
+#                     This phase wires tactical APIs only and does not add spell/class rotation logic.
+#        Default:     0 - (Disabled)
+#                     1 - (Enabled)
+
+Playerbot.PvpTactics.Enable = 0


### PR DESCRIPTION
### Motivation
- Provide a minimal, safe battleground tactical scaffold (objective selection, movement primitives, flag-carrier directives) so later phases can implement tactical behavior and queue lifecycle without touching class spell logic. 
- Keep the feature compile- and runtime-gated and disabled by default to avoid changing gameplay when flags are off.

### Description
- Added tactical types and a tactical API to `PvpCore` including `BattlegroundObjectiveType`, `BattlegroundMovementPrimitive`, `FlagCarrierDirective`, `BattlegroundObjectiveSelection`, `BattlegroundTacticalContext`, and the entrypoint `BuildBattlegroundTacticalContext(...)` with private skeleton selectors. 
- Added config gate `Playerbot.PvpTactics.Enable` (default `0`) and loaded it in `PvpCore::LoadConfig()`, and exposed the gate in bootstrap logging. 
- Files changed: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h`, `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`, `src/server/scripts/Playerbot/playerbot_loader.cpp`, and `src/server/worldserver/playerbots.conf.dist`. 
- Reference mapping (reference -> this PR): `mod-playerbots-master/src/Ai/Base/Actions/BattleGroundTactics.h` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h`; `mod-playerbots-master/src/Ai/Base/Actions/BattleGroundTactics.cpp` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`; `mod-playerbots-master/src/Ai/Base/Actions/FlagAction.h` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h`; `mod-playerbots-master/src/Ai/Base/Actions/FlagAction.cpp` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`.

### Testing
- Ran full CMake configure to export compile commands with: `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPLAYERBOT=ON -DSCRIPTS=static -DCMAKE_BUILD_TYPE=RelWithDebInfo`, which failed due to missing Boost development headers (Boost_FIND failure). (failed)
- Per-file syntax check for the new tactical logic succeeded with: `g++ -std=c++20 -fsyntax-only -DTRINITY_API_USE_DYNAMIC_LINKING $(find src -type d -print | sed 's#^#-I#') -Ibuild -Idep -Idep/g3dlite/include -pthread src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` (succeeded).
- Attempts to syntax-check `playerbot_loader.cpp` failed due to missing Boost headers using commands: `g++ -std=c++20 -fsyntax-only -DTRINITY_API_USE_DYNAMIC_LINKING $(find src -type d -print | sed 's#^#-I#') -Ibuild -Idep -Idep/g3dlite/include -pthread src/server/scripts/Playerbot/playerbot_loader.cpp` and `g++ -std=c++20 -fsyntax-only -DTRINITY_API_USE_DYNAMIC_LINKING $(find src -type d -print | sed 's#^#-I#') -Ibuild -Idep -Idep/boost -Idep/g3dlite/include -pthread src/server/scripts/Playerbot/playerbot_loader.cpp`, both failing with `fatal error: boost/version.hpp: No such file or directory`. (failed)
- Summary: touched Playerbot files pass local syntax-check where dependencies were available, CMake/configure and loader syntax-check are blocked by missing Boost headers in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdb99457c883278006263fb7c94628)