### PR TITLE
Playerbot PvP Phase 3: lifecycle action scaffolds and participation hook seams

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1,0 +1,198 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PlayerbotPvpLifecycleActions.h"
+
+#include "Log.h"
+#include "Player.h"
+
+namespace
+{
+bool IsLifecycleGateEnabled()
+{
+    playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
+    return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
+}
+}
+
+namespace playerbot
+{
+bool BattlegroundLifecycleActions::Execute(Player* player, BattlegroundLifecycleContext const& context)
+{
+    if (!player || !context.lifecycleEnabled || !IsLifecycleGateEnabled())
+        return false;
+
+    bool didExecute = false;
+
+    switch (context.queueOperation)
+    {
+        case QueueOperationType::Join:
+            didExecute = JoinQueuePrimitive(player) || didExecute;
+            break;
+        case QueueOperationType::Leave:
+            didExecute = LeaveQueuePrimitive(player) || didExecute;
+            break;
+        case QueueOperationType::None:
+        default:
+            break;
+    }
+
+    switch (context.invitationResponse)
+    {
+        case InvitationResponseType::Accept:
+            didExecute = AcceptInvitePlaceholder(player) || didExecute;
+            break;
+        case InvitationResponseType::Decline:
+            didExecute = DeclineInvitePlaceholder(player) || didExecute;
+            break;
+        case InvitationResponseType::None:
+        default:
+            break;
+    }
+
+    if (context.shouldHandleInProgressStatus)
+        didExecute = HandleInProgressStatusPlaceholder(player) || didExecute;
+
+    return didExecute;
+}
+
+bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground queue join primitive placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+
+bool BattlegroundLifecycleActions::LeaveQueuePrimitive(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground queue leave primitive placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+
+bool BattlegroundLifecycleActions::AcceptInvitePlaceholder(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground invite accept placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+
+bool BattlegroundLifecycleActions::DeclineInvitePlaceholder(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground invite decline placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+
+bool BattlegroundLifecycleActions::HandleInProgressStatusPlaceholder(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground in-progress status placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+
+bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const& context)
+{
+    if (!player || !context.lifecycleEnabled || !IsLifecycleGateEnabled())
+        return false;
+
+    bool didExecute = false;
+
+    switch (context.queueOperation)
+    {
+        case QueueOperationType::Join:
+            didExecute = JoinQueuePrimitive(player) || didExecute;
+            break;
+        case QueueOperationType::Leave:
+            didExecute = LeaveQueuePrimitive(player) || didExecute;
+            break;
+        case QueueOperationType::None:
+        default:
+            break;
+    }
+
+    switch (context.teamInteraction)
+    {
+        case ArenaTeamInteractionType::AcceptInvite:
+            didExecute = AcceptTeamInvitePlaceholder(player) || didExecute;
+            break;
+        case ArenaTeamInteractionType::DeclineInvite:
+            didExecute = DeclineTeamInvitePlaceholder(player) || didExecute;
+            break;
+        case ArenaTeamInteractionType::None:
+        default:
+            break;
+    }
+
+    return didExecute;
+}
+
+bool ArenaLifecycleActions::JoinQueuePrimitive(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle arena queue join primitive placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+
+bool ArenaLifecycleActions::LeaveQueuePrimitive(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle arena queue leave primitive placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+
+bool ArenaLifecycleActions::AcceptTeamInvitePlaceholder(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle arena team accept placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+
+bool ArenaLifecycleActions::DeclineTeamInvitePlaceholder(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle arena team decline placeholder for player {}.",
+        player->GetGUID().ToString());
+    return false;
+}
+}

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_PLAYERBOT_PVP_LIFECYCLE_ACTIONS_H
+#define TRINITY_PLAYERBOT_PVP_LIFECYCLE_ACTIONS_H
+
+#include "PlayerbotPvpCore.h"
+
+class Player;
+
+namespace playerbot
+{
+class BattlegroundLifecycleActions
+{
+public:
+    static bool Execute(Player* player, BattlegroundLifecycleContext const& context);
+
+    static bool JoinQueuePrimitive(Player* player);
+    static bool LeaveQueuePrimitive(Player* player);
+    static bool AcceptInvitePlaceholder(Player* player);
+    static bool DeclineInvitePlaceholder(Player* player);
+    static bool HandleInProgressStatusPlaceholder(Player* player);
+};
+
+class ArenaLifecycleActions
+{
+public:
+    static bool Execute(Player* player, ArenaLifecycleContext const& context);
+
+    static bool JoinQueuePrimitive(Player* player);
+    static bool LeaveQueuePrimitive(Player* player);
+    static bool AcceptTeamInvitePlaceholder(Player* player);
+    static bool DeclineTeamInvitePlaceholder(Player* player);
+};
+}
+
+#endif

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PlayerbotRandomBotParticipation.h"
+
+#include "PlayerbotPvpCore.h"
+#include "PlayerbotPvpLifecycleActions.h"
+
+#include "Player.h"
+
+namespace
+{
+bool IsLifecycleGateEnabled()
+{
+    playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
+    return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
+}
+}
+
+namespace playerbot
+{
+void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return;
+
+    // Hook seam for manager integration: caller determines whether this player is a random bot.
+    PvpValues const values = PvpCore::CollectValues(player);
+    RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
+
+    if (!hooks.lifecycleEnabled)
+        return;
+
+    if (hooks.battlegroundParticipationHook)
+    {
+        BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
+        BattlegroundLifecycleActions::Execute(player, battlegroundContext);
+    }
+
+    if (hooks.arenaParticipationHook)
+    {
+        ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
+        ArenaLifecycleActions::Execute(player, arenaContext);
+    }
+}
+}

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_PLAYERBOT_RANDOM_BOT_PARTICIPATION_H
+#define TRINITY_PLAYERBOT_RANDOM_BOT_PARTICIPATION_H
+
+class Player;
+
+namespace playerbot
+{
+class RandomBotParticipationLifecycle
+{
+public:
+    static void ProcessLifecycleEntryPoint(Player* player);
+};
+}
+
+#endif

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -18,10 +18,22 @@
 #include "Configuration/Config.h"
 #include "Log.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
+#include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
 #include "ScriptMgr.h"
 
 namespace
 {
+class PlayerbotPvpLifecyclePlayerScript final : public PlayerScript
+{
+public:
+    PlayerbotPvpLifecyclePlayerScript() : PlayerScript("PlayerbotPvpLifecyclePlayerScript") { }
+
+    void OnLogin(Player* player, bool /*firstLogin*/) override
+    {
+        playerbot::RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
+    }
+};
+
 class PlayerbotBootstrapWorldScript final : public WorldScript
 {
 public:
@@ -47,4 +59,5 @@ public:
 void AddPlayerbotScripts()
 {
     new PlayerbotBootstrapWorldScript();
+    new PlayerbotPvpLifecyclePlayerScript();
 }


### PR DESCRIPTION
### Motivation
- Continue Phase 3 of the Playerbot PvP port by providing explicit lifecycle entry points for battleground and arena participation while keeping all behavior gated and OFF by default.
- Provide minimal, safe no-op scaffolds and a manager-facing seam so random-bot participation can be wired without adding class PvP logic or tuning.

### Description
- Added PvP lifecycle scaffolding under `src/server/scripts/Playerbot/Pvp`: `PlayerbotPvpLifecycleActions.h/.cpp` with battleground queue join/leave primitives, invite accept/decline placeholders, in-progress status handler, and arena queue/team placeholders, all implemented as no-op placeholders with debug logging and strict gate checks.
- Added manager hook seam `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player*)` in `PlayerbotRandomBotParticipation.h/.cpp` which builds `PvpCore` values/hooks and dispatches to battleground/arena lifecycle actions when the gate chain is enabled.
- Wired the participation seam to a script entry point by adding `PlayerbotPvpLifecyclePlayerScript::OnLogin(...)` in `src/server/scripts/Playerbot/playerbot_loader.cpp` so the hook is callable at player login without enabling Phase 4 behavior.
- Preserved the strict gate chain `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable` and avoided any SQL, queue cadence, balancing, or class PvP decision logic; reference mapping: `BattleGroundJoinAction`/`AcceptBattlegroundInvitationAction`/`ArenaTeamActions` -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.*`, and `RandomPlayerbotMgr.cpp` -> `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.*` plus the loader change.

### Testing
- Ran CMake configure: `cmake -S . -B build-playerbot -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPLAYERBOT=ON -DSCRIPTS=static -DTOOLS=0`, which failed due to missing Boost development components in the environment (missing Boost include targets: `system filesystem program_options iostreams regex locale`).
- Attempted direct syntax checks with `c++ -std=c++20 -fsyntax-only ...` on the touched files, which were blocked by missing include dependencies (initially `DBCEnums.h` and then `boost/version.hpp`) because a full configured include graph was not available in-container.
- Commit created containing the changes: "Playerbot: scaffold PvP lifecycle actions and participation hooks" (files added/modified under `src/server/scripts/Playerbot/Pvp` and `playerbot_loader.cpp`), and no automated compile/syntax checks completed successfully due to the above environment blockers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdbf1dab508327867760767b897977)