### PR TITLE
Fix missing SpellAuras include in Playerbot PvP core

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -28,7 +28,7 @@
 #include "Map.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
-#include "SpellAura.h"
+#include "SpellAuras.h"
 #include "SpellHistory.h"
 #include "Unit.h"
 


### PR DESCRIPTION
### Motivation
- Fix a build failure caused by an outdated `#include "SpellAura.h"` that is not present in the source tree by using the correct `#include "SpellAuras.h"`.

### Description
- Update `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` to replace `#include "SpellAura.h"` with `#include "SpellAuras.h"`.

### Testing
- Verified the change with `rg` to confirm `PlayerbotPvpCore.cpp` now contains `#include "SpellAuras.h"` and the search returned the updated file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d42acda9d48327972ae3aa66489a9b)