### PR TITLE
Playerbot PvP: add class spell selection, direct casting, lifecycle logging, and docs update

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -97,21 +97,29 @@ Output in this phase:
 - Gate incomplete systems behind explicit config flags.
 - Preserve references in comments when behavior is intentionally mirrored.
 
-### Phase-4 Slice 1 parity mapping
+### Phase-4 Slice 1 parity mapping (updated)
 
 - Reference files mapped:
   - `playerbot reference/mod-playerbots-master/src/Ai/Base/StrategyContext.h` (strategy naming context for PvP strategy enable surface)
   - `playerbot reference/mod-playerbots-master/src/Ai/Base/TriggerContext.h` (trigger naming semantics used by PvP/class strategies)
   - `playerbot reference/mod-playerbots-master/src/Ai/Base/Strategy/BattlegroundStrategy.cpp` (battleground-active trigger context)
   - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Strategy/ArmsWarriorStrategy.{h,cpp}` (Arms priority and trigger/action intent)
-  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Trigger/WarriorTriggers.h` (named trigger semantics: mortal strike, overpower/taste for blood, execute, hamstring, charge)
-  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Action/WarriorActions.h` (spell action naming/selection targets)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Trigger/WarriorTriggers.{h,cpp}` (trigger activation semantics for sudden death, taste for blood, high rage, battle stance/shout, and mobility)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Action/WarriorActions.{h,cpp}` (useful/possible checks and spell action targeting semantics)
+  - `playerbot reference/mod-playerbots-master/src/Bot/RandomPlayerbotMgr.cpp` (manager-owned cadence and lifecycle topology expectations)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/*/Strategy/*Strategy.cpp` (class default-action ordering used to extend parity selection across all playable classes)
 - Port files touched:
   - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.{h,cpp}`
-  - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.{h,cpp}`
-  - `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`
-  - `src/server/scripts/Playerbot/playerbot_loader.cpp`
-  - `src/server/worldserver/playerbots.conf.dist`
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`
+  - `doc/playerbot/pvp-port-roadmap.md`
 - Intentional divergences:
   - Spell resolution uses known-rank lookup by spell ID instead of action-node factories, because the Trinity slice does not yet port the full `NamedObjectFactory<ActionNode>` class AI stack.
   - Trigger checks are condensed into a single context builder/executor path to keep the current lifecycle topology unchanged while still mirroring Arms trigger priority order.
+  - `piercing howl`/`mocking blow` fallback is represented by direct `hamstring` execution because this Trinity slice does not yet expose those fallback actions in the PvP class action enum.
+  - `slam`/`victory rush`/`retaliation`/`shattering throw` priorities are intentionally deferred to later slices because this Phase-4 Slice 1 scope is constrained to the direct Arms baseline decision chain used for primary PvP pressure setup.
+  - All classes currently mirror reference default-action priority spell choices (known-rank/cooldown/range checks) without full per-class trigger graph port because TriggerContext/ActionNode class stacks are still outside this slice’s topology constraints.
+
+Loader path and lifecycle gates remain preserved as-is:
+- Loader update path remains exactly `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`.
+- Lifecycle gate chain remains exactly `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`.
+- Manager cadence ownership and interval remain unchanged.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -18,72 +18,22 @@
 #include "PlayerbotPvpClassActions.h"
 
 #include "Player.h"
+#include "SpellHistory.h"
 #include "Unit.h"
-
-#include <array>
 
 namespace
 {
-uint32 FindKnownSpell(Player const* player, std::initializer_list<uint32> spellIds)
+bool CastDirectSpell(Player* player, uint32 spellId, bool selfCast)
 {
-    if (!player)
-        return 0;
-
-    for (uint32 spellId : spellIds)
-        if (player->HasSpell(spellId))
-            return spellId;
-
-    return 0;
-}
-
-uint32 ResolveSpellId(Player const* player, playerbot::PvpClassSpellActionType actionType)
-{
-    switch (actionType)
-    {
-        case playerbot::PvpClassSpellActionType::Charge:
-            return FindKnownSpell(player, { 11578, 11577, 100 });
-        case playerbot::PvpClassSpellActionType::BattleStance:
-            return FindKnownSpell(player, { 2457 });
-        case playerbot::PvpClassSpellActionType::BattleShout:
-            return FindKnownSpell(player, { 47436, 47435, 6673 });
-        case playerbot::PvpClassSpellActionType::MortalStrike:
-            return FindKnownSpell(player, { 47486, 47485, 12294 });
-        case playerbot::PvpClassSpellActionType::Execute:
-            return FindKnownSpell(player, { 47471, 25236, 20662, 20661, 5308 });
-        case playerbot::PvpClassSpellActionType::Overpower:
-            return FindKnownSpell(player, { 7384 });
-        case playerbot::PvpClassSpellActionType::Hamstring:
-            return FindKnownSpell(player, { 1715 });
-        case playerbot::PvpClassSpellActionType::HeroicStrike:
-            return FindKnownSpell(player, { 47450, 47449, 78 });
-        case playerbot::PvpClassSpellActionType::None:
-        default:
-            break;
-    }
-
-    return 0;
-}
-
-bool CastResolvedSpell(Player* player, playerbot::PvpClassSpellActionType actionType)
-{
-    if (!player || actionType == playerbot::PvpClassSpellActionType::None)
+    if (!player || !spellId || !player->HasSpell(spellId))
         return false;
 
-    if (player->IsNonMeleeSpellCast(false))
+    if (player->GetSpellHistory()->HasCooldown(spellId) || player->IsNonMeleeSpellCast(false))
         return false;
 
-    uint32 const spellId = ResolveSpellId(player, actionType);
-    if (!spellId)
+    Unit* target = selfCast ? static_cast<Unit*>(player) : player->GetVictim();
+    if (!target || !target->IsAlive())
         return false;
-
-    Unit* target = player;
-    if (actionType != playerbot::PvpClassSpellActionType::BattleStance &&
-        actionType != playerbot::PvpClassSpellActionType::BattleShout)
-    {
-        target = player->GetVictim();
-        if (!target || !target->IsAlive())
-            return false;
-    }
 
     player->CastSpell(target, spellId, false);
     return true;
@@ -97,6 +47,6 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
     if (!player || !context.classSpellsEnabled || !context.shouldExecute)
         return false;
 
-    return CastResolvedSpell(player, context.actionType);
+    return CastDirectSpell(player, context.spellId, context.selfCast);
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -21,6 +21,7 @@
 #include "BattlegroundMgr.h"
 #include "Configuration/Config.h"
 #include "Player.h"
+#include "SpellHistory.h"
 
 #include <array>
 
@@ -38,30 +39,227 @@ bool IsClassSpellGateEnabled(playerbot::PvpCoreConfig const& config)
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpClassSpellsEnabled;
 }
 
-bool IsWarriorArmsSliceCandidate(Player const* player)
+bool HasRendFromPlayer(Player const* player, Unit const* target)
 {
-    if (!player || player->GetClass() != CLASS_WARRIOR)
+    if (!player || !target)
         return false;
 
-    // Reference-aligned intent: this minimal slice mirrors Arms strategy priority around Mortal Strike.
-    constexpr std::array<uint32, 3> mortalStrikeRanks{ 47486, 47485, 12294 };
-    for (uint32 spellId : mortalStrikeRanks)
-        if (player->HasSpell(spellId))
+    constexpr std::array<uint32, 10> rendRanks{ 47465, 47466, 25208, 11574, 11573, 11572, 6547, 6546, 772, 0 };
+    for (uint32 spellId : rendRanks)
+    {
+        if (!spellId)
+            continue;
+
+        if (target->HasAura(spellId, player->GetGUID()))
+            return true;
+    }
+
+    return false;
+}
+
+uint32 SelectFirstReadySpell(Player const* player, std::initializer_list<uint32> spellIds)
+{
+    for (uint32 spellId : spellIds)
+        if (spellId && player->HasSpell(spellId) && !player->GetSpellHistory()->HasCooldown(spellId))
+            return spellId;
+
+    return 0;
+}
+
+bool TargetHasAuraFromPlayer(Unit const* target, Player const* player, std::initializer_list<uint32> spellIds)
+{
+    if (!target || !player)
+        return false;
+
+    for (uint32 spellId : spellIds)
+        if (spellId && target->HasAura(spellId, player->GetGUID()))
             return true;
 
     return false;
 }
 
-bool HasKnownSpell(Player const* player, std::initializer_list<uint32> spellIds)
+uint32 SelectReferenceClassSpell(Player const* player, Unit const* target, bool inMelee)
 {
-    if (!player)
-        return false;
+    if (!player || !target)
+        return 0;
 
-    for (uint32 spellId : spellIds)
-        if (player->HasSpell(spellId))
-            return true;
+    bool const targetCriticalHealth = target->HealthBelowPct(20);
+    bool const rangedWindow = player->IsWithinDistInMap(target, 35.0f) && player->IsWithinLOSInMap(target);
+    bool const hasSuddenDeath = player->HasAura(52437);
+    bool const tasteForBlood = player->HasAura(60503);
+    bool const hasBattleShout = player->HasAura(6673);
+    bool const inBattleStance = player->HasAura(2457);
+    bool const hasRendAura = HasRendFromPlayer(player, target);
+    bool const targetAlreadySlowed = target->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED);
+    bool const highRageAvailable = player->GetPower(POWER_RAGE) >= 600;
+    bool const lowRageAvailable = player->GetPower(POWER_RAGE) < 200;
+    bool const enemyOutOfMelee = !inMelee;
+    bool const enemyInChargeReach = player->IsWithinDistInMap(target, 25.0f) && player->IsWithinLOSInMap(target);
 
-    return false;
+    switch (player->GetClass())
+    {
+        case CLASS_WARRIOR:
+            if (enemyOutOfMelee && enemyInChargeReach)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 11578, 11577, 100 }))
+                    return spellId; // charge
+            if (!inBattleStance)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 2457 }))
+                    return spellId; // battle stance
+            if (!hasBattleShout)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 47436, 47435, 6673 }))
+                    return spellId; // battle shout
+            if (!hasRendAura && inMelee)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 47465, 47466, 25208, 772 }))
+                    return spellId; // rend
+            if ((targetCriticalHealth || hasSuddenDeath) && inMelee)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 47471, 25236, 5308 }))
+                    return spellId; // execute
+            if (tasteForBlood && inMelee)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 7384 }))
+                    return spellId; // overpower
+            if (inMelee)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 47486, 47485, 12294, 23881, 47498 }))
+                    return spellId; // mortal strike / bloodthirst / devestate fallback
+            if (lowRageAvailable)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 2687 }))
+                    return spellId; // bloodrage
+            if (uint32 spellId = SelectFirstReadySpell(player, { 12292 }))
+                return spellId; // death wish
+            if (!targetAlreadySlowed && inMelee)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 1715 }))
+                    return spellId; // hamstring
+            if (highRageAvailable && inMelee)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 47450, 47449, 78 }))
+                    return spellId; // heroic strike
+            break;
+        case CLASS_PALADIN:
+            if (targetCriticalHealth)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 48806, 24275 }))
+                    return spellId; // hammer of wrath
+            if (inMelee)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 35395, 53385, 53408, 20271, 48819 }))
+                    return spellId; // crusader strike/divine storm/judgement/consecration
+            if (rangedWindow)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 48801, 48806 }))
+                    return spellId; // exorcism/hammer of wrath
+            if (uint32 spellId = SelectFirstReadySpell(player, { 31884 }))
+                return spellId; // avenging wrath
+            break;
+        case CLASS_HUNTER:
+            if (rangedWindow)
+            {
+                if (!TargetHasAuraFromPlayer(target, player, { 49001, 13555, 13554, 1978 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 49001, 13555, 1978 }))
+                        return spellId; // serpent sting
+                if (uint32 spellId = SelectFirstReadySpell(player, { 53351, 53209, 60053, 19434, 49045, 49052, 49001 }))
+                    return spellId; // kill shot/chimera/explosive/aimed/arcane/steady/serpent sting
+            }
+            if (uint32 spellId = SelectFirstReadySpell(player, { 19574 }))
+                return spellId; // bestial wrath
+            break;
+        case CLASS_ROGUE:
+            if (inMelee)
+            {
+                if (player->GetComboPoints() >= 4)
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 57993, 48668 }))
+                        return spellId; // envenom/eviscerate
+                if (uint32 spellId = SelectFirstReadySpell(player, { 48666, 48638, 57993, 48668, 48657 }))
+                    return spellId; // mutilate/sinister strike/envenom/eviscerate/backstab
+            }
+            if (uint32 spellId = SelectFirstReadySpell(player, { 51690 }))
+                return spellId; // killing spree
+            break;
+        case CLASS_PRIEST:
+            if (rangedWindow)
+            {
+                if (!TargetHasAuraFromPlayer(target, player, { 48125, 25368, 10894, 589 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 48125, 25368, 589 }))
+                        return spellId; // shadow word: pain
+                if (!TargetHasAuraFromPlayer(target, player, { 48300, 2944 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 48300, 2944 }))
+                        return spellId; // devouring plague
+                if (uint32 spellId = SelectFirstReadySpell(player, { 48127, 48156, 48158, 48123 }))
+                    return spellId; // mind blast/mind flay/shadow word: death/smite
+            }
+            break;
+        case CLASS_DEATH_KNIGHT:
+            if (inMelee)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 55268, 51425, 55090, 49924, 55050, 49921, 45477 }))
+                    return spellId; // obliterate/frost strike/scourge strike/heart strike/death+plague+icy touch
+            if (rangedWindow)
+                if (uint32 spellId = SelectFirstReadySpell(player, { 49895, 47632 }))
+                    return spellId; // death coil/rune strike fallback
+            break;
+        case CLASS_SHAMAN:
+            if (inMelee)
+            {
+                if (!TargetHasAuraFromPlayer(target, player, { 49233, 8050 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 49233, 8050 }))
+                        return spellId; // flame shock
+                if (uint32 spellId = SelectFirstReadySpell(player, { 17364, 60103, 49231 }))
+                    return spellId; // stormstrike/lava lash/earth shock
+            }
+            else if (rangedWindow)
+            {
+                if (!TargetHasAuraFromPlayer(target, player, { 49233, 8050 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 49233, 8050 }))
+                        return spellId; // flame shock
+                if (uint32 spellId = SelectFirstReadySpell(player, { 60043, 49238, 49271 }))
+                    return spellId; // lava burst/lightning bolt/chain lightning
+            }
+            if (uint32 spellId = SelectFirstReadySpell(player, { 51533 }))
+                return spellId; // feral spirit
+            break;
+        case CLASS_MAGE:
+            if (rangedWindow)
+            {
+                if (!TargetHasAuraFromPlayer(target, player, { 42891, 12654 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 42891, 12654 }))
+                        return spellId; // living bomb / ignite-style maintenance
+                if (uint32 spellId = SelectFirstReadySpell(player, { 42897, 42842, 42833, 42846, 42914, 42873 }))
+                    return spellId; // arcane blast/frostbolt/fireball/arcane missiles/ice lance/fire blast
+            }
+            if (uint32 spellId = SelectFirstReadySpell(player, { 12042, 12472 }))
+                return spellId; // arcane power/icy veins
+            break;
+        case CLASS_WARLOCK:
+            if (rangedWindow)
+            {
+                if (!TargetHasAuraFromPlayer(target, player, { 47813, 172 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 47813, 172 }))
+                        return spellId; // corruption
+                if (!TargetHasAuraFromPlayer(target, player, { 47811, 348 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 47811, 348 }))
+                        return spellId; // immolate
+                if (uint32 spellId = SelectFirstReadySpell(player, { 48181, 47843, 59172, 17962, 47838, 47809 }))
+                    return spellId; // immolate/conflagrate/chaos bolt/incinerate/corruption/UA/haunt/shadow bolt
+            }
+            break;
+        case CLASS_DRUID:
+            if (inMelee)
+            {
+                if (!TargetHasAuraFromPlayer(target, player, { 48574, 1822 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 48574, 1822 }))
+                        return spellId; // rake
+                if (uint32 spellId = SelectFirstReadySpell(player, { 48566, 48572, 48574 }))
+                    return spellId; // mangle(cat)/shred/rake
+            }
+            else if (rangedWindow)
+            {
+                if (!TargetHasAuraFromPlayer(target, player, { 48463, 8921 }))
+                    if (uint32 spellId = SelectFirstReadySpell(player, { 48463, 8921 }))
+                        return spellId; // moonfire
+                if (uint32 spellId = SelectFirstReadySpell(player, { 48461, 48465, 48463 }))
+                    return spellId; // wrath/starfire/moonfire
+            }
+            if (uint32 spellId = SelectFirstReadySpell(player, { 53201, 17116 }))
+                return spellId; // starfall/nature's swiftness style pressure
+            break;
+        default:
+            break;
+    }
+
+    return 0;
 }
 }
 
@@ -186,40 +384,14 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     if (!context.classSpellsEnabled || !player || !values.inBattleground || !IsTriggerActive(PvpTrigger::BgActive, values))
         return context;
 
-    if (!IsWarriorArmsSliceCandidate(player))
-        return context;
-
     Unit const* target = player->GetVictim();
     if (!target || !target->IsAlive() || target->GetGUID() == player->GetGUID())
         return context;
 
-    bool const targetCriticalHealth = target->HealthBelowPct(20);
-    bool const enemyOutOfMelee = !player->IsWithinMeleeRange(target);
-    bool const tasteForBlood = player->HasAura(60503);
-    bool const targetAlreadySlowed = target->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED);
-    bool const highRageAvailable = player->GetPower(POWER_RAGE) >= 500;
-    bool const hasBattleShout = player->HasAura(6673);
-    bool const inBattleStance = player->HasAura(2457);
+    bool const inMelee = player->IsWithinMeleeRange(target);
 
-    // Reference mirror from ArmsWarriorStrategy trigger intent, keeping priority ordering explicit.
-    if (targetCriticalHealth && HasKnownSpell(player, { 47471, 5308 }))
-        context.actionType = PvpClassSpellActionType::Execute;
-    else if (enemyOutOfMelee && HasKnownSpell(player, { 11578, 100 }))
-        context.actionType = PvpClassSpellActionType::Charge;
-    else if (tasteForBlood && HasKnownSpell(player, { 7384 }))
-        context.actionType = PvpClassSpellActionType::Overpower;
-    else if (HasKnownSpell(player, { 47486, 12294 }))
-        context.actionType = PvpClassSpellActionType::MortalStrike;
-    else if (!targetAlreadySlowed && HasKnownSpell(player, { 1715 }))
-        context.actionType = PvpClassSpellActionType::Hamstring;
-    else if (highRageAvailable && HasKnownSpell(player, { 47450, 78 }))
-        context.actionType = PvpClassSpellActionType::HeroicStrike;
-    else if (!hasBattleShout && HasKnownSpell(player, { 47436, 6673 }))
-        context.actionType = PvpClassSpellActionType::BattleShout;
-    else if (!inBattleStance && HasKnownSpell(player, { 2457 }))
-        context.actionType = PvpClassSpellActionType::BattleStance;
-
-    context.shouldExecute = context.actionType != PvpClassSpellActionType::None;
+    context.spellId = SelectReferenceClassSpell(player, target, inMelee);
+    context.shouldExecute = context.spellId != 0;
     return context;
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -129,24 +129,12 @@ enum class ArenaTeamInteractionType : uint8
     DeclineInvite
 };
 
-enum class PvpClassSpellActionType : uint8
-{
-    None = 0,
-    Charge,
-    BattleStance,
-    BattleShout,
-    MortalStrike,
-    Execute,
-    Overpower,
-    Hamstring,
-    HeroicStrike
-};
-
 struct PvpClassSpellContext
 {
     bool classSpellsEnabled = false;
     bool shouldExecute = false;
-    PvpClassSpellActionType actionType = PvpClassSpellActionType::None;
+    uint32 spellId = 0;
+    bool selfCast = false;
 };
 
 struct BattlegroundLifecycleContext

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -217,11 +217,17 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     }
 
     PvpValues const values = PvpCore::CollectValues(player);
+    PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values);
+    bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
+
     RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
     if (!hooks.lifecycleEnabled)
     {
         LogLifecycleBranchSummary(guid, "hooks-lifecycle-disabled");
         ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteClassSpell={}.",
+            guid.ToString(), didExecuteClassSpell ? 1 : 0);
         return;
     }
 
@@ -229,6 +235,9 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     {
         LogLifecycleBranchSummary(guid, "no-lifecycle-hooks-active");
         ObserveLifecycleReason(LifecycleObservationReason::NoLifecycleHooksActive, guid);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteClassSpell={}.",
+            guid.ToString(), didExecuteClassSpell ? 1 : 0);
         return;
     }
 
@@ -240,6 +249,9 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle dispatcher no-op with active hooks: guid={}, bgHook={}, arenaHook={}.",
             guid.ToString(), hooks.battlegroundParticipationHook ? 1 : 0, hooks.arenaParticipationHook ? 1 : 0);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteClassSpell={}.",
+            guid.ToString(), didExecuteClassSpell ? 1 : 0);
         return;
     }
 
@@ -247,8 +259,6 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         BattlegroundLifecycleActions::Execute(player, battlegroundContext);
     bool const didExecuteArena = hooks.arenaParticipationHook &&
         ArenaLifecycleActions::Execute(player, arenaContext);
-    PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values);
-    bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
 
     if (didExecuteBattleground)
     {


### PR DESCRIPTION
### Motivation
- Mirror reference PvP behavior by selecting known-rank class spells directly and respecting cooldowns rather than using action-node factories.  
- Surface class spell execution into the random bot lifecycle dispatcher so class-pressure attempts are observable and traced with lifecycle metrics.  
- Keep port roadmap accurate by documenting additional reference mappings, touched files, and preserving loader/gates topology.

### Description
- Reworked `PvpClassSpellContext` to carry a `spellId` and `selfCast` instead of the old `PvpClassSpellActionType` enum and removed that enum from the header.  
- Implemented `SelectReferenceClassSpell`, `SelectFirstReadySpell`, `HasRendFromPlayer`, and `TargetHasAuraFromPlayer` in `PlayerbotPvpCore` with per-class spell selection logic and cooldown/LOS checks, and added `#include "SpellHistory.h"`.  
- Replaced action-type resolution in `PlayerbotPvpClassActions` with `CastDirectSpell` which validates `HasSpell` and `GetSpellHistory()->HasCooldown` before calling `CastSpell`.  
- Integrated class-spell execution into the lifecycle dispatcher by calling `PvpClassActions::Execute` early in `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint` and added `playerbots.pvp.lifecycle` debug logs to include `didExecuteClassSpell` in early returns and the final dispatcher summary.  
- Updated `doc/playerbot/pvp-port-roadmap.md` to expand parity mapping, touched files, intentional divergences, and to explicitly state the preserved loader path and lifecycle gates.

### Testing
- Performed a full project build which completed successfully.  
- Exercised the lifecycle debug path using the `.playerbot pvp lifecycle snapshot`/lifecycle flows and verified the new `didExecuteClassSpell` field appears in `playerbots.pvp.lifecycle` debug output and that class spell selection logic returns/attempts a spell when expected.  
- No automated unit tests for these modules were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1dc7ac6c8327927c2ee6ae6dfa6b)