### PR TITLE
Playerbot: trim Phase 3 loader include surface

### DIFF
--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -15,7 +15,6 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Configuration/Config.h"
 #include "Log.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"


### PR DESCRIPTION
### Motivation
- Remove an unused include to keep the Playerbot bootstrap loader minimal while preserving all Phase 3 PvP lifecycle scaffolds, manager-facing seams, and strict gate-chain semantics.

### Description
- Deleted the unused `#include "Configuration/Config.h"` from `src/server/scripts/Playerbot/playerbot_loader.cpp` and left all lifecycle scaffolding and no-op placeholders unchanged.

### Testing
- Ran `git status --short` which showed the single modified file and untracked `compile_commands.json` (pass). 
- Regenerated the compile database with `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` which configured and generated build files (pass).
- Attempted compile-database driven `-fsyntax-only` checks for the touched Playerbot files but the compile database contained no entries for those script files, so syntax-only checks could not be run against them (environment limitation; exact check reported zero matching entries in `build/compile_commands.json`). 
- Committed the change with `git add src/server/scripts/Playerbot/playerbot_loader.cpp && git commit -m "Playerbot: trim Phase 3 loader include surface"` (pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdcc0c42b4832789b1e40b71cb5710)