### PR TITLE
Phase-4 reference-aligned: tactical wiring and parity fixes

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -112,13 +112,15 @@ Output in this phase:
   - `playerbot reference/mod-playerbots-master/src/Bot/RandomPlayerbotMgr.cpp` (manager-owned cadence and lifecycle topology expectations)
 - Port files touched:
   - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.{h,cpp}`
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.{h,cpp}`
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`
   - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`
   - `src/server/worldserver/playerbots.conf.dist`
   - `doc/playerbot/pvp-port-roadmap.md`
 - Intentional divergences:
   - Spell resolution uses known-rank lookup by spell ID instead of action-node factories, because the Trinity slice does not yet port the full `NamedObjectFactory<ActionNode>` class AI stack.
-  - Trigger/action selection is executed in consolidated table-driven context builders instead of individual `TriggerNode`/`ActionNode` factories to preserve existing Trinity lifecycle topology.
-  - Battleground trigger decisions mirror `bg waiting/bg active/often/low health/low mana/timer bg` ordering as a tactical decision table, but remain context-only (no dedicated battleground action executor in this Phase-4 slice).
+  - Trigger/action selection is executed in consolidated table-driven context builders plus primitive tactical execution stubs instead of individual `TriggerNode`/`ActionNode` factories, to preserve existing Trinity lifecycle topology.
+  - Flag-carrier ownership/proximity triggers (`player has flag`, `enemy flagcarrier near`, `team flagcarrier near`) still return false in this slice because objective-state query seams are not yet ported from the upstream AI stack.
   - Spec strategy selection is inferred from active-spec talent ownership and rank-known spell availability, because full strategy graph context objects are not yet instantiated in this module.
 
 Loader path and lifecycle gates remain preserved as-is:

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -282,8 +282,12 @@ SpellDecision SelectReferenceClassSpell(Player const* player, Unit const* target
                 return decision;
             if (inMelee && tryAction("melee pressure", { 47486, 47485, 12294, 23881, 47498 }))
                 return decision;
-            if (!targetAlreadySlowed && inMelee && tryAction("snare fallback chain", { 12323, 20560, 1715 }))
-                return decision; // reference fallback chain: piercing howl -> mocking blow -> hamstring
+            if (!targetAlreadySlowed && inMelee && tryAction("piercing howl", { 12323 }))
+                return decision;
+            if (!targetAlreadySlowed && inMelee && tryAction("mocking blow", { 20560 }))
+                return decision;
+            if (!targetAlreadySlowed && inMelee && tryAction("hamstring", { 1715 }))
+                return decision;
             if (highRageAvailable && inMelee && tryAction("slam", { 47475, 47474, 25242, 1464 }))
                 return decision;
             if (highRageAvailable && inMelee && tryAction("heroic strike", { 47450, 47449, 78 }))
@@ -516,7 +520,10 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
 
     bool const lowHealth = player->HealthBelowPct(35);
     bool const lowMana = player->GetPower(POWER_MANA) > 0 && player->GetPowerPct(POWER_MANA) < 25.0f;
-    bool const periodicRefresh = values.battlegroundState == playerbot::BattlegroundState::Active;
+    bool const bgActive = values.battlegroundState == playerbot::BattlegroundState::Active;
+    bool const bgWaiting = values.battlegroundState == playerbot::BattlegroundState::WaitingToStart;
+    bool const periodicRefresh = bgActive;
+    bool const often = bgActive;
 
     struct TacticalRule
     {
@@ -526,13 +533,14 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
         float priority;
     };
 
-    std::array<TacticalRule, 8> const rules =
+    std::array<TacticalRule, 9> const rules =
     {{
-        { "bg waiting", values.battlegroundState == playerbot::BattlegroundState::WaitingToStart, "bg move to start", 50.0f },
+        { "bg waiting", bgWaiting, "bg move to start", 50.0f },
+        { "bg active", bgActive, "bg move to objective", 50.0f },
+        { "often", often, "bg check objective", 51.0f },
         { "player has flag", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::PlayerHasFlag, values), "bg move to objective", 90.0f },
         { "enemy flagcarrier near", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::EnemyFlagCarrierNear, values), "attack enemy flag carrier", 70.0f },
         { "team flagcarrier near", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::TeamFlagCarrierNear, values), "bg protect fc", 65.0f },
