### PR TITLE
Phase-4 Slice 1 - reference-aligned Warrior Arms PvP decision slice

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -96,3 +96,22 @@ Output in this phase:
 - Prefer adapter wrappers when AC and Trinity APIs differ.
 - Gate incomplete systems behind explicit config flags.
 - Preserve references in comments when behavior is intentionally mirrored.
+
+### Phase-4 Slice 1 parity mapping
+
+- Reference files mapped:
+  - `playerbot reference/mod-playerbots-master/src/Ai/Base/StrategyContext.h` (strategy naming context for PvP strategy enable surface)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Base/TriggerContext.h` (trigger naming semantics used by PvP/class strategies)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Strategy/BattlegroundStrategy.cpp` (battleground-active trigger context)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Strategy/ArmsWarriorStrategy.{h,cpp}` (Arms priority and trigger/action intent)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Trigger/WarriorTriggers.h` (named trigger semantics: mortal strike, overpower/taste for blood, execute, hamstring, charge)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Action/WarriorActions.h` (spell action naming/selection targets)
+- Port files touched:
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.{h,cpp}`
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.{h,cpp}`
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`
+  - `src/server/scripts/Playerbot/playerbot_loader.cpp`
+  - `src/server/worldserver/playerbots.conf.dist`
+- Intentional divergences:
+  - Spell resolution uses known-rank lookup by spell ID instead of action-node factories, because the Trinity slice does not yet port the full `NamedObjectFactory<ActionNode>` class AI stack.
+  - Trigger checks are condensed into a single context builder/executor path to keep the current lifecycle topology unchanged while still mirroring Arms trigger priority order.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PlayerbotPvpClassActions.h"
+
+#include "Player.h"
+#include "Unit.h"
+
+#include <array>
+
+namespace
+{
+uint32 FindKnownSpell(Player const* player, std::initializer_list<uint32> spellIds)
+{
+    if (!player)
+        return 0;
+
+    for (uint32 spellId : spellIds)
+        if (player->HasSpell(spellId))
+            return spellId;
+
+    return 0;
+}
+
+uint32 ResolveSpellId(Player const* player, playerbot::PvpClassSpellActionType actionType)
+{
+    switch (actionType)
+    {
+        case playerbot::PvpClassSpellActionType::Charge:
+            return FindKnownSpell(player, { 11578, 11577, 100 });
+        case playerbot::PvpClassSpellActionType::BattleStance:
+            return FindKnownSpell(player, { 2457 });
+        case playerbot::PvpClassSpellActionType::BattleShout:
+            return FindKnownSpell(player, { 47436, 47435, 6673 });
+        case playerbot::PvpClassSpellActionType::MortalStrike:
+            return FindKnownSpell(player, { 47486, 47485, 12294 });
+        case playerbot::PvpClassSpellActionType::Execute:
+            return FindKnownSpell(player, { 47471, 25236, 20662, 20661, 5308 });
+        case playerbot::PvpClassSpellActionType::Overpower:
+            return FindKnownSpell(player, { 7384 });
+        case playerbot::PvpClassSpellActionType::Hamstring:
+            return FindKnownSpell(player, { 1715 });
+        case playerbot::PvpClassSpellActionType::HeroicStrike:
+            return FindKnownSpell(player, { 47450, 47449, 78 });
+        case playerbot::PvpClassSpellActionType::None:
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+bool CastResolvedSpell(Player* player, playerbot::PvpClassSpellActionType actionType)
+{
+    if (!player || actionType == playerbot::PvpClassSpellActionType::None)
+        return false;
+
+    if (player->IsNonMeleeSpellCast(false))
+        return false;
+
+    uint32 const spellId = ResolveSpellId(player, actionType);
+    if (!spellId)
+        return false;
+
+    Unit* target = player;
+    if (actionType != playerbot::PvpClassSpellActionType::BattleStance &&
+        actionType != playerbot::PvpClassSpellActionType::BattleShout)
+    {
+        target = player->GetVictim();
+        if (!target || !target->IsAlive())
+            return false;
+    }
+
+    player->CastSpell(target, spellId, false);
+    return true;
+}
+}
+
+namespace playerbot
+{
+bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& context)
+{
+    if (!player || !context.classSpellsEnabled || !context.shouldExecute)
+        return false;
+
+    return CastResolvedSpell(player, context.actionType);
+}
+}

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_PLAYERBOT_PVP_CLASS_ACTIONS_H
+#define TRINITY_PLAYERBOT_PVP_CLASS_ACTIONS_H
+
+#include "PlayerbotPvpCore.h"
+
+class Player;
+
+namespace playerbot
+{
+class PvpClassActions
+{
+public:
+    static bool Execute(Player* player, PvpClassSpellContext const& context);
+};
+}
+
+#endif

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -22,6 +22,8 @@
 #include "Configuration/Config.h"
 #include "Player.h"
 
+#include <array>
+
 namespace
 {
 playerbot::PvpCoreConfig g_PvpCoreConfig;
@@ -29,6 +31,37 @@ playerbot::PvpCoreConfig g_PvpCoreConfig;
 bool IsLifecycleGateEnabled(playerbot::PvpCoreConfig const& config)
 {
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
+}
+
+bool IsClassSpellGateEnabled(playerbot::PvpCoreConfig const& config)
+{
+    return config.moduleEnabled && config.pvpCoreEnabled && config.pvpClassSpellsEnabled;
+}
+
+bool IsWarriorArmsSliceCandidate(Player const* player)
+{
+    if (!player || player->GetClass() != CLASS_WARRIOR)
+        return false;
+
+    // Reference-aligned intent: this minimal slice mirrors Arms strategy priority around Mortal Strike.
+    constexpr std::array<uint32, 3> mortalStrikeRanks{ 47486, 47485, 12294 };
+    for (uint32 spellId : mortalStrikeRanks)
+        if (player->HasSpell(spellId))
+            return true;
+
+    return false;
+}
+
+bool HasKnownSpell(Player const* player, std::initializer_list<uint32> spellIds)
+{
+    if (!player)
+        return false;
+
+    for (uint32 spellId : spellIds)
+        if (player->HasSpell(spellId))
+            return true;
+
+    return false;
 }
 }
 
@@ -40,6 +73,7 @@ void PvpCore::LoadConfig()
     g_PvpCoreConfig.pvpCoreEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpCore.Enable", false);
     g_PvpCoreConfig.pvpTacticsEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpTactics.Enable", false);
     g_PvpCoreConfig.pvpLifecycleEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpLifecycle.Enable", false);
+    g_PvpCoreConfig.pvpClassSpellsEnabled = sConfigMgr->GetBoolDefault("Playerbot.PvpClassSpells.Enable", false);
 }
 
 PvpCoreConfig const& PvpCore::GetConfig()
