### PR TITLE
Playerbot PvP lifecycle: manager cadence wiring and concrete lifecycle primitives

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -18,6 +18,7 @@
 #include "PlayerbotPvpCore.h"
 
 #include "Battleground.h"
+#include "BattlegroundMgr.h"
 #include "Configuration/Config.h"
 #include "Player.h"
 
@@ -49,8 +50,22 @@ PvpValues PvpCore::CollectValues(Player const* player)
 
     values.inBattleground = player->InBattleground();
     values.inBattlegroundQueue = IsInBattlegroundQueue(player);
-    values.hasInvite = !values.inBattleground && values.inBattlegroundQueue;
     values.battlegroundState = DetectBattlegroundState(player, values.inBattlegroundQueue);
+
+    for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+    {
+        BattlegroundQueueTypeId const bgQueueTypeId = player->GetBattlegroundQueueTypeId(i);
+        if (bgQueueTypeId == BATTLEGROUND_QUEUE_NONE)
+            continue;
+
+        bool const isArenaQueue = BattlegroundMgr::BGArenaType(bgQueueTypeId) != 0;
+        bool const isInvited = player->IsInvitedForBattlegroundQueueType(bgQueueTypeId);
+
+        values.hasArenaQueue = values.hasArenaQueue || isArenaQueue;
+        values.hasBattlegroundQueue = values.hasBattlegroundQueue || !isArenaQueue;
+        values.hasArenaInvite = values.hasArenaInvite || (isArenaQueue && isInvited);
+        values.hasBattlegroundInvite = values.hasBattlegroundInvite || (!isArenaQueue && isInvited);
+    }
 
     if (values.inBattleground)
         values.battlegroundTypeId = player->GetBattlegroundTypeId();
@@ -71,7 +86,7 @@ bool PvpCore::IsTriggerActive(PvpTrigger trigger, PvpValues const& values)
         case PvpTrigger::BgActive:
             return values.battlegroundState == BattlegroundState::Active;
         case PvpTrigger::BgInviteActive:
-            return values.hasInvite;
+            return values.hasBattlegroundInvite;
         case PvpTrigger::InBattlegroundWithoutFlag:
         case PvpTrigger::PlayerHasFlag:
         case PvpTrigger::EnemyFlagCarrierNear:
