### PR TITLE
Fix Playerbot PvP build errors from missing includes

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -18,6 +18,7 @@
 #include "PlayerbotPvpClassActions.h"
 
 #include "Player.h"
+#include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -18,6 +18,8 @@
 #ifndef TRINITY_PLAYERBOT_RANDOM_BOT_PARTICIPATION_H
 #define TRINITY_PLAYERBOT_RANDOM_BOT_PARTICIPATION_H
 
+#include "Define.h"
+
 class Player;
 
 namespace playerbot


### PR DESCRIPTION
### Motivation
- Resolve build failures caused by a missing `uint64` typedef and dereferencing a forward-declared `SpellInfo` by providing the proper includes so the Playerbot PvP scripts can compile.

### Description
- Add `#include "Define.h"` to `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h` so the `uint64` alias is visible where `LifecycleObservationSnapshot` fields are declared.
- Add `#include "SpellInfo.h"` to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` so `SpellInfo` is a complete type before calling methods like `IsPositive`, `GetMaxRange`, `GetMinRange`, and `CalcPowerCost`.

### Testing
- Ran a partial build with `ninja -C build -j4 scripts`, which progressed and compiled many targets but was interrupted by a time limit in this environment before the full build finished; no further occurrences of the original `uint64` or `SpellInfo` incomplete-type errors were observed up to the interruption.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01a83e8fc8327b1423135fb699eae)