@@ -142,6 +176,50 @@ ArenaLifecycleContext PvpCore::BuildArenaLifecycleContext(Player const* player, 
 
     context.queueOperation = SelectArenaQueueOperationSkeleton(values);
     context.teamInteraction = SelectArenaTeamInteractionSkeleton(values);
+    return context;
+}
+
+PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpValues const& values)
+{
+    PvpClassSpellContext context;
+    context.classSpellsEnabled = IsClassSpellGateEnabled(g_PvpCoreConfig);
+    if (!context.classSpellsEnabled || !player || !values.inBattleground || !IsTriggerActive(PvpTrigger::BgActive, values))
+        return context;
+
+    if (!IsWarriorArmsSliceCandidate(player))
+        return context;
+
+    Unit const* target = player->GetVictim();
+    if (!target || !target->IsAlive() || target->GetGUID() == player->GetGUID())
+        return context;
+
+    bool const targetCriticalHealth = target->HealthBelowPct(20);
+    bool const enemyOutOfMelee = !player->IsWithinMeleeRange(target);
+    bool const tasteForBlood = player->HasAura(60503);
+    bool const targetAlreadySlowed = target->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED);
+    bool const highRageAvailable = player->GetPower(POWER_RAGE) >= 500;
+    bool const hasBattleShout = player->HasAura(6673);
+    bool const inBattleStance = player->HasAura(2457);
+
+    // Reference mirror from ArmsWarriorStrategy trigger intent, keeping priority ordering explicit.
+    if (targetCriticalHealth && HasKnownSpell(player, { 47471, 5308 }))
+        context.actionType = PvpClassSpellActionType::Execute;
+    else if (enemyOutOfMelee && HasKnownSpell(player, { 11578, 100 }))
+        context.actionType = PvpClassSpellActionType::Charge;
+    else if (tasteForBlood && HasKnownSpell(player, { 7384 }))
+        context.actionType = PvpClassSpellActionType::Overpower;
+    else if (HasKnownSpell(player, { 47486, 12294 }))
+        context.actionType = PvpClassSpellActionType::MortalStrike;
+    else if (!targetAlreadySlowed && HasKnownSpell(player, { 1715 }))
+        context.actionType = PvpClassSpellActionType::Hamstring;
+    else if (highRageAvailable && HasKnownSpell(player, { 47450, 78 }))
+        context.actionType = PvpClassSpellActionType::HeroicStrike;
+    else if (!hasBattleShout && HasKnownSpell(player, { 47436, 6673 }))
+        context.actionType = PvpClassSpellActionType::BattleShout;
+    else if (!inBattleStance && HasKnownSpell(player, { 2457 }))
+        context.actionType = PvpClassSpellActionType::BattleStance;
+
+    context.shouldExecute = context.actionType != PvpClassSpellActionType::None;
     return context;
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -31,6 +31,7 @@ struct PvpCoreConfig
     bool pvpCoreEnabled = false;
     bool pvpTacticsEnabled = false;
     bool pvpLifecycleEnabled = false;