@@ -224,41 +239,53 @@ FlagCarrierDirective PvpCore::SelectFlagCarrierDirectiveSkeleton(PvpValues const
 
 QueueOperationType PvpCore::SelectBattlegroundQueueOperationSkeleton(PvpValues const& values)
 {
-    (void)values;
+    if (values.inBattleground)
+        return QueueOperationType::None;
 
-    // Phase 3 safety default: no-op until explicit non-placeholder join/leave triggers are introduced.
+    if (values.hasBattlegroundQueue && !values.hasBattlegroundInvite)
+        return QueueOperationType::Leave;
+
+    if (!values.inBattlegroundQueue && !values.hasBattlegroundQueue && !values.hasBattlegroundInvite)
+        return QueueOperationType::Join;
+
     return QueueOperationType::None;
 }
 
 InvitationResponseType PvpCore::SelectBattlegroundInvitationResponseSkeleton(PvpValues const& values)
 {
-    (void)values;
+    if (!values.hasBattlegroundInvite)
+        return InvitationResponseType::None;
 
-    // Phase 3 safety default: no-op until explicit invite response triggers are introduced.
-    return InvitationResponseType::None;
+    if (values.inBattleground)
+        return InvitationResponseType::Decline;
+
+    return InvitationResponseType::Accept;
 }
 
 bool PvpCore::ShouldHandleBattlegroundInProgressStatusSkeleton(PvpValues const& values)
 {
-    (void)values;
-
-    // Phase 3 safety default: no-op until explicit in-progress handling triggers are introduced.
-    return false;
+    return values.battlegroundState == BattlegroundState::Active;
 }
 
 QueueOperationType PvpCore::SelectArenaQueueOperationSkeleton(PvpValues const& values)
 {
-    (void)values;
+    if (values.inBattleground)
+        return QueueOperationType::None;
 
-    // Phase 3 safety default: no-op until explicit non-placeholder join/leave triggers are introduced.
+    if (values.hasArenaQueue && !values.hasArenaInvite)
+        return QueueOperationType::Leave;
+
+    if (!values.inBattlegroundQueue && !values.hasArenaQueue && !values.hasArenaInvite)
+        return QueueOperationType::Join;
+
     return QueueOperationType::None;
 }
 
 ArenaTeamInteractionType PvpCore::SelectArenaTeamInteractionSkeleton(PvpValues const& values)
 {
-    (void)values;
+    if (values.hasArenaInvite)
+        return ArenaTeamInteractionType::AcceptInvite;
 
-    // Phase 3 safety default: no-op until explicit arena team interaction triggers are introduced.
     return ArenaTeamInteractionType::None;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -47,7 +47,10 @@ struct PvpValues
     BattlegroundTypeId battlegroundTypeId = BATTLEGROUND_TYPE_NONE;
     bool inBattleground = false;
     bool inBattlegroundQueue = false;
-    bool hasInvite = false;
+    bool hasBattlegroundQueue = false;
+    bool hasArenaQueue = false;
+    bool hasBattlegroundInvite = false;
+    bool hasArenaInvite = false;
 };
 
 enum class PvpTrigger : uint8

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -17,8 +17,13 @@
 
 #include "PlayerbotPvpLifecycleActions.h"
 
+#include "BattlegroundMgr.h"
+#include "BattlegroundQueue.h"
+#include "DBCStores.h"
 #include "Log.h"
 #include "Player.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
 
 namespace
 {
@@ -26,6 +31,72 @@ bool IsLifecycleGateEnabled()
 {
     playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
+}
+
+bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
+{
+    if (!player || player->InBattleground())
+        return false;
+
+    Battleground* bgTemplate = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
+    if (!bgTemplate)
+        return false;
+
+    if (!player->CanJoinToBattleground(bgTemplate) || !player->HasFreeBattlegroundQueueId())
+        return false;
+
+    BattlegroundQueueTypeId const bgQueueTypeId = BattlegroundMgr::BGQueueTypeId(bgTypeId, arenaType);
+    if (bgQueueTypeId == BATTLEGROUND_QUEUE_NONE)
+        return false;
+
+    if (player->GetBattlegroundQueueIndex(bgQueueTypeId) < PLAYER_MAX_BATTLEGROUND_QUEUES)
+        return false;
+
+    PvPDifficultyEntry const* bracketEntry = GetBattlegroundBracketByLevel(bgTemplate->GetMapId(), player->GetLevel());
+    if (!bracketEntry)
+        return false;
+
+    BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
+    GroupQueueInfo* ginfo = bgQueue.AddGroup(player, nullptr, bgTypeId, bracketEntry, arenaType, false, false, 0, 0);
+    if (!ginfo)
+        return false;
+
+    uint32 const queueSlot = player->AddBattlegroundQueueId(bgQueueTypeId);
+    uint32 const avgTime = bgQueue.GetAverageQueueWaitTime(ginfo, bracketEntry->GetBracketId());
+
+    WorldPacket statusPacket;
+    sBattlegroundMgr->BuildBattlegroundStatusPacket(&statusPacket, bgTemplate, queueSlot, STATUS_WAIT_QUEUE, avgTime, 0, arenaType, 0);
+    player->SendDirectMessage(&statusPacket);
+    return true;
+}
+
+bool ProcessQueuePortAction(Player* player, bool accept, bool arenaOnly)
+{
+    if (!player || !player->GetSession() || !player->InBattlegroundQueue())
+        return false;
+
+    bool executed = false;
+    for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+    {
+        BattlegroundQueueTypeId const bgQueueTypeId = player->GetBattlegroundQueueTypeId(i);
+        if (bgQueueTypeId == BATTLEGROUND_QUEUE_NONE)
+            continue;
+
+        bool const isArenaQueue = BattlegroundMgr::BGArenaType(bgQueueTypeId) != 0;
+        if (arenaOnly != isArenaQueue)
+            continue;
+
+        if (accept && !player->IsInvitedForBattlegroundQueueType(bgQueueTypeId))
+            continue;
+
+        WorldPacket packet(CMSG_BATTLEFIELD_PORT, 20);
+        packet << uint8(BattlegroundMgr::BGArenaType(bgQueueTypeId)) << uint8(0)
+               << uint32(BattlegroundMgr::BGTemplateId(bgQueueTypeId)) << uint16(0x1F90) << uint8(accept ? 1 : 0);
+        player->GetSession()->HandleBattleFieldPortOpcode(packet);
+        executed = true;
+    }
+
+    return executed;
 }
 }
 
@@ -54,10 +125,10 @@ bool BattlegroundLifecycleActions::Execute(Player* player, BattlegroundLifecycle
     switch (context.invitationResponse)
     {
         case InvitationResponseType::Accept:
-            didExecute = AcceptInvitePlaceholder(player) || didExecute;
+            didExecute = AcceptInvitePrimitive(player) || didExecute;
             break;
         case InvitationResponseType::Decline:
-            didExecute = DeclineInvitePlaceholder(player) || didExecute;
+            didExecute = DeclineInvitePrimitive(player) || didExecute;
             break;
         case InvitationResponseType::None:
         default:
@@ -65,7 +136,7 @@ bool BattlegroundLifecycleActions::Execute(Player* player, BattlegroundLifecycle
     }
 
     if (context.shouldHandleInProgressStatus)
-        didExecute = HandleInProgressStatusPlaceholder(player) || didExecute;
+        didExecute = HandleInProgressStatusPrimitive(player) || didExecute;
 
     return didExecute;
 }
@@ -75,9 +146,7 @@ bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground queue join primitive placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    return QueuePlayer(player, BATTLEGROUND_RB, 0);
 }
 
 bool BattlegroundLifecycleActions::LeaveQueuePrimitive(Player* player)
@@ -85,39 +154,41 @@ bool BattlegroundLifecycleActions::LeaveQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground queue leave primitive placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    return ProcessQueuePortAction(player, false, false);
 }
 
