### PR TITLE
Fix Playerbot random participation DB API compatibility

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -27,6 +27,8 @@
 #include "Globals/ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "StringConvert.h"
+#include "StringFormat.h"
 #include "Util.h"
 
 #include <algorithm>
@@ -280,10 +282,12 @@ std::vector<RandomBotPoolCandidate> QueryOfflinePool(RandomBotPopulationConfig c
         accountList += std::to_string(accountId);
     }
 
-    QueryResult result = CharacterDatabase.Query(
+    std::string const query = Trinity::StringFormat(
         "SELECT guid, account, level, race FROM characters "
         "WHERE online = 0 AND account IN ({}) AND level >= {} AND level <= {}",
-        accountList, config.minLevel, config.maxLevel);
+        accountList, static_cast<uint32>(config.minLevel), static_cast<uint32>(config.maxLevel));
+
+    QueryResult result = CharacterDatabase.Query(query.c_str());
 
     if (!result)
         return candidates;
@@ -292,10 +296,10 @@ std::vector<RandomBotPoolCandidate> QueryOfflinePool(RandomBotPopulationConfig c
     {
         Field* fields = result->Fetch();
         RandomBotPoolCandidate candidate;
-        candidate.lowGuid = fields[0].Get<uint32>();
-        candidate.account = fields[1].Get<uint32>();
-        candidate.level = fields[2].Get<uint8>();
-        candidate.race = fields[3].Get<uint8>();
+        candidate.lowGuid = fields[0].GetUInt32();
+        candidate.account = fields[1].GetUInt32();
+        candidate.level = fields[2].GetUInt8();
+        candidate.race = fields[3].GetUInt8();
         candidates.push_back(candidate);
     }
     while (result->NextRow());


### PR DESCRIPTION
### Motivation
- Restore compilation for the Playerbot random population code by addressing API mismatches between this branch and the local TrinityCore utility/database APIs that caused Jenkins build failures.
- Ensure query construction, field extraction and string conversion calls use the branch-compatible interfaces.

### Description
- Replace variadic `CharacterDatabase.Query(...)` usage with a formatted string via `Trinity::StringFormat(...)` and call `CharacterDatabase.Query(query.c_str())`.
- Change `Field::Get<T>()` uses to the supported typed accessors `GetUInt32()` and `GetUInt8()` when extracting query columns.
- Add includes for `StringConvert.h` and `StringFormat.h` and cast level bounds to `uint32` when formatting the SQL to match `StringFormat` expectations.

### Testing
- Ran `git diff --check` which produced no issues.
- Performed a build dry-run with `ninja -C build -n worldserver` which completed and showed the planned build steps.
- Started a full incremental build with `ninja -C build -j4 worldserver`; the build began compiling files successfully but was not completed in this environment due to time/resource constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d042ca32d88327a5f55c869269bcd7)