+    bool pvpClassSpellsEnabled = false;
 };
 
 enum class BattlegroundState : uint8
@@ -128,6 +129,26 @@ enum class ArenaTeamInteractionType : uint8
     DeclineInvite
 };
 
+enum class PvpClassSpellActionType : uint8
+{
+    None = 0,
+    Charge,
+    BattleStance,
+    BattleShout,
+    MortalStrike,
+    Execute,
+    Overpower,
+    Hamstring,
+    HeroicStrike
+};
+
+struct PvpClassSpellContext
+{
+    bool classSpellsEnabled = false;
+    bool shouldExecute = false;
+    PvpClassSpellActionType actionType = PvpClassSpellActionType::None;
+};
+
 struct BattlegroundLifecycleContext
 {
     bool lifecycleEnabled = false;
@@ -161,6 +182,7 @@ public:
     static BattlegroundTacticalContext BuildBattlegroundTacticalContext(Player const* player, PvpValues const& values);
     static BattlegroundLifecycleContext BuildBattlegroundLifecycleContext(Player const* player, PvpValues const& values);
     static ArenaLifecycleContext BuildArenaLifecycleContext(Player const* player, PvpValues const& values);
+    static PvpClassSpellContext BuildClassSpellContext(Player const* player, PvpValues const& values);
     static RandomBotParticipationHooks BuildRandomBotParticipationHooks(Player const* player, PvpValues const& values);
 
 private:

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -18,6 +18,7 @@
 #include "PlayerbotRandomBotParticipation.h"
 
 #include "PlayerbotPvpCore.h"
+#include "PlayerbotPvpClassActions.h"
 #include "PlayerbotPvpLifecycleActions.h"
 
 #include "Log.h"
@@ -246,6 +247,8 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         BattlegroundLifecycleActions::Execute(player, battlegroundContext);
     bool const didExecuteArena = hooks.arenaParticipationHook &&
         ArenaLifecycleActions::Execute(player, arenaContext);
+    PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values);
+    bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
 
     if (didExecuteBattleground)
     {
@@ -260,8 +263,8 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     }
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-        "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground={}, didExecuteArena={}.",
-        guid.ToString(), didExecuteBattleground ? 1 : 0, didExecuteArena ? 1 : 0);
+        "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground={}, didExecuteArena={}, didExecuteClassSpell={}.",
+        guid.ToString(), didExecuteBattleground ? 1 : 0, didExecuteArena ? 1 : 0, didExecuteClassSpell ? 1 : 0);
 }
 
 bool RandomBotParticipationLifecycle::ProcessBattlegroundLifecycleEntryPoint(Player* player, PvpValues const& values,

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -43,9 +43,10 @@ public:
         playerbot::RandomBotParticipationManager::ResetCadence();
         playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
 
-        TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}, pvp tactics: {}, pvp lifecycle: {}).",
+        TC_LOG_INFO("server.loading", "Playerbot bootstrap loaded (enabled: {}, pvp core: {}, pvp tactics: {}, pvp lifecycle: {}, pvp class spells: {}).",
             config.moduleEnabled ? "true" : "false", config.pvpCoreEnabled ? "true" : "false",
-            config.pvpTacticsEnabled ? "true" : "false", config.pvpLifecycleEnabled ? "true" : "false");
+            config.pvpTacticsEnabled ? "true" : "false", config.pvpLifecycleEnabled ? "true" : "false",
+            config.pvpClassSpellsEnabled ? "true" : "false");
     }
 
 };

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -51,3 +51,12 @@ Playerbot.PvpTactics.Enable = 0
 #                     1 - (Enabled)
 
 Playerbot.PvpLifecycle.Enable = 0
