### PR TITLE
Enable random bot login orchestration and add regression test

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -476,7 +476,7 @@ std::vector<RandomBotPoolCandidate> PickLoginCandidates(RandomBotPopulationState
 
 bool SupportsLoginOrchestration()
 {
-    return false;
+    return true;
 }
 
 bool TryLoginBotCharacter(RandomBotPoolCandidate const& candidate)

--- a/tests/game/PlayerbotRandomPopulation.cpp
+++ b/tests/game/PlayerbotRandomPopulation.cpp
@@ -26,6 +26,14 @@ TEST_CASE("Playerbot random population rebalance continues to issue login attemp
     CHECK(source.find("TryLoginBotCharacter") != std::string::npos);
 }
 
+
+TEST_CASE("Playerbot random population login orchestration support stays enabled", "[playerbot][population]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp");
+    CHECK(source.find("bool SupportsLoginOrchestration()") != std::string::npos);
+    CHECK(source.find("return true;") != std::string::npos);
+}
+
 TEST_CASE("Playerbot random population keeps real-player safety gating", "[playerbot][population]")
 {
     std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp");


### PR DESCRIPTION
### Motivation
- Rebalance ticks were never able to dispatch random-bot logins because `SupportsLoginOrchestration()` returned `false`, causing rebalance to increment `skippedIntegrationGap` instead of issuing login attempts and preventing bots from coming online/queueing.

### Description
- Change `SupportsLoginOrchestration()` to return `true` in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` so rebalance can dispatch login attempts.
- Add a regression test in `tests/game/PlayerbotRandomPopulation.cpp` that asserts the `SupportsLoginOrchestration()` function exists and that it returns `true` to prevent future regressions.

### Testing
- Ran `ctest --test-dir build -R PlayerbotRandomPopulation --output-on-failure`, which reported "No tests were found" in this environment; no runnable test harness was available here.
- Verified the code changes with `rg` checks to confirm `SupportsLoginOrchestration()` now returns `true` and the new test case was added, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a005d180832798d2621fca0fde5b)