### PR TITLE
playerbot: convert core PvP class actions to Classic-targeted behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -18,6 +18,7 @@
 #include "PlayerbotPvpClassActions.h"
 
 #include "ObjectAccessor.h"
+#include "Log.h"
 #include "Player.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
@@ -26,42 +27,71 @@
 
 namespace
 {
-bool CastDirectSpell(Player* player, uint32 spellId, bool selfCast, ObjectGuid const& targetGuid)
+char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
 {
-    if (!player || !spellId || !player->HasSpell(spellId))
+    switch (mode)
+    {
+        case playerbot::PvpClassSpellContext::TargetMode::Enemy: return "enemy";
+        case playerbot::PvpClassSpellContext::TargetMode::Self: return "self";
+        case playerbot::PvpClassSpellContext::TargetMode::Ally: return "ally";
+        case playerbot::PvpClassSpellContext::TargetMode::None:
+        default: return "none";
+    }
+}
+
+Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& context)
+{
+    if (!player)
+        return nullptr;
+
+    switch (context.targetMode)
+    {
+        case playerbot::PvpClassSpellContext::TargetMode::Self:
+            return player;
+        case playerbot::PvpClassSpellContext::TargetMode::Ally:
+        case playerbot::PvpClassSpellContext::TargetMode::Enemy:
+            if (!context.targetGuid.IsEmpty())
+                return ObjectAccessor::GetUnit(*player, context.targetGuid);
+            return (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy) ? player->GetVictim() : nullptr;
+        case playerbot::PvpClassSpellContext::TargetMode::None:
+        default:
+            return nullptr;
+    }
+}
+
+bool CastDirectSpell(Player* player, PvpClassSpellContext const& context)
+{
+    if (!player || !context.spellId || !player->HasSpell(context.spellId))
         return false;
 
-    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(context.spellId);
     if (!spellInfo)
         return false;
 
-    if (player->GetSpellHistory()->HasCooldown(spellId) ||
+    if (player->GetSpellHistory()->HasCooldown(context.spellId) ||
         player->GetSpellHistory()->HasGlobalCooldown(spellInfo) ||
         player->IsNonMeleeSpellCast(false, false, true))
         return false;
 
-    Unit* target = selfCast ? static_cast<Unit*>(player) : player->GetVictim();
-    if (!selfCast && !targetGuid.IsEmpty())
-    {
-        if (Unit* explicitTarget = ObjectAccessor::GetUnit(*player, targetGuid))
-            target = explicitTarget;
-    }
+    Unit* target = ResolveTarget(player, context);
 
     if (!target || !target->IsAlive())
         return false;
-    if (selfCast && target != player)
+    if (context.targetMode == PvpClassSpellContext::TargetMode::Self && target != player)
         return false;
 
-    if (!selfCast)
+    if (context.targetMode == PvpClassSpellContext::TargetMode::Enemy)
     {
-        if (spellInfo->IsPositive())
-        {
-            if (!player->IsValidAssistTarget(target, spellInfo))
-                return false;
-        }
-        else if (!player->IsValidAttackTarget(target, spellInfo))
+        if (!player->IsValidAttackTarget(target, spellInfo))
             return false;
     }
+    else if (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
+    {
+        if (!player->IsValidAssistTarget(target, spellInfo))
+            return false;
+    }
+    else if (context.targetMode == PvpClassSpellContext::TargetMode::None)
+        return false;
 
     if (!player->IsWithinLOSInMap(target))
         return false;
@@ -78,7 +108,7 @@ bool CastDirectSpell(Player* player, uint32 spellId, bool selfCast, ObjectGuid c
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
             return false;
 
-    player->CastSpell(target, spellId, false);
+    player->CastSpell(target, context.spellId, false);
     return true;
 }
 }
@@ -90,6 +120,15 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
     if (!player || !context.classSpellsEnabled || !context.shouldExecute)
         return false;
 
-    return CastDirectSpell(player, context.spellId, context.selfCast, context.targetGuid);
+    bool const casted = CastDirectSpell(player, context);
+    TC_LOG_DEBUG("playerbots.pvp.class",
+        "Playerbot PvP class execution: action={} spell={} target_mode={} target_guid={} success={} reason={}.",
+        context.actionName ? context.actionName : "none",
+        context.spellId,
+        GetTargetModeLabel(context.targetMode),
+        context.targetGuid.ToString(),
+        casted,
+        context.reason ? context.reason : "none");
+    return casted;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -43,15 +43,6 @@ bool IsClassSpellGateEnabled(playerbot::PvpCoreConfig const& config)
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpClassSpellsEnabled;
 }
 
-uint32 SelectFirstReadySpell(Player const* player, std::initializer_list<uint32> spellIds)
-{
-    for (uint32 spellId : spellIds)
-        if (spellId && player->HasSpell(spellId) && !player->GetSpellHistory()->HasCooldown(spellId))
-            return spellId;
-
-    return 0;
-}
-
 bool IsFlagCarrierNear(Player const* player, ObjectGuid const& carrierGuid, float maxDistance)
 {
     if (!player || carrierGuid.IsEmpty())
@@ -115,8 +106,9 @@ void PopulateObjectiveStateTriggers(Player const* player, playerbot::PvpValues& 
 struct SpellDecision
 {
     char const* actionName = nullptr;
+    char const* reason = nullptr;
     uint32 spellId = 0;
-    bool selfCast = false;
+    playerbot::PvpClassSpellContext::TargetMode targetMode = playerbot::PvpClassSpellContext::TargetMode::None;
 };
 
 struct TacticalDecision
@@ -142,24 +134,6 @@ struct ClassicProfileSelection
     bool unsupportedClass = false;
 };
 
-struct ClassicSpellCatalog
-{
-    std::initializer_list<uint32> interrupt;
-    std::initializer_list<uint32> opener;
-    std::initializer_list<uint32> control;
-    std::initializer_list<uint32> primaryPressure;
-    std::initializer_list<uint32> secondaryPressure;
-    std::initializer_list<uint32> tertiaryPressure;
-    std::initializer_list<uint32> baselinePressure;
-    std::initializer_list<uint32> defensive;
-};
-
-// Classic-only PvP scaffold audit notes:
-// - Removed Wrath-only spec markers from detection: Chimera Shot, Explosive Shot, Killing Spree, Shadow Dance,
-//   Penance, Haunt, Metamorphosis, Chaos Bolt, Arcane Barrage, Starfall, Divine Storm, Avenger's Shield,
-//   Riptide, Thunderstorm, and Icy Veins marker usage.
-// - Removed Wrath-era selector pressure choices from the main decision path and replaced with this Classic catalog.
-// - Death Knight is explicitly treated as unsupported for Classic profile behavior in this pass.
 ClassicProfileSelection DetectClassicClassProfile(Player const* player)
 {
     ClassicProfileSelection selection;
@@ -250,105 +224,228 @@ ClassicProfileSelection DetectClassicClassProfile(Player const* player)
     return selection;
 }
 
-ClassicSpellCatalog BuildClassicSpellCatalog(Player const* player)
+bool IsSpellReady(Player const* player, uint32 spellId)
 {
-    if (!player)
-        return {};
-
-    switch (player->GetClass())
-    {
-        case CLASS_WARRIOR:
-            return { { 6552 }, { 100 }, { 1715 }, { 12294 }, { 23881 }, { 23922 }, { 772, 5308 }, { 871, 12975 } };
-        case CLASS_PALADIN:
-            return { { 10308, 853 }, { 20271 }, { 853 }, { 20473 }, { 20925 }, { 20066 }, { 35395, 24275 }, { 498 } };
-        case CLASS_HUNTER:
-            return { { 14251 }, { 1513 }, { 19503 }, { 19574 }, { 19434 }, { 19386 }, { 1978, 2643, 3044, 56641 }, { 19263 } };
-        case CLASS_ROGUE:
-            return { { 1766 }, { 1752 }, { 2094, 1776 }, { 14177 }, { 13750 }, { 14185 }, { 1752, 53, 1943 }, { 5277 } };
-        case CLASS_PRIEST:
-            return { { 15487 }, { 589 }, { 605 }, { 10060 }, { 724 }, { 15473 }, { 8092, 585, 2944 }, { 33206 } };
-        case CLASS_SHAMAN:
-            return { { 8042 }, { 8050 }, { 8056 }, { 16166 }, { 17364 }, { 16188 }, { 403, 421, 8050 }, { 2645 } };
-        case CLASS_MAGE:
-            return { { 2139 }, { 133 }, { 118 }, { 12042 }, { 133, 2136 }, { 116, 44614 }, { 133, 116, 5143 }, { 45438 } };
-        case CLASS_WARLOCK:
-            return { { 19647 }, { 172 }, { 5782 }, { 18220 }, { 19028 }, { 17962 }, { 172, 348, 686 }, { 6229 } };
-        case CLASS_DRUID:
-            return { { 16979 }, { 8921 }, { 339 }, { 24858 }, { 18562 }, { 17007 }, { 8921, 5176, 1822 }, { 22812 } };
-        default:
-            return {};
-    }
+    return player && spellId && player->HasSpell(spellId) && !player->GetSpellHistory()->HasCooldown(spellId);
 }
 
-SpellDecision SelectClassicClassSpell(Player const* player, Unit const* target, bool inMelee, ClassicProfileSelection const& profileSelection)
+bool HasHostileTarget(Player const* player, Unit const* target)
+{
+    return player && target && target->IsAlive() && target->GetGUID() != player->GetGUID() && player->IsValidAttackTarget(target);
+}
+
+Unit const* SelectAllyTarget(Player const* player)
+{
+    if (!player)
+        return nullptr;
+
+    ObjectGuid const selectedGuid = player->GetSelection();
+    if (selectedGuid.IsEmpty())
+        return nullptr;
+
+    Unit const* selected = ObjectAccessor::GetUnit(*player, selectedGuid);
+    if (!selected || !selected->IsAlive() || selected->GetGUID() == player->GetGUID())
+        return nullptr;
+
+    if (!player->IsValidAssistTarget(selected))
+        return nullptr;
+
+    if (!player->IsWithinLOSInMap(selected) || !player->IsWithinDistInMap(selected, 40.0f))
+        return nullptr;
+
+    return selected;
+}
+
+SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool inMelee)
+{
+    SpellDecision decision;
+    if (!HasHostileTarget(player, target))
+        return decision;
+
+    bool const targetClose = player->IsWithinDistInMap(target, 8.0f);
+
+    if (!targetClose && !target->HasAura(1978) && IsSpellReady(player, 1978))
+        return { "hunter serpent sting", "apply ranged dot pressure", 1978, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+
+    if (!targetClose && IsSpellReady(player, 5116))
+        return { "hunter concussive shot", "kite or chase control", 5116, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+
+    if (targetClose && IsSpellReady(player, 2974))
+        return { "hunter wing clip", "close-range fallback snare", 2974, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+
+    if (!inMelee && IsSpellReady(player, 19434))
+        return { "hunter aimed shot", "long cast pressure from range", 19434, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (!inMelee && IsSpellReady(player, 2643))
+        return { "hunter multi-shot", "ranged burst pressure", 2643, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (!inMelee && IsSpellReady(player, 3044))
+        return { "hunter arcane shot", "ranged instant pressure", 3044, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+
+    if (player->HealthBelowPct(25) && inMelee && IsSpellReady(player, 5384))
+        return { "hunter feign death", "defensive reset under melee pressure", 5384, playerbot::PvpClassSpellContext::TargetMode::Self };
+
+    return decision;
+}
+
+SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inMelee)
+{
+    SpellDecision decision;
+    if (!HasHostileTarget(player, target))
+        return decision;
+
+    bool const closePressure = player->IsWithinDistInMap(target, 8.0f);
+
+    if (player->HealthBelowPct(25) && IsSpellReady(player, 11958))
+        return { "mage ice block", "self-preservation emergency", 11958, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (closePressure && IsSpellReady(player, 122))
+        return { "mage frost nova", "close defensive peel", 122, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (closePressure && IsSpellReady(player, 1953))
+        return { "mage blink", "escape melee pressure", 1953, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (!closePressure && target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 2139))
+        return { "mage counterspell", "interrupt enemy cast at range", 2139, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (!target->HasAura(118) && !closePressure && IsSpellReady(player, 118))
+        return { "mage polymorph", "safe ranged crowd control", 118, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (closePressure && IsSpellReady(player, 120))
+        return { "mage cone of cold", "short-range defensive pressure", 120, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (closePressure && IsSpellReady(player, 2136))
+        return { "mage fire blast", "instant close burst", 2136, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (IsSpellReady(player, 116))
+        return { "mage frostbolt", "default ranged pressure", 116, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+
+    return decision;
+}
+
+SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit const* allyTarget)
 {
     SpellDecision decision;
     if (!player)
         return decision;
 
-    if (profileSelection.unsupportedClass)
+    if (player->HealthBelowPct(45) && !player->HasAura(17) && IsSpellReady(player, 17))
+        return { "priest power word shield self", "self-preservation under pressure", 17, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (player->HealthBelowPct(65) && !player->HasAura(139) && IsSpellReady(player, 139))
+        return { "priest renew self", "self-preservation heal over time", 139, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (player->HealthBelowPct(60) && player->IsInCombat() && IsSpellReady(player, 8122))
+        return { "priest psychic scream", "defensive peel while pressured", 8122, playerbot::PvpClassSpellContext::TargetMode::Self };
+
+    if (allyTarget && allyTarget->HealthBelowPct(50) && !allyTarget->HasAura(17) && IsSpellReady(player, 17))
+        return { "priest power word shield ally", "lightweight ally preservation", 17, playerbot::PvpClassSpellContext::TargetMode::Ally };
+    if (allyTarget && allyTarget->HealthBelowPct(70) && !allyTarget->HasAura(139) && IsSpellReady(player, 139))
+        return { "priest renew ally", "lightweight ally heal support", 139, playerbot::PvpClassSpellContext::TargetMode::Ally };
+
+    if (!HasHostileTarget(player, target))
         return decision;
 
-    ClassicSpellCatalog const catalog = BuildClassicSpellCatalog(player);
-    bool const lowHealth = player->HealthBelowPct(40);
-    bool const hasTarget = target && target->IsAlive() && target->GetGUID() != player->GetGUID();
-    bool const rangedWindow = hasTarget && player->IsWithinDistInMap(target, 35.0f) && player->IsWithinLOSInMap(target);
-    bool const enemyCasting = hasTarget && target->HasUnitState(UNIT_STATE_CASTING);
-
-    auto tryAction = [&](char const* actionName, std::initializer_list<uint32> spellIds, bool selfCast = false) -> bool
-    {
-        if (uint32 spellId = SelectFirstReadySpell(player, spellIds))
-        {
-            decision.actionName = actionName;
-            decision.spellId = spellId;
-            decision.selfCast = selfCast;
-            return true;
-        }
-        return false;
-    };
-
-    if (lowHealth && tryAction("classic defensive", catalog.defensive, true))
-        return decision;
-
-    if (!hasTarget)
-        return decision;
-
-    if (enemyCasting)
-    {
-        bool const canInterruptNow = (inMelee || rangedWindow);
-        if (canInterruptNow && tryAction("classic interrupt", catalog.interrupt))
-            return decision;
-    }
-
-    if (!inMelee && rangedWindow && tryAction("classic opener", catalog.opener))
-        return decision;
-
-    if (tryAction("classic control", catalog.control))
-        return decision;
-
-    switch (profileSelection.profile)
-    {
-        case ClassicClassProfile::PrimaryClassic:
-            if (tryAction("classic primary pressure", catalog.primaryPressure))
-                return decision;
-            break;
-        case ClassicClassProfile::SecondaryClassic:
-            if (tryAction("classic secondary pressure", catalog.secondaryPressure))
-                return decision;
-            break;
-        case ClassicClassProfile::TertiaryClassic:
-            if (tryAction("classic tertiary pressure", catalog.tertiaryPressure))
-                return decision;
-            break;
-        case ClassicClassProfile::UnknownClassic:
-        default:
-            break;
-    }
-
-    if (tryAction("classic baseline pressure", catalog.baselinePressure))
-        return decision;
+    if (!target->HasAura(589) && IsSpellReady(player, 589))
+        return { "priest shadow word pain", "maintain dot pressure", 589, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (IsSpellReady(player, 8092))
+        return { "priest mind blast", "direct shadow burst", 8092, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (IsSpellReady(player, 585))
+        return { "priest smite fallback", "fallback ranged cast", 585, playerbot::PvpClassSpellContext::TargetMode::Enemy };
 
     return decision;
+}
+
+SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
+{
+    SpellDecision decision;
+    if (!HasHostileTarget(player, target))
+        return decision;
+
+    bool const closePressure = player->IsWithinDistInMap(target, 8.0f);
+    if (closePressure && IsSpellReady(player, 5782))
+        return { "warlock fear", "close defensive control", 5782, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (!target->HasAura(172) && IsSpellReady(player, 172))
+        return { "warlock corruption", "maintain corruption dot", 172, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (!target->HasAura(980) && IsSpellReady(player, 980))
+        return { "warlock curse of agony", "apply curse pressure", 980, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 19647))
+        return { "warlock spell lock", "pet interrupt when available", 19647, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (IsSpellReady(player, 686))
+        return { "warlock shadow bolt", "default ranged pressure", 686, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+
+    return decision;
+}
+
+SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, ClassicProfileSelection const& profileSelection)
+{
+    SpellDecision decision;
+    if (!HasHostileTarget(player, target))
+        return decision;
+
+    if (!player->IsWithinMeleeRange(target) && IsSpellReady(player, 100))
+        return { "warrior charge", "close gap to target", 100, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (!target->HasAura(1715) && IsSpellReady(player, 1715))
+        return { "warrior hamstring", "maintain stickiness snare", 1715, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (!target->HasAura(772) && IsSpellReady(player, 772))
+        return { "warrior rend", "bleed pressure baseline", 772, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (target->HealthBelowPct(20) && IsSpellReady(player, 5308))
+        return { "warrior execute", "finisher at low enemy health", 5308, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (profileSelection.profile == ClassicClassProfile::PrimaryClassic && IsSpellReady(player, 12294))
+        return { "warrior mortal strike", "arms-like burst pressure", 12294, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (IsSpellReady(player, 7384))
+        return { "warrior overpower", "classic melee punish", 7384, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+
+    return decision;
+}
+
+SpellDecision SelectRogueSpell(Player const* player, Unit const* target)
+{
+    SpellDecision decision;
+    if (!HasHostileTarget(player, target))
+        return decision;
+
+    if (target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 1766))
+        return { "rogue kick", "interrupt enemy cast", 1766, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (player->HealthBelowPct(40) && IsSpellReady(player, 5277))
+        return { "rogue evasion", "defensive survival in melee", 5277, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (!player->HealthBelowPct(50) && !player->IsWithinMeleeRange(target) && IsSpellReady(player, 2983))
+        return { "rogue sprint", "close gap for melee pressure", 2983, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (IsSpellReady(player, 1776))
+        return { "rogue gouge", "short control in melee", 1776, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (player->GetComboPoints() >= 3 && IsSpellReady(player, 2098))
+        return { "rogue eviscerate", "combo finisher pressure", 2098, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (player->HasSpell(53) && IsSpellReady(player, 53))
+        return { "rogue backstab", "positional melee pressure", 53, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (IsSpellReady(player, 1752))
+        return { "rogue sinister strike", "default combo builder", 1752, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+
+    return decision;
+}
+
+SpellDecision SelectClassicClassSpell(Player const* player, Unit const* target, Unit const* allyTarget, ClassicProfileSelection const& profileSelection)
+{
+    SpellDecision decision;
+    if (!player)
+    {
+        decision.reason = "missing-player";
+        return decision;
+    }
+
+    if (profileSelection.unsupportedClass)
+    {
+        decision.reason = "unsupported-class";
+        return decision;
+    }
+
+    bool const inMelee = target && player->IsWithinMeleeRange(target);
+    switch (player->GetClass())
+    {
+        case CLASS_HUNTER:
+            return SelectHunterSpell(player, target, inMelee);
+        case CLASS_MAGE:
+            return SelectMageSpell(player, target, inMelee);
+        case CLASS_PRIEST:
+            return SelectPriestSpell(player, target, allyTarget);
+        case CLASS_WARLOCK:
+            return SelectWarlockSpell(player, target);
+        case CLASS_WARRIOR:
+            return SelectWarriorSpell(player, target, profileSelection);
+        case CLASS_ROGUE:
+            return SelectRogueSpell(player, target);
+        default:
+            decision.reason = "class-not-in-this-pass";
+            return decision;
+    }
 }
 
 char const* GetClassLabel(uint8 classId)
@@ -568,22 +665,46 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    bool const inMelee = hasValidTarget && player->IsWithinMeleeRange(target);
     ClassicProfileSelection const profileSelection = DetectClassicClassProfile(player);
-
-    SpellDecision const decision = SelectClassicClassSpell(player, hasValidTarget ? target : nullptr, inMelee, profileSelection);
+    Unit const* allyTarget = SelectAllyTarget(player);
+    SpellDecision const decision = SelectClassicClassSpell(player, hasValidTarget ? target : nullptr, allyTarget, profileSelection);
 
     context.actionName = decision.actionName;
+    context.reason = decision.reason;
     context.spellId = decision.spellId;
-    context.selfCast = decision.selfCast;
+    context.targetMode = decision.targetMode;
+    context.selfCast = context.targetMode == PvpClassSpellContext::TargetMode::Self;
     context.targetGuid = hasValidTarget ? target->GetGUID() : ObjectGuid::Empty;
+    context.allyTargetGuid = allyTarget ? allyTarget->GetGUID() : ObjectGuid::Empty;
+    if (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
+        context.targetGuid = context.allyTargetGuid;
+    else if (context.targetMode == PvpClassSpellContext::TargetMode::Self)
+        context.targetGuid = player->GetGUID();
     context.shouldExecute = context.spellId != 0;
 
+    char const* targetModeLabel = "none";
+    switch (context.targetMode)
+    {
+        case PvpClassSpellContext::TargetMode::Enemy:
+            targetModeLabel = "enemy";
+            break;
+        case PvpClassSpellContext::TargetMode::Self:
+            targetModeLabel = "self";
+            break;
+        case PvpClassSpellContext::TargetMode::Ally:
+            targetModeLabel = "ally";
+            break;
+        case PvpClassSpellContext::TargetMode::None:
+        default:
+            break;
+    }
+
     TC_LOG_DEBUG("playerbots.pvp.class",
-        "Playerbot PvP Classic scaffold: class={} profile={} fallback={} unsupported={} wrath_path_replaced={} has_target={} target_guid={} spell={} action={}.",
+        "Playerbot PvP class context: class={} profile={} fallback={} unsupported={} has_enemy_target={} enemy_target_guid={} ally_target_guid={} target_mode={} spell={} action={} reason={}.",
         GetClassLabel(player->GetClass()), profileSelection.profileLabel, profileSelection.usedFallback,
-        profileSelection.unsupportedClass, true, hasValidTarget, context.targetGuid.ToString(),
-        context.spellId, context.actionName ? context.actionName : "none");
+        profileSelection.unsupportedClass, hasValidTarget, hasValidTarget ? target->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+        context.allyTargetGuid.ToString(), targetModeLabel, context.spellId, context.actionName ? context.actionName : "none",
+        context.reason ? context.reason : "none");
     return context;
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -140,9 +140,19 @@ struct PvpClassSpellContext
     bool classSpellsEnabled = false;
     bool shouldExecute = false;
     char const* actionName = nullptr;
+    char const* reason = nullptr;
     uint32 spellId = 0;
     bool selfCast = false;
+    enum class TargetMode : uint8
+    {
+        None = 0,
+        Enemy,
+        Self,
+        Ally
+    };
+    TargetMode targetMode = TargetMode::None;
     ObjectGuid targetGuid = ObjectGuid::Empty;
+    ObjectGuid allyTargetGuid = ObjectGuid::Empty;
 };
 
 struct BattlegroundLifecycleContext


### PR DESCRIPTION
### Motivation

- Replace remaining Wrath-shaped / placeholder class PvP logic with Classic-era spells and simple, reviewable behavior for priority classes.
- Make class spell execution target-aware so casts can explicitly target `enemy`, `self`, or an `ally` instead of being limited to self/current victim.
- Keep talent handling conservative and avoid adding Wrath-only abilities or database changes.

### Description

- Added explicit target metadata and diagnostics to the class spell context by extending `PvpClassSpellContext` with `reason`, `TargetMode` (`None/Enemy/Self/Ally`) and `allyTargetGuid` and wired these through the context builder in `BuildClassSpellContext`.
- Replaced the flat placeholder/Wrath-shaped catalog with first-pass Classic-focused per-class selectors (implemented as `SelectHunterSpell`, `SelectMageSpell`, `SelectPriestSpell`, `SelectWarlockSpell`, `SelectWarriorSpell`, `SelectRogueSpell`) that choose Classic-era spells and return a `SpellDecision` including `targetMode` and a short `reason` string.
- Added a lightweight ally-target heuristic via `SelectAllyTarget` that uses the player's current selection for simple assist casts, and conservative role/profile cues via `DetectClassicClassProfile` remain unchanged.
- Updated execution plumbing in `PvpClassActions::Execute` and `CastDirectSpell` to resolve the final `Unit*` by `TargetMode`, validate attack vs assist semantics before casting, and log concise debug information (action, spell, `target_mode`, `target_guid`, `success`, `reason`).
- Preserved existing gate chains and avoided any SQL/DB modifications; behavior remains iterative and reviewable.

### Testing

- Attempted an automated build with `cmake --build build --target worldserver -j2`; CMake configuration succeeded and compilation progressed (objects started compiling), but the full build did not complete within the session window so a full-success build artifact was not produced (partial/indeterminate).
- Verified repository state and applied changes by committing the patch and inspecting the diff; the commit containing these changes is present locally.
- No unit tests or DB migration scripts were executed as part of this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40785d0ec8327965d07a5be0d9d20)