### PR TITLE
Playerbots: allow BG/arena participation while dead and relax movement gate

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -75,6 +75,12 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     if (!player || player->InBattleground())
         return false;
 
+    // Allow managed bots to keep participating in queue/invite lifecycle even if
+    // they died in the open world. Battleground queue/port handlers can reject
+    // dead actors, so recover to alive before queueing.
+    if (!player->IsAlive())
+        player->ResurrectPlayer(1.0f);
+
     Battleground* bgTemplate = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
     if (!bgTemplate)
         return false;
@@ -172,6 +178,11 @@ bool AcceptMatchingInvite(Player* player, bool arenaInvite)
 {
     if (!player || player->InBattleground())
         return false;
+
+    // Keep battleground/arena participation consistent for dead managed bots:
+    // invites should still be accepted and transitioned immediately.
+    if (!player->IsAlive())
+        player->ResurrectPlayer(1.0f);
 
     for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
     {
@@ -300,11 +311,6 @@ bool CanIssueBotMovement(Player const* player)
         return false;
 
     if (player->HasUnitState(UNIT_STATE_ROOT) || player->HasUnitState(UNIT_STATE_STUNNED))
-        return false;
-
-    // Player MotionMaster movement splines can bypass expected snare feel for
-    // managed bots. When snared, do not inject synthetic movement commands.
-    if (player->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED))
         return false;
 
     return true;


### PR DESCRIPTION
### Motivation
- Managed random bots could not join Warsong/Arena lifecycle while dead because battleground queue/port handlers reject dead actors. 
- Overly strict movement gating (blocking when slowed) could cause bots to stall at base in Warsong until a player approached.

### Description
- Resurrect bots before attempting to queue by calling `ResurrectPlayer(1.0f)` in the `QueuePlayer` path so dead bots can join battleground queues. 
- Resurrect bots before accepting invites by calling `ResurrectPlayer(1.0f)` in the `AcceptMatchingInvite` path so dead bots can accept arena/bg invites and be ported. 
- Relax movement gating by removing the blanket `SPELL_AURA_MOD_DECREASE_SPEED` check from `CanIssueBotMovement` while keeping dead/ghost/root/stun checks intact. 
- Changes applied to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to implement the above behavior.

### Testing
- Started a local build with `cmake --build build --target game -- -j4`; the build progressed deeply through server targets and no compilation errors related to these changes were observed before the run was stopped due to runtime limits. 
- No automated unit tests were run as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4302a9b9c83279d7ca70ebf9b6830)