### PR TITLE
Playerbot: invoke PvP lifecycle from per-player OnUpdateZone

### DIFF
--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -51,7 +51,7 @@ class PlayerbotLifecyclePlayerScript final : public PlayerScript
 public:
     PlayerbotLifecyclePlayerScript() : PlayerScript("PlayerbotLifecyclePlayerScript") { }
 
-    void OnMapChanged(Player* player) override
+    void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
     {
         playerbot::RandomBotParticipationManager::ProcessPlayerLifecycle(player);
     }


### PR DESCRIPTION
### Motivation
- `OnMapChanged` was too sparse to reliably exercise queue/invite lifecycle transitions at runtime, so a higher-frequency per-player callback is required while avoiding sweeps, polling, or manager-side changes.

### Description
- Replaced `PlayerbotLifecyclePlayerScript::OnMapChanged` with `OnUpdateZone(Player*, uint32, uint32)` and kept the single dispatch call to `playerbot::RandomBotParticipationManager::ProcessPlayerLifecycle(player)` in `src/server/scripts/Playerbot/playerbot_loader.cpp`, preserving the existing gating and manager cadence.

### Testing
- Ran `cmake -S . -B build -DPLAYERBOT=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` (success), verified `compile_commands.json` contains the modified `playerbot_loader.cpp` entry, executed the compile-db derived `-fsyntax-only` check for that file (success), and built the narrow object target `cmake --build build --target src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o -j4` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cee16cdbf48327abbffa365f2b2fc9)