### PR TITLE
Playerbot PvP: human-first Warsong objective behavior and fair flag returns

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "PlayerbotPvpCore.h"
+#include "PlayerbotRandomBotParticipation.h"
 
 #include "Battleground.h"
 #include "BattlegroundMgr.h"
@@ -23,6 +24,7 @@
 #include "BattlegroundWS.h"
 #include "Configuration/Config.h"
 #include "Log.h"
+#include "Map.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "SpellHistory.h"
@@ -491,7 +493,7 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
     // highest-priority emergency handling first, then raid/bg pressure, then sustain.
     std::array<TacticalRule, 9> const rules =
     {{
-        { "player has flag", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::PlayerHasFlag, values), "bg move to objective", 90.0f },
+        { "player has flag", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::PlayerHasFlag, values) && !values.battlegroundTeamHasHumans, "bg move to objective", 90.0f },
         { "enemy flagcarrier near", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::EnemyFlagCarrierNear, values), "attack enemy flag carrier", 70.0f },
         { "team flagcarrier near", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::TeamFlagCarrierNear, values), "bg protect fc", 65.0f },
         { "bg waiting", bgWaiting, "bg move to start", 50.0f },
@@ -519,6 +521,41 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
 
 namespace playerbot
 {
+uint32 PvpCore::CountHumanPlayersOnBattlegroundTeam(Player const* player)
+{
+    if (!player || !player->InBattleground() || !player->GetMap())
+        return 0;
+
+    Battleground const* battleground = player->GetBattleground();
+    if (!battleground)
+        return 0;
+
+    uint32 const botBgTeam = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
+    uint32 humanCount = 0;
+
+    Map::PlayerList const& players = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+    {
+        Player const* teammate = itr->GetSource();
+        if (!teammate || teammate->GetBattlegroundId() != player->GetBattlegroundId())
+            continue;
+
+        uint32 const teammateBgTeam = teammate->GetBGTeam() ? teammate->GetBGTeam() : teammate->GetTeam();
+        if (teammateBgTeam != botBgTeam)
+            continue;
+
+        if (!IsManagedRandomBot(teammate))
+            ++humanCount;
+    }
+
+    return humanCount;
+}
+
+bool PvpCore::TeamHasHumanPlayers(Player const* player)
+{
+    return CountHumanPlayersOnBattlegroundTeam(player) > 0;
+}
+
 void PvpCore::LoadConfig()
 {
     g_PvpCoreConfig.moduleEnabled = sConfigMgr->GetBoolDefault("Playerbot.Enable", false);
@@ -564,6 +601,8 @@ PvpValues PvpCore::CollectValues(Player const* player)
         values.battlegroundTypeId = player->GetBattlegroundTypeId();
 
     PopulateObjectiveStateTriggers(player, values);
+    values.battlegroundTeamHumanCount = CountHumanPlayersOnBattlegroundTeam(player);
+    values.battlegroundTeamHasHumans = values.battlegroundTeamHumanCount > 0;
 
     return values;
 }
@@ -615,6 +654,11 @@ BattlegroundTacticalContext PvpCore::BuildBattlegroundTacticalContext(Player con
     context.objective = SelectObjectiveSkeleton(values);
     context.movement = SelectMovementPrimitiveSkeleton(values, context.objective);
     context.flagCarrierDirective = SelectFlagCarrierDirectiveSkeleton(values);
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP human-first context: guid={} human_count={} has_humans={} player_has_flag={} blocked_player_fc={} directive={} action={}.",
+        player->GetGUID().ToString(), values.battlegroundTeamHumanCount, values.battlegroundTeamHasHumans, values.playerHasFlag,
+        values.battlegroundTeamHasHumans && values.playerHasFlag, static_cast<uint8>(context.flagCarrierDirective),
+        context.actionName ? context.actionName : "none");
     return context;
 }
 
@@ -769,7 +813,8 @@ BattlegroundObjectiveSelection PvpCore::SelectObjectiveSkeleton(PvpValues const&
 
     if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierNear, values))
         objective.type = BattlegroundObjectiveType::AttackFlagCarrier;
-    else if (IsTriggerActive(PvpTrigger::PlayerHasFlag, values) || IsTriggerActive(PvpTrigger::TeamFlagCarrierNear, values))
+    else if ((!values.battlegroundTeamHasHumans && IsTriggerActive(PvpTrigger::PlayerHasFlag, values)) ||
+        IsTriggerActive(PvpTrigger::TeamFlagCarrierNear, values))
         objective.type = BattlegroundObjectiveType::ProtectFlagCarrier;
 
     return objective;
@@ -801,7 +846,8 @@ FlagCarrierDirective PvpCore::SelectFlagCarrierDirectiveSkeleton(PvpValues const
     if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierNear, values))
         return FlagCarrierDirective::AttackEnemyCarrier;
 
