### PR TITLE
Implement managed random-bot login/logout orchestration for Playerbot random population

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -309,7 +309,7 @@ bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    return QueuePlayer(player, BATTLEGROUND_WS, 0);
+    return QueuePlayer(player, BattlegroundLifecycleActions::ManagedRandomBotQueueTarget(), 0);
 }
 
 bool BattlegroundLifecycleActions::LeaveQueuePrimitive(Player* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
@@ -27,6 +27,8 @@ namespace playerbot
 class BattlegroundLifecycleActions
 {
 public:
+    static constexpr BattlegroundTypeId ManagedRandomBotQueueTarget() { return BATTLEGROUND_WS; }
+
     static bool Execute(Player* player, BattlegroundLifecycleContext const& context);
 
     static bool JoinQueuePrimitive(Player* player);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -21,14 +21,20 @@
 #include "PlayerbotPvpClassActions.h"
 #include "PlayerbotPvpLifecycleActions.h"
 
+#include "AccountMgr.h"
 #include "Configuration/Config.h"
+#include "CharacterCache.h"
 #include "DatabaseEnv.h"
 #include "GameTime.h"
 #include "Globals/ObjectAccessor.h"
 #include "Log.h"
+#include "Opcodes.h"
 #include "Player.h"
 #include "StringConvert.h"
 #include "Util.h"
+#include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
 
 #include <algorithm>
 #include <atomic>
@@ -198,8 +204,7 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    // Playerbot lifecycle hooks must never run for real players.
-    if (player->GetSession())
+    if (!playerbot::IsManagedRandomBot(player))
     {
         ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
         return false;
@@ -225,15 +230,44 @@ bool CanProcessPlayerLifecycle(Player const* player)
     return true;
 }
 
-bool IsRandomBotCandidate(Player const* player, std::unordered_set<uint32> const& /*botAccounts*/)
+uint32 ResolvePlayerAccountId(Player const* player)
 {
     if (!player)
+        return 0;
+
+    if (WorldSession const* session = player->GetSession())
+        return session->GetAccountId();
+
+    return sCharacterCache->GetCharacterAccountIdByGuid(player->GetGUID());
+}
+
+bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> const& botAccounts)
+{
+    if (!player || botAccounts.empty())
         return false;
 
-    if (player->GetSession())
+    uint32 const accountId = ResolvePlayerAccountId(player);
+    if (!accountId || botAccounts.find(accountId) == botAccounts.end())
         return false;
+
+    if (WorldSession const* session = player->GetSession())
+    {
+        // Safety invariant: connected human sessions are never treated as managed random bots.
+        return session->PlayerDisconnected();
+    }
 
     return true;
+}
+
+std::unordered_set<uint32> GetManagedBotAccountIdsSnapshot()
+{
+    std::lock_guard<std::mutex> lock(g_RandomPopulationLock);
+    return g_RandomPopulation.config.botAccountIds;
+}
+
+bool IsRandomBotCandidate(Player const* player, std::unordered_set<uint32> const& botAccounts)
+{
+    return IsManagedRandomBotImpl(player, botAccounts);
 }
 
 struct OnlineRandomBotMetrics
@@ -441,21 +475,77 @@ std::vector<RandomBotPoolCandidate> PickLoginCandidates(RandomBotPopulationState
 
 bool SupportsLoginOrchestration()
 {
-    return false;
+    return true;
 }
 
 bool TryLoginBotCharacter(RandomBotPoolCandidate const& candidate)
 {
-    TC_LOG_INFO("playerbots.population", "Random bot population manager selected offline bot guidLow={} account={} level={} (login orchestration unavailable in this module).",
-        candidate.lowGuid, candidate.account, candidate.level);
-    return false;
+    if (!candidate.lowGuid || !candidate.account)
+    {
+        TC_LOG_ERROR("playerbots.population", "Random bot login skipped due to invalid candidate payload (guidLow={}, account={}).",
+            candidate.lowGuid, candidate.account);
+        return false;
+    }
+
+    if (sWorld->FindSession(candidate.account))
+    {
+        TC_LOG_WARN("playerbots.population", "Random bot login skipped: account {} already has an active world session (candidate guidLow={}).",
+            candidate.account, candidate.lowGuid);
+        return false;
+    }
+
+    std::string accountName;
+    if (!sAccountMgr->GetName(candidate.account, accountName))
+    {
+        TC_LOG_ERROR("playerbots.population", "Random bot login failed: unable to resolve account name for account {} (candidate guidLow={}).",
+            candidate.account, candidate.lowGuid);
+        return false;
+    }
+
+    AccountTypes const security = static_cast<AccountTypes>(sAccountMgr->GetSecurity(candidate.account, int32(realmid)));
+    uint8 const expansion = static_cast<uint8>(sWorld->getIntConfig(CONFIG_EXPANSION));
+    WorldSession* session = new WorldSession(candidate.account, std::move(accountName), nullptr, security, expansion, 0, Minutes(0),
+        LOCALE_enUS, 0, false);
+    sWorld->AddSession(session);
+
+    WorldPacket loginPacket(CMSG_PLAYER_LOGIN, 8);
+    ObjectGuid const playerGuid = ObjectGuid::Create<HighGuid::Player>(candidate.lowGuid);
+    loginPacket << playerGuid;
+    session->HandlePlayerLoginOpcode(loginPacket);
+
+    TC_LOG_INFO("playerbots.population", "Random bot login dispatched: guid={} guidLow={} account={} level={}.",
+        playerGuid.ToString(), candidate.lowGuid, candidate.account, candidate.level);
+    return true;
 }
 
 bool TryLogoutRandomBot(ObjectGuid const& guid)
 {
-    TC_LOG_INFO("playerbots.population", "Random bot population manager selected online bot guid={} for logout (logout orchestration unavailable in this module).",
-        guid.ToString());
-    return false;
+    Player* player = ObjectAccessor::FindConnectedPlayer(guid);
+    if (!player)
+    {
+        TC_LOG_WARN("playerbots.population", "Random bot logout skipped: guid {} is no longer online.", guid.ToString());
+        return false;
+    }
+
+    if (!playerbot::IsManagedRandomBot(player))
+    {
+        TC_LOG_WARN("playerbots.population", "Random bot logout safety skip: guid {} account {} is not a managed random bot.",
+            guid.ToString(), ResolvePlayerAccountId(player));
+        return false;
+    }
+
+    WorldSession* session = player->GetSession();
+    if (!session)
+    {
+        TC_LOG_WARN("playerbots.population", "Random bot logout skipped: managed bot guid {} account {} has no world session. TODO: add sessionless bot eviction adapter.",
+            guid.ToString(), ResolvePlayerAccountId(player));
+        return false;
+    }
+
+    TC_LOG_INFO("playerbots.population", "Random bot logout dispatched: guid={} account={}.", guid.ToString(), session->GetAccountId());
+    session->LogoutPlayer(true);
+    session->KickPlayer("Random bot population manager logout");
+    return true;
 }
 
 bool RebalanceRandomPopulation(RandomBotPopulationState& state)
@@ -513,9 +603,11 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
 
             if (Player const* player = ObjectAccessor::FindConnectedPlayer(guid))
             {
-                if (player->GetSession())
+                if (!IsManagedRandomBotImpl(player, state.config.botAccountIds))
                 {
                     state.skippedSafetyRealPlayers++;
+                    TC_LOG_WARN("playerbots.population", "Random bot logout safety skip: guid={} account={} is not a managed random bot.",
+                        guid.ToString(), ResolvePlayerAccountId(player));
                     continue;
                 }
             }
@@ -579,6 +671,11 @@ void LoadPopulationConfigLocked(RandomBotPopulationState& state)
 
 namespace playerbot
 {
+bool IsManagedRandomBot(Player const* player)
+{
+    return IsManagedRandomBotImpl(player, GetManagedBotAccountIdsSnapshot());
+}
+
 void RandomBotParticipationManager::ResetCadence()
 {
     std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.h
@@ -60,6 +60,8 @@ struct RandomBotPopulationSnapshot
     uint64 lastRebalanceUnixTime = 0;
 };
 
+bool IsManagedRandomBot(Player const* player);
+
 class RandomBotParticipationManager
 {
 public:

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -69,7 +69,8 @@ Playerbot.PvpClassSpells.Enable = 0
 #    Playerbot.RandomPopulation.Enable
 #        Description: Enables random-bot population manager orchestration. When enabled and runtime started,
 #                     periodic rebalance ticks evaluate online random-bot count (bots are always identified as
-#                     players without a real session) against target range and attempt login/logout actions.
+#                     explicit managed bot accounts from Playerbot.RandomPopulation.BotAccountIds and attempt
+#                     server-side login/logout orchestration for those accounts/characters only.
 #                     Real players are hard-excluded from all lifecycle and population automation.
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
@@ -98,6 +99,8 @@ Playerbot.RandomPopulation.RebalanceIntervalMs = 15000
 #    Playerbot.RandomPopulation.BotAccountIds
 #        Description: Comma-separated account IDs reserved for random population bot pool selection.
 #                     Only characters from these accounts are considered for offline pool candidate picks.
+#                     This list is also the explicit managed identity boundary for lifecycle/login/logout:
+#                     characters outside this list are always treated as real-player safety scope.
 #                     Keep this list strictly bot-only to prevent selecting real-player characters.
 #        Default:     "" (empty, no pool)
 

--- a/tests/game/PlayerbotRandomPopulation.cpp
+++ b/tests/game/PlayerbotRandomPopulation.cpp
@@ -1,0 +1,41 @@
+#include "../tc_catch2.h"
+
+#include <fstream>
+#include <string>
+
+namespace
+{
+std::string ReadFile(std::string const& path)
+{
+    std::ifstream in(path);
+    REQUIRE(in.good());
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+}
+
+TEST_CASE("Playerbot random population startup bootstrap wiring remains enabled", "[playerbot][population]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/playerbot_loader.cpp");
+    CHECK(source.find("OnStartupBootstrap") != std::string::npos);
+}
+
+TEST_CASE("Playerbot random population rebalance continues to issue login attempts", "[playerbot][population]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp");
+    CHECK(source.find("state.loginAttempts++") != std::string::npos);
+    CHECK(source.find("TryLoginBotCharacter") != std::string::npos);
+}
+
+TEST_CASE("Playerbot random population keeps real-player safety gating", "[playerbot][population]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp");
+    CHECK(source.find("IsManagedRandomBot") != std::string::npos);
+    CHECK(source.find("state.skippedSafetyRealPlayers++") != std::string::npos);
+}
+
+TEST_CASE("Playerbot battleground queue target remains Warsong", "[playerbot][population]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp");
+    CHECK(source.find("ManagedRandomBotQueueTarget") != std::string::npos);
+    CHECK(source.find("BATTLEGROUND_WS") != std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Provide a safe server-side orchestration path to log in/out manually-created bot characters and allow them to be driven by the existing Playerbot PvP lifecycle while never mutating or queuing real players.
- Keep the existing Playerbot population UX (`.playerbot population status/start/stop/rebalance/list`) and maintain the battleground target (Warsong) used by the lifecycle.
- Add observability and safety guards so operators can reason about integration gaps and skips during orchestration.

### Description
- Introduced explicit managed-bot identity and gating by adding `IsManagedRandomBot(Player const*)` and resolving the character account via active `WorldSession` or `CharacterCache`, scoped to configured `Playerbot.RandomPopulation.BotAccountIds` (files changed: `PlayerbotRandomBotParticipation.cpp/.h`).
- Replaced the no-op stubs `SupportsLoginOrchestration()`, `TryLoginBotCharacter(...)`, and `TryLogoutRandomBot(...)` with a concrete adapter that creates a server `WorldSession`, dispatches a `CMSG_PLAYER_LOGIN` packet for login, and performs safe `LogoutPlayer/KickPlayer` for logout with account/guid safety checks and detailed logging (file changed: `PlayerbotRandomBotParticipation.cpp`).
- Preserved Warsong queue target by adding a lifecycle seam `BattlegroundLifecycleActions::ManagedRandomBotQueueTarget()` and wiring the battleground join primitive to use that constant (files changed: `PlayerbotPvpLifecycleActions.h/.cpp`).
- Added config documentation clarifying that `Playerbot.RandomPopulation.BotAccountIds` is the explicit managed identity boundary, and added source-level regression tests validating startup bootstrap wiring, rebalance login-attempt path presence, safety gating, and Warsong anchoring (files changed: `playerbots.conf.dist`, `tests/game/PlayerbotRandomPopulation.cpp`).
- Kept existing runtime counters (`loginAttempts/loginSuccess/logoutAttempts/logoutSuccess/skippedSafetyRealPlayers/skippedIntegrationGap`) and added logs including guid/account context for skip/failure reasons; left a TODO for sessionless eviction adapter where applicable.

### Testing
- Configured build with tests enabled using `cmake -S . -B build -DBUILD_TESTING=1` which completed successfully.
- Built the new test translation unit object with `cd build && ninja tests/CMakeFiles/tests.dir/game/PlayerbotRandomPopulation.cpp.o` which succeeded and verified the regression source checks compile into the test object.
- Attempted broader build (`cmake --build build --target worldserver tests -j4`) which produced a long-running compile and progress output in this environment but did not fully complete within the task window; no playerbot-specific compile errors were observed in the captured output.
- Noted and preserved runtime skip/counter behavior (tests are source-regression checks and no behavioral E2E login was executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1407f2d548327a3b6c44f9e0c2c1e)