### PR TITLE
Synthesize teleport ACKs for bot teleports and handle Blink destination

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -20,10 +20,12 @@
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "Protocol/Opcodes.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
+#include "WorldSession.h"
 
 namespace
 {
@@ -108,7 +110,61 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
             return false;
 
-    player->CastSpell(target, context.spellId, false);
+    // Blink (1953) is a leap-forward spell with a destination target
+    // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
+    // on a unit target can leave relocation unresolved; provide an explicit
+    // front destination to mirror client cast payload semantics.
+    if (context.spellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
+    {
+        Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
+        player->CastSpell(CastSpellTargetArg(dest), context.spellId);
+    }
+    else
+        player->CastSpell(target, context.spellId, false);
+
+    bool hasTeleportEffect = false;
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        switch (spellInfo->GetEffect(SpellEffIndex(effectIndex)).Effect)
+        {
+            case SPELL_EFFECT_TELEPORT_UNITS:
+            case SPELL_EFFECT_TELEPORT_UNITS_FACE_CASTER:
+            case SPELL_EFFECT_LEAP:
+            case SPELL_EFFECT_JUMP:
+            case SPELL_EFFECT_JUMP_DEST:
+            case SPELL_EFFECT_LEAP_BACK:
+            case SPELL_EFFECT_CHARGE:
+            case SPELL_EFFECT_CHARGE_DEST:
+                hasTeleportEffect = true;
+                break;
+            default:
+                break;
+        }
+
+        if (hasTeleportEffect)
+            break;
+    }
+
+    // Bot players do not own a real game client to naturally ACK near teleports
+    // (for example Blink). If a teleport is still pending after cast, synthesize
+    // the teleport ACK immediately so other combat actions (like Charge) resolve
+    // against the post-Blink location.
+    if (hasTeleportEffect && player->IsBeingTeleportedNear())
+    {
+        WorldSession* session = player->GetSession();
+        if (session && session->IsVirtualSession())
+        {
+            TC_LOG_DEBUG("playerbots.pvp.class",
+                "Playerbot PvP teleport ACK synthesized: guid={} spell={} map={} x={} y={} z={}.",
+                player->GetGUID().ToString(), context.spellId, player->GetMapId(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+            WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+            teleportAck << player->GetPackGUID();
+            teleportAck << uint32(0);
+            teleportAck << uint32(0);
+            session->HandleMoveTeleportAck(teleportAck);
+        }
+    }
+
     return true;
 }
 }


### PR DESCRIPTION
### Motivation
- Prevent bot players from getting stuck or causing desyncs after near-teleport spells (e.g. Blink) due to missing client-side teleport ACKs.
- Ensure teleport-like spells resolve immediately so follow-up PvP actions (like Charge) operate against the post-teleport location.

### Description
- Added includes for `Protocol/Opcodes.h` and `WorldSession.h` and updated `CastDirectSpell` in `PlayerbotPvpClassActions.cpp` to special-case Blink (`1953`) by casting with an explicit front destination using `GetFirstCollisionPosition`.
- Detects teleport/leap/charge effects by scanning `spellInfo` effects and sets a `hasTeleportEffect` flag for relevant `SPELL_EFFECT_*` types.
- For virtual bot sessions, synthesizes a teleport ACK packet (`MSG_MOVE_TELEPORT_ACK`) and calls `session->HandleMoveTeleportAck` when a teleport is pending to immediately acknowledge relocation.
- Emits a debug log entry describing the synthesized ACK including player GUID, spell id, map and coordinates.

### Testing
- Built the server with the change and verified compilation succeeded.
- Exercised PvP bot scenarios involving Blink and follow-up movement/charge actions and confirmed no teleport-related desynchronization occurred and debug ACK logs were produced.
- Existing automated tests and server startup checks passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)