### PR TITLE
[Playerbot][PvP] Pre-Phase-4 validation-only lifecycle observability surfacing

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -70,6 +70,26 @@ Output in this phase:
 - Validate lifecycle debug logs include deterministic no-op guard output when lifecycle hooks are active but built contexts are both no-op.
 - Inspect lifecycle reason counters through the manager snapshot seam to verify gate-disabled, cadence-throttled, invalid-state, no-hook, and executed-path counts are incrementing as expected during runtime checks.
 
+### Phase 6 manual validation procedure (pre-Phase-4, validation-only)
+
+- Config prerequisites:
+  - `Playerbot.Enable = 1`
+  - `Playerbot.PvpCore.Enable = 1`
+  - `Playerbot.PvpLifecycle.Enable = 1`
+  - Optional for branch visibility tests: enable `playerbots.pvp.lifecycle` debug log filtering in your logger config.
+- In-game command hook:
+  - Run `.playerbot pvp lifecycle snapshot` from a GM account to print `RandomBotParticipationManager::GetLifecycleObservationSnapshot()` counters.
+- Expected log lines:
+  - Branch marker line: `Playerbot PvP lifecycle branch: guid=<...> branch=<...>.`
+  - Observation reason line: `Playerbot PvP lifecycle observation: reason=<...> guid=<...> count=<...>.`
+  - Dispatcher summary line: `Playerbot PvP lifecycle dispatcher complete: guid=<...>, didExecuteBattleground=<0|1>, didExecuteArena=<0|1>.`
+- Expected counter movement patterns:
+  - `gateDisabled` increases only when any lifecycle gate in `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable` is false at runtime.
+  - `cadenceThrottled` increases during repeated `OnUpdate` calls inside the manager-owned cadence interval.
+  - `invalidPlayerState` increases for null/out-of-world/teleporting players.
+  - `noLifecycleHooksActive` increases when lifecycle gate is on but both participation hooks are false.
+  - `battlegroundLifecycleExecuted`/`arenaLifecycleExecuted` increase only when their corresponding lifecycle action path actually executes.
+
 ## Porting policy
 
 - Keep each commit focused on one subsystem and compilable.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -118,6 +118,11 @@ void ObserveLifecycleReason(LifecycleObservationReason reason, ObjectGuid const&
         reasonLabel, guid.ToString(), total);
 }
 
+void LogLifecycleBranchSummary(ObjectGuid const& guid, char const* branchLabel)
+{
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "Playerbot PvP lifecycle branch: guid={} branch={}.", guid.ToString(), branchLabel);
+}
+
 bool CanProcessPlayerLifecycle(Player const* player)
 {
     if (!player)
@@ -196,6 +201,7 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 {
     if (!player)
     {
+        LogLifecycleBranchSummary(ObjectGuid::Empty, "invalid-player-state");
         ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, ObjectGuid::Empty);
         return;
     }
@@ -204,6 +210,7 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 
     if (!IsLifecycleGateEnabled())
     {
+        LogLifecycleBranchSummary(guid, "gate-disabled");
         ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
         return;
     }
@@ -212,12 +219,14 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
     if (!hooks.lifecycleEnabled)
     {
+        LogLifecycleBranchSummary(guid, "hooks-lifecycle-disabled");
         ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
         return;
     }
 
     if (!hooks.battlegroundParticipationHook && !hooks.arenaParticipationHook)
     {
+        LogLifecycleBranchSummary(guid, "no-lifecycle-hooks-active");
         ObserveLifecycleReason(LifecycleObservationReason::NoLifecycleHooksActive, guid);
         return;
     }
@@ -226,6 +235,7 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
     if (IsNoOp(battlegroundContext) && IsNoOp(arenaContext))
     {
+        LogLifecycleBranchSummary(guid, "active-hooks-no-op-context");
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle dispatcher no-op with active hooks: guid={}, bgHook={}, arenaHook={}.",
             guid.ToString(), hooks.battlegroundParticipationHook ? 1 : 0, hooks.arenaParticipationHook ? 1 : 0);
@@ -238,10 +248,16 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         ArenaLifecycleActions::Execute(player, arenaContext);
 
     if (didExecuteBattleground)
+    {
+        LogLifecycleBranchSummary(guid, "battleground-lifecycle-executed");
         ObserveLifecycleReason(LifecycleObservationReason::BattlegroundLifecycleExecuted, guid);
+    }
 
     if (didExecuteArena)
+    {
+        LogLifecycleBranchSummary(guid, "arena-lifecycle-executed");
         ObserveLifecycleReason(LifecycleObservationReason::ArenaLifecycleExecuted, guid);
+    }
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
         "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground={}, didExecuteArena={}.",

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -16,9 +16,13 @@
  */
 
 #include "Log.h"
+#include "Chat.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
+#include "RBAC.h"
 #include "ScriptMgr.h"
+
+using namespace Trinity::ChatCommands;
 
 namespace
 {
@@ -62,10 +66,59 @@ public:
     }
 };
 
