### PR TITLE
Phase-5 validation-ready completion pass for Playerbot PvP objective seams

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -120,7 +120,7 @@ Output in this phase:
 - Intentional divergences:
   - Spell resolution uses known-rank lookup by spell ID instead of action-node factories, because the Trinity slice does not yet port the full `NamedObjectFactory<ActionNode>` class AI stack.
   - Trigger/action selection is executed in consolidated table-driven context builders plus primitive tactical execution stubs instead of individual `TriggerNode`/`ActionNode` factories, to preserve existing Trinity lifecycle topology.
-  - Flag-carrier ownership/proximity triggers (`player has flag`, `enemy flagcarrier near`, `team flagcarrier near`) still return false in this slice because objective-state query seams are not yet ported from the upstream AI stack.
+  - (Historical in Phase-4) Flag-carrier ownership/proximity triggers were hard-disabled before objective-state seams were added in the later Phase-5/Phase-6 completion pass.
   - Spec strategy selection is inferred from active-spec talent ownership and rank-known spell availability, because full strategy graph context objects are not yet instantiated in this module.
 
 Loader path and lifecycle gates remain preserved as-is:
@@ -156,3 +156,58 @@ Loader path and lifecycle gates remain preserved as-is:
   - Class behavior remains table-driven in a consolidated selector rather than full upstream `TriggerNode`/`ActionNode` graph factories.
 - Preservation statement:
   - Loader path remains exactly `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`; lifecycle gate chain remains exactly `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`; cadence ownership and interval remain manager-owned and unchanged.
