### PR TITLE
Playerbot: wire lifecycle processing to map-change callback

### DIFF
--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -46,9 +46,21 @@ public:
 
 };
 
+class PlayerbotLifecyclePlayerScript final : public PlayerScript
+{
+public:
+    PlayerbotLifecyclePlayerScript() : PlayerScript("PlayerbotLifecyclePlayerScript") { }
+
+    void OnMapChanged(Player* player) override
+    {
+        playerbot::RandomBotParticipationManager::ProcessPlayerLifecycle(player);
+    }
+};
+
 }
 
 void AddPlayerbotScripts()
 {
     new PlayerbotBootstrapWorldScript();
+    new PlayerbotLifecyclePlayerScript();
 }


### PR DESCRIPTION
### Motivation
- Provide the smallest possible per-player runtime hook to invoke PvP lifecycle processing (`RandomBotParticipationManager::ProcessPlayerLifecycle`) without adding global sweeps, loader polling, SQL changes, or altering PvP tactics, and while preserving the existing gate chain (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`).

### Description
- Add a minimal `PlayerScript` (`PlayerbotLifecyclePlayerScript`) in `src/server/scripts/Playerbot/playerbot_loader.cpp` that implements `OnMapChanged(Player*)` and calls `playerbot::RandomBotParticipationManager::ProcessPlayerLifecycle(player)`, and register the script in `AddPlayerbotScripts()`; lifecycle dispatch remains in `RandomBotParticipationLifecycle` and cadence ownership remains in `RandomBotParticipationManager`.

### Testing
- Configured the build with `-DPLAYERBOT=1`, confirmed the compile database contains an entry for `src/server/scripts/Playerbot/playerbot_loader.cpp`, ran a compile-db-derived syntax-only compile (`-fsyntax-only`) for that file, and built the narrow object target `src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cedec03754832794b7ec23ba66ae31)