### PR TITLE
Fix random bot realm id lookup during login orchestration

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -502,7 +502,7 @@ bool TryLoginBotCharacter(RandomBotPoolCandidate const& candidate)
         return false;
     }
 
-    int32 const realmId = sWorld->GetRealm().Id.Realm;
+    int32 const realmId = static_cast<int32>(realm.Id.Realm);
     AccountTypes const security = static_cast<AccountTypes>(sAccountMgr->GetSecurity(candidate.account, realmId));
     uint8 const expansion = static_cast<uint8>(sWorld->getIntConfig(CONFIG_EXPANSION));
     WorldSession* session = new WorldSession(candidate.account, std::move(accountName), nullptr, security, expansion, 0, Minutes(0),


### PR DESCRIPTION
### Motivation
- Fix a compilation error caused by calling a non-existent `World::GetRealm()` in `TryLoginBotCharacter`; the codebase uses the global `realm` handle for realm id access.

### Description
- Replace `sWorld->GetRealm().Id.Realm` with `static_cast<int32>(realm.Id.Realm)` in `TryLoginBotCharacter` to obtain the realm id and pass it to `AccountMgr::GetSecurity`.

### Testing
- Ran a partial automated build with `cmake --build build --target worldserver -j2` which started but was not completed due to runtime constraints. 
- Attempted a targeted build of the script object which failed with an unknown ninja target error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3054635848327bd472ce1a7140009)