-        { "bg active", values.battlegroundState == playerbot::BattlegroundState::Active, "bg move to objective", 50.0f },
         { "low health", lowHealth, "bg use buff", 45.0f },
         { "low mana", lowMana, "bg use buff", 45.0f },
         { "timer bg", periodicRefresh, "bg reset objective force", 80.0f }
@@ -543,10 +551,12 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
         if (!rule.condition)
             continue;
 
-        decision.triggerName = rule.triggerName;
-        decision.actionName = rule.actionName;
-        decision.priority = rule.priority;
-        return decision;
+        if (!decision.actionName || rule.priority > decision.priority)
+        {
+            decision.triggerName = rule.triggerName;
+            decision.actionName = rule.actionName;
+            decision.priority = rule.priority;
+        }
     }
 
     return decision;
@@ -617,10 +627,13 @@ bool PvpCore::IsTriggerActive(PvpTrigger trigger, PvpValues const& values)
         case PvpTrigger::BgInviteActive:
             return values.hasBattlegroundInvite;
         case PvpTrigger::InBattlegroundWithoutFlag:
+            return values.inBattleground;
         case PvpTrigger::PlayerHasFlag:
+            return false; // Phase-4 divergence: battleground flag ownership lookups are not yet wired in this Trinity slice.
         case PvpTrigger::EnemyFlagCarrierNear:
+            return false; // Phase-4 divergence: enemy flag-carrier proximity queries require map-objective scans not yet ported.
         case PvpTrigger::TeamFlagCarrierNear:
-            return false;
+            return false; // Phase-4 divergence: team flag-carrier proximity queries require BG objective state APIs not yet ported.
         default:
             break;
     }
@@ -632,7 +645,10 @@ BattlegroundTacticalContext PvpCore::BuildBattlegroundTacticalContext(Player con
 {
     BattlegroundTacticalContext context;
     context.tacticsEnabled = g_PvpCoreConfig.moduleEnabled && g_PvpCoreConfig.pvpCoreEnabled && g_PvpCoreConfig.pvpTacticsEnabled;
-    if (!context.tacticsEnabled || !player || !IsTriggerActive(PvpTrigger::BgActive, values))
+    if (!context.tacticsEnabled || !player)
+        return context;
+
+    if (!IsTriggerActive(PvpTrigger::BgWaiting, values) && !IsTriggerActive(PvpTrigger::BgActive, values))
         return context;
 
     context.shouldEvaluate = true;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -27,6 +27,8 @@
 #include "Player.h"
 #include "World.h"
 
+#include <cstring>
+
 namespace
 {
 bool IsLifecycleGateEnabled()
@@ -182,6 +184,11 @@ bool HasConflictingArenaLifecycleContext(playerbot::ArenaLifecycleContext const&
     return (context.queueOperation != playerbot::QueueOperationType::None) &&
         (context.teamInteraction != playerbot::ArenaTeamInteractionType::None);
 }
+
+bool IsTacticalAction(char const* actionName, char const* expected)
+{
+    return actionName && expected && std::strcmp(actionName, expected) == 0;
+}
 }
 
 namespace playerbot
@@ -281,6 +288,95 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     }
 
     return true;
+}
+
+bool BattlegroundTacticalActions::Execute(Player* player, BattlegroundTacticalContext const& context)
+{
+    if (!player || !context.tacticsEnabled || !context.shouldEvaluate || !context.actionName)
+        return false;
+
+    if (IsTacticalAction(context.actionName, "bg move to start"))
+        return MoveToStartPrimitive(player);
+    if (IsTacticalAction(context.actionName, "bg move to objective"))
+        return MoveToObjectivePrimitive(player, context);
+    if (IsTacticalAction(context.actionName, "bg check objective"))
+        return CheckObjectivePrimitive(player, context);
+    if (IsTacticalAction(context.actionName, "bg reset objective force"))
+        return ResetObjectiveForcePrimitive(player);
+    if (IsTacticalAction(context.actionName, "bg use buff"))
+        return UseBuffPrimitive(player);
+    if (IsTacticalAction(context.actionName, "attack enemy flag carrier"))
+        return AttackEnemyFlagCarrierPrimitive(player, context);
+    if (IsTacticalAction(context.actionName, "bg protect fc"))
+        return ProtectFlagCarrierPrimitive(player, context);
+
+    return false;
+}
+
+bool BattlegroundTacticalActions::MoveToStartPrimitive(Player* player)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    if (Battleground* battleground = player->GetBattleground())
+        return battleground->GetStatus() == STATUS_WAIT_JOIN;
+
+    return false;
+}
+
+bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    if (context.objective.type == BattlegroundObjectiveType::None &&
+        context.movement == BattlegroundMovementPrimitive::None &&
+        context.flagCarrierDirective == FlagCarrierDirective::None)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    return context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None;
+}
+
+bool BattlegroundTacticalActions::ResetObjectiveForcePrimitive(Player* player)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    return true;
+}
+
+bool BattlegroundTacticalActions::UseBuffPrimitive(Player* player)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    return true;
+}
+
+bool BattlegroundTacticalActions::AttackEnemyFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    return context.flagCarrierDirective == FlagCarrierDirective::AttackEnemyCarrier;
+}
+
+bool BattlegroundTacticalActions::ProtectFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    return context.flagCarrierDirective == FlagCarrierDirective::ProtectTeamCarrier;
 }
 
 bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const& context)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
