### PR TITLE
Improve playerbot PvP queue/invite handling and reorder lifecycle execution

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -27,9 +27,12 @@
 #include "CharacterCache.h"
 #include "Log.h"
 #include "MotionMaster.h"
+#include "Opcodes.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
 
 #include <cstring>
 
@@ -50,7 +53,10 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     if (!bgTemplate)
         return false;
 
-    if (!player->CanJoinToBattleground(bgTemplate) || !player->HasFreeBattlegroundQueueId())
+    // Managed random bots can run on disconnected virtual sessions where RBAC
+    // battleground permissions are not always populated like live client sessions.
+    // Gate queue eligibility by battleground level + free queue slots instead.
+    if (!player->GetBGAccessByLevel(bgTypeId) || !player->HasFreeBattlegroundQueueId())
         return false;
 
     BattlegroundQueueTypeId const bgQueueTypeId = BattlegroundMgr::BGQueueTypeId(bgTypeId, arenaType);
@@ -70,6 +76,8 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
         return false;
 
     player->AddBattlegroundQueueId(bgQueueTypeId);
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, bgQueueTypeId, bgTypeId,
+        bracketEntry->GetBracketId());
     return true;
 }
 
@@ -148,29 +156,36 @@ bool AcceptMatchingInvite(Player* player, bool arenaInvite)
             continue;
 
         BattlegroundTypeId const bgTypeId = BattlegroundMgr::BGTemplateId(bgQueueTypeId);
+        uint8 const arenaType = BattlegroundMgr::BGArenaType(bgQueueTypeId);
+        if ((arenaType != 0) != arenaInvite)
+            continue;
+
         BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
         GroupQueueInfo ginfo;
         if (!bgQueue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
             continue;
 
-        Battleground* battleground = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
-        if (!battleground)
-            continue;
-
-        if (!player->InBattleground())
-            player->SetBattlegroundEntryPoint();
-
-        if (!player->IsAlive())
+        BattlegroundTypeId packetBgTypeId = bgTypeId;
+        if (arenaType != 0)
         {
-            player->ResurrectPlayer(1.0f);
-            player->SpawnCorpseBones();
+            // Arena invites can target dynamic map-specific arena templates rather
+            // than BATTLEGROUND_AA; resolve the invited instance type first.
+            Battleground* invited = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, BATTLEGROUND_TYPE_NONE);
+            if (!invited)
+                continue;
+
+            packetBgTypeId = invited->GetTypeID();
         }
 
-        player->FinishTaxiFlight();
-        bgQueue.RemovePlayer(player->GetGUID(), false);
-        player->SetBattlegroundId(battleground->GetInstanceID(), bgTypeId);
-        player->SetBGTeam(ginfo.Team);
-        sBattlegroundMgr->SendToBattleground(player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
+        WorldSession* session = player->GetSession();
+        if (!session)
+            continue;
+
+        // Queue the opcode packet to mirror the reference module flow and avoid
+        // processing invite acceptance inline during AI update iteration.
+        WorldPacket packet(CMSG_BATTLEFIELD_PORT, 20);
+        packet << arenaType << uint8(0) << uint32(packetBgTypeId) << uint16(0x1F90) << uint8(1);
+        session->QueuePacket(new WorldPacket(packet));
         return true;
     }
 
@@ -512,6 +527,8 @@ bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const&
         default:
             break;
     }
+
+    didExecute = AcceptMatchingInvite(player, true) || didExecute;
 
     return didExecute;
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -884,24 +884,34 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         return;
     }
 
-    BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
-    ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
-    if (IsNoOp(battlegroundContext) && IsNoOp(arenaContext))
+    bool didExecuteBattleground = false;
+    bool didExecuteArena = false;
+
+    if (hooks.battlegroundParticipationHook)
+    {
+        BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
+        if (!IsNoOp(battlegroundContext))
+            didExecuteBattleground = BattlegroundLifecycleActions::Execute(player, battlegroundContext);
+    }
+
+    // Re-sample lifecycle values after battleground execution so arena decisions
+    // are based on current queue/invite state and do not operate on stale data.
+    PvpValues const postBattlegroundValues = PvpCore::CollectValues(player);
+    RandomBotParticipationHooks const postBattlegroundHooks = PvpCore::BuildRandomBotParticipationHooks(player, postBattlegroundValues);
+    if (postBattlegroundHooks.arenaParticipationHook)
+    {
+        ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, postBattlegroundValues);
+        if (!IsNoOp(arenaContext))
+            didExecuteArena = ArenaLifecycleActions::Execute(player, arenaContext);
+    }
+
+    if (!didExecuteBattleground && !didExecuteArena)
     {
         LogLifecycleBranchSummary(guid, "active-hooks-no-op-context");
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle dispatcher no-op with active hooks: guid={}, bgHook={}, arenaHook={}.",
             guid.ToString(), hooks.battlegroundParticipationHook ? 1 : 0, hooks.arenaParticipationHook ? 1 : 0);
-        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteTactical={}, didExecuteClassSpell={}.",
-            guid.ToString(), didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
-        return;
     }
-
-    bool const didExecuteBattleground = hooks.battlegroundParticipationHook &&
-        BattlegroundLifecycleActions::Execute(player, battlegroundContext);
-    bool const didExecuteArena = hooks.arenaParticipationHook &&
-        ArenaLifecycleActions::Execute(player, arenaContext);
 
     if (didExecuteBattleground)
     {


### PR DESCRIPTION
### Motivation
- Ensure managed random bots can queue for battlegrounds when running on disconnected/virtual sessions and avoid stale arena decisions after battleground processing.
- Make acceptance of battleground/arena invites more robust and defer side-effectful invite acceptance to the session packet queue to avoid inline processing during AI updates.
- Recompute arena lifecycle inputs after battleground actions so arena decisions reflect current queue/invite state.

### Description
- Replace `CanJoinToBattleground` gating with `GetBGAccessByLevel` in `QueuePlayer` and add a call to `sBattlegroundMgr->ScheduleQueueUpdate` after adding a group to the queue.
- Update `AcceptMatchingInvite` to properly handle arena vs non-arena invitations by resolving the invited instance type, require a valid `WorldSession`, and queue a `CMSG_BATTLEFIELD_PORT` `WorldPacket` to the session instead of performing direct battleground transfers inline; add necessary includes (`Opcodes.h`, `WorldPacket.h`, `WorldSession.h`).
- Invoke `AcceptMatchingInvite(player, true)` from `ArenaLifecycleActions::Execute` so arena invite acceptance is considered during arena lifecycle execution.
- Rework `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint` to execute battleground lifecycle first, re-collect `PvpValues`, and then execute arena lifecycle so arena decisions are based on updated state, and track `didExecuteBattleground`/`didExecuteArena` flags for clearer logging.

### Testing
- Project compiled successfully with the modified files using the existing build system (`cmake`/`make`).
- Ran automated unit and integration tests related to PvP and playerbot lifecycle (CI test suite), and no regressions were detected.
- Performed automated smoke tests for lifecycle dispatcher paths to validate that battleground enqueueing and invite packet queuing occur without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af215d1c8327b9743cc4bc36ad12)