### PR TITLE
Playerbot: Phase 3 PvP lifecycle scaffold (queueing & participation)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -33,6 +33,7 @@ void PvpCore::LoadConfig()
     g_PvpCoreConfig.moduleEnabled = sConfigMgr->GetBoolDefault("Playerbot.Enable", false);
     g_PvpCoreConfig.pvpCoreEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpCore.Enable", false);
     g_PvpCoreConfig.pvpTacticsEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpTactics.Enable", false);
+    g_PvpCoreConfig.pvpLifecycleEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpLifecycle.Enable", false);
 }
 
 PvpCoreConfig const& PvpCore::GetConfig()
@@ -95,6 +96,54 @@ BattlegroundTacticalContext PvpCore::BuildBattlegroundTacticalContext(Player con
     context.movement = SelectMovementPrimitiveSkeleton(values, context.objective);
     context.flagCarrierDirective = SelectFlagCarrierDirectiveSkeleton(values);
     return context;
+}
+
+BattlegroundLifecycleContext PvpCore::BuildBattlegroundLifecycleContext(Player const* player, PvpValues const& values)
+{
+    BattlegroundLifecycleContext context;
+    context.lifecycleEnabled = IsLifecycleEnabled();
+    if (!context.lifecycleEnabled || !player)
+        return context;
+
+    context.queueOperation = SelectBattlegroundQueueOperationSkeleton(values);
+    context.invitationResponse = SelectBattlegroundInvitationResponseSkeleton(values);
+    context.shouldHandleInProgressStatus = ShouldHandleBattlegroundInProgressStatusSkeleton(values);
+    return context;
+}
+
+ArenaLifecycleContext PvpCore::BuildArenaLifecycleContext(Player const* player, PvpValues const& values)
+{
+    ArenaLifecycleContext context;
+    context.lifecycleEnabled = IsLifecycleEnabled();
+    if (!context.lifecycleEnabled || !player)
+        return context;
+
+    context.queueOperation = SelectArenaQueueOperationSkeleton(values);
+    context.teamInteraction = SelectArenaTeamInteractionSkeleton(values);
+    return context;
+}
+
+RandomBotParticipationHooks PvpCore::BuildRandomBotParticipationHooks(Player const* player, PvpValues const& values)
+{
+    RandomBotParticipationHooks hooks;
+    hooks.lifecycleEnabled = IsLifecycleEnabled();
+    if (!hooks.lifecycleEnabled || !player)
+        return hooks;
+
+    BattlegroundLifecycleContext bgContext = BuildBattlegroundLifecycleContext(player, values);
+    ArenaLifecycleContext arenaContext = BuildArenaLifecycleContext(player, values);
+
+    hooks.battlegroundParticipationHook = (bgContext.queueOperation != QueueOperationType::None) ||
+        (bgContext.invitationResponse != InvitationResponseType::None) || bgContext.shouldHandleInProgressStatus;
+    hooks.arenaParticipationHook = (arenaContext.queueOperation != QueueOperationType::None) ||
+        (arenaContext.teamInteraction != ArenaTeamInteractionType::None);
+
+    return hooks;
+}
+
+bool PvpCore::IsLifecycleEnabled()
+{
+    return g_PvpCoreConfig.moduleEnabled && g_PvpCoreConfig.pvpCoreEnabled && g_PvpCoreConfig.pvpLifecycleEnabled;
 }
 
 bool PvpCore::IsInBattlegroundQueue(Player const* player)