@@ -36,6 +36,20 @@ public:
     static bool HandleInProgressStatusPrimitive(Player* player);
 };
 
+class BattlegroundTacticalActions
+{
+public:
+    static bool Execute(Player* player, BattlegroundTacticalContext const& context);
+
+    static bool MoveToStartPrimitive(Player* player);
+    static bool MoveToObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context);
+    static bool CheckObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context);
+    static bool ResetObjectiveForcePrimitive(Player* player);
+    static bool UseBuffPrimitive(Player* player);
+    static bool AttackEnemyFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context);
+    static bool ProtectFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context);
+};
+
 class ArenaLifecycleActions
 {
 public:

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -217,6 +217,8 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     }
 
     PvpValues const values = PvpCore::CollectValues(player);
+    BattlegroundTacticalContext const tacticalContext = PvpCore::BuildBattlegroundTacticalContext(player, values);
+    bool const didExecuteTactical = BattlegroundTacticalActions::Execute(player, tacticalContext);
     PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values);
     bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
 
@@ -226,8 +228,8 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         LogLifecycleBranchSummary(guid, "hooks-lifecycle-disabled");
         ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteClassSpell={}.",
-            guid.ToString(), didExecuteClassSpell ? 1 : 0);
+            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteTactical={}, didExecuteClassSpell={}.",
+            guid.ToString(), didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
         return;
     }
 
@@ -236,8 +238,8 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         LogLifecycleBranchSummary(guid, "no-lifecycle-hooks-active");
         ObserveLifecycleReason(LifecycleObservationReason::NoLifecycleHooksActive, guid);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteClassSpell={}.",
-            guid.ToString(), didExecuteClassSpell ? 1 : 0);
+            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteTactical={}, didExecuteClassSpell={}.",
+            guid.ToString(), didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
         return;
     }
 
@@ -250,8 +252,8 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
             "Playerbot PvP lifecycle dispatcher no-op with active hooks: guid={}, bgHook={}, arenaHook={}.",
             guid.ToString(), hooks.battlegroundParticipationHook ? 1 : 0, hooks.arenaParticipationHook ? 1 : 0);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteClassSpell={}.",
-            guid.ToString(), didExecuteClassSpell ? 1 : 0);
+            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteTactical={}, didExecuteClassSpell={}.",
+            guid.ToString(), didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
         return;
     }
 
