### PR TITLE
playerbot: enable PvP class spell logic during active duels

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -912,7 +912,12 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
 {
     PvpClassSpellContext context;
     context.classSpellsEnabled = IsClassSpellGateEnabled(g_PvpCoreConfig);
-    if (!context.classSpellsEnabled || !player || !values.inBattleground || !IsTriggerActive(PvpTrigger::BgActive, values))
+    if (!context.classSpellsEnabled || !player)
+        return context;
+
+    bool const inActiveBattleground = values.inBattleground && IsTriggerActive(PvpTrigger::BgActive, values);
+    bool const inActiveDuel = player->duel && player->duel->State == DUEL_STATE_IN_PROGRESS;
+    if (!inActiveBattleground && !inActiveDuel)
         return context;
 
     Unit const* target = SelectCombatTarget(player);


### PR DESCRIPTION
### Motivation
- Playerbot class-spell evaluation was only running for active battlegrounds, causing playerbots (e.g., frost mage) to stand idle during duels instead of executing PvP class logic.

### Description
- Update `PvpCore::BuildClassSpellContext` (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`) to early-return only when `classSpellsEnabled` is false or `player` is null, and add a check that allows execution when either the player is in an active battleground or in an active duel (`DUEL_STATE_IN_PROGRESS`).
- Preserve existing battleground behavior and reuse the same class-spell decision pipeline for duel combat without changing downstream logic.

### Testing
- Ran `git diff --check` and it completed without errors.
- Started `cmake --build build --target worldserver -j2` to validate compilation and the build entered normal compilation flow (compile proceeded but a full build did not finish within the session window).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d43a8df97c83278d7b0ff7010116b8)