### PR TITLE
Playerbot PvP: class-aware combat shell positioning and LOS recovery

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -17,6 +17,7 @@
 
 #include "PlayerbotPvpClassActions.h"
 
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
@@ -25,7 +26,7 @@
 
 namespace
 {
-bool CastDirectSpell(Player* player, uint32 spellId, bool selfCast)
+bool CastDirectSpell(Player* player, uint32 spellId, bool selfCast, ObjectGuid const& targetGuid)
 {
     if (!player || !spellId || !player->HasSpell(spellId))
         return false;
@@ -40,6 +41,12 @@ bool CastDirectSpell(Player* player, uint32 spellId, bool selfCast)
         return false;
 
     Unit* target = selfCast ? static_cast<Unit*>(player) : player->GetVictim();
+    if (!selfCast && !targetGuid.IsEmpty())
+    {
+        if (Unit* explicitTarget = ObjectAccessor::GetUnit(*player, targetGuid))
+            target = explicitTarget;
+    }
+
     if (!target || !target->IsAlive())
         return false;
     if (selfCast && target != player)
@@ -83,6 +90,6 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
     if (!player || !context.classSpellsEnabled || !context.shouldExecute)
         return false;
 
-    return CastDirectSpell(player, context.spellId, context.selfCast);
+    return CastDirectSpell(player, context.spellId, context.selfCast, context.targetGuid);
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -554,21 +554,36 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         return context;
 
     Unit const* target = player->GetVictim();
-    bool const hasValidVictim = target && target->IsAlive() && target->GetGUID() != player->GetGUID();
-    bool const inMelee = hasValidVictim && player->IsWithinMeleeRange(target);
+    bool hasValidTarget = target && target->IsAlive() && target->GetGUID() != player->GetGUID();
+    if (!hasValidTarget)
+    {
+        ObjectGuid const selectedGuid = player->GetSelection();
+        if (!selectedGuid.IsEmpty())
+        {
+            if (Unit const* selectedTarget = ObjectAccessor::GetUnit(*player, selectedGuid))
+            {
+                target = selectedTarget;
+                hasValidTarget = target->IsAlive() && target->GetGUID() != player->GetGUID();
+            }
+        }
+    }
+
+    bool const inMelee = hasValidTarget && player->IsWithinMeleeRange(target);
     ClassicProfileSelection const profileSelection = DetectClassicClassProfile(player);
 
-    SpellDecision const decision = SelectClassicClassSpell(player, hasValidVictim ? target : nullptr, inMelee, profileSelection);
+    SpellDecision const decision = SelectClassicClassSpell(player, hasValidTarget ? target : nullptr, inMelee, profileSelection);
 
     context.actionName = decision.actionName;
     context.spellId = decision.spellId;
     context.selfCast = decision.selfCast;
+    context.targetGuid = hasValidTarget ? target->GetGUID() : ObjectGuid::Empty;
     context.shouldExecute = context.spellId != 0;
 
     TC_LOG_DEBUG("playerbots.pvp.class",
-        "Playerbot PvP Classic scaffold: class={} profile={} fallback={} unsupported={} wrath_path_replaced={} has_victim={} spell={} action={}.",
+        "Playerbot PvP Classic scaffold: class={} profile={} fallback={} unsupported={} wrath_path_replaced={} has_target={} target_guid={} spell={} action={}.",
         GetClassLabel(player->GetClass()), profileSelection.profileLabel, profileSelection.usedFallback,
-        profileSelection.unsupportedClass, true, hasValidVictim, context.spellId, context.actionName ? context.actionName : "none");
+        profileSelection.unsupportedClass, true, hasValidTarget, context.targetGuid.ToString(),
+        context.spellId, context.actionName ? context.actionName : "none");
     return context;
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -142,6 +142,7 @@ struct PvpClassSpellContext
     char const* actionName = nullptr;
     uint32 spellId = 0;
     bool selfCast = false;
+    ObjectGuid targetGuid = ObjectGuid::Empty;
 };
 
 struct BattlegroundLifecycleContext

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -38,6 +38,7 @@
 #include "Util.h"
 
 #include <cstring>
