### PR TITLE
Allow programmatic character login for random bots and verify post-login GUID

### DIFF
--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -509,6 +509,7 @@ class TC_GAME_API WorldSession
 
         void LogoutPlayer(bool save);
         void KickPlayer(std::string const& reason);
+        void AllowCharacterLogin(ObjectGuid guid) { _legitCharacters.insert(guid); }
         // Returns true if all contained hyperlinks are valid
         // May kick player on false depending on world config (handler should abort)
         bool ValidateHyperlinksAndMaybeKick(std::string const& str);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -30,6 +30,7 @@
 #include "Log.h"
 #include "Opcodes.h"
 #include "Player.h"
+#include "Realm.h"
 #include "StringConvert.h"
 #include "Util.h"
 #include "World.h"
@@ -502,20 +503,43 @@ bool TryLoginBotCharacter(RandomBotPoolCandidate const& candidate)
         return false;
     }
 
+    ObjectGuid const playerGuid = ObjectGuid::Create<HighGuid::Player>(candidate.lowGuid);
     int32 const realmId = static_cast<int32>(realm.Id.Realm);
     AccountTypes const security = static_cast<AccountTypes>(sAccountMgr->GetSecurity(candidate.account, realmId));
     uint8 const expansion = static_cast<uint8>(sWorld->getIntConfig(CONFIG_EXPANSION));
     WorldSession* session = new WorldSession(candidate.account, std::move(accountName), nullptr, security, expansion, 0, Minutes(0),
         LOCALE_enUS, 0, false);
     sWorld->AddSession(session);
+    session->AllowCharacterLogin(playerGuid);
 
     WorldPacket loginPacket(CMSG_PLAYER_LOGIN, 8);
-    ObjectGuid const playerGuid = ObjectGuid::Create<HighGuid::Player>(candidate.lowGuid);
     loginPacket << playerGuid;
     session->HandlePlayerLoginOpcode(loginPacket);
 
-    TC_LOG_INFO("playerbots.population", "Random bot login dispatched: guid={} guidLow={} account={} level={}.",
-        playerGuid.ToString(), candidate.lowGuid, candidate.account, candidate.level);
+    Player* loggedInPlayer = session->GetPlayer();
+    if (loggedInPlayer && loggedInPlayer->GetGUID() != playerGuid)
+    {
+        TC_LOG_WARN("playerbots.population",
+            "Random bot login failed post-dispatch verification: guid={} guidLow={} account={} hasPlayer={} guidMismatch=1.",
+            playerGuid.ToString(), candidate.lowGuid, candidate.account, loggedInPlayer ? 1 : 0,
+            1);
+
+        session->KickPlayer("Random bot login verification failed");
+        return false;
+    }
+
+    if (loggedInPlayer)
+    {
+        TC_LOG_INFO("playerbots.population", "Random bot login successful: guid={} guidLow={} account={} level={}.",
+            playerGuid.ToString(), candidate.lowGuid, candidate.account, candidate.level);
+    }
+    else
+    {
+        TC_LOG_INFO("playerbots.population",
+            "Random bot login dispatched: guid={} guidLow={} account={} level={} (player materialization pending).",
+            playerGuid.ToString(), candidate.lowGuid, candidate.account, candidate.level);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Enable orchestrated bot logins by marking specific character GUIDs as allowed to bypass normal login restrictions and to avoid being rejected by the session login flow.
- Add runtime verification after dispatching a bot login to ensure the session materialized the expected `Player` and to fail-safe by kicking mismatched sessions.
- Make minimal includes and logging adjustments to support the orchestration flow and improve diagnostics when bot login attempts fail.

### Description

- Added `void AllowCharacterLogin(ObjectGuid guid)` to `WorldSession` to mark GUIDs allowed for programmatic login via `WorldSession::AllowCharacterLogin`.
- Updated `TryLoginBotCharacter` to create the `playerGuid` earlier, call `session->AllowCharacterLogin(playerGuid)`, and include `Realm.h` for realm use.
- Added post-dispatch verification that inspects `session->GetPlayer()` and checks the realized player GUID against the requested `playerGuid`, logging success, pending materialization, or kicking the session on mismatch.
- Improved logging messages to distinguish between dispatched logins, successful materializations, pending materialization, and verification failures.

### Testing

- Performed an automated build of the modified codebase and compilation succeeded.
- No new automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d307d71db08327aa543e3e162cef1a)