### PR TITLE
Fix bot teleport handling: Blink position refresh and teleport ACK

### DIFF
--- a/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.cpp
+++ b/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.cpp
@@ -140,5 +140,11 @@ bool CastBlinkBackAction::Execute(Event event)
         return false;
     // can cast spell check passed in isUseful()
     bot->SetOrientation(bot->GetAngle(target) + M_PI);
-    return CastSpellAction::Execute(event);
+    if (!CastSpellAction::Execute(event))
+        return false;
+
+    // Blink is an instant teleport; refresh cached position immediately instead of
+    // waiting for CurrentPositionValue's long minChangeInterval.
+    RESET_AI_VALUE(WorldPosition, "current position");
+    return true;
 }

--- a/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.h
+++ b/playerbot reference/mod-playerbots-master/src/Ai/Class/Mage/Action/MageActions.h
@@ -136,6 +136,7 @@ class CastBlinkBackAction : public CastSpellAction
 {
 public:
     CastBlinkBackAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "blink") {}
+    std::string const GetTargetName() override { return "self target"; }
     bool Execute(Event event) override;
 };
 

--- a/playerbot reference/mod-playerbots-master/src/Bot/PlayerbotAI.cpp
+++ b/playerbot reference/mod-playerbots-master/src/Bot/PlayerbotAI.cpp
@@ -3707,6 +3707,40 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         TellMasterNoFacing(out);
     }
 
+    bool hasTeleportEffect = false;
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        if (spellInfo->Effects[effectIndex].Effect == SPELL_EFFECT_TELEPORT_UNITS)
+        {
+            hasTeleportEffect = true;
+            break;
+        }
+    }
+
+    // Playerbots do not have a real client to ACK spell teleports (e.g. Blink).
+    // When the server still marks a near-teleport pending, complete the synthetic
+    // ACK immediately so other actors (charge/intercept callers) see the new spot.
+    if (!IsRealPlayer() && hasTeleportEffect && bot->IsBeingTeleportedNear())
+    {
+        if (HasStrategy("debug spell", BOT_STATE_NON_COMBAT))
+        {
+            std::ostringstream out;
+            out << "Teleport ACK pre: map=" << bot->GetMapId() << " x=" << bot->GetPositionX() << " y="
+                << bot->GetPositionY() << " z=" << bot->GetPositionZ();
+            TellMasterNoFacing(out);
+        }
+
+        HandleTeleportAck();
+
+        if (HasStrategy("debug spell", BOT_STATE_NON_COMBAT))
+        {
+            std::ostringstream out;
+            out << "Teleport ACK post: map=" << bot->GetMapId() << " x=" << bot->GetPositionX() << " y="
+                << bot->GetPositionY() << " z=" << bot->GetPositionZ();
+            TellMasterNoFacing(out);
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Ensure playerbot position and other systems observe instantaneous teleports (like `Blink`) immediately instead of waiting on long `CurrentPositionValue` intervals.
- Ensure server-side teleport state for bots is acknowledged so other AI actions that depend on the new position see the updated location.

### Description

- In `CastBlinkBackAction::Execute` check the result of `CastSpellAction::Execute`, return early on failure, and call `RESET_AI_VALUE(WorldPosition, "current position")` after a successful blink to refresh cached location immediately.
- Add `GetTargetName()` override for `CastBlinkBackAction` to return `"self target"` so the action targets the caster correctly.
- In `PlayerbotAI::CastSpell(uint32, Unit*, Item*)` detect teleport effects by checking `SPELL_EFFECT_TELEPORT_UNITS`, and for non-real players that are flagged as `IsBeingTeleportedNear()` call `HandleTeleportAck()` to complete the synthetic teleport acknowledgment; include debug output when `debug spell` strategy is enabled.

### Testing

- Built the project to ensure the changes compile successfully and there are no build regressions (build succeeded). 
- Ran the automated unit/integration test suite and existing tests completed without failures. 
- Executed an automated bot teleport test that casts `Blink` and verifies the bot's `current position` is refreshed immediately and other AI actions observe the new location (test passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)