### PR TITLE
Phase-4 reference-aligned PvP parity completion pass

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -103,7 +103,7 @@ Output in this phase:
   - `playerbot reference/mod-playerbots-master/src/Ai/Base/StrategyContext.h` (strategy naming context for PvP strategy enable surface)
   - `playerbot reference/mod-playerbots-master/src/Ai/Base/TriggerContext.h` (trigger naming semantics used by PvP/class strategies)
   - `playerbot reference/mod-playerbots-master/src/Ai/Base/Strategy/BattlegroundStrategy.cpp` (battleground-active trigger context)
-  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Strategy/ArmsWarriorStrategy.{h,cpp}` (Arms priority and trigger/action intent)
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Strategy/ArmsWarriorStrategy.{h,cpp}` (Arms priority ordering and ActionNode-style fallback intent)
   - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Trigger/WarriorTriggers.{h,cpp}` (trigger activation semantics for sudden death, taste for blood, high rage, battle stance/shout, and mobility)
   - `playerbot reference/mod-playerbots-master/src/Ai/Class/Warrior/Action/WarriorActions.{h,cpp}` (useful/possible checks and spell action targeting semantics)
   - `playerbot reference/mod-playerbots-master/src/Ai/Class/*/Strategy/*Strategy*.{h,cpp}` (default PvP action ordering across class/spec strategies used as class parity baseline)
@@ -117,8 +117,8 @@ Output in this phase:
   - `doc/playerbot/pvp-port-roadmap.md`
 - Intentional divergences:
   - Spell resolution uses known-rank lookup by spell ID instead of action-node factories, because the Trinity slice does not yet port the full `NamedObjectFactory<ActionNode>` class AI stack.
-  - Trigger/action selection is executed in a consolidated class context builder instead of individual `TriggerNode`/`ActionNode` factories to preserve existing Trinity lifecycle topology.
-  - Arms `piercing howl -> mocking blow -> hamstring` fallback is collapsed to direct `hamstring` execution because only `hamstring` is currently represented in the local class-spell bridge.
+  - Trigger/action selection is executed in consolidated table-driven context builders instead of individual `TriggerNode`/`ActionNode` factories to preserve existing Trinity lifecycle topology.
+  - Battleground trigger decisions mirror `bg waiting/bg active/often/low health/low mana/timer bg` ordering as a tactical decision table, but remain context-only (no dedicated battleground action executor in this Phase-4 slice).
   - Spec strategy selection is inferred from active-spec talent ownership and rank-known spell availability, because full strategy graph context objects are not yet instantiated in this module.
 
 Loader path and lifecycle gates remain preserved as-is:

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -18,6 +18,7 @@
 #include "PlayerbotPvpClassActions.h"
 
 #include "Player.h"
+#include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
 
@@ -28,14 +29,32 @@ bool CastDirectSpell(Player* player, uint32 spellId, bool selfCast)
     if (!player || !spellId || !player->HasSpell(spellId))
         return false;
 
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!spellInfo)
+        return false;
+
     if (player->GetSpellHistory()->HasCooldown(spellId) || player->IsNonMeleeSpellCast(false))
         return false;
 
     Unit* target = selfCast ? static_cast<Unit*>(player) : player->GetVictim();
     if (!target || !target->IsAlive())
         return false;
-    if (!selfCast && (!player->IsWithinLOSInMap(target) || !player->IsWithinDistInMap(target, 35.0f)))
+    if (!selfCast && !player->IsValidAttackTarget(target))
         return false;
+
+    if (!player->IsWithinLOSInMap(target))
+        return false;
+
+    if (!selfCast)
+    {
+        float const maxRange = spellInfo->GetMaxRange(false);
+        if (maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
+            return false;
+    }
+
+    if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
+        if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
+            return false;
 
     player->CastSpell(target, spellId, false);
     return true;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -109,6 +109,13 @@ struct SpellDecision
     bool selfCast = false;
 };
 
+struct TacticalDecision
+{
+    char const* triggerName = nullptr;
+    char const* actionName = nullptr;
+    float priority = 0.0f;
+};
+
 enum class ClassSpecProfile : uint8
 {
     Unknown = 0,
@@ -229,10 +236,12 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
     bool const targetAlreadySlowed = target->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED);
     bool const highRageAvailable = player->GetPower(POWER_RAGE) >= 600;
     bool const lowRageAvailable = player->GetPower(POWER_RAGE) < 200;
+    bool const lowHealth = player->HealthBelowPct(40);
     bool const enemyOutOfMelee = !inMelee;
     bool const enemyInChargeReach = player->IsWithinDistInMap(target, 25.0f) && player->IsWithinLOSInMap(target);
     bool const mediumHealth = player->HealthBelowPct(60);
     bool const almostFullHealth = player->GetHealthPct() >= 85.0f;
+    bool const enemyCasting = target->HasUnitState(UNIT_STATE_CASTING);
     ClassSpecProfile const specProfile = DetectClassSpecProfile(player);
     auto tryAction = [&](char const* actionName, std::initializer_list<uint32> spellIds, bool selfCast = false) -> bool
     {
@@ -249,6 +258,8 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
     switch (player->GetClass())
     {
         case CLASS_WARRIOR:
+            if (enemyCasting && inMelee && tryAction("pummel", { 6552 }))
+                return decision;
             if (enemyOutOfMelee && enemyInChargeReach && tryAction("charge", { 11578, 11577, 100 }))
                 return decision;
             if (!inBattleStance && tryAction("battle stance", { 2457 }, true))
@@ -271,7 +282,7 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             if (inMelee && tryAction("melee pressure", { 47486, 47485, 12294, 23881, 47498 }))
                 return decision;
-            if (!targetAlreadySlowed && inMelee && tryAction("hamstring", { 1715 }))
+            if (!targetAlreadySlowed && inMelee && tryAction("snare fallback chain", { 12323, 20560, 1715 }))
                 return decision; // reference fallback chain: piercing howl -> mocking blow -> hamstring
             if (highRageAvailable && inMelee && tryAction("slam", { 47475, 47474, 25242, 1464 }))
                 return decision;
@@ -290,6 +301,10 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             break;
         case CLASS_PALADIN:
+            if (enemyCasting && inMelee && tryAction("hammer of justice", { 10308, 853 }))
+                return decision;
+            if (lowHealth && tryAction("divine protection", { 498 }, true))
+                return decision;
             if (targetCriticalHealth && tryAction("hammer of wrath", { 48806, 24275 }))
                 return decision;
             if (inMelee && specProfile == ClassSpecProfile::Tertiary && tryAction("retribution burst", { 35395, 53385, 53408, 20271 }))
@@ -304,6 +319,10 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             break;
         case CLASS_HUNTER:
+            if (enemyCasting && rangedWindow && tryAction("silencing shot", { 34490 }))
+                return decision;
+            if (lowHealth && tryAction("deterrence", { 19263 }, true))
+                return decision;
             if (rangedWindow)
             {
                 if (!TargetHasAuraFromPlayer(target, player, { 49001, 13555, 13554, 1978 }))
@@ -323,6 +342,10 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             break;
         case CLASS_ROGUE:
+            if (enemyCasting && inMelee && tryAction("kick", { 1766 }))
+                return decision;
+            if (lowHealth && tryAction("evasion", { 26669, 5277 }, true))
+                return decision;
             if (inMelee)
             {
                 if (player->GetComboPoints() >= 4)
@@ -341,6 +364,8 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             break;
         case CLASS_PRIEST:
+            if (lowHealth && tryAction("dispersion", { 47585 }, true))
+                return decision;
             if (rangedWindow)
             {
                 if (specProfile != ClassSpecProfile::Tertiary && tryAction("discipline-holy pressure", { 48123, 48127, 48066 }))
@@ -356,6 +381,10 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
             }
             break;
         case CLASS_DEATH_KNIGHT:
+            if (enemyCasting && inMelee && tryAction("mind freeze", { 47528 }))
+                return decision;
+            if (lowHealth && tryAction("icebound fortitude", { 48792 }, true))
+                return decision;
             if (inMelee && specProfile == ClassSpecProfile::Primary && tryAction("blood strike chain", { 55050, 49924, 55262 }))
                 return decision;
             if (inMelee && specProfile == ClassSpecProfile::Secondary && tryAction("frost strike chain", { 55268, 51425, 49184 }))
@@ -368,6 +397,10 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             break;
         case CLASS_SHAMAN:
+            if (enemyCasting && rangedWindow && tryAction("wind shear", { 57994 }))
+                return decision;
+            if (lowHealth && tryAction("shamanistic rage", { 30823 }, true))
+                return decision;
             if (inMelee)
             {
                 if (!TargetHasAuraFromPlayer(target, player, { 49233, 8050 }))
@@ -394,6 +427,10 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             break;
         case CLASS_MAGE:
+            if (enemyCasting && rangedWindow && tryAction("counterspell", { 2139 }))
+                return decision;
+            if (lowHealth && tryAction("ice block", { 45438 }, true))
+                return decision;
             if (rangedWindow)
             {
                 if (!TargetHasAuraFromPlayer(target, player, { 42891, 12654 }))
@@ -412,6 +449,10 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             break;
         case CLASS_WARLOCK:
+            if (enemyCasting && rangedWindow && tryAction("spell lock", { 19647 }))
+                return decision;
+            if (lowHealth && tryAction("death coil", { 47860, 6789 }))
+                return decision;
             if (rangedWindow)
             {
                 if (!TargetHasAuraFromPlayer(target, player, { 47813, 172 }))
@@ -431,6 +472,10 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
             }
             break;
         case CLASS_DRUID:
+            if (enemyCasting && rangedWindow && tryAction("bash", { 8983 }))
+                return decision;
+            if (lowHealth && tryAction("barkskin", { 22812 }, true))
+                return decision;
             if (inMelee)
             {
                 if (!TargetHasAuraFromPlayer(target, player, { 48574, 1822 }))
@@ -458,6 +503,50 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
             break;
         default:
             break;
+    }
+
+    return decision;
+}
+
+TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, playerbot::PvpValues const& values)
+{
+    TacticalDecision decision;
+    if (!player)
+        return decision;
+
+    bool const lowHealth = player->HealthBelowPct(35);
+    bool const lowMana = player->GetPower(POWER_MANA) > 0 && player->GetPowerPct(POWER_MANA) < 25.0f;
+    bool const periodicRefresh = values.battlegroundState == playerbot::BattlegroundState::Active;
+
+    struct TacticalRule
+    {
+        char const* triggerName;
+        bool condition;
+        char const* actionName;
+        float priority;
+    };
+
+    std::array<TacticalRule, 8> const rules =
+    {{
+        { "bg waiting", values.battlegroundState == playerbot::BattlegroundState::WaitingToStart, "bg move to start", 50.0f },
+        { "player has flag", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::PlayerHasFlag, values), "bg move to objective", 90.0f },
+        { "enemy flagcarrier near", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::EnemyFlagCarrierNear, values), "attack enemy flag carrier", 70.0f },
+        { "team flagcarrier near", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::TeamFlagCarrierNear, values), "bg protect fc", 65.0f },
+        { "bg active", values.battlegroundState == playerbot::BattlegroundState::Active, "bg move to objective", 50.0f },
+        { "low health", lowHealth, "bg use buff", 45.0f },
+        { "low mana", lowMana, "bg use buff", 45.0f },
+        { "timer bg", periodicRefresh, "bg reset objective force", 80.0f }
+    }};
+
+    for (TacticalRule const& rule : rules)
+    {
+        if (!rule.condition)
+            continue;
+
+        decision.triggerName = rule.triggerName;
+        decision.actionName = rule.actionName;
+        decision.priority = rule.priority;
+        return decision;
     }
 
     return decision;
@@ -547,6 +636,10 @@ BattlegroundTacticalContext PvpCore::BuildBattlegroundTacticalContext(Player con
         return context;
 
     context.shouldEvaluate = true;
+    TacticalDecision const decision = SelectBattlegroundTacticalDecision(player, values);
+    context.triggerName = decision.triggerName;
+    context.actionName = decision.actionName;
+    context.actionPriority = decision.priority;
     context.objective = SelectObjectiveSkeleton(values);
     context.movement = SelectMovementPrimitiveSkeleton(values, context.objective);
     context.flagCarrierDirective = SelectFlagCarrierDirectiveSkeleton(values);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -103,6 +103,9 @@ struct BattlegroundTacticalContext
 {
     bool tacticsEnabled = false;
     bool shouldEvaluate = false;
+    char const* triggerName = nullptr;
+    char const* actionName = nullptr;
+    float actionPriority = 0.0f;
     BattlegroundObjectiveSelection objective;
     BattlegroundMovementPrimitive movement = BattlegroundMovementPrimitive::None;
     FlagCarrierDirective flagCarrierDirective = FlagCarrierDirective::None;

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -54,9 +54,9 @@ Playerbot.PvpLifecycle.Enable = 0
 
 #    Playerbot.PvpClassSpells.Enable
 #        Description: Enables Phase-4 class/spec PvP spell decision slices.
-#                     Current implementation provides reference-vocabulary trigger/action ordering
-#                     for all playable classes, including expanded Warrior Arms deferred actions
-#                     (slam, victory rush, retaliation, shattering throw) while remaining default OFF.
+#                     Current implementation provides reference-aligned trigger/action vocabulary
+#                     and priority layering (offense, defensive, interrupt/cc, sustain/boost)
+#                     for all playable classes while remaining default OFF.
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
 


### PR DESCRIPTION
### Motivation
- Finish Phase-4 class/spec PvP parity against the playerbot reference by porting trigger/action intent, priority ordering and useful runtime checks into a table-driven shape that preserves Trinity integration constraints.

### Description
- Key technical changes: added tactical metadata to `BattlegroundTacticalContext` (`triggerName`, `actionName`, `actionPriority`), introduced a table-driven `SelectBattlegroundTacticalDecision` mapping canonical BG triggers to actions/priorities, expanded `SelectReferenceClassSpell` with interrupt/defensive layers and a Warrior snare fallback chain, and tightened runtime checks in `PvpClassActions::CastDirectSpell` (spell info, target validity, LOS, spell range and power-cost checks). 
- Reference files used: mirrors vocabulary/ordering from `playerbot reference/mod-playerbots-master/src/Ai/Base/StrategyContext.h`, `.../TriggerContext.h`, `.../Strategy/BattlegroundStrategy.cpp`, and class `Strategy/Trigger/Action` files under `playerbot reference/mod-playerbots-master/src/Ai/Class/*` plus `RandomPlayerbotMgr.cpp` for lifecycle topology.
- Parity decisions: canonical battleground triggers (`bg waiting`, `bg active`, `low health`, `low mana`, `timer bg`, flag-carrier triggers) are evaluated in a tactical decision table and class spell ordering now includes explicit interrupt/defensive checks before rotation pressure; Warrior snare fallback is represented as an ordered alternate chain. 
- Intentional divergences: spell resolution still uses known-rank spell-ID lookup rather than full `ActionNode` factories; trigger/action orchestration is implemented as consolidated table-driven context builders instead of instantiated `TriggerNode`/`ActionNode` graphs; battleground tactical behavior is context-selection-only in this slice (no dedicated tactical executor yet); spec selection is inferred from talents/known spells rather than full strategy graph objects.
- Documentation/config: updated `doc/playerbot/pvp-port-roadmap.md` with mapping and divergence notes and adjusted `src/server/worldserver/playerbots.conf.dist` wording; feature remains gated and default OFF.
- Lifecycle/topology invariants preserved: loader/on-update path (`RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`), lifecycle gate chain (`Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`), and manager cadence ownership/interval are explicitly preserved.

### Testing
- Generated build metadata with `cmake -S . -B build -DPLAYERBOT=ON -DSCRIPTS_PLAYERBOT=static -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` which configured successfully. (Success)
- Ran compile-db-derived `-fsyntax-only` checks for touched files (`PlayerbotPvpCore.cpp` and `PlayerbotPvpClassActions.cpp`) using the generated `compile_commands.json`; both returned no syntax errors. (Success)
- Performed narrow object-target builds via `ninja -C build` for the two touched object targets (`PlayerbotPvpCore.cpp.o` and `PlayerbotPvpClassActions.cpp.o`); both objects built successfully. (Success)
- All automated checks above completed and the changes were committed as a single logical change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf5dd750b883279a61227b1b9e03bd)