+#include <cmath>
 #include <limits>
 #include <sstream>
 
@@ -265,6 +266,74 @@ bool IsTacticalAction(char const* actionName, char const* expected)
     return actionName && expected && std::strcmp(actionName, expected) == 0;
 }
 
+struct CombatPositioningProfile
+{
+    float preferredMinRange = 0.0f;
+    float preferredIdealRange = 0.0f;
+    float preferredMaxPressureRange = 0.0f;
+    bool primarilyRanged = false;
+    bool createDistanceWhenCrowded = false;
+    bool meleeFallbackAcceptable = true;
+    char const* label = "default";
+};
+
+CombatPositioningProfile GetCombatPositioningProfile(Player const* player)
+{
+    if (!player)
+        return {};
+
+    switch (player->GetClass())
+    {
+        case CLASS_HUNTER: return { 8.0f, 28.0f, 38.0f, true, true, false, "hunter-ranged" };
+        case CLASS_MAGE: return { 12.0f, 27.0f, 36.0f, true, true, false, "mage-ranged" };
+        case CLASS_PRIEST: return { 10.0f, 25.0f, 34.0f, true, true, false, "priest-ranged" };
+        case CLASS_WARLOCK: return { 10.0f, 26.0f, 35.0f, true, true, false, "warlock-ranged" };
+        case CLASS_WARRIOR: return { 0.0f, 1.5f, 5.0f, false, false, true, "warrior-melee" };
+        case CLASS_ROGUE: return { 0.0f, 1.5f, 5.0f, false, false, true, "rogue-melee" };
+        case CLASS_PALADIN: return { 0.0f, 3.0f, 8.0f, false, false, true, "paladin-hybrid" };
+        case CLASS_SHAMAN: return { 5.0f, 20.0f, 30.0f, true, true, true, "shaman-hybrid" };
+        case CLASS_DRUID: return { 4.0f, 18.0f, 28.0f, true, true, true, "druid-hybrid" };
+        default: return { 0.0f, 3.0f, 8.0f, false, false, true, "default-melee" };
+    }
+}
+
+bool MoveAwayFromUnit(Player* player, Unit* target, float desiredDistance)
+{
+    if (!player || !target)
+        return false;
+
+    float const angleAway = target->GetAngle(player);
+    float const currentDistance = player->GetDistance(target);
+    float const moveDistance = std::max(4.0f, desiredDistance - currentDistance + 2.0f);
+
+    Position destination(player->GetPositionX() + std::cos(angleAway) * moveDistance,
+        player->GetPositionY() + std::sin(angleAway) * moveDistance,
+        player->GetPositionZ(), player->GetOrientation());
+    player->GetMotionMaster()->MovePoint(0, destination);
+    return true;
+}
+
+bool TryRecoverLineOfSight(Player* player, Unit* target, CombatPositioningProfile const& profile, char const* reason)
+{
+    if (!player || !target || !target->IsAlive())
+        return false;
+
+    if (player->IsWithinLOSInMap(target))
+        return false;
+
+    float const orbitAngle = target->GetAngle(player) + frand(-0.85f, 0.85f);
+    float const orbitRange = std::max(profile.preferredMinRange + 2.0f, profile.preferredIdealRange);
+    Position reposition(target->GetPositionX() + std::cos(orbitAngle) * orbitRange,
+        target->GetPositionY() + std::sin(orbitAngle) * orbitRange,
+        target->GetPositionZ(), player->GetOrientation());
+    player->GetMotionMaster()->MovePoint(0, reposition);
+
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP LOS recovery: bot={} target={} profile={} reason={} orbitRange={}.",
+        player->GetGUID().ToString(), target->GetGUID().ToString(), profile.label, reason ? reason : "unknown", orbitRange);
+    return true;
+}
+
 Player* FindFlagCarrierForDirective(Player* player, playerbot::FlagCarrierDirective directive)
 {
     if (!player || directive == playerbot::FlagCarrierDirective::None || !player->InBattleground())
@@ -315,8 +384,9 @@ bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
     if (!player || !target || !target->IsAlive() || player->GetMapId() != target->GetMapId())
         return false;
 
+    CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     if (!player->IsWithinLOSInMap(target))
-        return false;
+        return TryRecoverLineOfSight(player, target, profile, "move-toward-unit");
 
     if (!player->IsWithinDistInMap(target, desiredDistance))
         player->GetMotionMaster()->MoveFollow(target, desiredDistance, player->GetFollowAngle());
@@ -361,17 +431,100 @@ Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance)
     return nearestEnemy;
 }
 
-bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
+Unit* AcquireCombatTarget(Player* player, float scanDistance)
 {
-    Player* enemy = FindNearestEnemyBattlegroundPlayer(player, scanDistance);
-    if (!enemy)
+    if (!player)
+        return nullptr;
+
+    Unit* target = player->GetVictim();
+    if (!target || !target->IsAlive())
+        target = ObjectAccessor::GetUnit(*player, player->GetSelection());
+    if ((!target || !target->IsAlive()) && player->InBattleground())
+        target = FindNearestEnemyBattlegroundPlayer(player, scanDistance);
+    if (!target || !target->IsAlive())
+        return nullptr;
+
+    player->SetSelection(target->GetGUID());
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP chosen combat target: bot={} target={} class={} distance={}.",
+        player->GetGUID().ToString(), target->GetGUID().ToString(), uint32(player->GetClass()), player->GetDistance(target));
+    return target;
+}
+
+bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfile const& profile)
+{
+    if (!player || !target || !target->IsAlive())
         return false;
 
-    player->SetSelection(enemy->GetGUID());
-    if (!player->GetVictim())
-        player->Attack(enemy, true);
+    float const distance = player->GetDistance(target);
+    bool const hasLos = player->IsWithinLOSInMap(target);
+    if (!hasLos)
+        return TryRecoverLineOfSight(player, target, profile, "drive-combat-positioning");
 
-    return MoveTowardUnit(player, enemy, 8.0f);
+    if (profile.primarilyRanged)
+    {
+        if (distance < profile.preferredMinRange && profile.createDistanceWhenCrowded)
+        {
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP distance band: bot={} profile={} decision=create-distance distance={} min={} ideal={} max={}.",
+                player->GetGUID().ToString(), profile.label, distance, profile.preferredMinRange, profile.preferredIdealRange,
+                profile.preferredMaxPressureRange);
+            return MoveAwayFromUnit(player, target, profile.preferredIdealRange);
+        }
+
+        if (distance > profile.preferredMaxPressureRange)
+        {
+            player->GetMotionMaster()->MoveFollow(target, profile.preferredIdealRange, player->GetFollowAngle());
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP distance band: bot={} profile={} decision=close-distance distance={} min={} ideal={} max={}.",
+                player->GetGUID().ToString(), profile.label, distance, profile.preferredMinRange, profile.preferredIdealRange,
+                profile.preferredMaxPressureRange);
+            return true;
+        }
+
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP distance band: bot={} profile={} decision=hold-band distance={} min={} ideal={} max={}.",
+            player->GetGUID().ToString(), profile.label, distance, profile.preferredMinRange, profile.preferredIdealRange,
+            profile.preferredMaxPressureRange);
+        return true;
+    }
+
+    if (distance > profile.preferredMaxPressureRange || !player->IsWithinMeleeRange(target))
+    {
+        player->GetMotionMaster()->MoveChase(target);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP distance band: bot={} profile={} decision=melee-close distance={} max={}.",
+            player->GetGUID().ToString(), profile.label, distance, profile.preferredMaxPressureRange);
+        return true;
+    }
+
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP distance band: bot={} profile={} decision=melee-stick distance={} max={}.",
+        player->GetGUID().ToString(), profile.label, distance, profile.preferredMaxPressureRange);
+    return true;
+}
+
+bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
+{
+    Unit* target = AcquireCombatTarget(player, scanDistance);
+    if (!target)
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP movement skipped: bot={} reason=no-combat-target scanDistance={}.",
+            player ? player->GetGUID().ToString() : ObjectGuid::Empty.ToString(), scanDistance);
+        return false;
+    }
+
+    CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
+    bool const useMeleeAttack = !profile.primarilyRanged || profile.meleeFallbackAcceptable;
+    player->Attack(target, useMeleeAttack);
+
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP positioning profile: bot={} profile={} ranged={} createDistance={} meleeFallback={}.",
+        player->GetGUID().ToString(), profile.label, profile.primarilyRanged, profile.createDistanceWhenCrowded,
+        profile.meleeFallbackAcceptable);
+
+    return DriveCombatPositioning(player, target, profile);
 }
 }
 
