### PR TITLE
Playerbot: finalize Phase 3 lifecycle selectors as explicit no-op defaults

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -224,47 +224,41 @@ FlagCarrierDirective PvpCore::SelectFlagCarrierDirectiveSkeleton(PvpValues const
 
 QueueOperationType PvpCore::SelectBattlegroundQueueOperationSkeleton(PvpValues const& values)
 {
-    // Phase 3 safety default: no-op until explicit non-placeholder join/leave triggers are introduced.
-    if (IsTriggerActive(PvpTrigger::BgQueueing, values) || IsTriggerActive(PvpTrigger::BgWaiting, values) ||
-        IsTriggerActive(PvpTrigger::BgActive, values))
-        return QueueOperationType::None;
+    (void)values;
 
+    // Phase 3 safety default: no-op until explicit non-placeholder join/leave triggers are introduced.
     return QueueOperationType::None;
 }
 
 InvitationResponseType PvpCore::SelectBattlegroundInvitationResponseSkeleton(PvpValues const& values)
 {
-    // Phase 3 safety default: no-op until explicit invite response triggers are introduced.
-    if (IsTriggerActive(PvpTrigger::BgInviteActive, values))
-        return InvitationResponseType::None;
+    (void)values;
 
+    // Phase 3 safety default: no-op until explicit invite response triggers are introduced.
     return InvitationResponseType::None;
 }
 
 bool PvpCore::ShouldHandleBattlegroundInProgressStatusSkeleton(PvpValues const& values)
 {
-    // Phase 3 safety default: no-op until explicit in-progress handling triggers are introduced.
-    if (IsTriggerActive(PvpTrigger::BgActive, values))
-        return false;
+    (void)values;
 
+    // Phase 3 safety default: no-op until explicit in-progress handling triggers are introduced.
     return false;
 }
 
 QueueOperationType PvpCore::SelectArenaQueueOperationSkeleton(PvpValues const& values)
 {
-    // Phase 3 safety default: no-op until explicit non-placeholder join/leave triggers are introduced.
-    if (values.inBattleground || values.inBattlegroundQueue)
-        return QueueOperationType::None;
+    (void)values;
 
+    // Phase 3 safety default: no-op until explicit non-placeholder join/leave triggers are introduced.
     return QueueOperationType::None;
 }
 
 ArenaTeamInteractionType PvpCore::SelectArenaTeamInteractionSkeleton(PvpValues const& values)
 {
-    // Phase 3 safety default: no-op until explicit arena team interaction triggers are introduced.
-    if (IsTriggerActive(PvpTrigger::BgInviteActive, values))
-        return ArenaTeamInteractionType::None;
+    (void)values;
 
+    // Phase 3 safety default: no-op until explicit arena team interaction triggers are introduced.
     return ArenaTeamInteractionType::None;
 }
 }


### PR DESCRIPTION
### Motivation
- Resolve unresolved Phase 3 review feedback by hardening lifecycle selector scaffolds to explicit no-op defaults while preserving all manager-facing seams and the OFF-by-default gate chain (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`).

### Description
- Simplified the Phase 3 selector skeletons in `PlayerbotPvpCore.cpp` to remove redundant branches and return explicit no-op defaults, and added `(void)values` to silence unused-parameter warnings while keeping the placeholder scaffolds intact; the lifecycle gating/placeholder actions remain unchanged. 【F:src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp†L225-L263】【F:src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp†L120-L141】
- Kept neutral manager-facing registration and lifecycle entry seams for random-bot participation and left battleground/arena primitive placeholders as no-op implementations. 【F:src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp†L1-L40】【F:src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp†L20-L37】
- Commit created: `998d2723` with the single focused change to `PlayerbotPvpCore.cpp` (no behavior tuning or Phase 4 work included).

Reference mapping (reference file -> new file)
| Reference file | New file |
|---|---|
| `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` | `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` 【F:src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp†L225-L263】
| `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h` | `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h` 【F:src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h†L1-L40】
| `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` | `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` 【F:src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp†L20-L37】
| `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h` | `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h` 【F:src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h†L1-L40】
| `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` | `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` 【F:src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp†L1-L40】
| `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h` | `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h` 【F:src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h†L1-L40】
| `src/server/scripts/Playerbot/playerbot_loader.cpp` | `src/server/scripts/Playerbot/playerbot_loader.cpp` 【F:src/server/scripts/Playerbot/playerbot_loader.cpp†L1-L40】

### Testing
- Attempted compile-commands-driven syntax check: ran a `-fsyntax-only` style invocation against the modified file using entries from `compile_commands.json`, but the file had no matching entry so the check reported the missing entry exactly: `MISSING src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` (the `compile_commands.json`-based check therefore could not be executed for this file). The exact command attempted and output are captured in the rollout logs. 
- Performed a repo-level sanity check and created the single commit locally using `git add`/`git commit` which succeeded (commit `998d2723`).

Commands run (exact):
- `nl -ba src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp | sed -n '220,280p'` (used to inspect the updated region).
- Python-based compile-commands lookup and `-fsyntax-only` invocation (attempt): the script reported `MISSING src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` because the file was not present in `compile_commands.json`.
- `git add src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp && git commit -m "Playerbot: simplify Phase 3 lifecycle no-op selectors"` (created commit `998d2723`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdc6af0dc08327a6fac55df520c1af)