### PR TITLE
pvp: diagnostics, robust invite/queue handling, and sequential lifecycle execution for managed bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -25,13 +25,18 @@
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "CharacterCache.h"
+#include "Chat.h"
 #include "Log.h"
 #include "MotionMaster.h"
+#include "Opcodes.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
 
 #include <cstring>
+#include <sstream>
 
 namespace
 {
@@ -39,6 +44,22 @@ bool IsLifecycleGateEnabled()
 {
     playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
+}
+
+void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string const& detail)
+{
+    if (!player || !phase)
+        return;
+
+    std::ostringstream oss;
+    oss << "[Playerbot PvP][" << phase << "] bot=" << player->GetName() << " guid=" << player->GetGUID().ToString()
+        << " map=" << player->GetMapId() << " detail=" << detail;
+    std::string const message = oss.str();
+
+    TC_LOG_WARN("playerbots.pvp.lifecycle", "{}", message);
+
+    if (WorldSession* session = player->GetSession())
+        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
 }
 
 bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
@@ -50,7 +71,10 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     if (!bgTemplate)
         return false;
 
-    if (!player->CanJoinToBattleground(bgTemplate) || !player->HasFreeBattlegroundQueueId())
+    // Managed random bots can run on disconnected virtual sessions where RBAC
+    // battleground permissions are not always populated like live client sessions.
+    // Gate queue eligibility by battleground level + free queue slots instead.
+    if (!player->GetBGAccessByLevel(bgTypeId) || !player->HasFreeBattlegroundQueueId())
         return false;
 
     BattlegroundQueueTypeId const bgQueueTypeId = BattlegroundMgr::BGQueueTypeId(bgTypeId, arenaType);
@@ -67,9 +91,16 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
     GroupQueueInfo* ginfo = bgQueue.AddGroup(player, nullptr, bgTypeId, bracketEntry, arenaType, false, false, 0, 0);
     if (!ginfo)
+    {
+        EmitLifecycleDiagnostic(player, "queue-add-failed", "BattlegroundQueue::AddGroup returned null.");
         return false;
+    }
 
     player->AddBattlegroundQueueId(bgQueueTypeId);
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, bgQueueTypeId, bgTypeId,
+        bracketEntry->GetBracketId());
+    EmitLifecycleDiagnostic(player, "queue-add-success",
+        "Queued for bgTypeId=" + std::to_string(uint32(bgTypeId)) + " queueTypeId=" + std::to_string(uint32(bgQueueTypeId)));
     return true;
 }
 
@@ -148,29 +179,66 @@ bool AcceptMatchingInvite(Player* player, bool arenaInvite)
             continue;
 
         BattlegroundTypeId const bgTypeId = BattlegroundMgr::BGTemplateId(bgQueueTypeId);
+        uint8 const arenaType = BattlegroundMgr::BGArenaType(bgQueueTypeId);
+        if ((arenaType != 0) != arenaInvite)
+            continue;
+
         BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
         GroupQueueInfo ginfo;
         if (!bgQueue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
-            continue;
-
-        Battleground* battleground = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
-        if (!battleground)
-            continue;
-
-        if (!player->InBattleground())
-            player->SetBattlegroundEntryPoint();
-
-        if (!player->IsAlive())
         {
-            player->ResurrectPlayer(1.0f);
-            player->SpawnCorpseBones();
+            EmitLifecycleDiagnostic(player, "invite-missing-group-info",
+                "No GroupQueueInfo for queueTypeId=" + std::to_string(uint32(bgQueueTypeId)));
+            continue;
         }
 
-        player->FinishTaxiFlight();
-        bgQueue.RemovePlayer(player->GetGUID(), false);
-        player->SetBattlegroundId(battleground->GetInstanceID(), bgTypeId);
-        player->SetBGTeam(ginfo.Team);
-        sBattlegroundMgr->SendToBattleground(player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
+        BattlegroundTypeId packetBgTypeId = bgTypeId;
+        if (arenaType != 0)
+        {
+            // Arena invites can target dynamic map-specific arena templates rather
+            // than BATTLEGROUND_AA; resolve the invited instance type first.
+            Battleground* invited = sBattlegroundMgr->GetBattleground(ginfo.IsInvitedToBGInstanceGUID, BATTLEGROUND_TYPE_NONE);
+            if (!invited)
+            {
+                EmitLifecycleDiagnostic(player, "invite-arena-instance-missing",
+                    "No invited arena instance for guid=" + std::to_string(ginfo.IsInvitedToBGInstanceGUID));
+                continue;
+            }
+
+            packetBgTypeId = invited->GetTypeID();
+        }
+
+        WorldSession* session = player->GetSession();
+        if (!session)
+        {
+            EmitLifecycleDiagnostic(player, "invite-no-session", "WorldSession is null.");
+            continue;
+        }
+
+        // Execute invite acceptance directly. Managed random bots can run on
+        // disconnected virtual sessions where queued outbound packets are not
+        // guaranteed to be pumped like real client traffic.
+        WorldPacket packet(CMSG_BATTLEFIELD_PORT, 20);
+        packet << arenaType << uint8(0) << uint32(packetBgTypeId) << uint16(0x1F90) << uint8(1);
+        session->HandleBattleFieldPortOpcode(packet);
+
+        if (player->IsBeingTeleportedFar())
+        {
+            EmitLifecycleDiagnostic(player, "invite-accept-far-teleport-pending",
+                "Issuing server-side HandleMoveWorldportAck for bot teleport finalization.");
+            session->HandleMoveWorldportAck();
+        }
+
+        if (!player->InBattleground() && !player->IsBeingTeleported())
+        {
+            EmitLifecycleDiagnostic(player, "invite-accept-no-transition",
+                "HandleBattleFieldPortOpcode did not transition to battleground/teleport.");
+        }
+        else
+        {
+            EmitLifecycleDiagnostic(player, "invite-accept-transition",
+                "Accepted invite for bgTypeId=" + std::to_string(uint32(packetBgTypeId)));
+        }
         return true;
     }
 
@@ -512,6 +580,8 @@ bool ArenaLifecycleActions::Execute(Player* player, ArenaLifecycleContext const&
         default:
             break;
     }
+
+    didExecute = AcceptMatchingInvite(player, true) || didExecute;
 
     return didExecute;
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -253,8 +253,9 @@ bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> con
 
     if (WorldSession const* session = player->GetSession())
     {
-        // Safety invariant: connected human sessions are never treated as managed random bots.
-        return session->PlayerDisconnected();
+        // BotAccountIds is an explicit allow-list; treat listed accounts as
+        // managed bots even when their virtual session is marked connected.
+        return true;
     }
 
     return true;
@@ -884,24 +885,34 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         return;
     }
 