-    if (IsTriggerActive(PvpTrigger::PlayerHasFlag, values) || IsTriggerActive(PvpTrigger::TeamFlagCarrierNear, values))
+    if ((!values.battlegroundTeamHasHumans && IsTriggerActive(PvpTrigger::PlayerHasFlag, values)) ||
+        IsTriggerActive(PvpTrigger::TeamFlagCarrierNear, values))
         return FlagCarrierDirective::ProtectTeamCarrier;
 
     return FlagCarrierDirective::None;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -56,6 +56,8 @@ struct PvpValues
     bool playerHasFlag = false;
     bool enemyFlagCarrierNear = false;
     bool teamFlagCarrierNear = false;
+    uint32 battlegroundTeamHumanCount = 0;
+    bool battlegroundTeamHasHumans = false;
 };
 
 enum class PvpTrigger : uint8
@@ -190,6 +192,8 @@ public:
     static ArenaLifecycleContext BuildArenaLifecycleContext(Player const* player, PvpValues const& values);
     static PvpClassSpellContext BuildClassSpellContext(Player const* player, PvpValues const& values);
     static RandomBotParticipationHooks BuildRandomBotParticipationHooks(Player const* player, PvpValues const& values);
+    static uint32 CountHumanPlayersOnBattlegroundTeam(Player const* player);
+    static bool TeamHasHumanPlayers(Player const* player);
 
 private:
     static bool IsLifecycleEnabled();

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -22,6 +22,8 @@
 #include "BattlegroundEY.h"
 #include "BattlegroundWS.h"
 #include "DBCStores.h"
+#include "Time/GameTime.h"
+#include "GameObject.h"
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "CharacterCache.h"
@@ -41,6 +43,7 @@
 #include <cmath>
 #include <limits>
 #include <sstream>
+#include <unordered_map>
 
 namespace
 {
@@ -394,6 +397,102 @@ bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
     return true;
 }
 
+std::unordered_map<uint64, uint32> g_WsgReturnAttemptNotBeforeMsByGuid;
+
+GameObject* GetFriendlyDroppedWsgFlag(Player* player, BattlegroundWS* bgWs)
+{
+    if (!player || !bgWs || !player->GetMap())
+        return nullptr;
+
+    uint32 const botBgTeam = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
+    if (bgWs->GetFlagState(botBgTeam) != BG_WS_FLAG_STATE_ON_GROUND)
+        return nullptr;
+
+    ObjectGuid const droppedFlagGuid = bgWs->GetDroppedFlagGUID(botBgTeam);
+    if (droppedFlagGuid.IsEmpty())
+        return nullptr;
+
+    return player->GetMap()->GetGameObject(droppedFlagGuid);
+}
+
+bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag, float veryCloseDistance)
+{
+    if (!player || !droppedFlag || !player->GetMap())
+        return false;
+
+    uint32 const botBgTeam = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
+    float const botDistance = player->GetDistance(droppedFlag);
+
+    Map::PlayerList const& players = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+    {
+        Player* teammate = itr->GetSource();
+        if (!teammate || teammate == player || !teammate->IsAlive())
+            continue;
+        if (teammate->GetBattlegroundId() != player->GetBattlegroundId())
+            continue;
+
+        uint32 const teammateBgTeam = teammate->GetBGTeam() ? teammate->GetBGTeam() : teammate->GetTeam();
+        if (teammateBgTeam != botBgTeam || playerbot::IsManagedRandomBot(teammate))
+            continue;
+
+        float const teammateDistance = teammate->GetDistance(droppedFlag);
+        if (teammateDistance <= veryCloseDistance && teammateDistance <= botDistance + 1.0f)
+            return true;
+    }
+
+    return false;
+}
+
+bool TryReturnDroppedFriendlyFlagWithHumanPriority(Player* player)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    BattlegroundWS* bgWs = dynamic_cast<BattlegroundWS*>(player->GetBattleground());
+    if (!bgWs || bgWs->GetStatus() != STATUS_IN_PROGRESS)
+        return false;
+
+    GameObject* droppedFlag = GetFriendlyDroppedWsgFlag(player, bgWs);
+    if (!droppedFlag)
+        return false;
+
+    uint64 const botRawGuid = player->GetGUID().GetRawValue();
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint32& attemptNotBeforeMs = g_WsgReturnAttemptNotBeforeMsByGuid[botRawGuid];
+
+    if (HumanTeammateNearDroppedFlag(player, droppedFlag, 7.0f))
+    {
+        attemptNotBeforeMs = nowMs + urand(700, 1300);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP WSG return yielded: guid={} reason=nearby-human-priority wait_until_ms={}.",
+            player->GetGUID().ToString(), attemptNotBeforeMs);
+        return false;
+    }
+
+    if (attemptNotBeforeMs == 0)
+    {
+        attemptNotBeforeMs = nowMs + urand(350, 900);
+        return false;
+    }
+
+    if (nowMs < attemptNotBeforeMs)
+        return false;
+
+    if (!player->IsWithinDistInMap(droppedFlag, 10.0f))
+    {
+        player->GetMotionMaster()->MovePoint(0, droppedFlag->GetPosition());
+        return true;
+    }
+
+    bgWs->EventPlayerClickedOnFlag(player, droppedFlag);
+    attemptNotBeforeMs = nowMs + urand(1200, 2200);
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP WSG return attempted: guid={} flag_guid={} next_attempt_ms={}.",
+        player->GetGUID().ToString(), droppedFlag->GetGUID().ToString(), attemptNotBeforeMs);
+    return true;
+}
+
 Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance)
 {
     if (!player || !player->InBattleground() || !player->GetMap())
@@ -666,6 +765,10 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!player || !player->InBattleground())
         return false;
 
