### PR TITLE
Phase-6 signoff: Playerbot PvP build-integration & validation closeout

### DIFF
--- a/doc/playerbot/pvp-port-roadmap.md
+++ b/doc/playerbot/pvp-port-roadmap.md
@@ -212,65 +212,81 @@ Loader path and lifecycle gates remain preserved as-is:
   - Regression safety:
     - With `Playerbot.PvpCore.Enable = 0` or `Playerbot.PvpLifecycle.Enable = 0`, lifecycle remains gated and no queue/tactical/class PvP behavior executes.
 
-### Phase-6 runtime validation + closeout signoff (2026-04-03)
+### Phase-6 runtime validation + closeout signoff (2026-04-03, build-integration rerun)
 
 #### Validation commands run
 
-1. Compile DB coverage checks:
+1. Build integration fix + generator refresh:
+   - `cmake -S . -B build -DPLAYERBOT=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
+   - Key outcome lines:
+     - `* Build with scripts     : Yes (static)`
+     - `|   +- Playerbot`
+     - `-- Build files have been written to: /workspace/TrinityCore112/build`
+   - Exit code: `0`.
+
+2. Compile DB coverage checks:
    - `python3 - <<'PY' ...` (checked `compile_commands.json` and `build/compile_commands.json` for:
      - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`
      - `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`
      - `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`)
-   - Observed outcome: all three files had `0` entries in both compile DB files.
+   - Observed outcome (both DB files): each path had `1` entry.
+   - Exit code: `0`.
 
-2. Build graph ownership checks:
-   - `ninja -C build -t targets all | rg 'Playerbot'`
-   - `ninja -C build -t targets all | rg -i 'scripts.dir.*/Pvp'`
-   - Observed outcome: no Playerbot PvP object targets were present.
-
-3. Compile-db-derived syntax checks (fallback-derived from existing scripts compile command flags):
-   - `python3 - <<'PY' ...` (extract first `src/server/scripts/*.cpp` compile command from `build/compile_commands.json`, strip source/output args, run `-fsyntax-only` for each Playerbot PvP `.cpp` file above)
-   - Observed outcome: all three syntax checks exited `0` with no diagnostics.
+3. Compile-db-derived syntax checks:
+   - `python3 - <<'PY' ...` (for each touched Playerbot PvP `.cpp`, derive command flags from `build/compile_commands.json` and run `-fsyntax-only`)
+   - Observed outcome:
+     - `FILE src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` -> `EXIT 0`
+     - `FILE src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` -> `EXIT 0`
+     - `FILE src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` -> `EXIT 0`
+   - Exit code: `0`.
 
 4. Narrow object-target builds:
-   - `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpCore.cpp.o`
-   - `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o`
-   - `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o`
-   - Observed outcome: each failed with `unknown target`.
+   - `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpCore.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o`
+   - Key outcome lines:
+     - `[3/5] Building CXX object ...PlayerbotRandomBotParticipation.cpp.o`
+     - `[4/5] Building CXX object ...PlayerbotPvpLifecycleActions.cpp.o`
+     - `[5/5] Building CXX object ...PlayerbotPvpCore.cpp.o`
+   - Exit code: `0`.
 
-5. Static invariant/observability presence checks:
-   - `rg -n "ProcessPlayerLifecycle\(player\)|moduleEnabled && config\.pvpCoreEnabled && config\.pvpLifecycleEnabled|RandomBotLifecycleCadenceInterval|Playerbot PvP lifecycle branch|Playerbot PvP lifecycle observation|dispatcher complete|player has flag|enemy flagcarrier near|team flagcarrier near|Playerbot\.PvpClassSpells\.Enable = 0" ...`
-   - Observed outcome: all expected markers/gates/ordering text were found in source/config.
+5. Runtime execution attempt prerequisites:
+   - `test -x build/bin/worldserver && echo 'worldserver-binary-present' || echo 'worldserver-binary-missing'`
+   - Outcome: `worldserver-binary-missing`.
+   - Exit code: `0`.
+   - Attempted to build runtime binary for manual checks:
+     - `ninja -C build worldserver`
+     - Build began (`[1/1104] ...`) but was manually interrupted in this environment:
+       - `ninja: build stopped: interrupted by user.`
+     - Exit code: `2`.
+
+6. Static invariant/observability presence checks:
+   - `rg -n "ProcessPlayerLifecycle\(player\)|moduleEnabled && config\.pvpCoreEnabled && config\.pvpLifecycleEnabled|RandomBotLifecycleCadenceInterval|Playerbot PvP lifecycle branch|Playerbot PvP lifecycle observation|Playerbot PvP lifecycle dispatcher complete|player has flag|enemy flagcarrier near|team flagcarrier near|Playerbot\.PvpClassSpells\.Enable = 0|gateDisabled|cadenceThrottled|invalidPlayerState|noLifecycleHooksActive|battlegroundLifecycleExecuted|arenaLifecycleExecuted|HandlePlayerbotPvpLifecycleSnapshotCommand" ...`
+   - Observed outcome: all expected invariant, trigger-ordering, log, and snapshot counter markers found.
+   - Exit code: `0`.
 
 #### Runtime/manual validation outcomes
 
