### PR TITLE
Revive managed playerbots once after server startup

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -63,6 +63,9 @@ constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;
+std::unordered_set<uint64> g_StartupRevivedManagedBotGuids;
+std::mutex g_StartupReviveLock;
+bool g_StartupRevivePending = false;
 
 enum class LifecycleObservationReason : uint8
 {
@@ -229,6 +232,28 @@ bool CanProcessPlayerLifecycle(Player const* player)
 
     nextProcessTime = now + RandomBotLifecycleCadenceInterval;
     return true;
+}
+
+void TryReviveManagedBotAfterStartup(Player* player)
+{
+    if (!player || !playerbot::IsManagedRandomBot(player))
+        return;
+
+    bool shouldAttemptRevive = false;
+    {
+        std::lock_guard<std::mutex> startupReviveLock(g_StartupReviveLock);
+        if (!g_StartupRevivePending)
+            return;
+
+        auto const [_, inserted] = g_StartupRevivedManagedBotGuids.emplace(player->GetGUID().GetRawValue());
+        shouldAttemptRevive = inserted;
+    }
+
+    if (!shouldAttemptRevive || player->IsAlive())
+        return;
+
+    player->ResurrectPlayer(1.0f);
+    TC_LOG_INFO("playerbots.population", "Startup managed bot revive applied: guid={}", player->GetGUID().ToString());
 }
 
 uint32 ResolvePlayerAccountId(Player const* player)
@@ -717,6 +742,10 @@ void RandomBotParticipationManager::ResetCadence()
 {
     std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
     g_NextRandomBotLifecycleProcessTimeByGuid.clear();
+
+    std::lock_guard<std::mutex> startupReviveLock(g_StartupReviveLock);
+    g_StartupRevivePending = false;
+    g_StartupRevivedManagedBotGuids.clear();
 }
 
 void RandomBotParticipationManager::LoadPopulationConfig()
@@ -732,6 +761,10 @@ void RandomBotParticipationManager::OnStartupBootstrap()
     {
         g_RandomPopulation.startupBootstrapDone = true;
         g_RandomPopulation.rebalanceRequested = true;
+
+        std::lock_guard<std::mutex> startupReviveLock(g_StartupReviveLock);
+        g_StartupRevivePending = true;
+        g_StartupRevivedManagedBotGuids.clear();
     }
 }
 
@@ -770,6 +803,8 @@ void RandomBotParticipationManager::OnPlayerLogout(Player const* player)
 
 void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
 {
+    TryReviveManagedBotAfterStartup(player);
+
     if (!CanProcessPlayerLifecycle(player))
         return;
 


### PR DESCRIPTION
### Motivation
- Ensure managed random playerbots that are dead at server startup are revived once so they can participate in PvP and other lifecycle logic immediately after boot.

### Description
- Added startup revive state: `g_StartupRevivedManagedBotGuids`, `g_StartupReviveLock`, and `g_StartupRevivePending` in `PlayerbotRandomBotParticipation.cpp` to track one-time revive attempts.
- Implemented `TryReviveManagedBotAfterStartup(Player*)` which resurrects a managed bot to full health the first time it is observed after startup and logs the action.
- Invoked `TryReviveManagedBotAfterStartup` at the start of `RandomBotParticipationManager::ProcessPlayerLifecycle` so bots are checked on first lifecycle processing.
- Set `g_StartupRevivePending` during `OnStartupBootstrap` and clear the pending state and GUID set in `ResetCadence` to make the behavior a one-time, per-GUID pass.

### Testing
- Started an automated build with `cmake --build build --target worldserver -j4`; compilation progressed and no immediate compile errors were observed during the captured output, but the full build was still running in this environment so final pass/fail is pending.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d435d3e9548327a707a4ba0b436d52)