### PR TITLE
Playerbot PvP lifecycle pre-Phase-4 observability hardening

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -64,6 +64,12 @@ Output in this phase:
 - Arena smoke tests (2v2/3v3 queue, engage, reset).
 - Regression checks for non-PvP behavior when PvP flags are off.
 
+### Lifecycle observability checks
+
+- Validate lifecycle debug logs include dispatcher completion with explicit battleground/arena `didExecute` booleans.
+- Validate lifecycle debug logs include deterministic no-op guard output when lifecycle hooks are active but built contexts are both no-op.
+- Inspect lifecycle reason counters through the manager snapshot seam to verify gate-disabled, cadence-throttled, invalid-state, no-hook, and executed-path counts are incrementing as expected during runtime checks.
+
 ## Porting policy
 
 - Keep each commit focused on one subsystem and compilable.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -66,6 +66,19 @@ struct LifecycleObservationCounters
 
 LifecycleObservationCounters g_LifecycleObservationCounters;
 
+bool IsNoOp(playerbot::BattlegroundLifecycleContext const& context)
+{
+    return context.queueOperation == playerbot::QueueOperationType::None &&
+        context.invitationResponse == playerbot::InvitationResponseType::None &&
+        !context.shouldHandleInProgressStatus;
+}
+
+bool IsNoOp(playerbot::ArenaLifecycleContext const& context)
+{
+    return context.queueOperation == playerbot::QueueOperationType::None &&
+        context.teamInteraction == playerbot::ArenaTeamInteractionType::None;
+}
+
 void ObserveLifecycleReason(LifecycleObservationReason reason, ObjectGuid const& guid)
 {
     char const* reasonLabel = "unknown";
@@ -167,6 +180,18 @@ void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
     RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(player);
 }
 
+LifecycleObservationSnapshot RandomBotParticipationManager::GetLifecycleObservationSnapshot()
+{
+    LifecycleObservationSnapshot snapshot;
+    snapshot.gateDisabled = g_LifecycleObservationCounters.gateDisabled.load(std::memory_order_relaxed);
+    snapshot.cadenceThrottled = g_LifecycleObservationCounters.cadenceThrottled.load(std::memory_order_relaxed);
+    snapshot.invalidPlayerState = g_LifecycleObservationCounters.invalidPlayerState.load(std::memory_order_relaxed);
+    snapshot.noLifecycleHooksActive = g_LifecycleObservationCounters.noLifecycleHooksActive.load(std::memory_order_relaxed);
+    snapshot.battlegroundLifecycleExecuted = g_LifecycleObservationCounters.battlegroundLifecycleExecuted.load(std::memory_order_relaxed);
+    snapshot.arenaLifecycleExecuted = g_LifecycleObservationCounters.arenaLifecycleExecuted.load(std::memory_order_relaxed);
+    return snapshot;
+}
+
 void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 {
     if (!player)
@@ -197,11 +222,30 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         return;
     }
 
-    if (ProcessBattlegroundLifecycleEntryPoint(player, values, hooks))
+    BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
+    ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
+    if (IsNoOp(battlegroundContext) && IsNoOp(arenaContext))
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle dispatcher no-op with active hooks: guid={}, bgHook={}, arenaHook={}.",
+            guid.ToString(), hooks.battlegroundParticipationHook ? 1 : 0, hooks.arenaParticipationHook ? 1 : 0);
+        return;
+    }
+
+    bool const didExecuteBattleground = hooks.battlegroundParticipationHook &&
+        BattlegroundLifecycleActions::Execute(player, battlegroundContext);
+    bool const didExecuteArena = hooks.arenaParticipationHook &&
+        ArenaLifecycleActions::Execute(player, arenaContext);
+
+    if (didExecuteBattleground)
         ObserveLifecycleReason(LifecycleObservationReason::BattlegroundLifecycleExecuted, guid);
 
-    if (ProcessArenaLifecycleEntryPoint(player, values, hooks))
+    if (didExecuteArena)
         ObserveLifecycleReason(LifecycleObservationReason::ArenaLifecycleExecuted, guid);
+
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground={}, didExecuteArena={}.",
+        guid.ToString(), didExecuteBattleground ? 1 : 0, didExecuteArena ? 1 : 0);
 }
 
 bool RandomBotParticipationLifecycle::ProcessBattlegroundLifecycleEntryPoint(Player* player, PvpValues const& values,

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -25,12 +25,23 @@ namespace playerbot
 struct PvpValues;
 struct RandomBotParticipationHooks;
 
+struct LifecycleObservationSnapshot
+{
+    uint64 gateDisabled = 0;
+    uint64 cadenceThrottled = 0;
+    uint64 invalidPlayerState = 0;
+    uint64 noLifecycleHooksActive = 0;
+    uint64 battlegroundLifecycleExecuted = 0;
+    uint64 arenaLifecycleExecuted = 0;
+};
+
 class RandomBotParticipationManager
 {
 public:
     static void ResetCadence();
     static void OnPlayerLogout(Player const* player);
     static void ProcessPlayerLifecycle(Player* player);
+    static LifecycleObservationSnapshot GetLifecycleObservationSnapshot();
 };
 
 class RandomBotParticipationLifecycle


### PR DESCRIPTION
### Motivation

- Add a minimal, non-behavioral observability and deterministic-guard slice for Playerbot PvP lifecycle runtime prior to Phase 4 class/spec behavior work. 
- Surface existing internal reason counters via a safe read-only API and add deterministic dispatcher logging to make runtime validation easier without changing lifecycle cadence, gate logic, or queue/behavior policy.

### Description

- Add a lightweight read-only snapshot API (`LifecycleObservationSnapshot` + `RandomBotParticipationManager::GetLifecycleObservationSnapshot`) that returns atomic lifecycle counters without locking or mutating runtime state; files changed: `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h` and `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`.
- Add deterministic dispatcher-entry guard that logs and returns when lifecycle hooks are active but both built lifecycle contexts are effectively no-op, preserving the existing contradictory-context no-op guards and not changing behavior flow; change located in `PlayerbotRandomBotParticipation.cpp`.
- Add a debug log at dispatcher completion that summarizes the battleground/arena `didExecute` booleans (read-only diagnostic only); change located in `PlayerbotRandomBotParticipation.cpp`.
- Small documentation update adding a Phase 6 subsection describing lifecycle observability checks to `doc/playerbot/pvp-port-roadmap.md`.
- Preserved constraints: no Phase-4 behavior trees, no class/tactics/queue policy changes, host loader callback path is unchanged (`RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)` in `src/server/scripts/Playerbot/playerbot_loader.cpp`), the cadence model and interval remain unchanged, and the gate chain (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`) is preserved in `PlayerbotPvpCore.cpp`.

### Testing

- ✅ `cmake -S . -B build -DPLAYERBOT=ON` (configuration completed successfully).
- ✅ Verified `build/compile_commands.json` contains Playerbot entries for touched files via a small Python check (compile database presence confirmed).
- ✅ Ran compile-db-derived syntax check for the touched translation unit: used the compile command with `-fsyntax-only` for `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` (succeeded).
- ✅ Built narrow object targets to validate link/compile for the touched objects: `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceece495288327afab4757a1fae8f2)