### PR TITLE
Fix Playerbot PvP API mismatches (ObjectGuid, selection/angle, context type, managed-bot include)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -59,7 +59,7 @@ Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& conte
     }
 }
 
-bool CastDirectSpell(Player* player, PvpClassSpellContext const& context)
+bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context)
 {
     if (!player || !context.spellId || !player->HasSpell(context.spellId))
         return false;
@@ -77,20 +77,20 @@ bool CastDirectSpell(Player* player, PvpClassSpellContext const& context)
 
     if (!target || !target->IsAlive())
         return false;
-    if (context.targetMode == PvpClassSpellContext::TargetMode::Self && target != player)
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self && target != player)
         return false;
 
-    if (context.targetMode == PvpClassSpellContext::TargetMode::Enemy)
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
     {
         if (!player->IsValidAttackTarget(target, spellInfo))
             return false;
     }
-    else if (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
+    else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
     {
         if (!player->IsValidAssistTarget(target, spellInfo))
             return false;
     }
-    else if (context.targetMode == PvpClassSpellContext::TargetMode::None)
+    else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::None)
         return false;
 
     if (!player->IsWithinLOSInMap(target))

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -241,11 +241,7 @@ Unit const* SelectAllyTarget(Player const* player)
     if (!player)
         return nullptr;
 
-    ObjectGuid const selectedGuid = player->GetSelection();
-    if (selectedGuid.IsEmpty())
-        return nullptr;
-
-    Unit const* selected = ObjectAccessor::GetUnit(*player, selectedGuid);
+    Unit const* selected = player->GetSelectedUnit();
     if (!selected || !selected->IsAlive() || selected->GetGUID() == player->GetGUID())
         return nullptr;
 
@@ -698,14 +694,10 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     bool hasValidTarget = target && target->IsAlive() && target->GetGUID() != player->GetGUID();
     if (!hasValidTarget)
     {
-        ObjectGuid const selectedGuid = player->GetSelection();
-        if (!selectedGuid.IsEmpty())
+        if (Unit const* selectedTarget = player->GetSelectedUnit())
         {
-            if (Unit const* selectedTarget = ObjectAccessor::GetUnit(*player, selectedGuid))
-            {
-                target = selectedTarget;
-                hasValidTarget = target->IsAlive() && target->GetGUID() != player->GetGUID();
-            }
+            target = selectedTarget;
+            hasValidTarget = target->IsAlive() && target->GetGUID() != player->GetGUID();
         }
     }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -19,6 +19,7 @@
 #define TRINITY_PLAYERBOT_PVP_CORE_H
 
 #include "Common.h"
+#include "ObjectGuid.h"
 #include "SharedDefines.h"
 
 class Player;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "PlayerbotPvpLifecycleActions.h"
+#include "PlayerbotRandomBotParticipation.h"
 
 #include "BattlegroundMgr.h"
 #include "BattlegroundQueue.h"
@@ -305,7 +306,7 @@ bool MoveAwayFromUnit(Player* player, Unit* target, float desiredDistance)
     if (!player || !target)
         return false;
 
-    float const angleAway = target->GetAngle(player);
+    float const angleAway = target->GetAbsoluteAngle(player);
     float const currentDistance = player->GetDistance(target);
     float const moveDistance = std::max(4.0f, desiredDistance - currentDistance + 2.0f);
 
@@ -324,7 +325,7 @@ bool TryRecoverLineOfSight(Player* player, Unit* target, CombatPositioningProfil
     if (player->IsWithinLOSInMap(target))
         return false;
 
-    float const orbitAngle = target->GetAngle(player) + frand(-0.85f, 0.85f);
+    float const orbitAngle = target->GetAbsoluteAngle(player) + frand(-0.85f, 0.85f);
     float const orbitRange = std::max(profile.preferredMinRange + 2.0f, profile.preferredIdealRange);
     Position reposition(target->GetPositionX() + std::cos(orbitAngle) * orbitRange,
         target->GetPositionY() + std::sin(orbitAngle) * orbitRange,
@@ -537,7 +538,7 @@ Unit* AcquireCombatTarget(Player* player, float scanDistance)
 
     Unit* target = player->GetVictim();
     if (!target || !target->IsAlive())
-        target = ObjectAccessor::GetUnit(*player, player->GetSelection());
+        target = player->GetSelectedUnit();
     if ((!target || !target->IsAlive()) && player->InBattleground())
         target = FindNearestEnemyBattlegroundPlayer(player, scanDistance);
     if (!target || !target->IsAlive())


### PR DESCRIPTION
### Motivation
- Resolve compile failures caused by API mismatches between the Playerbot PvP scripts and the current engine headers, including unknown `ObjectGuid`, removed `Player::GetSelection()` and `Unit::GetAngle()` usages, and unresolved `PvpClassSpellContext` type references.

### Description
- Add `#include "ObjectGuid.h"` to `PlayerbotPvpCore.h` so `PvpClassSpellContext` can declare `ObjectGuid` fields (`targetGuid`, `allyTargetGuid`).
- Fully qualify the class-spell helper parameter/type usage in the anonymous namespace by using `playerbot::PvpClassSpellContext` to avoid unqualified lookup errors.
- Replace `Player::GetSelection()` + `ObjectAccessor::GetUnit(...)` with `Player::GetSelectedUnit()` in target lookup paths to match the current `Player` API.
- Replace `Unit::GetAngle(...)` calls with `GetAbsoluteAngle(...)` for orientation calculations and add `#include "PlayerbotRandomBotParticipation.h"` to resolve `IsManagedRandomBot` references.

### Testing
- Ran `rg` scans across the modified files to confirm there are no remaining references to the removed APIs in the touched files, which succeeded.
- Attempted a targeted object compile which failed due to an unknown ninja target, then started a full scripts build with `cd build && ninja -j4 scripts -k 1`; the build progressed into `src/server/scripts` compilation and did not reproduce the original Playerbot PvP type errors prior to the run being stopped manually (build was not allowed to complete in this environment).
- No automated unit tests were executed; compilation progress indicates the reported API errors were addressed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d410b429a483278c26a69112125e84)