### PR TITLE
Playerbot PvP: move lifecycle cadence to manager/core seam

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -22,9 +22,24 @@
 #include "Configuration/Config.h"
 #include "Player.h"
 
+#include <chrono>
+#include <unordered_map>
+
 namespace
 {
 playerbot::PvpCoreConfig g_PvpCoreConfig;
+
+using LifecycleCadenceClock = std::chrono::steady_clock;
+using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
+
+constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
+
+std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
+
+bool IsLifecycleGateEnabled(playerbot::PvpCoreConfig const& config)
+{
+    return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
+}
 }
 
 namespace playerbot
@@ -40,6 +55,32 @@ void PvpCore::LoadConfig()
 PvpCoreConfig const& PvpCore::GetConfig()
 {
     return g_PvpCoreConfig;
+}
+
+bool PvpCore::CanProcessRandomBotLifecycle(Player const* player)
+{
+    if (!player)
+        return false;
+
+    if (!IsLifecycleGateEnabled(g_PvpCoreConfig))
+        return false;
+
+    if (!player->IsInWorld() || player->IsBeingTeleported())
+        return false;
+
+    uint64 const playerGuid = player->GetGUID().GetRawValue();
+    LifecycleCadenceTimePoint const now = LifecycleCadenceClock::now();
+    LifecycleCadenceTimePoint& nextProcessTime = g_NextRandomBotLifecycleProcessTimeByGuid[playerGuid];
+    if (nextProcessTime > now)
+        return false;
+
+    nextProcessTime = now + RandomBotLifecycleCadenceInterval;
+    return true;
+}
+
+void PvpCore::ResetRandomBotLifecycleCadence()
+{
+    g_NextRandomBotLifecycleProcessTimeByGuid.clear();
 }
 
 PvpValues PvpCore::CollectValues(Player const* player)
