### PR TITLE
Include Item.h and SpellAura.h in PlayerbotPvpCore to fix incomplete type errors

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -23,10 +23,12 @@
 #include "BattlegroundEY.h"
 #include "BattlegroundWS.h"
 #include "Configuration/Config.h"
+#include "Item.h"
 #include "Log.h"
 #include "Map.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "SpellAura.h"
 #include "SpellHistory.h"
 #include "Unit.h"
 


### PR DESCRIPTION
### Motivation
- Resolve compile errors caused by member access into forward-declared types `Item` and `Aura` in `PlayerbotPvpCore.cpp` (checks like `GetTemplate()->InventoryType`, `INVTYPE_2HWEAPON`, and `GetAura(...)->GetDuration()`).

### Description
- Added `#include "Item.h"` to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` so `Item` is a complete type where weapon inventory checks are performed.
- Added `#include "SpellAura.h"` to the same file so `Aura` methods like `GetDuration()` are available without relying on forward declarations.

### Testing
- Ran an incremental Ninja object-target build (`ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpCore.cpp.o`) which failed due to the target name not being exposed in the generated Ninja graph (expected target naming mismatch).;
- Ran a full build invocation (`ninja -j4`) which completed configuration and began compilation successfully and did not show the original incomplete-type diagnostics before the run was stopped by the workflow; the change was committed with no further compile-time errors observed in the initial build output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4273c8cc483279824c6812b75a9a0)