### PR TITLE
Playerbot PvP: pre-Phase-4 lifecycle observability and safety guards

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -23,6 +23,7 @@
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "CharacterCache.h"
+#include "Log.h"
 #include "Player.h"
 #include "World.h"
 
@@ -169,6 +170,18 @@ bool AcceptMatchingInvite(Player* player, bool arenaInvite)
 
     return false;
 }
+
+bool HasConflictingBattlegroundLifecycleContext(playerbot::BattlegroundLifecycleContext const& context)
+{
+    return (context.queueOperation != playerbot::QueueOperationType::None) &&
+        (context.invitationResponse != playerbot::InvitationResponseType::None);
+}
+
+bool HasConflictingArenaLifecycleContext(playerbot::ArenaLifecycleContext const& context)
+{
+    return (context.queueOperation != playerbot::QueueOperationType::None) &&
+        (context.teamInteraction != playerbot::ArenaTeamInteractionType::None);
+}
 }
 
 namespace playerbot
@@ -177,6 +190,15 @@ bool BattlegroundLifecycleActions::Execute(Player* player, BattlegroundLifecycle
 {
     if (!player || !context.lifecycleEnabled || !IsLifecycleGateEnabled())
         return false;
+
+    if (HasConflictingBattlegroundLifecycleContext(context))
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP battleground lifecycle no-op due to conflicting context: guid={}, queueOperation={}, invitationResponse={}, handleInProgress={}.",
+            player->GetGUID().ToString(), static_cast<uint8>(context.queueOperation), static_cast<uint8>(context.invitationResponse),
+            context.shouldHandleInProgressStatus ? 1 : 0);
+        return false;
+    }
 
     bool didExecute = false;
 
@@ -265,6 +287,14 @@ bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const&
 {
     if (!player || !context.lifecycleEnabled || !IsLifecycleGateEnabled())
         return false;
+
+    if (HasConflictingArenaLifecycleContext(context))
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP arena lifecycle no-op due to conflicting context: guid={}, queueOperation={}, teamInteraction={}.",
+            player->GetGUID().ToString(), static_cast<uint8>(context.queueOperation), static_cast<uint8>(context.teamInteraction));
+        return false;
+    }
 
     bool didExecute = false;
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -20,8 +20,10 @@
 #include "PlayerbotPvpCore.h"
 #include "PlayerbotPvpLifecycleActions.h"
 
+#include "Log.h"
 #include "Player.h"
 
+#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <unordered_map>
@@ -42,23 +44,98 @@ constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;
 
+enum class LifecycleObservationReason : uint8
+{
+    GateDisabled = 0,
+    CadenceThrottled,
+    InvalidPlayerState,
+    NoLifecycleHooksActive,
+    BattlegroundLifecycleExecuted,
+    ArenaLifecycleExecuted
+};
+
+struct LifecycleObservationCounters
+{
+    std::atomic<uint64> gateDisabled{ 0 };
+    std::atomic<uint64> cadenceThrottled{ 0 };
+    std::atomic<uint64> invalidPlayerState{ 0 };
+    std::atomic<uint64> noLifecycleHooksActive{ 0 };
+    std::atomic<uint64> battlegroundLifecycleExecuted{ 0 };
+    std::atomic<uint64> arenaLifecycleExecuted{ 0 };
+};
+
+LifecycleObservationCounters g_LifecycleObservationCounters;
+
+void ObserveLifecycleReason(LifecycleObservationReason reason, ObjectGuid const& guid)
+{
+    char const* reasonLabel = "unknown";
+    uint64 total = 0;
+
+    switch (reason)
+    {
+        case LifecycleObservationReason::GateDisabled:
+            total = ++g_LifecycleObservationCounters.gateDisabled;
+            reasonLabel = "gate-disabled";
+            break;
+        case LifecycleObservationReason::CadenceThrottled:
+            total = ++g_LifecycleObservationCounters.cadenceThrottled;
+            reasonLabel = "cadence-throttled";
+            break;
+        case LifecycleObservationReason::InvalidPlayerState:
+            total = ++g_LifecycleObservationCounters.invalidPlayerState;
+            reasonLabel = "invalid-player-state";
+            break;
+        case LifecycleObservationReason::NoLifecycleHooksActive:
+            total = ++g_LifecycleObservationCounters.noLifecycleHooksActive;
+            reasonLabel = "no-lifecycle-hooks-active";
+            break;
+        case LifecycleObservationReason::BattlegroundLifecycleExecuted:
+            total = ++g_LifecycleObservationCounters.battlegroundLifecycleExecuted;
+            reasonLabel = "battleground-lifecycle-executed";
+            break;
+        case LifecycleObservationReason::ArenaLifecycleExecuted:
+            total = ++g_LifecycleObservationCounters.arenaLifecycleExecuted;
+            reasonLabel = "arena-lifecycle-executed";
+            break;
+        default:
+            break;
+    }
+
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "Playerbot PvP lifecycle observation: reason={} guid={} count={}.",
+        reasonLabel, guid.ToString(), total);
+}
+
 bool CanProcessPlayerLifecycle(Player const* player)
 {
     if (!player)
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, ObjectGuid::Empty);
         return false;
