### PR TITLE
Phase-6 signoff: Playerbot PvP migration runtime validation closeout

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -211,3 +211,71 @@ Loader path and lifecycle gates remain preserved as-is:
     - Arena queue join/leave and team invite handling continue to execute with unchanged policy.
   - Regression safety:
     - With `Playerbot.PvpCore.Enable = 0` or `Playerbot.PvpLifecycle.Enable = 0`, lifecycle remains gated and no queue/tactical/class PvP behavior executes.
+
+### Phase-6 runtime validation + closeout signoff (2026-04-03)
+
+#### Validation commands run
+
+1. Compile DB coverage checks:
+   - `python3 - <<'PY' ...` (checked `compile_commands.json` and `build/compile_commands.json` for:
+     - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
+     - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`
+     - `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`)
+   - Observed outcome: all three files had `0` entries in both compile DB files.
+
+2. Build graph ownership checks:
+   - `ninja -C build -t targets all | rg 'Playerbot'`
+   - `ninja -C build -t targets all | rg -i 'scripts.dir.*/Pvp'`
+   - Observed outcome: no Playerbot PvP object targets were present.
+
+3. Compile-db-derived syntax checks (fallback-derived from existing scripts compile command flags):
+   - `python3 - <<'PY' ...` (extract first `src/server/scripts/*.cpp` compile command from `build/compile_commands.json`, strip source/output args, run `-fsyntax-only` for each Playerbot PvP `.cpp` file above)
+   - Observed outcome: all three syntax checks exited `0` with no diagnostics.
+
+4. Narrow object-target builds:
+   - `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpCore.cpp.o`
+   - `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o`
+   - `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o`
+   - Observed outcome: each failed with `unknown target`.
+
+5. Static invariant/observability presence checks:
+   - `rg -n "ProcessPlayerLifecycle\(player\)|moduleEnabled && config\.pvpCoreEnabled && config\.pvpLifecycleEnabled|RandomBotLifecycleCadenceInterval|Playerbot PvP lifecycle branch|Playerbot PvP lifecycle observation|dispatcher complete|player has flag|enemy flagcarrier near|team flagcarrier near|Playerbot\.PvpClassSpells\.Enable = 0" ...`
+   - Observed outcome: all expected markers/gates/ordering text were found in source/config.
+
+#### Runtime/manual validation outcomes
+
+- Battleground queue + invite behavior: **blocked** (no runtime worldserver/BG session executed in this environment).
+- WSG/EotS objective trigger checks (`player has flag`, `enemy flagcarrier near`, `team flagcarrier near`): **blocked** for live execution; static code path presence confirmed.
+- Trigger ordering emergency/objective first: **statically confirmed** by ordered tactical table priority (`player has flag` > timer > enemy carrier > team carrier > sustain).
+- Arena queue/team invite behavior unchanged: **statically confirmed** in lifecycle primitive selection and dispatcher wiring; live queue test **blocked**.
+- Regression with PvP flags OFF: **statically confirmed** via lifecycle gate checks and default-off config values; live runtime toggle test **blocked**.
+
+#### Observability verification outcomes
+
+- Lifecycle log formats for:
+  - branch marker,
+  - reason observation,
+  - dispatcher completion booleans,
+  are **statically confirmed** in `PlayerbotRandomBotParticipation.cpp`.
+- `.playerbot pvp lifecycle snapshot` command exposure and counter printing are **statically confirmed** in `playerbot_loader.cpp`.
+- Counter movement verification (`gateDisabled`, `cadenceThrottled`, `invalidPlayerState`, `noLifecycleHooksActive`, `battlegroundLifecycleExecuted`, `arenaLifecycleExecuted`) is **blocked for live observation** because runtime execution was not performed.
+
+#### Remaining blockers / divergences
+
+- **Blocker:** current generated build graph does not include Playerbot PvP objects (compile DB entries absent; object targets unknown).
+- **Blocker:** no in-game runtime session was executed for BG/Arena/manual command verification in this environment.
+- No new functional divergences were introduced in this closeout pass; blockers are validation-environment/build-integration related.
+
+#### Go/No-Go recommendation
+
+- **Recommendation: NO-GO (as of 2026-04-03)** for final Phase-6 signoff until blockers are cleared:
+  1. Playerbot PvP sources are included in build graph/compile DB and narrow object builds succeed.
+  2. Runtime manual checklist is executed in-world (BG/Arena + `.playerbot pvp lifecycle snapshot`) with logs captured.
+
+#### Explicit preservation statement
+
+- Loader update path remains exactly `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`.
+- Lifecycle gate chain remains exactly `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`.
+- Cadence ownership/interval remain unchanged (manager-owned, `RandomBotLifecycleCadenceInterval(2000)`).
+- Queue policy in lifecycle actions remains unchanged.
+- Class-slice default remains OFF unless explicitly enabled.


### PR DESCRIPTION
### Motivation

- Finalize Phase-6 validation by recording exact compile/build checks, runtime/manual verification checklist status, observability evidence, remaining blockers, and an explicit go/no-go recommendation in the PvP roadmap.

### Description

- Add a Phase-6 runtime validation & closeout signoff section to `doc/playerbot/pvp-port-roadmap.md` that enumerates the validation commands executed, observed outcomes, remaining blockers, an explicit NO-GO recommendation (pending environment/build fixes), and a preservation statement for loader/gates/cadence; no source code changes were made.
- Preserve all hard invariants: loader update path remains `RandomBotParticipationManager::ProcessPlayerLifecycle(Player*)`, lifecycle gates remain `Playerbot.Enable && Playerbot.PvpCore.Enable && Playerbot.PvpLifecycle.Enable`, cadence ownership/interval unchanged, queue policy unchanged, and class-slice default stays OFF unless explicitly enabled.

### Testing

- Compile DB coverage checks: inspected `compile_commands.json` and `build/compile_commands.json` for `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`, `PlayerbotPvpLifecycleActions.cpp`, and `PlayerbotRandomBotParticipation.cpp` and observed `0` entries for each file in both compile DB files (automated check succeeded).
- Compile-db-derived syntax checks: ran `-fsyntax-only` (derived from an existing `src/server/scripts/*.cpp` compile command) for the three Playerbot PvP `.cpp` files and all three returned exit code `0` with no diagnostics (automated check succeeded).
- Narrow object-target builds: attempted `ninja -C build` for the per-object targets (e.g. `src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpCore.cpp.o`) and each failed as `unknown target` because the generated build graph/compile DB does not currently include Playerbot PvP object targets (automated check failed / blocker).
- Static invariants and observability string checks: used `rg` to confirm presence of lifecycle wiring, cadence symbol, lifecycle log lines, tactical trigger names (`player has flag`, `enemy flagcarrier near`, `team flagcarrier near`), and the `.playerbot pvp lifecycle snapshot` output; these strings and command handlers are present in source/config (automated check succeeded).

Automated runtime/worldserver verification (BG/Arena queue flows, `.playerbot pvp lifecycle snapshot` counter movements) was not executed in this environment and is reported as blocked; recommendation is NO-GO until build-graph inclusion and live runtime checks are performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfffff08148327b01bd43903568aa6)