### PR TITLE
Playerbot PvP: exclude real players from lifecycle and target Warsong Gulch queue

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -309,7 +309,7 @@ bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    return QueuePlayer(player, BATTLEGROUND_RB, 0);
+    return QueuePlayer(player, BATTLEGROUND_WS, 0);
 }
 
 bool BattlegroundLifecycleActions::LeaveQueuePrimitive(Player* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -140,6 +140,13 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
+    // Playerbot lifecycle hooks must never run for real players.
+    if (player->GetSession())
+    {
+        ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
+        return false;
+    }
+
     if (!player->IsInWorld() || player->IsBeingTeleported())
     {
         ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -46,7 +46,9 @@ Playerbot.PvpTactics.Enable = 0
 
 #    Playerbot.PvpLifecycle.Enable
 #        Description: Enables battleground/arena queue participation lifecycle scaffolding and random-bot
-#                     participation hooks. This phase wires lifecycle entry points only and does not
+#                     participation hooks. Real players are always excluded from these hooks.
+#                     Battleground queue primitive currently targets Warsong Gulch.
+#                     This phase wires lifecycle entry points only and does not
 #                     include class spell logic, queue cadence tuning, or SQL payloads.
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)


### PR DESCRIPTION
### Motivation

- Prevent Playerbot PvP lifecycle hooks from affecting real players and make the default battleground queue target explicit.

### Description

- Added a guard in `CanProcessPlayerLifecycle` to skip processing when `player->GetSession()` is present so lifecycle hooks run only for bots.
- Changed `JoinQueuePrimitive` to call `QueuePlayer(..., BATTLEGROUND_WS, 0)` so the battleground queue primitive targets Warsong Gulch by default.
- Updated `playerbots.conf.dist` comments for `Playerbot.PvpLifecycle.Enable` to document that real players are excluded and that the queue primitive targets Warsong Gulch.

### Testing

- Project compiled successfully after changes with no build errors. 
- Existing automated test suite was executed and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01f55aab48327ba59ca8be8384822)