### PR TITLE
Playerbot PvP: Move lifecycle cadence ownership to manager seam

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -22,19 +22,9 @@
 #include "Configuration/Config.h"
 #include "Player.h"
 
-#include <chrono>
-#include <unordered_map>
-
 namespace
 {
 playerbot::PvpCoreConfig g_PvpCoreConfig;
-
-using LifecycleCadenceClock = std::chrono::steady_clock;
-using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
-
-constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
-
-std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 
 bool IsLifecycleGateEnabled(playerbot::PvpCoreConfig const& config)
 {
@@ -55,32 +45,6 @@ void PvpCore::LoadConfig()
 PvpCoreConfig const& PvpCore::GetConfig()
 {
     return g_PvpCoreConfig;
-}
-
-bool PvpCore::CanProcessRandomBotLifecycle(Player const* player)
-{
-    if (!player)
-        return false;
-
-    if (!IsLifecycleGateEnabled(g_PvpCoreConfig))
-        return false;
-
-    if (!player->IsInWorld() || player->IsBeingTeleported())
-        return false;
-
-    uint64 const playerGuid = player->GetGUID().GetRawValue();
-    LifecycleCadenceTimePoint const now = LifecycleCadenceClock::now();
-    LifecycleCadenceTimePoint& nextProcessTime = g_NextRandomBotLifecycleProcessTimeByGuid[playerGuid];
-    if (nextProcessTime > now)
-        return false;
-
-    nextProcessTime = now + RandomBotLifecycleCadenceInterval;
-    return true;
-}
-
-void PvpCore::ResetRandomBotLifecycleCadence()
-{
-    g_NextRandomBotLifecycleProcessTimeByGuid.clear();
 }
 
 PvpValues PvpCore::CollectValues(Player const* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -155,8 +155,6 @@ class PvpCore
 public:
     static void LoadConfig();
     static PvpCoreConfig const& GetConfig();
-    static bool CanProcessRandomBotLifecycle(Player const* player);
-    static void ResetRandomBotLifecycleCadence();
 
     static PvpValues CollectValues(Player const* player);
     static bool IsTriggerActive(PvpTrigger trigger, PvpValues const& values);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -22,6 +22,9 @@
 
 #include "Player.h"
 
+#include <chrono>
+#include <unordered_map>
+
 namespace
 {
 bool IsLifecycleGateEnabled()
@@ -30,16 +33,48 @@ bool IsLifecycleGateEnabled()
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
 }
 
+using LifecycleCadenceClock = std::chrono::steady_clock;
+using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
+
+constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
+
+std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
+
+bool CanProcessPlayerLifecycle(Player const* player)
+{
+    if (!player)
+        return false;
+
+    if (!IsLifecycleGateEnabled())
+        return false;
+
+    if (!player->IsInWorld() || player->IsBeingTeleported())
+        return false;
+
+    uint64 const playerGuid = player->GetGUID().GetRawValue();
+    LifecycleCadenceTimePoint const now = LifecycleCadenceClock::now();
+    LifecycleCadenceTimePoint& nextProcessTime = g_NextRandomBotLifecycleProcessTimeByGuid[playerGuid];
+    if (nextProcessTime > now)
+        return false;
+
+    nextProcessTime = now + RandomBotLifecycleCadenceInterval;
+    return true;
+}
 }
 
 namespace playerbot
 {
-void RandomBotParticipationLifecycle::ProcessManagerLifecycleEntryPoint(Player* player)
+void RandomBotParticipationManager::ResetCadence()
 {
-    if (!PvpCore::CanProcessRandomBotLifecycle(player))
+    g_NextRandomBotLifecycleProcessTimeByGuid.clear();
+}
+
+void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
+{
+    if (!CanProcessPlayerLifecycle(player))
         return;
 
-    ProcessLifecycleEntryPoint(player);
+    RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
 }
 
 void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -25,12 +25,16 @@ namespace playerbot
 struct PvpValues;
 struct RandomBotParticipationHooks;
 
+class RandomBotParticipationManager
+{
+public:
+    static void ResetCadence();
+    static void ProcessPlayerLifecycle(Player* player);
+};
+
 class RandomBotParticipationLifecycle
 {
 public:
-    // Manager-facing seam for per-bot update cadence/eligibility ownership.
-    static void ProcessManagerLifecycleEntryPoint(Player* player);
-
     // Lifecycle seam: dispatcher only, executes decisions from context.
     static void ProcessLifecycleEntryPoint(Player* player);
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -35,7 +35,7 @@ public:
     void OnStartup() override
     {
         playerbot::PvpCore::LoadConfig();
-        playerbot::PvpCore::ResetRandomBotLifecycleCadence();
+        playerbot::RandomBotParticipationManager::ResetCadence();
         playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
 
         TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}, pvp tactics: {}, pvp lifecycle: {}).",


### PR DESCRIPTION
### Motivation

- Remove per-bot lifecycle cadence/eligibility ownership from the PvP core and place it in a true manager-owned seam so manager layer owns cadence and scheduling. 
- Keep the lifecycle layer strictly as a dispatcher/decision executor and preserve the exact config gate chain `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`.
- Fix the compile DB blocker by ensuring touched Playerbot .cpp files are present in the build compile database so syntax/build checks can run.

### Description

- Removed manager-facing cadence APIs from `PvpCore` by deleting `CanProcessRandomBotLifecycle` and `ResetRandomBotLifecycleCadence` (header + impl) so `PvpCore` remains a config/context/helpers-only class (`PlayerbotPvpCore.h/.cpp`).
- Added a minimal manager-owned seam `RandomBotParticipationManager` in `PlayerbotRandomBotParticipation.{h,cpp}` that owns per-bot cadence state, timing, eligibility checks, and a `ResetCadence()` API; also provided `ProcessPlayerLifecycle(Player*)` as the manager entry for per-player invocation. 
- Kept `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player*)` as the lifecycle dispatcher/decision seam only; it now continues to collect values/hooks and invoke BG/Arena lifecycle handlers without owning cadence. 
- Updated bootstrap to call the new manager reset method (`RandomBotParticipationManager::ResetCadence()`) during startup, without adding any player-sweep or global lifecycle dispatch in the loader. 
- Preserved concrete lifecycle selectors and safe internal API-backed primitives for BG/Arena actions (join/leave, accept/decline invites, in-progress handling) in `PlayerbotPvpLifecycleActions.cpp`. 
- Files changed: `PlayerbotPvpCore.h/.cpp`, `PlayerbotRandomBotParticipation.h/.cpp`, `playerbot_loader.cpp`.

### Testing

- Ran CMake configure with Playerbot enabled (`cmake -S . -B build -DPLAYERBOT=ON`) to ensure Playerbot sources are included in `build/compile_commands.json`, and verified the compile DB now contains the touched Playerbot .cpp files; this succeeded. 
- Per-file compile-db-derived syntax checks (`-fsyntax-only`) were executed for `PlayerbotPvpCore.cpp`, `PlayerbotRandomBotParticipation.cpp`, and `playerbot_loader.cpp`, and all returned success (no syntax errors). 
- Performed a narrow targeted object build invocation for the three modified sources (`ninja -C build ... PlayerbotPvpCore.cpp.o PlayerbotRandomBotParticipation.cpp.o playerbot_loader.cpp.o`) to validate integration of the changes; the targeted object builds completed successfully. 
- A broader `scripts` build was started for context but is non-essential; narrow targeted validations above demonstrate the change compiles where it matters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9924fc688327af3f9a5d4c91b185)