+
+#    Playerbot.PvpClassSpells.Enable
+#        Description: Enables Phase-4 class/spec PvP spell decision slices.
+#                     Current slice is reference-aligned Warrior Arms trigger/action priority for
+#                     battleground/arena combat contexts.
+#        Default:     0 - (Disabled)
+#                     1 - (Enabled)
+
+Playerbot.PvpClassSpells.Enable = 0


### PR DESCRIPTION
### Motivation
- Add a minimal Phase-4 class/spec PvP spell-decision slice implementing Warrior (Arms) PvP spell choices with high fidelity to the reference module while keeping the Trinity integration topology and lifecycle constraints unchanged.

### Description
- Implemented a gated Warrior Arms Phase-4 slice by adding `PvpClassSpellActionType`/`PvpClassSpellContext`, `BuildClassSpellContext`, and a config flag `Playerbot.PvpClassSpells.Enable` and wiring a lightweight executor `PvpClassActions` that resolves known-rank spell IDs and issues casts; touched files: `PlayerbotPvpCore.{h,cpp}`, `PlayerbotPvpClassActions.{h,cpp}`, `PlayerbotRandomBotParticipation.cpp`, `playerbot_loader.cpp`, and `playerbots.conf.dist`.
- Reference files used: `playerbot reference/mod-playerbots-master/src/Ai/Base/StrategyContext.h`, `.../TriggerContext.h`, `.../Strategy/BattlegroundStrategy.cpp`, `.../Ai/Class/Warrior/Strategy/ArmsWarriorStrategy.{h,cpp}`, `.../Ai/Class/Warrior/Trigger/WarriorTriggers.h`, and `.../Ai/Class/Warrior/Action/WarriorActions.h` to mirror trigger/action naming and priority intent.
- Parity decisions: preserve Arms priority ordering (execute → charge → overpower/taste-for-blood → mortal strike → hamstring → heroic strike → stance/shout upkeep), resolve spells by known-rank spell-id lookups, and integrate execution into the existing lifecycle dispatcher rather than porting full ActionNode factories.
- Intentional divergences and rationale: spell resolution uses explicit rank ID lookup instead of full `NamedObjectFactory<ActionNode>` because the class AI object graph is not yet ported, and trigger checks are condensed into a single context builder/executor to keep the current lifecycle seam minimal and compatible with Trinity.
- Integration invariants preserved: loader OnUpdate path remains `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`, lifecycle gate chain remains `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`, and the manager-owned cadence/interval and queue/lifecycle policy decisions were not changed.

### Testing
- ✅ `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPLAYERBOT=ON -DSCRIPTS_PLAYERBOT=static` — configuration completed successfully with Playerbot scripts included.
- ✅ Verified `build/compile_commands.json` contains entries for all touched Playerbot translation units (`PlayerbotPvpCore.cpp`, `PlayerbotRandomBotParticipation.cpp`, `PlayerbotPvpClassActions.cpp`, `playerbot_loader.cpp`).
- ✅ Ran compile-db derived `-fsyntax-only` checks for the touched `.cpp` files (syntax-only checks succeeded for all targeted files).
- ✅ Narrow object-target build for the touched translation units (built `PlayerbotPvpCore.cpp.o`, `PlayerbotRandomBotParticipation.cpp.o`, `PlayerbotPvpClassActions.cpp.o`, `playerbot_loader.cpp.o`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef6d8a18083278accfdd848ef2466)