+    }
+
+    ObjectGuid const guid = player->GetGUID();
 
     if (!IsLifecycleGateEnabled())
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
         return false;
+    }
 
     if (!player->IsInWorld() || player->IsBeingTeleported())
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
         return false;
+    }
 
-    uint64 const playerGuid = player->GetGUID().GetRawValue();
+    uint64 const playerGuid = guid.GetRawValue();
     LifecycleCadenceTimePoint const now = LifecycleCadenceClock::now();
     std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
     LifecycleCadenceTimePoint& nextProcessTime = g_NextRandomBotLifecycleProcessTimeByGuid[playerGuid];
     if (nextProcessTime > now)
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::CadenceThrottled, guid);
         return false;
+    }
 
     nextProcessTime = now + RandomBotLifecycleCadenceInterval;
     return true;
@@ -92,41 +169,64 @@ void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
 
 void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 {
-    if (!player || !IsLifecycleGateEnabled())
+    if (!player)
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, ObjectGuid::Empty);
         return;
+    }
+
+    ObjectGuid const guid = player->GetGUID();
+
+    if (!IsLifecycleGateEnabled())
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
+        return;
+    }
 
     PvpValues const values = PvpCore::CollectValues(player);
     RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
     if (!hooks.lifecycleEnabled)
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
         return;
+    }
 
-    ProcessBattlegroundLifecycleEntryPoint(player, values, hooks);
-    ProcessArenaLifecycleEntryPoint(player, values, hooks);
+    if (!hooks.battlegroundParticipationHook && !hooks.arenaParticipationHook)
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::NoLifecycleHooksActive, guid);
+        return;
+    }
+
+    if (ProcessBattlegroundLifecycleEntryPoint(player, values, hooks))
+        ObserveLifecycleReason(LifecycleObservationReason::BattlegroundLifecycleExecuted, guid);
+
+    if (ProcessArenaLifecycleEntryPoint(player, values, hooks))
+        ObserveLifecycleReason(LifecycleObservationReason::ArenaLifecycleExecuted, guid);
 }
 
