### PR TITLE
Harden Playerbot PvP lifecycle cadence state and logout cleanup

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -23,6 +23,7 @@
 #include "Player.h"
 
 #include <chrono>
+#include <mutex>
 #include <unordered_map>
 
 namespace
@@ -39,6 +40,7 @@ using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
+std::mutex g_RandomBotLifecycleCadenceLock;
 
 bool CanProcessPlayerLifecycle(Player const* player)
 {
@@ -53,6 +55,7 @@ bool CanProcessPlayerLifecycle(Player const* player)
 
     uint64 const playerGuid = player->GetGUID().GetRawValue();
     LifecycleCadenceTimePoint const now = LifecycleCadenceClock::now();
+    std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
     LifecycleCadenceTimePoint& nextProcessTime = g_NextRandomBotLifecycleProcessTimeByGuid[playerGuid];
     if (nextProcessTime > now)
         return false;
@@ -66,7 +69,17 @@ namespace playerbot
 {
 void RandomBotParticipationManager::ResetCadence()
 {
+    std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
     g_NextRandomBotLifecycleProcessTimeByGuid.clear();
+}
+
+void RandomBotParticipationManager::OnPlayerLogout(Player const* player)
+{
+    if (!player)
+        return;
+
+    std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
+    g_NextRandomBotLifecycleProcessTimeByGuid.erase(player->GetGUID().GetRawValue());
 }
 
 void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -29,6 +29,7 @@ class RandomBotParticipationManager
 {
 public:
     static void ResetCadence();
+    static void OnPlayerLogout(Player const* player);
     static void ProcessPlayerLifecycle(Player* player);
 };
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -55,6 +55,11 @@ public:
     {
         playerbot::RandomBotParticipationManager::ProcessPlayerLifecycle(player);
     }
+
+    void OnLogout(Player* player) override
+    {
+        playerbot::RandomBotParticipationManager::OnPlayerLogout(player);
+    }
 };
 
 }


### PR DESCRIPTION
### Motivation
- Prevent concurrent access races on the per-player lifecycle cadence map and stop unbounded stale GUID growth over long uptime while keeping the Playerbot PvP lifecycle architecture and gates unchanged.
- Implement the smallest, low-risk runtime hardening slice after Phase 3 that preserves manager-owned cadence and the single `OnUpdate` runtime host path.

### Description
- Add a mutex `g_RandomBotLifecycleCadenceLock` and guard accesses to the shared cadence map in `PlayerbotRandomBotParticipation.cpp` to remove data-race windows around cadence checks and resets.
- Add a minimal manager API `RandomBotParticipationManager::OnPlayerLogout(Player const*)` to erase per-player cadence state on logout and call it from `PlayerbotLifecyclePlayerScript::OnLogout` in `playerbot_loader.cpp`.
- Keep cadence interval and ownership unchanged (2s, manager-owned), preserve the exact gate chain (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`), and do not change any tactics/queueing/class behavior or add global sweeps/SQL changes.

### Testing
- Ran configuration with `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPLAYERBOT=ON` and the configure step completed successfully.
- Verified the compile database entries for the touched translation units with `rg` against `build/compile_commands.json` and found the `playerbot` translation units present.
- Performed compile-db-derived `-fsyntax-only` checks for `/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` and `/src/server/scripts/Playerbot/playerbot_loader.cpp` and both checks passed with exit code 0.
- Built narrow object targets for the touched script objects and a narrow core object with `cmake --build build --target src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o` and related narrow targets, and these builds succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cee60e69d88327a0b0bcc67cbaca1a)