### PR TITLE
Playerbot PvP Phase 3: manager-facing lifecycle seams and no-op selector safety

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -224,40 +224,46 @@ FlagCarrierDirective PvpCore::SelectFlagCarrierDirectiveSkeleton(PvpValues const
 
 QueueOperationType PvpCore::SelectBattlegroundQueueOperationSkeleton(PvpValues const& values)
 {
+    // Phase 3 safety default: no-op until explicit non-placeholder join/leave triggers are introduced.
     if (IsTriggerActive(PvpTrigger::BgQueueing, values) || IsTriggerActive(PvpTrigger::BgWaiting, values) ||
         IsTriggerActive(PvpTrigger::BgActive, values))
-    {
         return QueueOperationType::None;
-    }
 
-    return QueueOperationType::Join;
+    return QueueOperationType::None;
 }
 
 InvitationResponseType PvpCore::SelectBattlegroundInvitationResponseSkeleton(PvpValues const& values)
 {
+    // Phase 3 safety default: no-op until explicit invite response triggers are introduced.
     if (IsTriggerActive(PvpTrigger::BgInviteActive, values))
-        return InvitationResponseType::Accept;
+        return InvitationResponseType::None;
 
     return InvitationResponseType::None;
 }
 
 bool PvpCore::ShouldHandleBattlegroundInProgressStatusSkeleton(PvpValues const& values)
 {
-    return IsTriggerActive(PvpTrigger::BgActive, values);
+    // Phase 3 safety default: no-op until explicit in-progress handling triggers are introduced.
+    if (IsTriggerActive(PvpTrigger::BgActive, values))
+        return false;
+
+    return false;
 }
 
 QueueOperationType PvpCore::SelectArenaQueueOperationSkeleton(PvpValues const& values)
 {
+    // Phase 3 safety default: no-op until explicit non-placeholder join/leave triggers are introduced.
     if (values.inBattleground || values.inBattlegroundQueue)
         return QueueOperationType::None;
 
-    return QueueOperationType::Join;
+    return QueueOperationType::None;
 }
 
 ArenaTeamInteractionType PvpCore::SelectArenaTeamInteractionSkeleton(PvpValues const& values)
 {
+    // Phase 3 safety default: no-op until explicit arena team interaction triggers are introduced.
     if (IsTriggerActive(PvpTrigger::BgInviteActive, values))
-        return ArenaTeamInteractionType::AcceptInvite;
+        return ArenaTeamInteractionType::None;
 
     return ArenaTeamInteractionType::None;
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -33,28 +33,50 @@ bool IsLifecycleGateEnabled()
 
 namespace playerbot
 {
+void RandomBotParticipationLifecycle::RegisterManagerHooks()
+{
+    if (!IsLifecycleGateEnabled())
+        return;
+
+    // Intentionally neutral/no-op: manager-owned integration points are declared and ready for explicit wiring.
+}
+
 void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 {
     if (!player || !IsLifecycleGateEnabled())
         return;
 
-    // Hook seam for manager integration: caller determines whether this player is a random bot.
-    PvpValues const values = PvpCore::CollectValues(player);
-    RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
+    ProcessBattlegroundLifecycleEntryPoint(player);
+    ProcessArenaLifecycleEntryPoint(player);
+}
 
-    if (!hooks.lifecycleEnabled)
+void RandomBotParticipationLifecycle::ProcessBattlegroundLifecycleEntryPoint(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
         return;
 
-    if (hooks.battlegroundParticipationHook)
-    {
-        BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
-        BattlegroundLifecycleActions::Execute(player, battlegroundContext);
-    }
+    // Hook seam for manager integration: caller determines random-bot eligibility and cadence.
+    PvpValues const values = PvpCore::CollectValues(player);
+    RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
+    if (!hooks.lifecycleEnabled || !hooks.battlegroundParticipationHook)
+        return;
 
-    if (hooks.arenaParticipationHook)
-    {
-        ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
-        ArenaLifecycleActions::Execute(player, arenaContext);
-    }
+    BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
+    BattlegroundLifecycleActions::Execute(player, battlegroundContext);
+}
+
+void RandomBotParticipationLifecycle::ProcessArenaLifecycleEntryPoint(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return;
+
+    // Hook seam for manager integration: caller determines random-bot eligibility and cadence.
+    PvpValues const values = PvpCore::CollectValues(player);
+    RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
+    if (!hooks.lifecycleEnabled || !hooks.arenaParticipationHook)
+        return;
+
+    ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
+    ArenaLifecycleActions::Execute(player, arenaContext);
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -25,7 +25,15 @@ namespace playerbot
 class RandomBotParticipationLifecycle
 {
 public:
+    // Neutral registration seam for manager-facing integration wiring.
+    static void RegisterManagerHooks();
+
+    // Manager-facing seam: neutral lifecycle dispatcher for a random bot player.
     static void ProcessLifecycleEntryPoint(Player* player);
+
+    // Seam entry points for future random-bot manager wiring (Phase 4+).
+    static void ProcessBattlegroundLifecycleEntryPoint(Player* player);
+    static void ProcessArenaLifecycleEntryPoint(Player* player);
 };
 }
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -23,17 +23,6 @@
 
 namespace
 {
-class PlayerbotPvpLifecyclePlayerScript final : public PlayerScript
-{
-public:
-    PlayerbotPvpLifecyclePlayerScript() : PlayerScript("PlayerbotPvpLifecyclePlayerScript") { }
-
-    void OnLogin(Player* player, bool /*firstLogin*/) override
-    {
-        playerbot::RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
-    }
-};
-
 class PlayerbotBootstrapWorldScript final : public WorldScript
 {
 public:
@@ -47,6 +36,7 @@ public:
     void OnStartup() override
     {
         playerbot::PvpCore::LoadConfig();
+        playerbot::RandomBotParticipationLifecycle::RegisterManagerHooks();
         playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
 
         TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}, pvp tactics: {}, pvp lifecycle: {}).",
@@ -59,5 +49,4 @@ public:
 void AddPlayerbotScripts()
 {
     new PlayerbotBootstrapWorldScript();
-    new PlayerbotPvpLifecyclePlayerScript();
 }


### PR DESCRIPTION
### Motivation
- Harden Phase 3 random-bot participation wiring by replacing implicit `OnLogin` execution with explicit, manager-facing seam entry points so a future manager can control cadence and eligibility. 
- Ensure lifecycle behavior is gated strictly by `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable` everywhere to preserve OFF-by-default safety. 
- Keep lifecycle scaffolds explicit but safe (placeholders only) so no queueing, invite, team interaction, or in-progress behavior is performed in Phase 3.

### Description
- Replaced `OnLogin` execution wiring in `playerbot_loader.cpp` with a neutral startup registration seam: `RandomBotParticipationLifecycle::RegisterManagerHooks()` is called at startup and the `OnLogin` PlayerScript was removed to avoid implicit runtime behavior. (file: `src/server/scripts/Playerbot/playerbot_loader.cpp`)
- Added manager-facing APIs to the random-bot participation lifecycle and kept the original dispatcher: `RegisterManagerHooks()`, `ProcessBattlegroundLifecycleEntryPoint(Player*)`, `ProcessArenaLifecycleEntryPoint(Player*)`, and preserved `ProcessLifecycleEntryPoint(Player*)` as a dispatcher. (files: `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h`, `...cpp`)
- Hardened `PvpCore` selector skeletons so all Phase 3 decisions are no-op by default: battleground queue operation -> `QueueOperationType::None`, invitation response -> `InvitationResponseType::None`, battleground in-progress handling -> `false`, arena queue operation -> `QueueOperationType::None`, arena team interaction -> `ArenaTeamInteractionType::None`. This preserves placeholders and prevents accidental automatic queueing/accepting. (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`)
- Preserved lifecycle primitives and placeholders (join/leave primitives, invite/team accept/decline placeholders, in-progress status placeholder) without adding any behavior tuning, SQL, PvP spells, rotations, or Phase 4 logic.

Reference mapping (reference concept -> implemented file):
- random-bot manager participation/cadence concept -> `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h` & `.cpp`
- lifecycle gating & selector skeletons -> `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
- loader/bootstrap separation pattern -> `src/server/scripts/Playerbot/playerbot_loader.cpp`

### Testing
- Attempted to produce `compile_commands.json`: `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` which failed during configure; blocker: missing Boost components. Exact error snippet: `Could NOT find Boost (missing: Boost_INCLUDE_DIR system filesystem program_options iostreams regex locale)`. Result: `compile_commands.json` not generated.
- Per-file syntax checks attempted with `c++ -std=c++20 -fsyntax-only` on touched files to validate syntax without a full build; commands run (examples):
  - `c++ -std=c++20 -fsyntax-only -Isrc -Isrc/common -Isrc/common/Logging -Isrc/server -Isrc/server/game -Isrc/server/shared -Isrc/server/shared/DataStores -Isrc/server/scripts -Isrc/server/scripts/Playerbot src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and similar for the other modified files.
  - First attempt failed with: `fatal error: DBCEnums.h: No such file or directory` when including `SharedDefines.h` (missing include path in ad-hoc invocation).
  - Second attempt (added more -I paths) failed with: `fatal error: EnumFlag.h: No such file or directory` and `fatal error: AsioHacksFwd.h: No such file or directory`, demonstrating the environment lacks the full include graph without CMake-generated compile flags.
- Summary of test results: syntax-check attempts were blocked by incomplete environment/configuration (missing Boost for `cmake` and missing include paths for manual `-fsyntax-only` runs); no successful full syntax validation could be produced in this environment.

Commands run (core):
- `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` (failed: missing Boost components)
- `c++ -std=c++20 -fsyntax-only -Isrc -Isrc/common -Isrc/common/Logging -Isrc/server -Isrc/server/game -Isrc/server/shared -Isrc/server/shared/DataStores -Isrc/server/scripts -Isrc/server/scripts/Playerbot src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` (failed: missing `DBCEnums.h`)
- A follow-up `-fsyntax-only` run with more `-I` paths was attempted and failed referencing `EnumFlag.h` and `AsioHacksFwd.h`.

Commit: one commit created: `Playerbot: harden Phase 3 PvP lifecycle seams` (hash: shown in repo HEAD).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdc24e3be88327ba1d6b40a8679362)