### PR TITLE
Include StringConvert.h in PlayerbotRandomBotParticipation.cpp

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -27,6 +27,7 @@
 #include "Globals/ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "StringConvert.h"
 #include "Util.h"
 
 #include <algorithm>


### PR DESCRIPTION
### Motivation
- Ensure string conversion utilities are available in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` to avoid compilation errors and enable use of conversion helpers.

### Description
- Add `#include "StringConvert.h"` to `PlayerbotRandomBotParticipation.cpp` so the file can use the project's string conversion utilities.

### Testing
- Built the project with `make` and the compilation of the modified translation unit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d04c06fea8832781819b1600ea543d)