-bool BattlegroundLifecycleActions::AcceptInvitePlaceholder(Player* player)
+bool BattlegroundLifecycleActions::AcceptInvitePrimitive(Player* player)
 {
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground invite accept placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    return ProcessQueuePortAction(player, true, false);
 }
 
-bool BattlegroundLifecycleActions::DeclineInvitePlaceholder(Player* player)
+bool BattlegroundLifecycleActions::DeclineInvitePrimitive(Player* player)
 {
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground invite decline placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    return ProcessQueuePortAction(player, false, false);
 }
 
-bool BattlegroundLifecycleActions::HandleInProgressStatusPlaceholder(Player* player)
+bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* player)
 {
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle battleground in-progress status placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    if (!player->InBattleground())
+        return false;
+
+    if (Battleground* battleground = player->GetBattleground())
+    {
+        if (battleground->GetStatus() != STATUS_IN_PROGRESS)
+            return false;
+    }
+
+    player->LeaveBattleground();
+    return true;
 }
 
 bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const& context)
@@ -143,10 +214,10 @@ bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const&
     switch (context.teamInteraction)
     {
         case ArenaTeamInteractionType::AcceptInvite:
-            didExecute = AcceptTeamInvitePlaceholder(player) || didExecute;
+            didExecute = AcceptTeamInvitePrimitive(player) || didExecute;
             break;
         case ArenaTeamInteractionType::DeclineInvite:
-            didExecute = DeclineTeamInvitePlaceholder(player) || didExecute;
+            didExecute = DeclineTeamInvitePrimitive(player) || didExecute;
             break;
         case ArenaTeamInteractionType::None:
         default:
@@ -161,9 +232,7 @@ bool ArenaLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle arena queue join primitive placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    return QueuePlayer(player, BATTLEGROUND_AA, ARENA_TYPE_2v2);
 }
 
 bool ArenaLifecycleActions::LeaveQueuePrimitive(Player* player)
@@ -171,28 +240,38 @@ bool ArenaLifecycleActions::LeaveQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle arena queue leave primitive placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    return ProcessQueuePortAction(player, false, true);
 }
 
-bool ArenaLifecycleActions::AcceptTeamInvitePlaceholder(Player* player)
+bool ArenaLifecycleActions::AcceptTeamInvitePrimitive(Player* player)
 {
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle arena team accept placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    if (!player->GetSession())
+        return false;
+
+    if (!player->GetArenaTeamIdInvited())
+        return false;
+
+    WorldPacket packet(CMSG_ARENA_TEAM_ACCEPT);
+    player->GetSession()->HandleArenaTeamAcceptOpcode(packet);
+    return true;
 }
 
-bool ArenaLifecycleActions::DeclineTeamInvitePlaceholder(Player* player)
+bool ArenaLifecycleActions::DeclineTeamInvitePrimitive(Player* player)
 {
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    TC_LOG_DEBUG("playerbot", "Playerbot PvP lifecycle arena team decline placeholder for player {}.",
-        player->GetGUID().ToString());
-    return false;
+    if (!player->GetSession())
+        return false;
+
+    if (!player->GetArenaTeamIdInvited())
+        return false;
+
+    WorldPacket packet(CMSG_ARENA_TEAM_DECLINE);
+    player->GetSession()->HandleArenaTeamDeclineOpcode(packet);
+    return true;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
@@ -31,9 +31,9 @@ public:
 
     static bool JoinQueuePrimitive(Player* player);
     static bool LeaveQueuePrimitive(Player* player);
-    static bool AcceptInvitePlaceholder(Player* player);
-    static bool DeclineInvitePlaceholder(Player* player);
-    static bool HandleInProgressStatusPlaceholder(Player* player);
+    static bool AcceptInvitePrimitive(Player* player);
+    static bool DeclineInvitePrimitive(Player* player);
+    static bool HandleInProgressStatusPrimitive(Player* player);
 };
 
 class ArenaLifecycleActions
@@ -43,8 +43,8 @@ public:
 
     static bool JoinQueuePrimitive(Player* player);
     static bool LeaveQueuePrimitive(Player* player);
