### PR TITLE
Handle virtual-session worldport ACKs and fix summon flight/recall to target

### DIFF
--- a/src/server/scripts/Commands/cs_group.cpp
+++ b/src/server/scripts/Commands/cs_group.cpp
@@ -214,6 +214,10 @@ public:
 
             std::string plNameLink = handler->GetNameLink(player);
 
+            if (player->IsBeingTeleportedFar())
+                if (WorldSession* playerSession = player->GetSession(); playerSession && playerSession->IsVirtualSession())
+                    playerSession->HandleMoveWorldportAck();
+
             if (player->IsBeingTeleported())
             {
                 handler->PSendSysMessage(LANG_IS_TELEPORTED, plNameLink.c_str());

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -615,6 +615,10 @@ public:
             if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
                 return false;
 
+            if (target->IsBeingTeleportedFar())
+                if (WorldSession* targetSession = target->GetSession(); targetSession && targetSession->IsVirtualSession())
+                    targetSession->HandleMoveWorldportAck();
+
             if (target->IsBeingTeleported())
             {
                 handler->PSendSysMessage(LANG_IS_TELEPORTED, nameLink.c_str());
@@ -673,11 +677,11 @@ public:
             if (handler->needReportToTarget(target))
                 ChatHandler(target->GetSession()).PSendSysMessage(LANG_SUMMONED_BY, handler->playerLink(_player->GetName()).c_str());
 
-            // stop flight if need
-            if (_player->IsInFlight())
-                _player->FinishTaxiFlight();
+            // stop target flight if needed before teleporting the target
+            if (target->IsInFlight())
+                target->FinishTaxiFlight();
             else
-                _player->SaveRecallPosition(); // save only in non-flight case
+                target->SaveRecallPosition(); // save only in non-flight case
 
             // before GM
             float x, y, z;


### PR DESCRIPTION
### Motivation
- Fix teleport/summon edge cases so virtual sessions properly acknowledge far teleports and ensure flight/recall handling is applied to the summoned target rather than the GM.

### Description
- In the group summon loop, call `HandleMoveWorldportAck()` on the player's `WorldSession` when `IsBeingTeleportedFar()` and the session is a virtual session to process pending worldport ACKs.
- In `HandleSummonCommand`, call `HandleMoveWorldportAck()` for the target's virtual `WorldSession` when `IsBeingTeleportedFar()` to mirror group summon behavior.
- Corrected flight/recall logic in `HandleSummonCommand` so `IsInFlight()`, `FinishTaxiFlight()`, and `SaveRecallPosition()` operate on the `target` instead of the GM player (`_player`).

### Testing
- Performed a project build and executed the automated server unit test suite; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d43d9d582483279901d42c3edeffb6)