### PR TITLE
Playerbot: wire Phase 4 PvP lifecycle manager seam and safe invite handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -244,10 +244,11 @@ QueueOperationType PvpCore::SelectBattlegroundQueueOperationSkeleton(PvpValues c
     if (values.inBattleground)
         return QueueOperationType::None;
 
-    if (values.hasBattlegroundQueue && !values.hasBattlegroundInvite)
+    if (values.hasBattlegroundQueue && values.hasArenaInvite)
         return QueueOperationType::Leave;
 
-    if (!values.inBattlegroundQueue && !values.hasBattlegroundQueue && !values.hasBattlegroundInvite)
+    if (!values.inBattlegroundQueue && !values.hasBattlegroundQueue && !values.hasBattlegroundInvite &&
+        !values.hasArenaQueue && !values.hasArenaInvite)
         return QueueOperationType::Join;
 
     return QueueOperationType::None;
@@ -258,7 +259,10 @@ InvitationResponseType PvpCore::SelectBattlegroundInvitationResponseSkeleton(Pvp
     if (!values.hasBattlegroundInvite)
         return InvitationResponseType::None;
 
-    return InvitationResponseType::Decline;
+    if (values.inBattleground)
+        return InvitationResponseType::Decline;
+
+    return InvitationResponseType::Accept;
 }
 
 bool PvpCore::ShouldHandleBattlegroundInProgressStatusSkeleton(PvpValues const& values)
@@ -271,10 +275,11 @@ QueueOperationType PvpCore::SelectArenaQueueOperationSkeleton(PvpValues const& v
     if (values.inBattleground)
         return QueueOperationType::None;
 
-    if (values.hasArenaQueue && !values.hasArenaInvite)
+    if (values.hasArenaQueue && values.hasBattlegroundInvite)
         return QueueOperationType::Leave;
 
-    if (!values.inBattlegroundQueue && !values.hasArenaQueue && !values.hasArenaInvite)
+    if (!values.inBattlegroundQueue && !values.hasArenaQueue && !values.hasArenaInvite &&
+        !values.hasBattlegroundQueue && !values.hasBattlegroundInvite)
         return QueueOperationType::Join;
 
     return QueueOperationType::None;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -126,6 +126,54 @@ bool RemoveMatchingQueues(Player* player, bool arenaOnly, bool invitedOnly, bool
 
     return removed;
 }
+
+bool AcceptMatchingInvite(Player* player, bool arenaInvite)
+{
+    if (!player || player->InBattleground())
+        return false;
+
+    for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+    {
+        BattlegroundQueueTypeId const bgQueueTypeId = player->GetBattlegroundQueueTypeId(i);
+        if (bgQueueTypeId == BATTLEGROUND_QUEUE_NONE)
+            continue;
+
+        bool const isArenaQueue = BattlegroundMgr::BGArenaType(bgQueueTypeId) != 0;
+        if (arenaInvite != isArenaQueue)
+            continue;
+
+        if (!player->IsInvitedForBattlegroundQueueType(bgQueueTypeId))
+            continue;
+
+        BattlegroundTypeId const bgTypeId = BattlegroundMgr::BGTemplateId(bgQueueTypeId);
+        BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
+        GroupQueueInfo ginfo;
+        if (!bgQueue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
+            continue;
+
+        Battleground* battleground = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
+        if (!battleground)
+            continue;
+
+        if (!player->InBattleground())
+            player->SetBattlegroundEntryPoint();
+
+        if (!player->IsAlive())
+        {
+            player->ResurrectPlayer(1.0f);
+            player->SpawnCorpseBones();
+        }
+
+        player->FinishTaxiFlight();
+        bgQueue.RemovePlayer(player->GetGUID(), false);
+        player->SetBattlegroundId(battleground->GetInstanceID(), bgTypeId);
+        player->SetBGTeam(ginfo.Team);
+        sBattlegroundMgr->SendToBattleground(player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
+        return true;
+    }
+
+    return false;
+}
 }
 
 namespace playerbot
@@ -187,8 +235,10 @@ bool BattlegroundLifecycleActions::LeaveQueuePrimitive(Player* player)
 
 bool BattlegroundLifecycleActions::AcceptInvitePrimitive(Player* player)
 {
-    (void)player;
-    return false;
+    if (!player || !IsLifecycleGateEnabled())
+        return false;
+
+    return AcceptMatchingInvite(player, false);
 }
 
 bool BattlegroundLifecycleActions::DeclineInvitePrimitive(Player* player)

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -18,6 +18,7 @@
 #include "Log.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
+#include "Player.h"
 #include "ScriptMgr.h"
 
 namespace
@@ -44,9 +45,26 @@ public:
     }
 
 };
+
+class PlayerbotPvpLifecyclePlayerScript final : public PlayerScript
+{
+public:
+    PlayerbotPvpLifecyclePlayerScript() : PlayerScript("PlayerbotPvpLifecyclePlayerScript") { }
+
+    void OnMapChanged(Player* player) override
+    {
+        playerbot::RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
+    }
+
+    void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
+    {
+        playerbot::RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
+    }
+};
 }
 
 void AddPlayerbotScripts()
 {
     new PlayerbotBootstrapWorldScript();
+    new PlayerbotPvpLifecyclePlayerScript();
 }