@@ -520,6 +673,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         context.movement == BattlegroundMovementPrimitive::None &&
         context.flagCarrierDirective == FlagCarrierDirective::None)
     {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP movement skipped: bot={} reason=no-objective-and-no-directive.",
+            player->GetGUID().ToString());
         return false;
     }
 
@@ -557,7 +713,15 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         }
     }
 
-    return EngageNearestEnemyPlayer(player, 55.0f) || true;
+    bool const fallbackEngage = EngageNearestEnemyPlayer(player, 55.0f);
+    if (!fallbackEngage)
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP movement skipped: bot={} reason=no-objective-movement-and-no-fallback-target.",
+            player->GetGUID().ToString());
+    }
+
+    return fallbackEngage;
 }
 
 bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context)


### PR DESCRIPTION
### Motivation
- Fix Classic-only PvP movement and engage issues so ranged bots (especially Hunters/Mages/Warlocks/Priests) stop collapsing into melee, LOS failure does not cause idle/stall, and the fixed 8-yard follow/attack pattern is replaced by class-aware positioning without reintroducing Wrath-only spell/talent assumptions.  
- PASS/FAIL checklist against inspected HEAD: LOS failure caused no-op (FAIL), engage logic used fixed follow distance (FAIL), ranged classes lacked class-aware spacing (FAIL), class spell flow relied primarily on `GetVictim()` (FAIL), tactical move-to-objective fell back to generic engage behavior (FAIL).

### Description
- Introduce a small Classic combat positioning model and profiles (`CombatPositioningProfile`) with preferred min/ideal/max ranges and behavior flags for Hunter, Mage, Priest, Warlock, Warrior, Rogue (and hybrid defaults for Paladin/Shaman/Druid), and a `GetCombatPositioningProfile` helper.  
- Replace the one-shot engage flow with helper primitives: `AcquireCombatTarget(...)`, `DriveCombatPositioning(...)`, and `TryRecoverLineOfSight(...)`, and update `EngageNearestEnemyPlayer(...)` to use these helpers and select melee vs ranged attack initiation sensibly.  
- Change LOS handling so `MoveTowardUnit()` attempts LOS recovery movement instead of immediately returning false, add `MoveAwayFromUnit()` for ranged spacing, and add targeted lifecycle debug logs for target selection, profile choice, distance-band decisions, LOS recovery, and movement-skip reasons.  
- Reduce `GetVictim()` coupling by adding `targetGuid` to `PvpClassSpellContext`, populating it from victim/selection in `BuildClassSpellContext`, and resolving it in `PvpClassActions::Execute`; touched files: `PlayerbotPvpLifecycleActions.cpp`, `PlayerbotPvpCore.cpp`, `PlayerbotPvpCore.h`, `PlayerbotPvpClassActions.cpp`.

### Testing
- Ran `git diff --check` with no whitespace issues and committed the change as "Playerbot PvP: add class-aware combat positioning and LOS recovery".  
- Started an incremental build with `cmake --build build --target game -- -j4`; the build was initiated and progressed in this environment (large tree), showing compilation progress without exposing fatal errors during the observed portion.  
- No unit/integration tests were added in this pass and no DB/SQL changes were made; further in-game verification (runtime behavior with managed bots) is recommended as the next step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d405488abc8327940041c4e801fa6c)