### PR TITLE
Fix Playerbot random participation DB query and field access APIs

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -281,7 +281,7 @@ std::vector<RandomBotPoolCandidate> QueryOfflinePool(RandomBotPopulationConfig c
         accountList += std::to_string(accountId);
     }
 
-    QueryResult result = CharacterDatabase.Query(
+    QueryResult result = CharacterDatabase.PQuery(
         "SELECT guid, account, level, race FROM characters "
         "WHERE online = 0 AND account IN ({}) AND level >= {} AND level <= {}",
         accountList, config.minLevel, config.maxLevel);
@@ -293,10 +293,10 @@ std::vector<RandomBotPoolCandidate> QueryOfflinePool(RandomBotPopulationConfig c
     {
         Field* fields = result->Fetch();
         RandomBotPoolCandidate candidate;
-        candidate.lowGuid = fields[0].Get<uint32>();
-        candidate.account = fields[1].Get<uint32>();
-        candidate.level = fields[2].Get<uint8>();
-        candidate.race = fields[3].Get<uint8>();
+        candidate.lowGuid = fields[0].GetUInt32();
+        candidate.account = fields[1].GetUInt32();
+        candidate.level = fields[2].GetUInt8();
+        candidate.race = fields[3].GetUInt8();
         candidates.push_back(candidate);
     }
     while (result->NextRow());
@@ -319,7 +319,7 @@ std::unordered_map<uint32, uint32> QueryOnlineBotCountsByAccount(RandomBotPopula
         accountList += std::to_string(accountId);
     }
 
-    QueryResult result = CharacterDatabase.Query(
+    QueryResult result = CharacterDatabase.PQuery(
         "SELECT account, COUNT(*) FROM characters WHERE online = 1 AND account IN ({}) GROUP BY account",
         accountList);
     if (!result)
@@ -328,7 +328,7 @@ std::unordered_map<uint32, uint32> QueryOnlineBotCountsByAccount(RandomBotPopula
     do
     {
         Field* fields = result->Fetch();
-        onlineByAccount[fields[0].Get<uint32>()] = fields[1].Get<uint32>();
+        onlineByAccount[fields[0].GetUInt32()] = fields[1].GetUInt32();
     } while (result->NextRow());
 
     return onlineByAccount;


### PR DESCRIPTION
### Motivation
- Resolve build errors where `CharacterDatabase.Query(...)` was called with formatted arguments and templated `Field::Get<T>()` was used, which do not match the codebase DB and Field APIs.
- Ensure the Playerbot random bot selection code uses the project's supported DB query and field-accessors to avoid runtime/compile-time failures.

### Description
- Replaced `CharacterDatabase.Query(...)` with `CharacterDatabase.PQuery(...)` for formatted SQL in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`.
- Replaced invalid templated `Field::Get<T>()` usage with TrinityCore-style accessors `GetUInt32()` and `GetUInt8()` for GUID, account, level, and race extraction.
- Adjusted online-by-account aggregation to use `GetUInt32()` when reading fields.
- Changes are minimal and targeted to the `QueryOfflinePool` and `QueryOnlineBotCountsByAccount` functions in the single modified file (commit `52992910`).

### Testing
- Ran `rg "Get<|CharacterDatabase\.Query\(" -n src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` to confirm the old invalid API usages were removed, which succeeded.
- Reviewed the patch with `git -C /workspace/TrinityCore112 diff -- src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` to verify the intended changes, which succeeded.
- Performed `git commit` to record the change, which succeeded (commit `52992910`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d049c8f4b88327a846d6425342ec39)