+    bool const teamHasHumans = PvpCore::TeamHasHumanPlayers(player);
+    if (teamHasHumans && TryReturnDroppedFriendlyFlagWithHumanPriority(player))
+        return true;
+
     if (EngageNearestEnemyPlayer(player, 80.0f))
         return true;
 
@@ -684,13 +787,26 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         context.flagCarrierDirective != FlagCarrierDirective::None)
     {
         if (Player* carrier = FindFlagCarrierForDirective(player, context.flagCarrierDirective))
+        {
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP objective support selected: guid={} directive={} target={}.",
+                player->GetGUID().ToString(), static_cast<uint8>(context.flagCarrierDirective), carrier->GetGUID().ToString());
             return MoveTowardUnit(player, carrier, 20.0f);
+        }
     }
 
     if (context.movement == BattlegroundMovementPrimitive::MoveToObjectivePosition)
     {
         if (Battleground* battleground = player->GetBattleground())
         {
+            if (teamHasHumans && battleground->GetTypeID(true) == BATTLEGROUND_WS)
+            {
+                TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                    "Playerbot PvP FC movement blocked: guid={} reason=team-has-humans.",
+                    player->GetGUID().ToString());
+                return false;
+            }
+
             uint32 const bgTeam = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
             TeamId const botTeam = (bgTeam == ALLIANCE) ? TEAM_ALLIANCE : TEAM_HORDE;
             TeamId const enemyTeam = (botTeam == TEAM_ALLIANCE) ? TEAM_HORDE : TEAM_ALLIANCE;
@@ -760,6 +876,12 @@ bool BattlegroundTacticalActions::AttackEnemyFlagCarrierPrimitive(Player* player
         return false;
 
     Player* enemyCarrier = FindFlagCarrierForDirective(player, FlagCarrierDirective::AttackEnemyCarrier);
+    if (enemyCarrier)
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP enemy-FC support selected: guid={} target={}.",
+            player->GetGUID().ToString(), enemyCarrier->GetGUID().ToString());
+    }
     return MoveTowardUnit(player, enemyCarrier, 15.0f);
 }
 
@@ -772,6 +894,12 @@ bool BattlegroundTacticalActions::ProtectFlagCarrierPrimitive(Player* player, Ba
         return false;
 
     Player* teamCarrier = FindFlagCarrierForDirective(player, FlagCarrierDirective::ProtectTeamCarrier);
+    if (teamCarrier)
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP protect-FC support selected: guid={} target={}.",
+            player->GetGUID().ToString(), teamCarrier->GetGUID().ToString());
+    }
     return MoveTowardUnit(player, teamCarrier, 18.0f);
 }
 


### PR DESCRIPTION
### Motivation
- Prevent bots from becoming flag carriers when human teammates are present and ensure fair, human-priority flag-return behavior in Classic Warsong Gulch without introducing Wrath-era assumptions. 
- Keep bots useful (attack enemy FCs, protect team FCs, support fights, return flags) while avoiding click-race or bot-dominant FC routes.

### Description
- Add battleground human-awareness helpers and values in `PvpCore`: `CountHumanPlayersOnBattlegroundTeam(...)`, `TeamHasHumanPlayers(...)`, plus `PvpValues` fields `battlegroundTeamHumanCount` and `battlegroundTeamHasHumans`.
- Enforce human-first tactical routing so `player has flag` and self-FC protect/objective routing are suppressed when the bot’s battleground team contains any human player, while leaving `attack enemy flag carrier` and `protect team carrier` semantics intact.
- Implement modest WSG-friendly return behavior with fairness guards: detect friendly dropped WSG flag, add randomized reaction delays, yield to very-close human teammates, throttle repeated interact attempts, and move-to-flag when appropriate rather than spam-clicking.
- Narrow movement/objective selection so bots will not switch to FC-style objective movement in WSG when humans exist on their team; maintain support movement toward enemy FCs and team FCs when allowed.
- Add debug logs for human counts, blocked FC behavior, yielded returns, allowed return attempts, and selected FC-support directives.
- Touched files: `PlayerbotPvpCore.h`, `PlayerbotPvpCore.cpp`, `PlayerbotPvpLifecycleActions.cpp`.

### Testing
- Ran `cmake --build build --target game -j4` in this environment; the build progressed and compiled many objects but final completion/link stage was not captured here (partial build progress observed). 
- Ran `git diff --check` and no whitespace or obvious diff-check issues were reported.
- No SQL or DB changes were made and all changes are gated by existing PvP config flags in `PvpCore`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40943c8408327bf658cbcfd4bb7b9)