### PR TITLE
Playerbot: schedule BG queue updates after bot queue join

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -70,6 +70,8 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
         return false;
 
     player->AddBattlegroundQueueId(bgQueueTypeId);
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, bgQueueTypeId, bgTypeId,
+        bracketEntry->GetBracketId());
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Playerbots were being added to battleground queues without triggering matchmaking processing, which can prevent Warsong/other BG queues from popping when bots join.
- The playerbot queue-join path should mirror the normal player join flow and schedule a queue update so the Battleground manager processes the new group immediately.

### Description

- Added a call to `sBattlegroundMgr->ScheduleQueueUpdate(...)` in `QueuePlayer` (file `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`) right after `AddGroup(...)` and `player->AddBattlegroundQueueId(...)`.
- The scheduled update forwards `ginfo->ArenaMatchmakerRating`, `ginfo->ArenaType`, `bgQueueTypeId`, `bgTypeId`, and `bracketEntry->GetBracketId()` so the queue manager has the same inputs as a normal join.
- The rest of the `QueuePlayer` early-return checks and error handling are unchanged, keeping the change minimal and low-risk.

### Testing

- Invoked a build with `cmake --build build --target worldserver -j4`, which reconfigured and started compiling successfully without compiler errors in the captured output. 
- Verified the new `ScheduleQueueUpdate` call appears in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and aligns with the existing battleground join flow used elsewhere in the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af215d1c8327b9743cc4bc36ad12)