### PR TITLE
Playerbot: whisper PvP duel decisions to duel opponent

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -17,6 +17,7 @@
 
 #include "PlayerbotPvpClassActions.h"
 
+#include "GameTime.h"
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
@@ -25,8 +26,40 @@
 #include "SpellHistory.h"
 #include "Unit.h"
 
+#include <sstream>
+#include <unordered_map>
+
 namespace
 {
+char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
+
+void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& context, bool casted)
+{
+    if (!player || !player->duel || player->duel->State != DUEL_STATE_IN_PROGRESS || !player->duel->Opponent)
+        return;
+
+    Player* opponent = player->duel->Opponent;
+    if (!opponent || !opponent->GetSession())
+        return;
+
+    static std::unordered_map<uint64, uint32> s_LastDecisionWhisperByBot;
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint32& lastWhisperMs = s_LastDecisionWhisperByBot[player->GetGUID().GetRawValue()];
+    if ((nowMs - lastWhisperMs) < 700)
+        return;
+
+    std::ostringstream message;
+    message << "[PvP duel] " << player->GetName() << " decision="
+        << (context.actionName ? context.actionName : "none")
+        << " spell=" << context.spellId
+        << " target=" << GetTargetModeLabel(context.targetMode)
+        << " success=" << (casted ? "yes" : "no")
+        << " reason=" << (context.reason ? context.reason : "none");
+
+    player->Whisper(message.str(), LANG_UNIVERSAL, opponent);
+    lastWhisperMs = nowMs;
+}
+
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
 {
     switch (mode)
@@ -121,6 +154,7 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         return false;
 
     bool const casted = CastDirectSpell(player, context);
+    NotifyDuelDecision(player, context, casted);
     TC_LOG_DEBUG("playerbots.pvp.class",
         "Playerbot PvP class execution: action={} spell={} target_mode={} target_guid={} success={} reason={}.",
         context.actionName ? context.actionName : "none",


### PR DESCRIPTION
### Motivation
- Provide in-duel visibility into playerbot PvP decision-making to aid debugging by whispering the bot's choice to its opponent.

### Description
- Added `NotifyDuelDecision` helper to `PlayerbotPvpClassActions.cpp` that builds a short debug message and sends it as a whisper to the duel opponent when a PvP class spell execution is attempted.
- The notifier is only active during active duels (`DUEL_STATE_IN_PROGRESS`) and requires the opponent to have a valid session before sending.
- Implemented a per-bot throttle using a static `std::unordered_map` and `GameTime::GetGameTimeMS()` to avoid chat spam (700ms minimum between messages per bot), and included message fields `action`, `spell`, `target`, `success`, and `reason`.
- Wired the notifier into `PvpClassActions::Execute` so it runs after `CastDirectSpell` and added required includes (`GameTime.h`, `<sstream>`, `<unordered_map>`).

### Testing
- Ran `cmake --build build --target scripts -- -j4` to validate compilation; the build started and produced compile output but did not complete within the interactive session window, and no compile errors for the modified file were observed in the captured output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d443e5fa508327baf884b9c8bdbb7f)