### PR TITLE
Improve battleground queue eligibility and arena invite handling for playerbots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -27,9 +27,12 @@
 #include "CharacterCache.h"
 #include "Log.h"
 #include "MotionMaster.h"
+#include "Opcodes.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
 
 #include <cstring>
 
@@ -50,7 +53,10 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     if (!bgTemplate)
         return false;
 
-    if (!player->CanJoinToBattleground(bgTemplate) || !player->HasFreeBattlegroundQueueId())
+    // Managed random bots can run on disconnected virtual sessions where RBAC
+    // battleground permissions are not always populated like live client sessions.
+    // Gate queue eligibility by battleground level + free queue slots instead.
+    if (!player->GetBGAccessByLevel(bgTypeId) || !player->HasFreeBattlegroundQueueId())
         return false;
 
     BattlegroundQueueTypeId const bgQueueTypeId = BattlegroundMgr::BGQueueTypeId(bgTypeId, arenaType);
@@ -70,6 +76,8 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
         return false;
 
     player->AddBattlegroundQueueId(bgQueueTypeId);
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, bgQueueTypeId, bgTypeId,
+        bracketEntry->GetBracketId());
     return true;
 }
 
@@ -148,29 +156,36 @@ bool AcceptMatchingInvite(Player* player, bool arenaInvite)
             continue;
 
         BattlegroundTypeId const bgTypeId = BattlegroundMgr::BGTemplateId(bgQueueTypeId);
+        uint8 const arenaType = BattlegroundMgr::BGArenaType(bgQueueTypeId);
+        if ((arenaType != 0) != arenaInvite)
+            continue;
+
         BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
         GroupQueueInfo ginfo;
         if (!bgQueue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
             continue;
 
-        Battleground* battleground = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
-        if (!battleground)
-            continue;
-
-        if (!player->InBattleground())
-            player->SetBattlegroundEntryPoint();
-
-        if (!player->IsAlive())
+        BattlegroundTypeId packetBgTypeId = bgTypeId;
+        if (arenaType != 0)
         {
-            player->ResurrectPlayer(1.0f);
-            player->SpawnCorpseBones();
+            // Arena invites can target dynamic map-specific arena templates rather
+            // than BATTLEGROUND_AA; resolve the invited instance type first.
+            Battleground* invited = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, BATTLEGROUND_TYPE_NONE);
+            if (!invited)
+                continue;
+
+            packetBgTypeId = invited->GetTypeID();
         }
 
-        player->FinishTaxiFlight();
-        bgQueue.RemovePlayer(player->GetGUID(), false);
-        player->SetBattlegroundId(battleground->GetInstanceID(), bgTypeId);
-        player->SetBGTeam(ginfo.Team);
-        sBattlegroundMgr->SendToBattleground(player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
+        WorldSession* session = player->GetSession();
+        if (!session)
+            continue;
+
+        // Queue the opcode packet to mirror the reference module flow and avoid
+        // processing invite acceptance inline during AI update iteration.
+        WorldPacket packet(CMSG_BATTLEFIELD_PORT, 20);
+        packet << arenaType << uint8(0) << uint32(packetBgTypeId) << uint16(0x1F90) << uint8(1);
+        session->QueuePacket(new WorldPacket(packet));
         return true;
     }
 
@@ -512,6 +527,8 @@ bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const&
         default:
             break;
     }
+
+    didExecute = AcceptMatchingInvite(player, true) || didExecute;
 
     return didExecute;
 }


### PR DESCRIPTION
### Motivation
- Ensure managed/random playerbots can reliably queue for battlegrounds even when client-like RBAC permissions are unavailable. 
- Prevent inline invite acceptance during AI update iterations and ensure arena invites target the correct dynamic arena instance. 
- Align playerbot battleground lifecycle flow with server packet-based invite handling to avoid inconsistent player state changes.

### Description
- Added necessary headers (`Opcodes.h`, `WorldPacket.h`, `WorldSession.h`) and adjusted includes to support packet-based invite queuing. 
- Changed `QueuePlayer` eligibility check from `CanJoinToBattleground` to `GetBGAccessByLevel` and added a call to `sBattlegroundMgr->ScheduleQueueUpdate(...)` after adding a group to the queue. 
- Reworked `AcceptMatchingInvite` to resolve arena instance templates for arena invites, verify `WorldSession` presence, and queue a `CMSG_BATTLEFIELD_PORT` `WorldPacket` via `session->QueuePacket(...)` instead of performing direct `SendToBattleground` and immediate player state mutations. 
- Added invocation of `AcceptMatchingInvite(player, true)` in `ArenaLifecycleActions::Execute` to process arena invite acceptance as part of the lifecycle step.

### Testing
- Built the server with the changes applied and the project compiled successfully. 
- Ran the automated PVP-related unit/integration tests exercising battleground queue and arena invite flows and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af215d1c8327b9743cc4bc36ad12)