### PR TITLE
Playerbot: synthesize teleport ACK for virtual sessions after teleport spells

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -20,10 +20,12 @@
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "Protocol/Opcodes.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
+#include "WorldSession.h"
 
 namespace
 {
@@ -109,6 +111,34 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             return false;
 
     player->CastSpell(target, context.spellId, false);
+
+    bool hasTeleportEffect = false;
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        if (spellInfo->GetEffect(SpellEffIndex(effectIndex)).Effect == SPELL_EFFECT_TELEPORT_UNITS)
+        {
+            hasTeleportEffect = true;
+            break;
+        }
+    }
+
+    // Bot players do not own a real game client to naturally ACK near teleports
+    // (for example Blink). If a teleport is still pending after cast, synthesize
+    // the teleport ACK immediately so other combat actions (like Charge) resolve
+    // against the post-Blink location.
+    if (hasTeleportEffect && player->IsBeingTeleportedNear())
+    {
+        WorldSession* session = player->GetSession();
+        if (session && session->IsVirtualSession())
+        {
+            WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+            teleportAck << player->GetPackGUID();
+            teleportAck << uint32(0);
+            teleportAck << uint32(0);
+            session->HandleMoveTeleportAck(teleportAck);
+        }
+    }
+
     return true;
 }
 }


### PR DESCRIPTION
### Motivation
- Bots do not have a real game client to ACK short-range teleports (e.g., `Blink`), which can leave a teleport pending and cause subsequent combat actions to resolve against the pre-teleport location.
- Ensure virtual bot sessions immediately reflect post-teleport position so follow-up actions behave correctly.

### Description
- Added includes for `Protocol/Opcodes.h` and `WorldSession.h` and extended `CastDirectSpell` to detect teleport effects on a spell via `SPELL_EFFECT_TELEPORT_UNITS`.
- After `player->CastSpell(...)`, if the spell has a teleport effect and `player->IsBeingTeleportedNear()` is true, the code retrieves the `WorldSession` and for virtual sessions synthesizes a `MSG_MOVE_TELEPORT_ACK` `WorldPacket` and calls `session->HandleMoveTeleportAck(...)` to apply the ACK.
- Kept existing range/LOS/power checks and logging behavior unchanged.

### Testing
- Verified the project builds successfully after the change using the standard build (`cmake`/`make`).
- Ran the automated test suite and playerbot-related tests; all tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)