### PR TITLE
Fix instant-cast aura persisting after AFK battleground leave

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22970,12 +22970,9 @@ void Player::LeaveBattleground(bool teleportToEntryPoint)
             {
                 //lets check if player was teleported from BG and schedule delayed Deserter spell cast
                 if (IsBeingTeleportedFar())
-                {
                     ScheduleDelayedOperation(DELAYED_SPELL_CAST_DESERTER);
-                    return;
-                }
-
-                CastSpell(this, 26013, true);               // Deserter
+                else
+                    CastSpell(this, 26013, true);               // Deserter
             }
         }
 


### PR DESCRIPTION
### Motivation
- Prevent an early exit in `Player::LeaveBattleground` that skipped post-leave cleanup when a far-teleport queued a delayed deserter cast, which caused `SPELL_INSTANT_CAST` (45813) to remain on the player after `/afk` leaves from battlegrounds.

### Description
- Change `Player::LeaveBattleground` to schedule `DELAYED_SPELL_CAST_DESERTER` when `IsBeingTeleportedFar()` is true but continue function execution instead of returning early, ensuring `RemoveAurasDueToSpell(SPELL_INSTANT_CAST)` still runs.

### Testing
- Ran `git diff --check` to verify no whitespace/style issues and inspected the modified `Player::LeaveBattleground` control flow, with the check succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af806bf48327bcc0d07fce80ca6b)