### PR TITLE
Phase 4: wire manager cadence seam for Playerbot PvP lifecycle entrypoint

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -22,12 +22,43 @@
 
 #include "Player.h"
 
+#include <chrono>
+#include <unordered_map>
+
 namespace
 {
+using CadenceClock = std::chrono::steady_clock;
+using TimePoint = CadenceClock::time_point;
+
+constexpr std::chrono::milliseconds LifecycleCadenceInterval(2000);
+
+bool g_ManagerHooksRegistered = false;
+std::unordered_map<uint64, TimePoint> g_NextLifecycleProcessTimeByGuid;
+
 bool IsLifecycleGateEnabled()
 {
     playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
+}
+
+bool IsEligibleForLifecycleProcessing(Player const* player)
+{
+    return player && player->IsInWorld() && !player->IsBeingTeleported();
+}
+
+bool IsCadenceReady(Player* player)
+{
+    if (!player)
+        return false;
+
+    uint64 const playerGuid = player->GetGUID().GetRawValue();
+    TimePoint const now = CadenceClock::now();
+    TimePoint& nextProcessTime = g_NextLifecycleProcessTimeByGuid[playerGuid];
+    if (nextProcessTime > now)
+        return false;
+
+    nextProcessTime = now + LifecycleCadenceInterval;
+    return true;
 }
 }
 
@@ -38,12 +69,13 @@ void RandomBotParticipationLifecycle::RegisterManagerHooks()
     if (!IsLifecycleGateEnabled())
         return;
 
-    // Intentionally neutral/no-op: manager-owned integration points are declared and ready for explicit wiring.
+    g_ManagerHooksRegistered = true;
+    g_NextLifecycleProcessTimeByGuid.clear();
 }
 
 void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 {
-    if (!player || !IsLifecycleGateEnabled())
+    if (!g_ManagerHooksRegistered || !IsLifecycleGateEnabled() || !IsEligibleForLifecycleProcessing(player) || !IsCadenceReady(player))
         return;
 
     PvpValues const values = PvpCore::CollectValues(player);


### PR DESCRIPTION
### Motivation
- Finish Phase 4 manager integration by giving the manager seam ownership of cadence and eligibility for random bot PvP lifecycle dispatch while preserving the exact config gate chain and lifecycle-only responsibilities.

### Description
- Replace the `RegisterManagerHooks()` no-op with an explicit manager state flag `g_ManagerHooksRegistered` and clearable per-player cadence state in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`.
- Add a per-player cadence using `std::chrono::steady_clock` and a `std::unordered_map<uint64, TimePoint>` with a 2s interval, gated by `IsCadenceReady()` to throttle `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint`.
- Add eligibility checks via `IsEligibleForLifecycleProcessing()` (player `IsInWorld()` and not `IsBeingTeleported()`), and require `g_ManagerHooksRegistered` plus the existing config gate (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`) before invoking `PvpCore::CollectValues` and lifecycle dispatch.
- Preserve strict layering: manager seam now owns cadence/eligibility and the lifecycle layer still executes concrete actions via `BattlegroundLifecycleActions::Execute` and `ArenaLifecycleActions::Execute` (no behavioral changes to those actions).

### Testing
- ✅ Verified presence of the touched file in the compile database after configuring CMake with `-DPLAYERBOT=1` (fixed initial missing compile-db entry). 
- ✅ Ran compile-db-derived syntax check (`-fsyntax-only`) for `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` and it returned clean.
- ✅ Built the targeted object `src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o` to validate integration into the scripts build.
- ⚠️ Attempted a full `scripts` target build as broader validation but replaced with the targeted object build to keep validation focused and avoid long-running global build output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7c3281908327b19e28e11f575e7f)