-    BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
-    ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, values);
-    if (IsNoOp(battlegroundContext) && IsNoOp(arenaContext))
+    bool didExecuteBattleground = false;
+    bool didExecuteArena = false;
+
+    if (hooks.battlegroundParticipationHook)
+    {
+        BattlegroundLifecycleContext const battlegroundContext = PvpCore::BuildBattlegroundLifecycleContext(player, values);
+        if (!IsNoOp(battlegroundContext))
+            didExecuteBattleground = BattlegroundLifecycleActions::Execute(player, battlegroundContext);
+    }
+
+    // Re-sample lifecycle values after battleground execution so arena decisions
+    // are based on current queue/invite state and do not operate on stale data.
+    PvpValues const postBattlegroundValues = PvpCore::CollectValues(player);
+    RandomBotParticipationHooks const postBattlegroundHooks = PvpCore::BuildRandomBotParticipationHooks(player, postBattlegroundValues);
+    if (postBattlegroundHooks.arenaParticipationHook)
+    {
+        ArenaLifecycleContext const arenaContext = PvpCore::BuildArenaLifecycleContext(player, postBattlegroundValues);
+        if (!IsNoOp(arenaContext))
+            didExecuteArena = ArenaLifecycleActions::Execute(player, arenaContext);
+    }
+
+    if (!didExecuteBattleground && !didExecuteArena)
     {
         LogLifecycleBranchSummary(guid, "active-hooks-no-op-context");
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle dispatcher no-op with active hooks: guid={}, bgHook={}, arenaHook={}.",
             guid.ToString(), hooks.battlegroundParticipationHook ? 1 : 0, hooks.arenaParticipationHook ? 1 : 0);
-        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteTactical={}, didExecuteClassSpell={}.",
-            guid.ToString(), didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
-        return;
     }
-
-    bool const didExecuteBattleground = hooks.battlegroundParticipationHook &&
-        BattlegroundLifecycleActions::Execute(player, battlegroundContext);
-    bool const didExecuteArena = hooks.arenaParticipationHook &&
-        ArenaLifecycleActions::Execute(player, arenaContext);
 
     if (didExecuteBattleground)
     {


### PR DESCRIPTION
### Motivation

- Improve observability for Playerbot PvP lifecycle operations to aid debugging of queue/invite failures.
- Make queue and invite handling more robust for managed random bots that run on virtual or disconnected sessions.
- Ensure arena decisions operate on up-to-date state by executing battleground lifecycle first and re-sampling values before arena processing.

### Description

- Add `EmitLifecycleDiagnostic` to emit lifecycle diagnostics to log and GM chat and sprinkle diagnostic calls across queue/invite code paths.
- Change `QueuePlayer` to gate by `GetBGAccessByLevel` instead of `CanJoinToBattleground`, schedule battleground queue updates, and log success/failure conditions.
- Harden `AcceptMatchingInvite` to resolve arena instance types, validate `WorldSession`, synthesize and dispatch a `CMSG_BATTLEFIELD_PORT` packet, handle teleport finalization via `HandleMoveWorldportAck`, and emit diagnostics for major outcomes.
- Treat configured bot account IDs as managed bots even when their `WorldSession` appears connected by returning `true` from `IsManagedRandomBotImpl` for listed accounts.
- Execute battleground lifecycle first, then re-collect `PvpValues` and re-evaluate/execute arena lifecycle to avoid operating on stale queue/invite state.
- Add required includes (`Chat.h`, `Opcodes.h`, `WorldPacket.h`, `WorldSession.h`, `<sstream>`) and a small `ArenaLifecycleActions` tweak to call `AcceptMatchingInvite` for arena invites.

### Testing

- Performed a local project build with `cmake --build` which completed successfully.
- Ran the automated test suite with `ctest` and observed no failing tests related to the modified PvP lifecycle paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af215d1c8327b9743cc4bc36ad12)