### PR TITLE
Playerbot: reset PvP lifecycle cadence on config reload

### DIFF
--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -30,6 +30,7 @@ public:
     void OnConfigLoad(bool /*reload*/) override
     {
         playerbot::PvpCore::LoadConfig();
+        playerbot::RandomBotParticipationManager::ResetCadence();
     }
 
     void OnStartup() override


### PR DESCRIPTION
### Motivation
- Prevent stale per-player PvP lifecycle cadence timestamps from surviving a config reload so subsequent lifecycle dispatches are not incorrectly suppressed.

### Description
- Add a call to `playerbot::RandomBotParticipationManager::ResetCadence()` in `PlayerbotBootstrapWorldScript::OnConfigLoad` in `src/server/scripts/Playerbot/playerbot_loader.cpp`.
- This keeps cadence ownership in `RandomBotParticipationManager` and preserves the loader as bootstrap-only without adding lifecycle dispatch logic.

### Testing
- Ran CMake configure with `-DPLAYERBOT=ON` and verified the touched Playerbot sources appear in `build/compile_commands.json`.
- Performed a compile-db-derived syntax check (`-fsyntax-only`) on `src/server/scripts/Playerbot/playerbot_loader.cpp` which passed.
- Built the narrow object target `src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea8cb6ad483279c0e1b6181f72acb)