@@ -171,5 +220,45 @@ FlagCarrierDirective PvpCore::SelectFlagCarrierDirectiveSkeleton(PvpValues const
         return FlagCarrierDirective::ProtectTeamCarrier;
 
     return FlagCarrierDirective::None;
+}
+
+QueueOperationType PvpCore::SelectBattlegroundQueueOperationSkeleton(PvpValues const& values)
+{
+    if (IsTriggerActive(PvpTrigger::BgQueueing, values) || IsTriggerActive(PvpTrigger::BgWaiting, values) ||
+        IsTriggerActive(PvpTrigger::BgActive, values))
+    {
+        return QueueOperationType::None;
+    }
+
+    return QueueOperationType::Join;
+}
+
+InvitationResponseType PvpCore::SelectBattlegroundInvitationResponseSkeleton(PvpValues const& values)
+{
+    if (IsTriggerActive(PvpTrigger::BgInviteActive, values))
+        return InvitationResponseType::Accept;
+
+    return InvitationResponseType::None;
+}
+
+bool PvpCore::ShouldHandleBattlegroundInProgressStatusSkeleton(PvpValues const& values)
+{
+    return IsTriggerActive(PvpTrigger::BgActive, values);
+}
+
+QueueOperationType PvpCore::SelectArenaQueueOperationSkeleton(PvpValues const& values)
+{
+    if (values.inBattleground || values.inBattlegroundQueue)
+        return QueueOperationType::None;
+
+    return QueueOperationType::Join;
+}
+
+ArenaTeamInteractionType PvpCore::SelectArenaTeamInteractionSkeleton(PvpValues const& values)
+{
+    if (IsTriggerActive(PvpTrigger::BgInviteActive, values))
+        return ArenaTeamInteractionType::AcceptInvite;
+
+    return ArenaTeamInteractionType::None;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -30,6 +30,7 @@ struct PvpCoreConfig
     bool moduleEnabled = false;
     bool pvpCoreEnabled = false;
     bool pvpTacticsEnabled = false;
+    bool pvpLifecycleEnabled = false;
 };
 
 enum class BattlegroundState : uint8
@@ -102,6 +103,49 @@ struct BattlegroundTacticalContext
     FlagCarrierDirective flagCarrierDirective = FlagCarrierDirective::None;
 };
 
+enum class QueueOperationType : uint8
+{
+    None = 0,
+    Join,
+    Leave
+};
+
+enum class InvitationResponseType : uint8
+{
+    None = 0,
+    Accept,
+    Decline
+};
+
+enum class ArenaTeamInteractionType : uint8
+{
+    None = 0,
+    AcceptInvite,
+    DeclineInvite
+};
+
+struct BattlegroundLifecycleContext
+{
+    bool lifecycleEnabled = false;
+    QueueOperationType queueOperation = QueueOperationType::None;
+    InvitationResponseType invitationResponse = InvitationResponseType::None;
+    bool shouldHandleInProgressStatus = false;
+};
+
+struct ArenaLifecycleContext
+{
+    bool lifecycleEnabled = false;
+    QueueOperationType queueOperation = QueueOperationType::None;
+    ArenaTeamInteractionType teamInteraction = ArenaTeamInteractionType::None;
+};
+
+struct RandomBotParticipationHooks
+{
+    bool lifecycleEnabled = false;
+    bool battlegroundParticipationHook = false;
+    bool arenaParticipationHook = false;
+};
+
 class PvpCore
 {
 public:
@@ -111,14 +155,23 @@ public:
     static PvpValues CollectValues(Player const* player);
     static bool IsTriggerActive(PvpTrigger trigger, PvpValues const& values);
     static BattlegroundTacticalContext BuildBattlegroundTacticalContext(Player const* player, PvpValues const& values);
+    static BattlegroundLifecycleContext BuildBattlegroundLifecycleContext(Player const* player, PvpValues const& values);
+    static ArenaLifecycleContext BuildArenaLifecycleContext(Player const* player, PvpValues const& values);
+    static RandomBotParticipationHooks BuildRandomBotParticipationHooks(Player const* player, PvpValues const& values);
 
 private:
+    static bool IsLifecycleEnabled();
     static bool IsInBattlegroundQueue(Player const* player);
     static BattlegroundState DetectBattlegroundState(Player const* player, bool inQueue);
     static BattlegroundObjectiveSelection SelectObjectiveSkeleton(PvpValues const& values);
     static BattlegroundMovementPrimitive SelectMovementPrimitiveSkeleton(PvpValues const& values,
         BattlegroundObjectiveSelection const& objective);
     static FlagCarrierDirective SelectFlagCarrierDirectiveSkeleton(PvpValues const& values);
+    static QueueOperationType SelectBattlegroundQueueOperationSkeleton(PvpValues const& values);
+    static InvitationResponseType SelectBattlegroundInvitationResponseSkeleton(PvpValues const& values);
+    static bool ShouldHandleBattlegroundInProgressStatusSkeleton(PvpValues const& values);
+    static QueueOperationType SelectArenaQueueOperationSkeleton(PvpValues const& values);
+    static ArenaTeamInteractionType SelectArenaTeamInteractionSkeleton(PvpValues const& values);
 };
 }
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -37,9 +37,9 @@ public:
         playerbot::PvpCore::LoadConfig();
         playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
 
-        TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}, pvp tactics: {}).",
+        TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}, pvp tactics: {}, pvp lifecycle: {}).",
             config.moduleEnabled ? "true" : "false", config.pvpCoreEnabled ? "true" : "false",
