### PR TITLE
Add per-player PlayerScript::OnUpdate hook and move Playerbot PvP lifecycle host to it

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1100,6 +1100,7 @@ void Player::Update(uint32 p_time)
     SetCanDelayTeleport(true);
     Unit::Update(p_time);
     SetCanDelayTeleport(false);
+    sScriptMgr->OnPlayerUpdate(this, p_time);
 
     UpdateStarfireSnare();
     VerifyStarfireSnare();

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1974,6 +1974,11 @@ void ScriptMgr::OnPlayerBindToInstance(Player* player, Difficulty difficulty, ui
     FOREACH_SCRIPT(PlayerScript)->OnBindToInstance(player, difficulty, mapid, permanent, extendState);
 }
 
+void ScriptMgr::OnPlayerUpdate(Player* player, uint32 diff)
+{
+    FOREACH_SCRIPT(PlayerScript)->OnUpdate(player, diff);
+}
+
 void ScriptMgr::OnPlayerUpdateZone(Player* player, uint32 newZone, uint32 newArea)
 {
     FOREACH_SCRIPT(PlayerScript)->OnUpdateZone(player, newZone, newArea);
@@ -2701,6 +2706,10 @@ void PlayerScript::OnSave(Player* /*player*/)
 }
 
 void PlayerScript::OnBindToInstance(Player* /*player*/, Difficulty /*difficulty*/, uint32 /*mapId*/, bool /*permanent*/, uint8 /*extendState*/)
+{
+}
+
+void PlayerScript::OnUpdate(Player* /*player*/, uint32 /*diff*/)
 {
 }
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -703,6 +703,9 @@ class TC_GAME_API PlayerScript : public ScriptObject
         // Called when a player is bound to an instance
         virtual void OnBindToInstance(Player* player, Difficulty difficulty, uint32 mapId, bool permanent, uint8 extendState);
 
+        // Called once per player update tick
+        virtual void OnUpdate(Player* player, uint32 diff);
+
         // Called when a player switches to a new zone
         virtual void OnUpdateZone(Player* player, uint32 newZone, uint32 newArea);
 
@@ -1036,6 +1039,7 @@ class TC_GAME_API ScriptMgr
         void OnPlayerFailedDelete(ObjectGuid guid, uint32 accountId);
         void OnPlayerSave(Player* player);
         void OnPlayerBindToInstance(Player* player, Difficulty difficulty, uint32 mapid, bool permanent, uint8 extendState);
+        void OnPlayerUpdate(Player* player, uint32 diff);
         void OnPlayerUpdateZone(Player* player, uint32 newZone, uint32 newArea);
         void OnQuestObjectiveProgress(Player* player, Quest const* quest, uint32 objectiveIndex, uint16 progress);
         void OnQuestStatusChange(Player* player, uint32 questId);

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -51,7 +51,7 @@ class PlayerbotLifecyclePlayerScript final : public PlayerScript
 public:
     PlayerbotLifecyclePlayerScript() : PlayerScript("PlayerbotLifecyclePlayerScript") { }
 
-    void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
+    void OnUpdate(Player* player, uint32 /*diff*/) override
     {
         playerbot::RandomBotParticipationManager::ProcessPlayerLifecycle(player);
     }


### PR DESCRIPTION
### Motivation

- The Playerbot PvP lifecycle host previously used `OnUpdateZone`, which is event-driven and cannot reliably run periodic lifecycle Phase 3 for active or idle bots. 
- A minimal per-player runtime hook is required to invoke `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)` exactly once per player tick without introducing global sweeps or polling loops.

### Description

- Add a new per-player script hook by introducing `PlayerScript::OnUpdate(Player*, uint32)` and a `ScriptMgr::OnPlayerUpdate(Player*, uint32)` dispatcher so PlayerScripts can run once per player tick (`src/server/game/Scripting/ScriptMgr.h`, `src/server/game/Scripting/ScriptMgr.cpp`).
- Wire the dispatcher into the core update path by invoking `sScriptMgr->OnPlayerUpdate(this, p_time)` from `Player::Update(uint32)` so scripts are dispatched once per player update (`src/server/game/Entities/Player/Player.cpp`).
- Move the Playerbot PvP lifecycle host from the zone-change hook to the new per-player hook by replacing `OnUpdateZone` with `OnUpdate` in the Playerbot loader and keep exactly one call site to `RandomBotParticipationManager::ProcessPlayerLifecycle(player)` (`src/server/scripts/Playerbot/playerbot_loader.cpp`).
- Preserve existing lifecycle architecture and gates, avoid global player sweeps, loader polling loops, SQL changes, and any PvP tactic/behavior modifications.

### Testing

- ✅ Ran CMake configure with `-DPLAYERBOT=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` and verified `compile_commands.json` was generated successfully.
- ✅ Verified touched files are present in `compile_commands.json` and ran compile-db derived `-fsyntax-only` checks for `src/server/scripts/Playerbot/playerbot_loader.cpp`, `src/server/game/Scripting/ScriptMgr.cpp`, and `src/server/game/Entities/Player/Player.cpp`, all succeeding.
- ✅ Built narrow object targets for the touched objects with `cmake --build build --target src/server/game/CMakeFiles/game.dir/Entities/Player/Player.cpp.o src/server/game/CMakeFiles/game.dir/Scripting/ScriptMgr.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o` which completed successfully (toolchain warnings are unrelated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cee33c84dc83278db9e6e90c2773d1)