-void RandomBotParticipationLifecycle::ProcessBattlegroundLifecycleEntryPoint(Player* player, PvpValues const& values,
+bool RandomBotParticipationLifecycle::ProcessBattlegroundLifecycleEntryPoint(Player* player, PvpValues const& values,
     RandomBotParticipationHooks const& hooks)
 {
     if (!player || !IsLifecycleGateEnabled())
-        return;
+        return false;
 
     if (!hooks.lifecycleEnabled || !hooks.battlegroundParticipationHook)
-        return;
+        return false;
 
     BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
-    BattlegroundLifecycleActions::Execute(player, battlegroundContext);
+    return BattlegroundLifecycleActions::Execute(player, battlegroundContext);
 }
 
-void RandomBotParticipationLifecycle::ProcessArenaLifecycleEntryPoint(Player* player, PvpValues const& values,
+bool RandomBotParticipationLifecycle::ProcessArenaLifecycleEntryPoint(Player* player, PvpValues const& values,
     RandomBotParticipationHooks const& hooks)
 {
     if (!player || !IsLifecycleGateEnabled())
-        return;
+        return false;
 
     if (!hooks.lifecycleEnabled || !hooks.arenaParticipationHook)
-        return;
+        return false;
 
     ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
-    ArenaLifecycleActions::Execute(player, arenaContext);
+    return ArenaLifecycleActions::Execute(player, arenaContext);
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -40,8 +40,8 @@ public:
     static void ProcessLifecycleEntryPoint(Player* player);
 
     // Seam entry points for future random-bot manager wiring (Phase 4+).
-    static void ProcessBattlegroundLifecycleEntryPoint(Player* player, PvpValues const& values, RandomBotParticipationHooks const& hooks);
-    static void ProcessArenaLifecycleEntryPoint(Player* player, PvpValues const& values, RandomBotParticipationHooks const& hooks);
+    static bool ProcessBattlegroundLifecycleEntryPoint(Player* player, PvpValues const& values, RandomBotParticipationHooks const& hooks);
+    static bool ProcessArenaLifecycleEntryPoint(Player* player, PvpValues const& values, RandomBotParticipationHooks const& hooks);
 };
 }
 


### PR DESCRIPTION
### Motivation
- Add a minimal, safe pre-Phase-4 reliability/observability slice for Playerbot PvP lifecycle runtime without enabling Phase-4 behavior trees.  
- Preserve the exact runtime host callback path (`RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`), manager-owned cadence, and the gate chain `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`.  
- Keep all queue selection/tactical/class behavior unchanged and avoid global sweeps, polling loops, or SQL changes.  

### Description
- Added lightweight lifecycle observability counters and debug tracing at manager/dispatcher boundaries for reasons: `gate disabled`, `cadence throttled`, `invalid player state`, `no lifecycle hooks active`, `battleground lifecycle executed`, and `arena lifecycle executed` in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`.  
- Introduced `ObserveLifecycleReason(...)` and atomic counter struct to record and log observations (no behavioral side effects).  
- Changed dispatcher seam signatures to return execution status for observability only: `ProcessBattlegroundLifecycleEntryPoint` and `ProcessArenaLifecycleEntryPoint` now return `bool` and their declaration was updated in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h`.  
- Added invariant-safe context guards that detect contradictory lifecycle contexts and safely no-op with a debug log in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` (conflicting queue operation + invite response for battlegrounds, and queue operation + team interaction for arenas).  
- Preserved cadence interval constant, manager-owned cadence model, runtime host callback in `playerbot_loader.cpp` and all gate checks (`PvpCore::GetConfig()` usage) so existing runtime flow and selection logic remains unchanged.  
- Changes are localized to: `PlayerbotRandomBotParticipation.{h,cpp}`, `PlayerbotPvpLifecycleActions.cpp`, and the header update noted; `playerbot_loader.cpp` is left intact (host path preserved).  

### Testing
- ✅ `cmake -S . -B build-playerbot -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPLAYERBOT=1 -DSCRIPTS_PLAYERBOT=static` — generated `build-playerbot/compile_commands.json` and configured build with Playerbot enabled.  
- ✅ Verified touched Playerbot `.cpp` entries exist in `build-playerbot/compile_commands.json` using a compile-db inspection script.  
- ✅ Ran compile-db-derived syntax checks (`-fsyntax-only`) for `PlayerbotRandomBotParticipation.cpp` and `PlayerbotPvpLifecycleActions.cpp` and they succeeded.  
- ✅ Ran narrow object-target builds by invoking the compile commands from `build-playerbot/compile_commands.json` for the touched objects (including `PlayerbotPvpCore.cpp` and `playerbot_loader.cpp`) and they completed successfully.  

Files changed (key citations):  
- `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` (observability counters, logging, dispatcher return-status wiring)  
- `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h` (dispatcher signatures)  
- `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` (conflict-detection guards + debug logging)  

This is strictly a pre-Phase-4 hardening/observability PR; it does not add class/spec behavior trees, change queue selection policy, alter tactical logic, perform global sweeps, nor modify SQL.  All host-path and gate-chain constraints specified were preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cee9eb641c8327afeb1b6c3d65531c)