### PR TITLE
Playerbot: schedule BG queue updates and mirror battlefield accept flow for invites

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -70,6 +70,8 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
         return false;
 
     player->AddBattlegroundQueueId(bgQueueTypeId);
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, bgQueueTypeId, bgTypeId,
+        bracketEntry->GetBracketId());
     return true;
 }
 
@@ -167,7 +169,14 @@ bool AcceptMatchingInvite(Player* player, bool arenaInvite)
         }
 
         player->FinishTaxiFlight();
+        player->RemoveBattlegroundQueueId(bgQueueTypeId);
         bgQueue.RemovePlayer(player->GetGUID(), false);
+
+        // Keep parity with the normal battlefield-port flow so bots do not remain
+        // attached to stale battleground state when they accept a new invite.
+        if (Battleground* currentBattleground = player->GetBattleground())
+            currentBattleground->RemovePlayerAtLeave(player->GetGUID(), false, true);
+
         player->SetBattlegroundId(battleground->GetInstanceID(), bgTypeId);
         player->SetBGTeam(ginfo.Team);
         sBattlegroundMgr->SendToBattleground(player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId);


### PR DESCRIPTION
### Motivation

- Ensure playerbots trigger battleground matchmaking immediately when they join a queue so BG/arena queues can pop as expected.
- Prevent bots from ending up logically "online" but detached from world/battleground state after accepting an invite by mirroring the normal battlefield port flow.

### Description

- In `QueuePlayer` (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`) schedule a battleground queue update via `sBattlegroundMgr->ScheduleQueueUpdate(...)` right after `player->AddBattlegroundQueueId(...)` so the Battleground manager processes the new join immediately.
- In `AcceptMatchingInvite` (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`) remove the accepted queue id from the player with `player->RemoveBattlegroundQueueId(bgQueueTypeId)` and call `currentBattleground->RemovePlayerAtLeave(...)` if the player is attached to a stale battleground, keeping parity with the normal battlefield-port flow before sending the bot to the new instance.

### Testing

- Ran `cmake --build build --target worldserver -j4`, which reconfigured and began compiling the project and progressed through many translation units without captured compiler errors, but full build completion was not captured within the run time.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af215d1c8327b9743cc4bc36ad12)