-- Battleground queue + invite behavior: **blocked** (no runtime worldserver/BG session executed in this environment).
-- WSG/EotS objective trigger checks (`player has flag`, `enemy flagcarrier near`, `team flagcarrier near`): **blocked** for live execution; static code path presence confirmed.
-- Trigger ordering emergency/objective first: **statically confirmed** by ordered tactical table priority (`player has flag` > timer > enemy carrier > team carrier > sustain).
-- Arena queue/team invite behavior unchanged: **statically confirmed** in lifecycle primitive selection and dispatcher wiring; live queue test **blocked**.
-- Regression with PvP flags OFF: **statically confirmed** via lifecycle gate checks and default-off config values; live runtime toggle test **blocked**.
+- Battleground queue + invite behavior: **blocked** (no runnable worldserver/BG session completed in this environment).
+- WSG/EotS objective trigger checks (`player has flag`, `enemy flagcarrier near`, `team flagcarrier near`): **blocked for live execution**; static code-path presence confirmed.
+- Trigger ordering emergency/objective first: **statically confirmed** (`player has flag` > timer > enemy carrier > team carrier > sustain priorities).
+- Arena queue/team invite behavior unchanged: **statically confirmed** in lifecycle context/action wiring; live arena test **blocked**.
+- Regression with PvP flags OFF: **statically confirmed** via lifecycle gate checks and default-off config; live toggle test **blocked**.
 
 #### Observability verification outcomes
 
-- Lifecycle log formats for:
-  - branch marker,
-  - reason observation,
-  - dispatcher completion booleans,
-  are **statically confirmed** in `PlayerbotRandomBotParticipation.cpp`.
-- `.playerbot pvp lifecycle snapshot` command exposure and counter printing are **statically confirmed** in `playerbot_loader.cpp`.
-- Counter movement verification (`gateDisabled`, `cadenceThrottled`, `invalidPlayerState`, `noLifecycleHooksActive`, `battlegroundLifecycleExecuted`, `arenaLifecycleExecuted`) is **blocked for live observation** because runtime execution was not performed.
+- Lifecycle log formats for branch marker, reason observation, and dispatcher completion booleans are **present** in source.
+- `.playerbot pvp lifecycle snapshot` command exposure and counter printing are **present** in loader command script.
+- Counter movement runtime verification for `gateDisabled`, `cadenceThrottled`, `invalidPlayerState`, `noLifecycleHooksActive`, `battlegroundLifecycleExecuted`, `arenaLifecycleExecuted` remains **blocked** without a live worldserver session.
 
 #### Remaining blockers / divergences
 
-- **Blocker:** current generated build graph does not include Playerbot PvP objects (compile DB entries absent; object targets unknown).
-- **Blocker:** no in-game runtime session was executed for BG/Arena/manual command verification in this environment.
-- No new functional divergences were introduced in this closeout pass; blockers are validation-environment/build-integration related.
+- **Build-integration blocker resolved:** Playerbot PvP files are now generated in compile DB and narrow object targets build successfully.
+- **Remaining blocker:** runtime/manual in-world validation checklist could not be completed in this container session (no completed worldserver runtime).
+- No new functional divergences were introduced in this signoff rerun.
 
 #### Go/No-Go recommendation
 
