### PR TITLE
Make Gurubashi guaranteed chest hour configurable

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Chat.h"
+#include "Configuration/Config.h"
 #include "Creature.h"
 #include "DBCStores.h"
 #include "GameObject.h"
@@ -72,6 +73,15 @@ char const* const GURUBASHI_REENTRY_RULE_WHISPER = "You died while the chest is 
 
 void ClearChestDeathLockouts();
 
+uint32 GetGuaranteedChestHourServerTime()
+{
+    int32 const configuredHour = sConfigMgr->GetIntDefault("GurubashiArena.GuaranteedChestHour", 21);
+    if (configuredHour < 0 || configuredHour > 23)
+        return 21u;
+
+    return static_cast<uint32>(configuredHour);
+}
+
 uint32 GetChestMarkRewardCount()
 {
     time_t const now = GameTime::GetGameTime();
@@ -81,7 +91,7 @@ uint32 GetChestMarkRewardCount()
 #else
     localtime_r(&now, &localTime);
 #endif
-    return localTime.tm_hour == 20 ? 3u : 1u;
+    return localTime.tm_hour == static_cast<int32>(GetGuaranteedChestHourServerTime()) ? 3u : 1u;
 }
 
 bool IsInGurubashiBattleRingByPvpState(Player const* player, uint32 zoneId)
@@ -493,7 +503,7 @@ private:
         return std::chrono::milliseconds(secondsUntilNextHour * IN_MILLISECONDS);
     }
 
-    static bool IsEightPmServerTime()
+    static bool IsGuaranteedChestHourServerTime()
     {
         time_t const now = GameTime::GetGameTime();
         tm localTime {};
@@ -502,7 +512,7 @@ private:
 #else
         localtime_r(&now, &localTime);
 #endif
-        return localTime.tm_hour == 20;
+        return localTime.tm_hour == static_cast<int32>(GetGuaranteedChestHourServerTime());
     }
 
     void ScheduleNextCheck(std::chrono::milliseconds delay)
@@ -521,7 +531,7 @@ private:
         uint32 const playerCount = CountEligiblePlayers(&summonerGuid);
         _lastEligibleCount = playerCount;
 
-        bool const bypassPlayerRequirement = !force && IsEightPmServerTime();
+        bool const bypassPlayerRequirement = !force && IsGuaranteedChestHourServerTime();
         if (!force && !bypassPlayerRequirement && playerCount < REQUIRED_PLAYER_COUNT)
             return SpawnResult::NotEnoughPlayers;
 

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3204,6 +3204,13 @@ DireMaulBeads.AreaIds = 495,496,498,2557,3217
 DireMaulBeads.ChestGameObjectId = 0
 DireMaulBeads.ChestDespawnSeconds = 300
 
+#    GurubashiArena.GuaranteedChestHour
+#        Description: Server local hour (0-23) when the Gurubashi chest spawn ignores the minimum player requirement
+#                     and grants the bonus mark payout when looted.
+#        Default:     21 - (9 PM server time)
+
+GurubashiArena.GuaranteedChestHour = 21
+
 #    StockadesPvPvE.ChestGameObjectId
 #        Description: GameObject entry to summon when a Stockades PvPvE run finishes.
 #                     Set to 0 to disable automatic chest spawning.


### PR DESCRIPTION
### Motivation
- Allow server operators to configure the server-local hour when the Gurubashi arena chest bypasses the minimum-player requirement and grants the bonus mark payout, and change the default from 20 (8 PM) to 21 (9 PM).

### Description
- Add a new `GurubashiArena.GuaranteedChestHour` setting to `worldserver.conf.dist` with documentation and default `21` (9 PM server time). 
- Add `GetGuaranteedChestHourServerTime()` to `src/server/scripts/Custom/custom_gurubashi_arena.cpp` which reads `sConfigMgr->GetIntDefault("GurubashiArena.GuaranteedChestHour", 21)` and validates the `0..23` range with a fallback to `21`.
- Replace hardcoded hour checks (`20`) with the configured hour via `GetGuaranteedChestHourServerTime()` and rename `IsEightPmServerTime()` to `IsGuaranteedChestHourServerTime()` so both the spawn bypass and the bonus mark payout use the same configurable hour.
- Include the configuration header by adding `#include "Configuration/Config.h"` to the Gurubashi script.

### Testing
- Ran `git diff --check` on the modified files and it reported no issues. 
- Verified the edits by searching for the new symbols (`GetGuaranteedChestHourServerTime`, `GurubashiArena.GuaranteedChestHour`) in the tree. 
- Changes were committed successfully to the branch; no compile or runtime tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4463d32d4832798d7dbb7c9bc897c)