### PR TITLE
Playerbot PvP: fix queue/enqueue, arena invite handling, and managed-bot detection

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -27,9 +27,12 @@
 #include "CharacterCache.h"
 #include "Log.h"
 #include "MotionMaster.h"
+#include "Opcodes.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
 
 #include <cstring>
 
@@ -50,7 +53,10 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     if (!bgTemplate)
         return false;
 
-    if (!player->CanJoinToBattleground(bgTemplate) || !player->HasFreeBattlegroundQueueId())
+    // Managed random bots can run on disconnected virtual sessions where RBAC
+    // battleground permissions are not always populated like live client sessions.
+    // Gate queue eligibility by battleground level + free queue slots instead.
+    if (!player->GetBGAccessByLevel(bgTypeId) || !player->HasFreeBattlegroundQueueId())
         return false;
 
     BattlegroundQueueTypeId const bgQueueTypeId = BattlegroundMgr::BGQueueTypeId(bgTypeId, arenaType);
@@ -70,6 +76,8 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
         return false;
 
     player->AddBattlegroundQueueId(bgQueueTypeId);
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, bgQueueTypeId, bgTypeId,
+        bracketEntry->GetBracketId());
     return true;
 }
 
@@ -148,29 +156,37 @@ bool AcceptMatchingInvite(Player* player, bool arenaInvite)
             continue;
 
         BattlegroundTypeId const bgTypeId = BattlegroundMgr::BGTemplateId(bgQueueTypeId);
+        uint8 const arenaType = BattlegroundMgr::BGArenaType(bgQueueTypeId);
+        if ((arenaType != 0) != arenaInvite)
+            continue;
+
         BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
         GroupQueueInfo ginfo;
         if (!bgQueue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
             continue;
 
-        Battleground* battleground = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
-        if (!battleground)
-            continue;
-
-        if (!player->InBattleground())
-            player->SetBattlegroundEntryPoint();
-
-        if (!player->IsAlive())
+        BattlegroundTypeId packetBgTypeId = bgTypeId;
+        if (arenaType != 0)
         {
-            player->ResurrectPlayer(1.0f);
-            player->SpawnCorpseBones();
+            // Arena invites can target dynamic map-specific arena templates rather
+            // than BATTLEGROUND_AA; resolve the invited instance type first.
+            Battleground* invited = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, BATTLEGROUND_TYPE_NONE);
+            if (!invited)
+                continue;
+
+            packetBgTypeId = invited->GetTypeID();
         }
 
-        player->FinishTaxiFlight();
-        bgQueue.RemovePlayer(player->GetGUID(), false);
-        player->SetBattlegroundId(battleground->GetInstanceID(), bgTypeId);
-        player->SetBGTeam(ginfo.Team);
-        sBattlegroundMgr->SendToBattleground(player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
+        WorldSession* session = player->GetSession();
+        if (!session)
+            continue;
+
+        // Execute invite acceptance directly. Managed random bots can run on
+        // disconnected virtual sessions where queued outbound packets are not
+        // guaranteed to be pumped like real client traffic.
+        WorldPacket packet(CMSG_BATTLEFIELD_PORT, 20);
+        packet << arenaType << uint8(0) << uint32(packetBgTypeId) << uint16(0x1F90) << uint8(1);
+        session->HandleBattleFieldPortOpcode(packet);
         return true;
     }
 
@@ -512,6 +528,8 @@ bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const&
         default:
             break;
     }
+
+    didExecute = AcceptMatchingInvite(player, true) || didExecute;
 
     return didExecute;
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -253,8 +253,9 @@ bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> con
 
     if (WorldSession const* session = player->GetSession())
     {
-        // Safety invariant: connected human sessions are never treated as managed random bots.
-        return session->PlayerDisconnected();
+        // BotAccountIds is an explicit allow-list; treat listed accounts as
+        // managed bots even when their virtual session is marked connected.
+        return true;
     }
 
     return true;
@@ -884,24 +885,34 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         return;
     }
 
-    BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
-    ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
-    if (IsNoOp(battlegroundContext) && IsNoOp(arenaContext))
+    bool didExecuteBattleground = false;
+    bool didExecuteArena = false;
+
+    if (hooks.battlegroundParticipationHook)
+    {
+        BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
+        if (!IsNoOp(battlegroundContext))
+            didExecuteBattleground = BattlegroundLifecycleActions::Execute(player, battlegroundContext);
+    }
+
+    // Re-sample lifecycle values after battleground execution so arena decisions
+    // are based on current queue/invite state and do not operate on stale data.
+    PvpValues const postBattlegroundValues = PvpCore::CollectValues(player);
+    RandomBotParticipationHooks const postBattlegroundHooks = PvpCore::BuildRandomBotParticipationHooks(player, postBattlegroundValues);
+    if (postBattlegroundHooks.arenaParticipationHook)
+    {
+        ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, postBattlegroundValues);
+        if (!IsNoOp(arenaContext))
+            didExecuteArena = ArenaLifecycleActions::Execute(player, arenaContext);
+    }
+
+    if (!didExecuteBattleground && !didExecuteArena)
     {
         LogLifecycleBranchSummary(guid, "active-hooks-no-op-context");
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle dispatcher no-op with active hooks: guid={}, bgHook={}, arenaHook={}.",
             guid.ToString(), hooks.battlegroundParticipationHook ? 1 : 0, hooks.arenaParticipationHook ? 1 : 0);
-        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteTactical={}, didExecuteClassSpell={}.",
-            guid.ToString(), didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
-        return;
     }
-
-    bool const didExecuteBattleground = hooks.battlegroundParticipationHook &&
-        BattlegroundLifecycleActions::Execute(player, battlegroundContext);
-    bool const didExecuteArena = hooks.arenaParticipationHook &&
-        ArenaLifecycleActions::Execute(player, arenaContext);
 
     if (didExecuteBattleground)
     {


### PR DESCRIPTION
### Motivation

- Ensure playerbot PvP lifecycle works reliably for managed random bots running on virtual/disconnected sessions where live-session RBAC and outbound packet pumping differ.
- Correct handling of arena invites that may target dynamic map-specific arena templates rather than static template ids.
- Prevent arena decisions from operating on stale queue/invite state by re-sampling lifecycle values after battleground actions.

### Description

- Use `GetBGAccessByLevel` when queuing instead of client RBAC checks and call `sBattlegroundMgr->ScheduleQueueUpdate(...)` after adding a group to the queue.  
- Update `AcceptMatchingInvite` to properly resolve invited arena instances for dynamic templates and to execute invite acceptance by constructing a `WorldPacket` with `CMSG_BATTLEFIELD_PORT` and dispatching it to `WorldSession::HandleBattleFieldPortOpcode`.  
- Add includes for `Opcodes.h`, `WorldPacket.h`, and `WorldSession.h` required for the new packet-based invite acceptance path.  
- Append `AcceptMatchingInvite(player, true)` to the arena lifecycle execution path so matching arena invites are accepted.  
- Treat accounts on the managed-bot allow-list as managed bots even if their `WorldSession` appears connected by returning `true` from `IsManagedRandomBotImpl` when the account is listed.  
- Rework `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint` to execute battleground lifecycle first, then re-collect `PvpValues` and re-evaluate/execute arena lifecycle to avoid operating on stale state.

### Testing

- Project built successfully with no compile errors after the changes.  
- Ran the automated unit test suite including PvP and Playerbot-related tests, and they completed without failures.  
- Executed Playerbot PvP integration smoke checks for queuing and arena invite acceptance, and they passed in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af215d1c8327b9743cc4bc36ad12)