### PR TITLE
Mage: refresh cached position after Blink and add self target name

### DIFF
--- a/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.cpp
+++ b/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.cpp
@@ -140,5 +140,11 @@ bool CastBlinkBackAction::Execute(Event event)
         return false;
     // can cast spell check passed in isUseful()
     bot->SetOrientation(bot->GetAngle(target) + M_PI);
-    return CastSpellAction::Execute(event);
+    if (!CastSpellAction::Execute(event))
+        return false;
+
+    // Blink is an instant teleport; refresh cached position immediately instead of
+    // waiting for CurrentPositionValue's long minChangeInterval.
+    RESET_AI_VALUE(WorldPosition, "current position");
+    return true;
 }

--- a/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.h
+++ b/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.h
@@ -136,6 +136,7 @@ class CastBlinkBackAction : public CastSpellAction
 {
 public:
     CastBlinkBackAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "blink") {}
+    std::string const GetTargetName() override { return "self target"; }
     bool Execute(Event event) override;
 };
 


### PR DESCRIPTION
### Motivation
- Ensure the bot's cached position is updated immediately after a successful `blink` teleport to avoid using stale coordinates for subsequent AI decisions.
- Explicitly mark `blink` as a self-targeting action so targeting logic treats it as `self target`.

### Description
- Update `CastBlinkBackAction::Execute` to return `false` when `CastSpellAction::Execute` fails and only proceed on success. 
- Call `RESET_AI_VALUE(WorldPosition, "current position")` after a successful `blink` to refresh the cached position immediately. 
- Add `GetTargetName()` override in `CastBlinkBackAction` returning `"self target"` to clarify targeting behavior.

### Testing
- Project was built after the change with `make` and the build completed successfully. 
- Ran the Mage action unit/integration tests focusing on blink/teleport behavior and related AI position checks, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)