@@ -273,8 +275,8 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     }
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-        "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground={}, didExecuteArena={}, didExecuteClassSpell={}.",
-        guid.ToString(), didExecuteBattleground ? 1 : 0, didExecuteArena ? 1 : 0, didExecuteClassSpell ? 1 : 0);
+        "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground={}, didExecuteArena={}, didExecuteTactical={}, didExecuteClassSpell={}.",
+        guid.ToString(), didExecuteBattleground ? 1 : 0, didExecuteArena ? 1 : 0, didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
 }
 
 bool RandomBotParticipationLifecycle::ProcessBattlegroundLifecycleEntryPoint(Player* player, PvpValues const& values,

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -35,9 +35,9 @@ Playerbot.Enable = 0
 Playerbot.PvpCore.Enable = 0
 
 #    Playerbot.PvpTactics.Enable
-#        Description: Enables battleground tactical scaffolding (objective selection, movement primitives,
-#                     and flag-carrier attack/protect placeholder decisions).
-#                     This phase wires tactical APIs only and does not add spell/class rotation logic.
+#        Description: Enables battleground tactical trigger/action selection plus primitive execution
+#                     stubs for waiting/active/often/low-health/low-mana/timer-bg flows.
+#                     This remains default OFF and does not change queue policy or class rotation logic.
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
 


### PR DESCRIPTION
### Motivation
- Close remaining Phase-4 parity gaps by wiring battleground tactical trigger→action selection into the existing lifecycle execution path while preserving lifecycle loader/gates/cadence invariants. 
- Improve fidelity to reference battleground strategy semantics (`bg waiting`, `bg active`, `often`, `low health`, `low mana`, `timer bg`) and tighten class fallback/trigger behavior where reference intent was collapsed.
- Keep execution-level checks conservative and avoid adding new host callbacks, SQL changes, queue policy changes, or lifecycle cadence ownership changes.

### Description
- Reference files used: `playerbot reference/mod-playerbots-master/src/Ai/Base/StrategyContext.h`, `.../TriggerContext.h`, `.../Strategy/BattlegroundStrategy.cpp`, `.../Class/Warrior/Strategy/ArmsWarriorStrategy.{h,cpp}`, `.../Class/Warrior/Trigger/WarriorTriggers.{h,cpp}`, `.../Class/Warrior/Action/WarriorActions.{h,cpp}`, class Strategy/Trigger/Action families under `playerbot reference/mod-playerbots-master/src/Ai/Class/**`, and `playerbot reference/mod-playerbots-master/src/Bot/RandomPlayerbotMgr.cpp` (listed in `doc/playerbot/pvp-port-roadmap.md`).
- Parity decisions: added `BattlegroundTacticalActions` primitives and dispatch, integrated tactical execution into `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint`, changed tactical decision selection to priority-based evaluation (rather than first-match short-circuit), made tactical context reachable in waiting and active BG states, and expanded warrior snare fallback into ordered alternates (`piercing howl` → `mocking blow` → `hamstring`).
- Intentional divergences: tactical execution is implemented as conservative primitive stubs (no upstream movement/objective handlers ported yet), flag-carrier ownership/proximity triggers (`player has flag`, `enemy flagcarrier near`, `team flagcarrier near`) deliberately return false until objective-state query seams are ported, and class strategy selection remains inferred from spec/talents and known-rank spells rather than a full upstream strategy graph.
- Files changed: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.{h,cpp}`, `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.{h,cpp}`, `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`, `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`, `src/server/worldserver/playerbots.conf.dist`, and `doc/playerbot/pvp-port-roadmap.md` (roadmap updated with exact refs, touched files, and divergences).
- Loader/gate/cadence preservation: loader update path and gate chain are explicitly preserved and unchanged: `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)` remains the loader entry; lifecycle gate chain remains `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`; manager cadence ownership/interval remain unchanged.

### Testing
- Generated build metadata with `cmake -S . -B build -DPLAYERBOT=ON -DSCRIPTS_PLAYERBOT=static -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` and confirmed script sources are included in the compile database (entries for each touched Playerbot `.cpp`).
- Verified compile DB `-fsyntax-only` for each touched Playerbot `.cpp` (used the compile_commands.json invocation per-file) and observed success for `PlayerbotPvpCore.cpp`, `PlayerbotPvpClassActions.cpp`, `PlayerbotPvpLifecycleActions.cpp`, and `PlayerbotRandomBotParticipation.cpp`.
- Performed narrow object-target builds for the touched objects using CMake/Ninja (built the object targets for the four touched Playerbot `.cpp` files) and observed successful compilation of those object files.
- All automated checks described above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf615c25588327aed0e3f9c7f7f03f)