### PR DESCRIPTION
### Motivation
- Integrate Phase 4 RandomBot PvP lifecycle execution into a manager-owned cadence to avoid global/session sweeps and preserve strict ownership between manager (cadence/eligibility) and lifecycle (decision execution).
- Replace placeholder/no-op lifecycle selectors and unsafe invite shortcuts with concrete, conflict-aware decisions and server-API-backed primitives under the exact gate chain `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`.

### Description
- Add a manager-owned cadence seam by registering a `PlayerScript` that calls `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player*)` on map/zone events, avoiding login-wide sweeps (file: `src/server/scripts/Playerbot/playerbot_loader.cpp`, approx lines 49-70). 
- Tighten selector logic in `PvpCore` so BG/arena join/leave and invite accept/decline decisions are concrete and conflict-aware (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`, approx lines 242-297). 
- Implement a safe invite-accept primitive `AcceptMatchingInvite` that consumes queue/invite state and uses battleground manager APIs (no synthetic client packets), and wire it into `AcceptInvitePrimitive` (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`, approx lines 130-176 and 236-242). 
- Add a `#include "Player.h"` where needed and keep all changes restricted to lifecycle integration and primitives without SQL, AI tactic, or global sweep changes (files touched: `playerbot_loader.cpp`, `PlayerbotPvpCore.cpp`, `PlayerbotPvpLifecycleActions.cpp`).

### Testing
- ✅ Reconfigured build with `cmake -S . -B build -DPLAYERBOT=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to include Playerbot scripts in compile DB and verified the configuration succeeded.
- ✅ Confirmed compile DB entries for the touched files exist and ran compile-db-derived syntax checks (`-fsyntax-only`) for `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`, `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`, and `src/server/scripts/Playerbot/playerbot_loader.cpp`, which passed.
- ✅ Built targeted object files for the modified Playerbot sources (`PlayerbotPvpCore.cpp.o`, `PlayerbotPvpLifecycleActions.cpp.o`, `playerbot_loader.cpp.o`) which completed successfully.
- ⚠️ Attempted full `scripts` target build produced extensive upstream output and warnings during run-time of the session; targeted builds for touched objects were used to validate integration due to environment/time constraints.
- Commands executed: `pwd; rg --files -g 'AGENTS.md'`; `git log --oneline -n 8 && git status --short`; `sed -n '1,260p' src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h`; `sed -n '1,320p' src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`; `sed -n '1,320p' src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h`; `sed -n '1,420p' src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`; `sed -n '1,300p' src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h`; `sed -n '1,420p' src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`; `sed -n '1,260p' src/server/scripts/Playerbot/playerbot_loader.cpp`; `rg -n "RandomBotParticipation|ProcessLifecycleEntryPoint|Participation" src/server/scripts/Playerbot -g '*.*'`; `rg -n "OnPlayerLogin|RandomBot|Update\(|Process.*EntryPoint|participation" src/server/scripts/Playerbot -g '*.cpp'`; various `find`/`rg` inspections of repository layout and references; `python3` checks against `build/compile_commands.json` to verify presence of compile DB entries; applied source edits to `PlayerbotPvpCore.cpp`, `PlayerbotPvpLifecycleActions.cpp`, and `playerbot_loader.cpp`; `cmake -S . -B build -DPLAYERBOT=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`; `python3` compile-db-derived `-fsyntax-only` runs; `cmake --build build --target scripts -- -j4` (full scripts build started but long-running), `cmake --build build --target src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpCore.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o -- -j4`; and local verification commands such as `git diff`, `git add` and a descriptive commit message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdfb6d739083278dfafda50dfc95ef)