-            config.pvpTacticsEnabled ? "true" : "false");
+            config.pvpTacticsEnabled ? "true" : "false", config.pvpLifecycleEnabled ? "true" : "false");
     }
 };
 }

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -42,3 +42,12 @@ Playerbot.PvpCore.Enable = 0
 #                     1 - (Enabled)
 
 Playerbot.PvpTactics.Enable = 0
+
+#    Playerbot.PvpLifecycle.Enable
+#        Description: Enables battleground/arena queue participation lifecycle scaffolding and random-bot
+#                     participation hooks. This phase wires lifecycle entry points only and does not
+#                     include class spell logic, queue cadence tuning, or SQL payloads.
+#        Default:     0 - (Disabled)
+#                     1 - (Enabled)
+
+Playerbot.PvpLifecycle.Enable = 0


### PR DESCRIPTION
### Motivation
- Provide Phase 3 lifecycle entry points for battleground and arena queue participation and random-bot participation hooks while keeping all behavior compile-gated and disabled by default.
- Add minimal skeletons for queue join/leave primitives, invitation accept/decline placeholders, in-progress status handling, and arena team interaction placeholders so higher-level tactics and class logic can be wired later. 
- Keep the change small and safe: no class spell decision trees, no queue cadence tuning, and no SQL/data payloads in this phase.

### Description
- Added a new config gate `Playerbot.PvpLifecycle.Enable` (default `0`) and extended `PvpCoreConfig` with `pvpLifecycleEnabled`, and wired it into `PvpCore::LoadConfig` and the playerbot startup log. 
- Extended `PvpCore` with lifecycle types and entry-point APIs including `BattlegroundLifecycleContext`, `ArenaLifecycleContext`, `RandomBotParticipationHooks`, selection skeletons and builders, and `IsLifecycleEnabled()` gating; lifecycle execution requires `Playerbot.Enable`, `Playerbot.PvpCore.Enable`, and `Playerbot.PvpLifecycle.Enable`. 
- Left out Phase 4 work: porting PvP class strategy/rotation decision trees, class/spec trigger wiring (interrupts/CC/defensives/offensives), spell availability/rank validation, and any queue cadence or SQL/data payloads. 
- Reference mapping (reference file -> new/updated file):
  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/BattleGroundJoinAction.h` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h`
  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/BattleGroundJoinAction.cpp` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/AcceptBattlegroundInvitationAction.h` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h`
  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/AcceptBattlegroundInvitationAction.cpp` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/ArenaTeamActions.h` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h`
  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/ArenaTeamActions.cpp` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
  - `playerbot reference/mod-playerbots-master/src/Bot/RandomPlayerbotMgr.cpp` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
  - bootstrap/config integration -> `src/server/scripts/Playerbot/playerbot_loader.cpp`, `src/server/worldserver/playerbots.conf.dist`

### Testing
- Project configure attempt: ran `cmake -S . -B build -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPLAYERBOT=ON` which failed during configure due to missing Boost components reported by CMake. 
- Header syntax-only check: ran `c++ -std=c++20 -fsyntax-only -x c++ src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h -I. -Isrc -Isrc/common -Isrc/common/Utilities -Isrc/server -Isrc/server/shared -Isrc/server/shared/DataStores` which succeeded. 
- Playerbot loader syntax-only check: ran `c++ -std=c++20 -fsyntax-only src/server/scripts/Playerbot/playerbot_loader.cpp -I. -Isrc -Isrc/common -Isrc/common/Asio -Isrc/common/Configuration -Isrc/common/Utilities -Isrc/common/Debugging -Isrc/common/Logging -Isrc/server -Isrc/server/shared -Isrc/server/shared/DataStores -Isrc/server/game -Isrc/server/game/Scripting -Isrc/server/scripts -Isrc/server/worldserver -Idep/fmt/include -Idep/spdlog/include` which succeeded when provided the explicit include paths. 
- Attempted `c++ -std=c++20 -fsyntax-only src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` with progressively-complete include path lists; this TU still required the full project include graph / build context and hit missing project headers before completion, so a full compile or a compile-commands-based `-fsyntax-only` run over the full compile database is recommended in a complete build environment. 
- Environment note: installed `libboost-dev` to satisfy Boost headers for local syntax checks, but a complete CMake configure/build may still need additional dependencies and a proper build environment to finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdbc1bee588327a40e1c32d7e6d5ee)