### PR TITLE
Support virtual (socketless) WorldSessions and enable bot login orchestration

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -115,6 +115,7 @@ WorldSession::WorldSession(uint32 id, std::string&& name, std::shared_ptr<WorldS
     m_GUIDLow(0),
     _player(nullptr),
     m_Socket(std::move(sock)),
+    m_virtualSession(!m_Socket),
     _security(sec),
     _accountId(id),
     _accountName(std::move(name)),
@@ -480,7 +481,14 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
         }
 
         if (!m_Socket)
+        {
+            // Virtual (socketless) sessions are server-driven actors (for example managed bots)
+            // and must not be culled by the disconnected-client path.
+            if (m_virtualSession && !forceExit)
+                return true;
+
             return false;                                       //Will remove this session from the world session map
+        }
     }
 
     return true;

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -442,6 +442,7 @@ class TC_GAME_API WorldSession
         bool PlayerLogoutWithSave() const { return m_playerLogout && m_playerSave; }
         bool PlayerRecentlyLoggedOut() const { return m_playerRecentlyLogout; }
         bool PlayerDisconnected() const { return !m_Socket; }
+        bool IsVirtualSession() const { return m_virtualSession; }
 
         void ReadAddonsInfo(ByteBuffer& data);
         void SendAddonsInfo();
@@ -1223,6 +1224,7 @@ class TC_GAME_API WorldSession
         ObjectGuid::LowType m_GUIDLow;                      // set logined or recently logout player (while m_playerRecentlyLogout set)
         Player* _player;
         std::shared_ptr<WorldSocket> m_Socket;
+        bool m_virtualSession;
         std::string m_Address;                              // Current Remote Address
      // std::string m_LAddress;                             // Last Attempted Remote Adress - we can not set attempted ip for a non-existing session!
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -476,7 +476,7 @@ std::vector<RandomBotPoolCandidate> PickLoginCandidates(RandomBotPopulationState
 
 bool SupportsLoginOrchestration()
 {
-    return false;
+    return true;
 }
 
 bool TryLoginBotCharacter(RandomBotPoolCandidate const& candidate)

--- a/tests/game/PlayerbotRandomPopulation.cpp
+++ b/tests/game/PlayerbotRandomPopulation.cpp
@@ -26,11 +26,27 @@ TEST_CASE("Playerbot random population rebalance continues to issue login attemp
     CHECK(source.find("TryLoginBotCharacter") != std::string::npos);
 }
 
+
+TEST_CASE("Playerbot random population login orchestration support stays enabled", "[playerbot][population]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp");
+    CHECK(source.find("bool SupportsLoginOrchestration()") != std::string::npos);
+    CHECK(source.find("return true;") != std::string::npos);
+}
+
 TEST_CASE("Playerbot random population keeps real-player safety gating", "[playerbot][population]")
 {
     std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp");
     CHECK(source.find("IsManagedRandomBot") != std::string::npos);
     CHECK(source.find("state.skippedSafetyRealPlayers++") != std::string::npos);
+}
+
+
+TEST_CASE("Socketless sessions are retained for managed bot orchestration", "[playerbot][population]")
+{
+    std::string const source = ReadFile("src/server/game/Server/WorldSession.cpp");
+    CHECK(source.find("m_virtualSession(!m_Socket)") != std::string::npos);
+    CHECK(source.find("if (m_virtualSession && !forceExit)") != std::string::npos);
 }
 
 TEST_CASE("Playerbot battleground queue target remains Warsong", "[playerbot][population]")


### PR DESCRIPTION
### Motivation
- Allow server-driven actors (managed bots) to exist as socketless sessions that should not be removed by the disconnected-client cleanup path.
- Re-enable login orchestration for the random bot population so the bot orchestration path is used when selecting and logging bots.
- Add assertions to the unit tests that ensure these safety and orchestration behaviors remain enabled.

### Description
- Introduce a `m_virtualSession` flag on `WorldSession`, set to `true` when constructed with a null socket via `m_virtualSession(!m_Socket)` and exposed with `IsVirtualSession()`.
- Preserve socketless (virtual) sessions in `WorldSession::Update` by skipping the disconnected-client removal when `m_virtualSession` is `true` and `forceExit` is not set.
- Change `SupportsLoginOrchestration()` in `PlayerbotRandomBotParticipation.cpp` to return `true` to enable orchestration-based logins.
- Add unit tests in `tests/game/PlayerbotRandomPopulation.cpp` to assert that login orchestration stays enabled and that socketless sessions are retained for managed bot orchestration.

### Testing
- Added tests in `tests/game/PlayerbotRandomPopulation.cpp` that check for `SupportsLoginOrchestration()` returning `true` and presence of the `m_virtualSession` handling, and they were executed as part of the unit test run; all checks passed.
- Existing population-related tests in the same test file were re-run and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a005d180832798d2621fca0fde5b)