@@ -160,7 +201,7 @@ RandomBotParticipationHooks PvpCore::BuildRandomBotParticipationHooks(Player con
 
 bool PvpCore::IsLifecycleEnabled()
 {
-    return g_PvpCoreConfig.moduleEnabled && g_PvpCoreConfig.pvpCoreEnabled && g_PvpCoreConfig.pvpLifecycleEnabled;
+    return IsLifecycleGateEnabled(g_PvpCoreConfig);
 }
 
 bool PvpCore::IsInBattlegroundQueue(Player const* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -155,6 +155,8 @@ class PvpCore
 public:
     static void LoadConfig();
     static PvpCoreConfig const& GetConfig();
+    static bool CanProcessRandomBotLifecycle(Player const* player);
+    static void ResetRandomBotLifecycleCadence();
 
     static PvpValues CollectValues(Player const* player);
     static bool IsTriggerActive(PvpTrigger trigger, PvpValues const& values);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -22,60 +22,29 @@
 
 #include "Player.h"
 
-#include <chrono>
-#include <unordered_map>
-
 namespace
 {
-using CadenceClock = std::chrono::steady_clock;
-using TimePoint = CadenceClock::time_point;
-
-constexpr std::chrono::milliseconds LifecycleCadenceInterval(2000);
-
-bool g_ManagerHooksRegistered = false;
-std::unordered_map<uint64, TimePoint> g_NextLifecycleProcessTimeByGuid;
-
 bool IsLifecycleGateEnabled()
 {
     playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
 }
 
-bool IsEligibleForLifecycleProcessing(Player const* player)
-{
-    return player && player->IsInWorld() && !player->IsBeingTeleported();
-}
-
-bool IsCadenceReady(Player* player)
-{
-    if (!player)
-        return false;
-
-    uint64 const playerGuid = player->GetGUID().GetRawValue();
-    TimePoint const now = CadenceClock::now();
-    TimePoint& nextProcessTime = g_NextLifecycleProcessTimeByGuid[playerGuid];
-    if (nextProcessTime > now)
-        return false;
-
-    nextProcessTime = now + LifecycleCadenceInterval;
-    return true;
-}
 }
 
 namespace playerbot
 {
-void RandomBotParticipationLifecycle::RegisterManagerHooks()
+void RandomBotParticipationLifecycle::ProcessManagerLifecycleEntryPoint(Player* player)
 {
-    if (!IsLifecycleGateEnabled())
+    if (!PvpCore::CanProcessRandomBotLifecycle(player))
         return;
 
-    g_ManagerHooksRegistered = true;
-    g_NextLifecycleProcessTimeByGuid.clear();
+    ProcessLifecycleEntryPoint(player);
 }
 
 void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 {
-    if (!g_ManagerHooksRegistered || !IsLifecycleGateEnabled() || !IsEligibleForLifecycleProcessing(player) || !IsCadenceReady(player))
+    if (!player || !IsLifecycleGateEnabled())
         return;
 
     PvpValues const values = PvpCore::CollectValues(player);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -28,10 +28,10 @@ struct RandomBotParticipationHooks;
 class RandomBotParticipationLifecycle
 {
 public:
-    // Neutral registration seam for manager-facing integration wiring.
-    static void RegisterManagerHooks();
+    // Manager-facing seam for per-bot update cadence/eligibility ownership.
+    static void ProcessManagerLifecycleEntryPoint(Player* player);
 
-    // Manager-facing seam: neutral lifecycle dispatcher for a random bot player.
+    // Lifecycle seam: dispatcher only, executes decisions from context.
     static void ProcessLifecycleEntryPoint(Player* player);
 
     // Seam entry points for future random-bot manager wiring (Phase 4+).

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -35,7 +35,7 @@ public:
     void OnStartup() override
     {
         playerbot::PvpCore::LoadConfig();
-        playerbot::RandomBotParticipationLifecycle::RegisterManagerHooks();
+        playerbot::PvpCore::ResetRandomBotLifecycleCadence();
         playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
 
         TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}, pvp tactics: {}, pvp lifecycle: {}).",


### PR DESCRIPTION
### Motivation
- Ensure strict separation of responsibilities so cadence/eligibility state is owned by the manager/core layer while the lifecycle layer remains a dispatcher that only executes decisions, and preserve existing OFF-by-default config gates.

### Description
- Add `PvpCore::CanProcessRandomBotLifecycle(Player const*)` and `PvpCore::ResetRandomBotLifecycleCadence()` and move per-player cadence storage into `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` (and declare in the header) to centralize cadence/eligibility logic.
- Convert the lifecycle seam so `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player*)` is dispatcher-only and introduce `RandomBotParticipationLifecycle::ProcessManagerLifecycleEntryPoint(Player*)` as the manager-facing per-bot entry that consults `PvpCore::CanProcessRandomBotLifecycle`; changes in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.{h,cpp}` implement this.
- Remove the previous manager-like cadence state and registration wiring from the lifecycle file and reset the cadence map on startup via `PvpCore::ResetRandomBotLifecycleCadence()` in `src/server/scripts/Playerbot/playerbot_loader.cpp` so startup remains deterministic and minimal.
- Preserve all original feature gates (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`) and keep lifecycle selectors and actions unchanged (BG/Arena queue join/leave and invite/team interaction execution remain concrete and in `PlayerbotPvpLifecycleActions`).

### Testing
- ✅ Reconfigured the build to include the Playerbot module and export compile commands using `cmake -S . -B build -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPLAYERBOT=1`, which populated `build/compile_commands.json` with the touched Playerbot sources.
- ✅ Verified touched Playerbot `.cpp` files are present in `build/compile_commands.json` and executed compile-db-derived `-fsyntax-only` checks for `src/server/scripts/Playerbot/playerbot_loader.cpp`, `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`, and `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` with success.
- ✅ Per-file targeted object builds succeeded using `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpCore.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o` to validate integration of the changes into the scripts project.
- ❌ A full `cmake --build build --target scripts -j4` was started but manually terminated due to long-running broad build time and is not required for the targeted integration validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce893104c08327abb4b82e23bdc2c6)