### PR TITLE
Playerbot: synthesize teleport ACK for bot players after teleport spells

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -20,10 +20,12 @@
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "Protocol/Opcodes.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
+#include "WorldSession.h"
 
 namespace
 {
@@ -109,6 +111,34 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             return false;
 
     player->CastSpell(target, context.spellId, false);
+
+    bool hasTeleportEffect = false;
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        if (spellInfo->Effects[effectIndex].Effect == SPELL_EFFECT_TELEPORT_UNITS)
+        {
+            hasTeleportEffect = true;
+            break;
+        }
+    }
+
+    // Bot players do not own a real game client to naturally ACK near teleports
+    // (for example Blink). If a teleport is still pending after cast, synthesize
+    // the teleport ACK immediately so other combat actions (like Charge) resolve
+    // against the post-Blink location.
+    if (hasTeleportEffect && player->IsBeingTeleportedNear())
+    {
+        WorldSession* session = player->GetSession();
+        if (session && session->IsBot())
+        {
+            WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+            teleportAck << player->GetPackGUID();
+            teleportAck << uint32(0);
+            teleportAck << uint32(0);
+            session->HandleMoveTeleportAck(teleportAck);
+        }
+    }
+
     return true;
 }
 }


### PR DESCRIPTION
### Motivation
- Ensure bot players do not leave teleport acknowledgements pending after casting teleport-like spells (e.g. Blink), which can cause subsequent combat actions to resolve against the pre-teleport location.
- Bots lack a real game client to send `MSG_MOVE_TELEPORT_ACK`, so the server must synthesize the ACK to keep movement and combat state consistent.

### Description
- Added `Protocol/Opcodes.h` and `WorldSession.h` includes to access move opcodes and session APIs.
- After casting the spell, detect if the spell has a `SPELL_EFFECT_TELEPORT_UNITS` effect by iterating `spellInfo->Effects[]` and check `player->IsBeingTeleportedNear()`.
- If the caster is a bot (`session->IsBot()`), construct a `WorldPacket` with `MSG_MOVE_TELEPORT_ACK` containing the player's GUID and zeroed timing fields, and call `session->HandleMoveTeleportAck(teleportAck)` to synthesize the ACK.

### Testing
- Performed a full server build after the change and the build completed successfully.
- Ran the repository's automated unit test suite and integration tests; all executed tests passed.
- Verified no regressions in `playerbots.pvp.class` logging paths by running automated logging checks which reported no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)