+class PlayerbotLifecycleCommandScript final : public CommandScript
+{
+public:
+    PlayerbotLifecycleCommandScript() : CommandScript("PlayerbotLifecycleCommandScript") { }
+
+    ChatCommandTable GetCommands() const override
+    {
+        static ChatCommandTable playerbotPvpLifecycleTable =
+        {
+            { "snapshot", HandlePlayerbotPvpLifecycleSnapshotCommand, rbac::RBAC_PERM_COMMAND_GM, Console::Yes },
+        };
+
+        static ChatCommandTable playerbotPvpTable =
+        {
+            { "lifecycle", playerbotPvpLifecycleTable },
+        };
+
+        static ChatCommandTable playerbotTable =
+        {
+            { "pvp", playerbotPvpTable },
+        };
+
+        static ChatCommandTable commandTable =
+        {
+            { "playerbot", playerbotTable },
+        };
+
+        return commandTable;
+    }
+
+    static bool HandlePlayerbotPvpLifecycleSnapshotCommand(ChatHandler* handler)
+    {
+        if (!handler)
+            return false;
+
+        playerbot::LifecycleObservationSnapshot const snapshot = playerbot::RandomBotParticipationManager::GetLifecycleObservationSnapshot();
+
+        handler->PSendSysMessage("Playerbot PvP lifecycle observation snapshot:");
+        handler->PSendSysMessage(" - gateDisabled: " UI64FMTD, snapshot.gateDisabled);
+        handler->PSendSysMessage(" - cadenceThrottled: " UI64FMTD, snapshot.cadenceThrottled);
+        handler->PSendSysMessage(" - invalidPlayerState: " UI64FMTD, snapshot.invalidPlayerState);
+        handler->PSendSysMessage(" - noLifecycleHooksActive: " UI64FMTD, snapshot.noLifecycleHooksActive);
+        handler->PSendSysMessage(" - battlegroundLifecycleExecuted: " UI64FMTD, snapshot.battlegroundLifecycleExecuted);
+        handler->PSendSysMessage(" - arenaLifecycleExecuted: " UI64FMTD, snapshot.arenaLifecycleExecuted);
+        return true;
+    }
+};
+
 }
 
 void AddPlayerbotScripts()
 {
     new PlayerbotBootstrapWorldScript();
     new PlayerbotLifecyclePlayerScript();
+    new PlayerbotLifecycleCommandScript();
 }


### PR DESCRIPTION
### Motivation

- Provide a minimal, non-behavioral observability slice to support Phase-6 validation by surfacing lifecycle counters and deterministic branch markers without changing runtime policy or behavior.
- Keep the change strictly read-only for lifecycle decisioning and preserve all runtime paths, cadence, and gate semantics required for pre-Phase-4 validation.
- Supply a short manual validation procedure to make it easy for testers to exercise and verify lifecycle observation counters and log markers.

### Description

- Added a narrow GM/debug command hook `.playerbot pvp lifecycle snapshot` (implemented in `src/server/scripts/Playerbot/playerbot_loader.cpp`) that prints the `RandomBotParticipationManager::GetLifecycleObservationSnapshot()` counters in read-only form.
- Added deterministic one-line lifecycle branch markers via `LogLifecycleBranchSummary` in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` to emit concise branch labels for early-exit and execution branches without altering branch outcomes or queue/action logic.
- Extended `doc/playerbot/pvp-port-roadmap.md` Phase 6 with a short "Phase 6 manual validation procedure" listing exact config prerequisites, expected log lines, and expected counter movement patterns.
- Preserved all hard constraints: preserved `OnUpdate` loader path `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`, preserved lifecycle gate chain `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`, left manager cadence and interval unchanged, and made no changes to queue policy, tactical/class behavior, SQL, or loader callbacks.

### Testing

- ✅ Ran CMake configure with Playerbot enabled: `cmake -S . -B build -DPLAYERBOT=ON -DSCRIPTS=static -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` and it completed successfully.
- ✅ Verified touched Playerbot `.cpp` files are present in `build/compile_commands.json` via `rg` against the generated compile database.
- ✅ Performed compile-db-derived `-fsyntax-only` checks for `src/server/scripts/Playerbot/playerbot_loader.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` by invoking the compile commands with `-fsyntax-only`, and they succeeded.
- ✅ Built narrow object targets for the touched translation units with `cmake --build build --target src/server/scripts/CMakeFiles/scripts.dir/Playerbot/playerbot_loader.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o` and the objects built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef27e526c83278ae27be0995943b4)