### PR TITLE
Playerbot: tighten PvP lifecycle manager seam behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -62,12 +62,7 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     if (!ginfo)
         return false;
 
-    uint32 const queueSlot = player->AddBattlegroundQueueId(bgQueueTypeId);
-    uint32 const avgTime = bgQueue.GetAverageQueueWaitTime(ginfo, bracketEntry->GetBracketId());
-
-    WorldPacket statusPacket;
-    sBattlegroundMgr->BuildBattlegroundStatusPacket(&statusPacket, bgTemplate, queueSlot, STATUS_WAIT_QUEUE, avgTime, 0, arenaType, 0);
-    player->SendDirectMessage(&statusPacket);
+    player->AddBattlegroundQueueId(bgQueueTypeId);
     return true;
 }
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -18,7 +18,6 @@
 #include "Log.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
-#include "Player.h"
 #include "ScriptMgr.h"
 
 namespace
@@ -46,25 +45,9 @@ public:
 
 };
 
-class PlayerbotPvpLifecyclePlayerScript final : public PlayerScript
-{
-public:
-    PlayerbotPvpLifecyclePlayerScript() : PlayerScript("PlayerbotPvpLifecyclePlayerScript") { }
-
-    void OnMapChanged(Player* player) override
-    {
-        playerbot::RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
-    }
-
-    void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
-    {
-        playerbot::RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
-    }
-};
 }
 
 void AddPlayerbotScripts()
 {
     new PlayerbotBootstrapWorldScript();
-    new PlayerbotPvpLifecyclePlayerScript();
 }


### PR DESCRIPTION
### Motivation
- Prevent broad implicit lifecycle dispatch from player map/zone hooks and preserve manager-owned cadence for random-bot PvP participation. 
- Replace a synthetic battleground status packet emission with safe internal API usage for queue join to avoid risky packet emulation.

### Description
- Removed the `PlayerScript`-driven lifecycle dispatch (`OnMapChanged` / `OnUpdateZone`) so lifecycle processing is not invoked from global player hooks and remains manager-driven (file: `src/server/scripts/Playerbot/playerbot_loader.cpp`, approx lines 25-53). 
- Left bootstrap wiring intact: `PvpCore::LoadConfig()` and `RandomBotParticipationLifecycle::RegisterManagerHooks()` remain in the startup path (file: `src/server/scripts/Playerbot/playerbot_loader.cpp`, approx lines 30-41). 
- Simplified battleground queue join primitive to stop constructing/sending a synthetic `BattlegroundStatus` packet and instead use `player->AddBattlegroundQueueId(...)` after `bgQueue.AddGroup(...)` (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`, approx lines 37-67). 
- Preserved lifecycle gate checks (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`) and kept lifecycle decision ownership in the manager/core layer while lifecycle primitives execute decisions only (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`, approx lines 31-35 and throughout lifecycle action methods). 

### Testing
- ✅ Reconfigured CMake with `-DPLAYERBOT=1` and exported compile commands using `cmake -S . -B build -G Ninja -DPLAYERBOT=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` and the configure completed successfully. 
- ✅ Verified touched Playerbot sources are present in `build/compile_commands.json` using a small Python check that inspected entries for `PlayerbotPvpCore.cpp`, `PlayerbotPvpLifecycleActions.cpp`, `PlayerbotRandomBotParticipation.cpp`, and `playerbot_loader.cpp`. 
- ✅ Per-file compile-db syntax checks were run by invoking each file's compile command with `-fsyntax-only` (scripted via Python against `build/compile_commands.json`), and all touched `.cpp` files returned exit code 0. 
- ✅ Built the targeted object files with Ninja using `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o` which completed successfully. 
- ⚠️ A full `ninja -C build scripts` run was started but was interrupted due to full-tree duration; targeted builds above were used instead to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce1d0257288327a090a9299b23ef05)