### PR TITLE
Fix stale bot position cache after Blink teleports

### DIFF
--- a/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.cpp
+++ b/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.cpp
@@ -140,5 +140,11 @@ bool CastBlinkBackAction::Execute(Event event)
         return false;
     // can cast spell check passed in isUseful()
     bot->SetOrientation(bot->GetAngle(target) + M_PI);
-    return CastSpellAction::Execute(event);
+    if (!CastSpellAction::Execute(event))
+        return false;
+
+    // Blink is an instant teleport; refresh cached position immediately instead of
+    // waiting for CurrentPositionValue's long minChangeInterval.
+    RESET_AI_VALUE(WorldPosition, "current position");
+    return true;
 }


### PR DESCRIPTION
### Motivation
- `CurrentPositionValue` uses a long `minChangeInterval` (60s) so instant teleports like Blink can leave the bot's AI using a stale location and cause incorrect follow/charge behavior.

### Description
- After a successful Blink cast the AI now invalidates the cached position immediately by calling `RESET_AI_VALUE(WorldPosition, "current position")` in `CastBlinkBackAction::Execute` in `playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.cpp` so subsequent decisions read the fresh location.

### Testing
- Ran `git diff --check -- "playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.cpp"` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)