### PR TITLE
Fix duels with bots: skip missing social check and auto-start duel countdown for playerbots

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4091,7 +4091,8 @@ void Spell::EffectDuel()
     Player* target = unitTarget->ToPlayer();
 
     // caster or target already have requested duel
-    if (caster->duel || target->duel || !target->GetSocial() || target->GetSocial()->HasIgnore(caster->GetGUID()))
+    // bots may not have social data, so only enforce ignore checks when social data exists
+    if (caster->duel || target->duel || (target->GetSocial() && target->GetSocial()->HasIgnore(caster->GetGUID())))
         return;
 
     // Players can only fight a duel in zones with this flag

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -17,6 +17,8 @@
 
 #include "Log.h"
 #include "Chat.h"
+#include "GameTime.h"
+#include "Player.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
 #include "RBAC.h"
@@ -77,6 +79,31 @@ public:
     void OnLogout(Player* player) override
     {
         playerbot::RandomBotParticipationManager::OnPlayerLogout(player);
+    }
+
+    void OnDuelRequest(Player* target, Player* challenger) override
+    {
+        if (!target || !challenger)
+            return;
+
+        if (!playerbot::IsManagedRandomBot(target))
+            return;
+
+        if (!target->duel || !challenger->duel || target->duel->State != DUEL_STATE_CHALLENGED)
+            return;
+
+        if (target->duel->Opponent != challenger || challenger->duel->Opponent != target)
+            return;
+
+        time_t const now = GameTime::GetGameTime();
+        target->duel->StartTime = now + 3;
+        challenger->duel->StartTime = now + 3;
+
+        target->duel->State = DUEL_STATE_COUNTDOWN;
+        challenger->duel->State = DUEL_STATE_COUNTDOWN;
+
+        target->SendDuelCountdown(3000);
+        challenger->SendDuelCountdown(3000);
     }
 };
 


### PR DESCRIPTION
### Motivation

- Prevent duels from being incorrectly blocked when the target (e.g. a bot) has no social data available. 
- Ensure managed playerbots transition from a challenged state into the duel countdown automatically so duels begin correctly.

### Description

- Change `Spell::EffectDuel()` to only call `GetSocial()->HasIgnore()` when `GetSocial()` is non-null to avoid false rejections for entities without social data. 
- Add `#include "GameTime.h"` and `#include "Player.h"` and implement `OnDuelRequest` in `PlayerbotLifecyclePlayerScript` to validate the duel relationship, set both players' `StartTime` to `GameTime::GetGameTime() + 3`, set both duel states to `DUEL_STATE_COUNTDOWN`, and call `SendDuelCountdown(3000)` for each participant. 
- No other gameplay logic was altered.

### Testing

- Project built successfully using the normal build (`make`) process. 
- Existing automated test suite executed via `ctest` and passed. 
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4305f64c083278037e8f2aec2be7b)