+
+### Phase-5 / Phase-6 completion pass (validation-ready behavior)
+
+- Exact reference files consulted in this pass:
+  - `playerbot reference/mod-playerbots-master/src/Ai/Base/StrategyContext.h`
+  - `playerbot reference/mod-playerbots-master/src/Ai/Base/TriggerContext.h`
+  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Strategy/BattlegroundStrategy.cpp`
+  - `playerbot reference/mod-playerbots-master/src/Ai/Base/Trigger/PvpTriggers.{h,cpp}`
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/*/Strategy/*Strategy*.{h,cpp}`
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/*/Trigger/*Triggers*.{h,cpp}`
+  - `playerbot reference/mod-playerbots-master/src/Ai/Class/*/Action/*Actions*.{h,cpp}`
+  - `playerbot reference/mod-playerbots-master/src/Bot/RandomPlayerbotMgr.cpp`
+- Exact local files touched in this pass:
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h`
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
+  - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`
+  - `src/server/worldserver/playerbots.conf.dist`
+  - `doc/playerbot/pvp-port-roadmap.md`
+- One-line intentional divergences still true after this pass:
+  - Class behavior remains table-driven in a consolidated selector rather than full upstream `TriggerNode`/`ActionNode` graph factories.
+  - Objective navigation still uses safe local movement primitives (follow/move-point) rather than full upstream tactical pathing graph and role-coordination state.
+- Preservation statement:
+  - Loader update path remains exactly `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`.
+  - Lifecycle gate chain remains exactly `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`.
+  - Cadence ownership/interval remain manager-owned and unchanged.
+  - Queue policy in lifecycle actions remains unchanged.
+  - Class-slice default remains OFF unless explicitly enabled.
+
+### Phase-6 validation upgrade checklist (compile + smoke)
+
+- Compile validation:
+  - Confirm `compile_commands.json` includes all touched Playerbot PvP `.cpp` paths.
+  - Run per-file syntax checks:
+    - `clang++ -std=c++20 -fsyntax-only <flags-from-compile_commands> src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
+    - `clang++ -std=c++20 -fsyntax-only <flags-from-compile_commands> src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`
+  - Run narrow object-target builds for touched objects from existing build tree.
+- Lifecycle observability expectations (runtime):
+  - `.playerbot pvp lifecycle snapshot` must still expose `gateDisabled`, `cadenceThrottled`, `invalidPlayerState`, `noLifecycleHooksActive`, `battlegroundLifecycleExecuted`, and `arenaLifecycleExecuted`.
+  - `playerbots.pvp.lifecycle` debug logs must still include:
+    - branch marker lines
+    - reason observation lines
+    - dispatcher completion lines including battleground/arena/tactical/class booleans.
+- Explicit manual verification checklist:
+  - Battleground queueing:
+    - Bot can join BG queue with lifecycle gates enabled.
+    - BG invites are accepted/declined according to existing lifecycle context policy.
+  - Battleground objective behavior:
+    - In WSG/EotS when bot carries objective flag, `player has flag` trigger can activate and objective movement executes.
+    - In WSG/EotS when enemy carrier is near, `enemy flagcarrier near` trigger can activate and `attack enemy flag carrier` movement executes.
+    - In WSG/EotS when friendly carrier is near (and not in both-flags-out suppression window for WSG), `team flagcarrier near` trigger can activate and `bg protect fc` movement executes.
+    - Trigger ordering semantics still prefer emergency/objective handling before sustain actions.
+  - Arena behavior:
+    - Arena queue join/leave and team invite handling continue to execute with unchanged policy.
+  - Regression safety:
+    - With `Playerbot.PvpCore.Enable = 0` or `Playerbot.PvpLifecycle.Enable = 0`, lifecycle remains gated and no queue/tactical/class PvP behavior executes.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -19,7 +19,10 @@
 
 #include "Battleground.h"
 #include "BattlegroundMgr.h"
+#include "BattlegroundEY.h"
+#include "BattlegroundWS.h"
 #include "Configuration/Config.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "SpellHistory.h"
 
@@ -82,6 +85,66 @@ bool TargetHasShieldImmunityAura(Unit const* target)
 {
     return target && (target->HasAura(642) || target->HasAura(45438) || target->HasAura(41450) ||
         target->HasAura(1022) || target->HasAura(5599) || target->HasAura(10278));
+}
+
+bool IsFlagCarrierNear(Player const* player, ObjectGuid const& carrierGuid, float maxDistance)
+{
+    if (!player || carrierGuid.IsEmpty())
+        return false;
+
+    Player const* carrier = ObjectAccessor::FindConnectedPlayer(carrierGuid);
+    if (!carrier || !carrier->IsAlive() || carrier->GetMapId() != player->GetMapId())
+        return false;
+
+    return player->IsWithinDistInMap(carrier, maxDistance);
+}
+
+void PopulateObjectiveStateTriggers(Player const* player, playerbot::PvpValues& values)
+{
+    if (!player || !values.inBattleground)
+        return;
+
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground || battleground->GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    TeamId const botTeam = player->GetTeamId();
+    TeamId const enemyTeam = (botTeam == TEAM_ALLIANCE) ? TEAM_HORDE : TEAM_ALLIANCE;
+    ObjectGuid const playerGuid = player->GetGUID();
+
+    if (BattlegroundWS* bgWs = dynamic_cast<BattlegroundWS*>(battleground))
+    {
+        ObjectGuid const enemyCarrierGuid = bgWs->GetFlagPickerGUID(botTeam);
+        ObjectGuid const teamCarrierGuid = bgWs->GetFlagPickerGUID(enemyTeam);
+
+        values.playerHasFlag = (teamCarrierGuid == playerGuid);
+        values.enemyFlagCarrierNear = IsFlagCarrierNear(player, enemyCarrierGuid, 100.0f);
+
+        bool const bothFlagsNotAtBase =
+            bgWs->GetFlagState(ALLIANCE) != BG_WS_FLAG_STATE_ON_BASE &&
+            bgWs->GetFlagState(HORDE) != BG_WS_FLAG_STATE_ON_BASE;
+        if (!bothFlagsNotAtBase)
+            values.teamFlagCarrierNear = IsFlagCarrierNear(player, teamCarrierGuid, 200.0f);
+
+        return;
+    }
+
+    if (BattlegroundEY* bgEy = dynamic_cast<BattlegroundEY*>(battleground))
+    {
+        ObjectGuid const carrierGuid = bgEy->GetFlagPickerGUID();
+        if (carrierGuid.IsEmpty())
+            return;
+
+        values.playerHasFlag = (carrierGuid == playerGuid);
+        Player const* carrier = ObjectAccessor::FindConnectedPlayer(carrierGuid);
+        if (!carrier || !carrier->IsAlive() || carrier->GetMapId() != player->GetMapId())
+            return;
+
+        if (carrier->GetTeamId() == botTeam)
+            values.teamFlagCarrierNear = player->IsWithinDistInMap(carrier, 200.0f);
+        else
+            values.enemyFlagCarrierNear = player->IsWithinDistInMap(carrier, 100.0f);
+    }
 }
 
 uint8 CountMeleeAttackers(Player const* player)
@@ -672,6 +735,8 @@ PvpValues PvpCore::CollectValues(Player const* player)
     if (values.inBattleground)
         values.battlegroundTypeId = player->GetBattlegroundTypeId();
 
+    PopulateObjectiveStateTriggers(player, values);
+
     return values;
 }
 
@@ -692,11 +757,11 @@ bool PvpCore::IsTriggerActive(PvpTrigger trigger, PvpValues const& values)
         case PvpTrigger::InBattlegroundWithoutFlag:
             return values.inBattleground;
         case PvpTrigger::PlayerHasFlag:
-            return false; // Phase-4 divergence: battleground flag ownership lookups are not yet wired in this Trinity slice.
+            return values.playerHasFlag;
         case PvpTrigger::EnemyFlagCarrierNear:
-            return false; // Phase-4 divergence: enemy flag-carrier proximity queries require map-objective scans not yet ported.
+            return values.enemyFlagCarrierNear;
         case PvpTrigger::TeamFlagCarrierNear:
-            return false; // Phase-4 divergence: team flag-carrier proximity queries require BG objective state APIs not yet ported.
+            return values.teamFlagCarrierNear;
         default:
             break;
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -53,6 +53,9 @@ struct PvpValues
     bool hasBattlegroundInvite = false;
     bool hasArenaInvite = false;
     bool hasArenaTeamInvite = false;
+    bool playerHasFlag = false;
+    bool enemyFlagCarrierNear = false;
+    bool teamFlagCarrierNear = false;
 };
 
 enum class PvpTrigger : uint8

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -19,11 +19,15 @@
 
 #include "BattlegroundMgr.h"
 #include "BattlegroundQueue.h"
+#include "BattlegroundEY.h"
+#include "BattlegroundWS.h"
 #include "DBCStores.h"
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "CharacterCache.h"
 #include "Log.h"
+#include "MotionMaster.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "World.h"
 
@@ -189,6 +193,65 @@ bool IsTacticalAction(char const* actionName, char const* expected)
 {
     return actionName && expected && std::strcmp(actionName, expected) == 0;
 }
+
+Player* FindFlagCarrierForDirective(Player* player, playerbot::FlagCarrierDirective directive)
+{
+    if (!player || directive == playerbot::FlagCarrierDirective::None || !player->InBattleground())
+        return nullptr;
+
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground || battleground->GetStatus() != STATUS_IN_PROGRESS)
+        return nullptr;
+
+    TeamId const botTeam = player->GetTeamId();
+    TeamId const enemyTeam = (botTeam == TEAM_ALLIANCE) ? TEAM_HORDE : TEAM_ALLIANCE;
+
+    if (BattlegroundWS* bgWs = dynamic_cast<BattlegroundWS*>(battleground))
+    {
+        ObjectGuid carrierGuid = ObjectGuid::Empty;
+        if (directive == playerbot::FlagCarrierDirective::AttackEnemyCarrier)
+            carrierGuid = bgWs->GetFlagPickerGUID(botTeam);
+        else if (directive == playerbot::FlagCarrierDirective::ProtectTeamCarrier)
+            carrierGuid = bgWs->GetFlagPickerGUID(enemyTeam);
+
+        if (carrierGuid.IsEmpty())
+            return nullptr;
+
+        return ObjectAccessor::FindConnectedPlayer(carrierGuid);
+    }
+
+    if (BattlegroundEY* bgEy = dynamic_cast<BattlegroundEY*>(battleground))
+    {
+        ObjectGuid const carrierGuid = bgEy->GetFlagPickerGUID();
+        if (carrierGuid.IsEmpty())
+            return nullptr;
+
+        Player* carrier = ObjectAccessor::FindConnectedPlayer(carrierGuid);
+        if (!carrier)
+            return nullptr;
+
+        if (directive == playerbot::FlagCarrierDirective::AttackEnemyCarrier && carrier->GetTeamId() != botTeam)
+            return carrier;
+        if (directive == playerbot::FlagCarrierDirective::ProtectTeamCarrier && carrier->GetTeamId() == botTeam)
+            return carrier;
+    }
+
+    return nullptr;
+}
+
+bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
+{
+    if (!player || !target || !target->IsAlive() || player->GetMapId() != target->GetMapId())
+        return false;
+
+    if (!player->IsWithinLOSInMap(target))
+        return false;
+
+    if (!player->IsWithinDistInMap(target, desiredDistance))
+        player->GetMotionMaster()->MoveFollow(target, desiredDistance, player->GetFollowAngle());
+
+    return true;
+}
 }
 
 namespace playerbot
@@ -336,6 +399,28 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         return false;
     }
 
+    if (context.movement == BattlegroundMovementPrimitive::MoveToObjectiveUnit ||
+        context.movement == BattlegroundMovementPrimitive::FollowFlagCarrier ||
+        context.flagCarrierDirective != FlagCarrierDirective::None)
+    {
+        if (Player* carrier = FindFlagCarrierForDirective(player, context.flagCarrierDirective))
+            return MoveTowardUnit(player, carrier, 20.0f);
+    }
+
+    if (context.movement == BattlegroundMovementPrimitive::MoveToObjectivePosition)
+    {
+        if (Battleground* battleground = player->GetBattleground())
+        {
+            if (WorldSafeLocsEntry const* graveyard = battleground->GetClosestGraveyard(player))
+            {
+                Position destination(graveyard->Loc.X, graveyard->Loc.Y, graveyard->Loc.Z, player->GetOrientation());
+                if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
+                    player->GetMotionMaster()->MovePoint(0, destination);
+                return true;
+            }
+        }
+    }
+
     return true;
 }
 
@@ -368,7 +453,11 @@ bool BattlegroundTacticalActions::AttackEnemyFlagCarrierPrimitive(Player* player
     if (!player || !player->InBattleground())
         return false;
 
-    return context.flagCarrierDirective == FlagCarrierDirective::AttackEnemyCarrier;
+    if (context.flagCarrierDirective != FlagCarrierDirective::AttackEnemyCarrier)
+        return false;
+
+    Player* enemyCarrier = FindFlagCarrierForDirective(player, FlagCarrierDirective::AttackEnemyCarrier);
+    return MoveTowardUnit(player, enemyCarrier, 15.0f);
 }
 
 bool BattlegroundTacticalActions::ProtectFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context)
@@ -376,7 +465,11 @@ bool BattlegroundTacticalActions::ProtectFlagCarrierPrimitive(Player* player, Ba
     if (!player || !player->InBattleground())
         return false;
 
-    return context.flagCarrierDirective == FlagCarrierDirective::ProtectTeamCarrier;
+    if (context.flagCarrierDirective != FlagCarrierDirective::ProtectTeamCarrier)
+        return false;
+
+    Player* teamCarrier = FindFlagCarrierForDirective(player, FlagCarrierDirective::ProtectTeamCarrier);
+    return MoveTowardUnit(player, teamCarrier, 18.0f);
 }
 
 bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const& context)

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -36,7 +36,8 @@ Playerbot.PvpCore.Enable = 0
 
 #    Playerbot.PvpTactics.Enable
 #        Description: Enables battleground tactical trigger/action selection plus primitive execution
-#                     stubs for waiting/active/often/low-health/low-mana/timer-bg flows.
+#                     for waiting/active/often/low-health/low-mana/timer-bg flows, including
+#                     objective-state flag-carrier pursuit/protection movement in WSG/EotS contexts.
 #                     This remains default OFF and does not change queue policy or class rotation logic.
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)


### PR DESCRIPTION
### Motivation

- Finish Phase-5/Phase-6 work to move Playerbot PvP from parity slice to validation-ready behavior by restoring battleground objective seams (flag-carrier ownership/proximity) and providing safe tactical movement primitives. 
- Preserve all lifecycle invariants: loader update path, lifecycle gate chain, manager cadence/interval, queue policy, and keep class-slice default OFF. 

### Description

- Add objective-state fields to `PvpValues` and populate them from runtime battleground state by implementing `PopulateObjectiveStateTriggers` (supports `BattlegroundWS` and `BattlegroundEY` using flag-picker GUIDs, WSG both-flags-out suppression, and proximity thresholds). 
- Wire `PvpCore::IsTriggerActive` to return `player has flag`, `enemy flagcarrier near`, and `team flagcarrier near` from the new `PvpValues` instead of hardcoded `false`. 
- Implement safe objective movement primitives in `PlayerbotPvpLifecycleActions.cpp`: `FindFlagCarrierForDirective`, `MoveTowardUnit`, follow-based pursuit/protection of carriers, and `MovePoint`-based objective-position fallback (closest graveyard); tactical wiring and trigger ordering remain unchanged. 
- Update documentation and config text: expand `doc/playerbot/pvp-port-roadmap.md` with references consulted, touched local files, intentional divergences, and Phase-6 validation checklist; adjust `src/server/worldserver/playerbots.conf.dist` wording to reflect objective-state movement (default OFF preserved). 

### Testing

- Confirmed `compile_commands.json` contains entries for the touched Playerbot PvP `.cpp` files after a local compile-db refresh. 
- Ran compile-db-derived per-file syntax checks with `-fsyntax-only` for `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`, and both returned success (`RC 0`). 
- Performed narrow object-target builds (compile command-derived object outputs) for both touched `.cpp` files which completed successfully (`RC 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cffbfb92a88327a82e1202054869df)