### PR TITLE
Fix Realm incomplete-type compile error in PlayerbotRandomBotParticipation

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -30,6 +30,7 @@
 #include "Log.h"
 #include "Opcodes.h"
 #include "Player.h"
+#include "Realm.h"
 #include "StringConvert.h"
 #include "Util.h"
 #include "World.h"


### PR DESCRIPTION
### Motivation
- Access to `realm.Id.Realm` in `TryLoginBotCharacter` required the full `Realm` definition but only a forward declaration was visible, causing a compile-time "member access into incomplete type 'Realm'" error.

### Description
- Add `#include "Realm.h"` to `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` so `Realm` is fully defined when referenced, with no functional behavior change.

### Testing
- Ran `git diff --check` (passed) and `git status --short` to confirm only the intended file was modified, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d307d71db08327aa543e3e162cef1a)