-- **Recommendation: NO-GO (as of 2026-04-03)** for final Phase-6 signoff until blockers are cleared:
-  1. Playerbot PvP sources are included in build graph/compile DB and narrow object builds succeed.
-  2. Runtime manual checklist is executed in-world (BG/Arena + `.playerbot pvp lifecycle snapshot`) with logs captured.
+- **Recommendation: NO-GO for final production signoff (as of 2026-04-03)** due to incomplete live runtime evidence.
+- **Sub-recommendation: GO for Phase-6 build-integration and compile-validation gate** (compile DB inclusion + syntax + narrow object build checks all pass).
 
 #### Explicit preservation statement
 


### PR DESCRIPTION
### Motivation
- Finish Phase-6 validation and closeout for the Playerbot PvP migration by resolving build-integration gaps and producing explicit GO/NO-GO evidence for compile and runtime gates.
- Preserve the Playerbot PvP invariants (loader/gates/cadence/queue policy/class-slice default) while confirming compile-time and narrow-build coverage for the PvP translation units.

### Description
- Added documentation evidence and refresh in `doc/playerbot/pvp-port-roadmap.md` describing exact commands executed and outcomes (new closeout section added).【F:doc/playerbot/pvp-port-roadmap.md†L215-L296】
- Regenerated build files with Playerbot enabled so the Playerbot PvP translation units are emitted into `compile_commands.json` and the static `scripts` library build graph. (CMake was invoked with `-DPLAYERBOT=1`.)
- No source behavior changes were made to lifecycle topology; the loader/gates/cadence invariants are preserved: loader call remains in `playerbot_loader.cpp` (ProcessPlayerLifecycle call), lifecycle gate check remains in `PlayerbotPvpCore.cpp`, and cadence constant remains in `PlayerbotRandomBotParticipation.cpp`.
  - Loader call: `playerbot::RandomBotParticipationManager::ProcessPlayerLifecycle(player);`【F:src/server/scripts/Playerbot/playerbot_loader.cpp†L61】
  - Lifecycle gate chain check: `moduleEnabled && pvpCoreEnabled && pvpLifecycleEnabled`【F:src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp†L37】
  - Cadence interval: `RandomBotLifecycleCadenceInterval(2000)`【F:src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp†L43】

### Testing
- `cmake -S . -B build -DPLAYERBOT=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` — PASS (exit 0); key lines: `* Build with scripts     : Yes (static)` and `-- Build files have been written to: /workspace/TrinityCore112/build`.
- `python3` compile-db coverage check (count entries in `compile_commands.json` / `build/compile_commands.json` for the three PvP .cpp paths) — PASS (exit 0); observed counts: each path reported `1` entry in the generated compile DBs for: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`, `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`, `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`.
- Compile-db-derived syntax checks (`-fsyntax-only` using flags from `build/compile_commands.json`) — PASS (exit 0); observed outputs:
  - `FILE src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` -> `EXIT 0`
  - `FILE src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` -> `EXIT 0`
  - `FILE src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` -> `EXIT 0`.
- Narrow object-target builds (ninja for the three object files) — PASS (exit 0); key observed lines during the targeted ninja invocation: `[3/5] Building CXX object ...PlayerbotRandomBotParticipation.cpp.o`, `[4/5] Building CXX object ...PlayerbotPvpLifecycleActions.cpp.o`, `[5/5] Building CXX object ...PlayerbotPvpCore.cpp.o`.
- Runtime binary presence check: `test -x build/bin/worldserver && echo 'worldserver-binary-present' || echo 'worldserver-binary-missing'` — PASS (exit 0); observed `worldserver-binary-missing` (no runnable worldserver in this environment).
- Attempt to build runtime `worldserver` for manual checks: `ninja -C build worldserver` — FAIL/INTERRUPTED (exit 2); observed `ninja: build stopped: interrupted by user.` so live in-world validation was blocked in this container.
- Static invariant/observability scans via `rg -n` — PASS (exit 0); lifecycle logs, dispatcher summary, `.playerbot pvp lifecycle snapshot` hook, trigger names and snapshot counter labels were found in source/config (see updated roadmap and sources).【F:src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp†L118-L127】【F:src/server/scripts/Playerbot/playerbot_loader.cpp†L100-L113】【F:src/server/worldserver/playerbots.conf.dist†L61-L75】

Automated test summary: all automated compile/build-integration checks (CMake regen, compile DB inclusion, per-file syntax checks, and narrow object-target builds) passed in this environment; runtime/manual checks requiring an active `worldserver` instance remain blocked and caused the NO-GO for final production signoff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0062f3e0c8327b97453389022c194)