### PR TITLE
Add post-login verification and session handling for random bot logins

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -30,6 +30,7 @@
 #include "Log.h"
 #include "Opcodes.h"
 #include "Player.h"
+#include "Realm.h"
 #include "StringConvert.h"
 #include "Util.h"
 #include "World.h"
@@ -502,6 +503,7 @@ bool TryLoginBotCharacter(RandomBotPoolCandidate const& candidate)
         return false;
     }
 
+    ObjectGuid const playerGuid = ObjectGuid::Create<HighGuid::Player>(candidate.lowGuid);
     int32 const realmId = static_cast<int32>(realm.Id.Realm);
     AccountTypes const security = static_cast<AccountTypes>(sAccountMgr->GetSecurity(candidate.account, realmId));
     uint8 const expansion = static_cast<uint8>(sWorld->getIntConfig(CONFIG_EXPANSION));
@@ -510,11 +512,22 @@ bool TryLoginBotCharacter(RandomBotPoolCandidate const& candidate)
     sWorld->AddSession(session);
 
     WorldPacket loginPacket(CMSG_PLAYER_LOGIN, 8);
-    ObjectGuid const playerGuid = ObjectGuid::Create<HighGuid::Player>(candidate.lowGuid);
     loginPacket << playerGuid;
     session->HandlePlayerLoginOpcode(loginPacket);
 
-    TC_LOG_INFO("playerbots.population", "Random bot login dispatched: guid={} guidLow={} account={} level={}.",
+    Player* loggedInPlayer = session->GetPlayer();
+    if (!loggedInPlayer || loggedInPlayer->GetGUID() != playerGuid || !loggedInPlayer->IsInWorld())
+    {
+        TC_LOG_WARN("playerbots.population",
+            "Random bot login failed post-dispatch verification: guid={} guidLow={} account={} hasPlayer={} inWorld={}.",
+            playerGuid.ToString(), candidate.lowGuid, candidate.account, loggedInPlayer ? 1 : 0,
+            (loggedInPlayer && loggedInPlayer->IsInWorld()) ? 1 : 0);
+
+        session->KickPlayer("Random bot login verification failed");
+        return false;
+    }
+
+    TC_LOG_INFO("playerbots.population", "Random bot login successful: guid={} guidLow={} account={} level={}.",
         playerGuid.ToString(), candidate.lowGuid, candidate.account, candidate.level);
     return true;
 }


### PR DESCRIPTION
### Motivation

- Improve robustness of the random bot login path by verifying that the player actually entered the world and ensuring incorrect/partial logins are cleaned up.

### Description

- Include `Realm.h` and create the `ObjectGuid` for the player earlier in `TryLoginBotCharacter` to use consistently.
- Add a post-dispatch verification that checks `session->GetPlayer()` exists, the player's GUID matches the expected GUID, and the player is in-world; if verification fails the session is kicked and the login is treated as failed.
- Update logging to reflect the new verification step and log warnings when post-login checks fail.

### Testing

- Project was built to ensure the change compiles (`cmake`/build step completed successfully). 
- Existing automated test suite was executed (`ctest`) and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d307d71db08327aa543e3e162cef1a)