-    static bool AcceptTeamInvitePlaceholder(Player* player);
-    static bool DeclineTeamInvitePlaceholder(Player* player);
+    static bool AcceptTeamInvitePrimitive(Player* player);
+    static bool DeclineTeamInvitePrimitive(Player* player);
 };
 }
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -18,7 +18,10 @@
 #include "Log.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
+#include "Player.h"
 #include "ScriptMgr.h"
+#include "World.h"
+#include "WorldSession.h"
 
 namespace
 {
@@ -42,6 +45,37 @@ public:
             config.moduleEnabled ? "true" : "false", config.pvpCoreEnabled ? "true" : "false",
             config.pvpTacticsEnabled ? "true" : "false", config.pvpLifecycleEnabled ? "true" : "false");
     }
+
+    void OnUpdate(uint32 diff) override
+    {
+        updateAccumulatorMs += diff;
+        if (updateAccumulatorMs < 1000)
+            return;
+
+        updateAccumulatorMs = 0;
+
+        playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
+        if (!config.moduleEnabled || !config.pvpCoreEnabled || !config.pvpLifecycleEnabled)
+            return;
+
+        SessionMap const& sessions = sWorld->GetAllSessions();
+        for (SessionMap::const_iterator itr = sessions.begin(); itr != sessions.end(); ++itr)
+        {
+            Player* player = itr->second ? itr->second->GetPlayer() : nullptr;
+            if (!player)
+                continue;
+
+            playerbot::PvpValues const values = playerbot::PvpCore::CollectValues(player);
+            playerbot::RandomBotParticipationHooks const hooks = playerbot::PvpCore::BuildRandomBotParticipationHooks(player, values);
+            if (!hooks.battlegroundParticipationHook && !hooks.arenaParticipationHook)
+                continue;
+
+            playerbot::RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
+        }
+    }
+
+private:
+    uint32 updateAccumulatorMs = 0;
 };
 }
 


### PR DESCRIPTION
### Motivation
- Implement Phase 4 manager integration and concrete PvP lifecycle behavior for Playerbot random-bot participation while preserving the existing lifecycle gate chain (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`).
- Replace Phase‑3 no-op selector/placeholders with explicit, compile-safe trigger logic and API-backed primitives for battleground and arena lifecycle seams.
- Ensure touched Playerbot sources are covered by the compile database so `-fsyntax-only` checks can validate changes.

### Description
- Wire manager cadence: added a `WorldScript` `OnUpdate` (1s cadence) to explicitly call `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player*)` after manager-side eligibility checks, leaving cadence/eligibility decisions on the manager side (`src/server/scripts/Playerbot/playerbot_loader.cpp`).
- Replace placeholder selectors/primitives in `PvpCore` and lifecycle actions: expanded `PvpValues` with separate BG/arena queue+invite flags; implemented explicit `Select*` logic for join/leave, invite accept/decline, and in-progress handling (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h` and `PlayerbotPvpCore.cpp`).
- Implement concrete lifecycle primitives: queue join via `BattlegroundQueue::AddGroup`, queue leave / invite accept/decline via emitting `CMSG_BATTLEFIELD_PORT` to `WorldSession::HandleBattleFieldPortOpcode`, arena-team accept/decline via `CMSG_ARENA_TEAM_ACCEPT/DECLINE`, and BG in-progress handling via `LeaveBattleground()` while keeping lifecycle gates (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h` and `PlayerbotPvpLifecycleActions.cpp`).
- Build/compile-db coverage: root cause identified as `PLAYERBOT` being excluded from script list when `PLAYERBOT` CMake option is off; validated by configuring the build with `-DPLAYERBOT=1` so Playerbot `.cpp` files appear in `build/compile_commands.json` (no SQL or DB schema changes). (`src/server/scripts/CMakeLists.txt` behavior).

### Testing
- ✅ Reconfigured CMake and generated compile DB with `cmake -S . -B build -DPLAYERBOT=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` and confirmed Playerbot `.cpp` entries appear in `build/compile_commands.json` (success).
- ✅ Per-file compile-db syntax checks using the compile_commands entries (`/usr/bin/c++ ... -fsyntax-only <file>`) run against all touched Playerbot `.cpp` files and succeeded after fixes (files: `PlayerbotPvpCore.cpp`, `PlayerbotPvpLifecycleActions.cpp`, `PlayerbotRandomBotParticipation.cpp`, `playerbot_loader.cpp`).
- ⚠️ Partial build: `cmake --build build --target scripts -j4` was started to validate the scripts target; compilation progressed and compiled the affected script objects, but the full build was interrupted due to environment long-runtime limitations (no functional regressions observed in the compile‑only checks performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdd91685088327b6556b7927ea6f0d)