### PR TITLE
Route battleground invite acceptance through core opcode and schedule queue updates

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -27,9 +27,12 @@
 #include "CharacterCache.h"
 #include "Log.h"
 #include "MotionMaster.h"
+#include "Opcodes.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
 
 #include <cstring>
 
@@ -70,6 +73,8 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
         return false;
 
     player->AddBattlegroundQueueId(bgQueueTypeId);
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, bgQueueTypeId, bgTypeId,
+        bracketEntry->GetBracketId());
     return true;
 }
 
@@ -148,29 +153,19 @@ bool AcceptMatchingInvite(Player* player, bool arenaInvite)
             continue;
 
         BattlegroundTypeId const bgTypeId = BattlegroundMgr::BGTemplateId(bgQueueTypeId);
-        BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
-        GroupQueueInfo ginfo;
-        if (!bgQueue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
+        uint8 const arenaType = BattlegroundMgr::BGArenaType(bgQueueTypeId);
+        if ((arenaType != 0) != arenaInvite)
             continue;
 
-        Battleground* battleground = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
-        if (!battleground)
+        WorldSession* session = player->GetSession();
+        if (!session)
             continue;
 
-        if (!player->InBattleground())
-            player->SetBattlegroundEntryPoint();
-
-        if (!player->IsAlive())
-        {
-            player->ResurrectPlayer(1.0f);
-            player->SpawnCorpseBones();
-        }
-
-        player->FinishTaxiFlight();
-        bgQueue.RemovePlayer(player->GetGUID(), false);
-        player->SetBattlegroundId(battleground->GetInstanceID(), bgTypeId);
-        player->SetBGTeam(ginfo.Team);
-        sBattlegroundMgr->SendToBattleground(player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
+        // Route invite acceptance through the core opcode handler so playerbots
+        // execute the same battlefield-port flow as real players.
+        WorldPacket packet(CMSG_BATTLEFIELD_PORT, 9);
+        packet << arenaType << uint8(0) << uint32(bgTypeId) << uint16(0) << uint8(1);
+        session->HandleBattleFieldPortOpcode(packet);
         return true;
     }
 
@@ -512,6 +507,8 @@ bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const&
         default:
             break;
     }
+
+    didExecute = AcceptMatchingInvite(player, true) || didExecute;
 
     return didExecute;
 }


### PR DESCRIPTION
### Motivation

- Ensure playerbots accept battleground invites using the same battlefield-port flow as real players to avoid inconsistencies in transport, resurrection, and battleground entry logic.
- Guarantee battleground queue state is propagated to the matchmaker after adding a player to a queue.
- Add missing includes required for opcode-based handling and packet construction.

### Description

- Added includes for `Opcodes.h`, `WorldPacket.h`, and `WorldSession.h` to support opcode routing and packet handling.
- In `QueuePlayer` call `sBattlegroundMgr->ScheduleQueueUpdate(...)` after adding a player to schedule matchmaker updates for the new queue entry.
- Reworked `AcceptMatchingInvite` to validate `arenaType` and route invite acceptance through a constructed `WorldPacket` containing `CMSG_BATTLEFIELD_PORT` and call `session->HandleBattleFieldPortOpcode(packet)` instead of performing manual battleground transfers and state changes.
- Added a call to `AcceptMatchingInvite(player, true)` inside `ArenaLifecycleActions::Execute` so arena invite acceptance is attempted as part of the arena lifecycle execution.

### Testing

- Project was built successfully after the changes with no compile errors.
- Ran the automated unit test suite and PvP integration tests exercising battleground queueing and invite acceptance, and they passed.
- Verified invite acceptance flow routing via the opcode handler in local integration checks and observed correct battleground entry behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af215d1c8327b9743cc4bc36ad12)