### PR TITLE
Synthesize teleport ACKs for virtual bots, handle Blink destination, and finalize pending teleports during lifecycle

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -20,10 +20,12 @@
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "Protocol/Opcodes.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
+#include "WorldSession.h"
 
 namespace
 {
@@ -108,7 +110,61 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
             return false;
 
-    player->CastSpell(target, context.spellId, false);
+    // Blink (1953) is a leap-forward spell with a destination target
+    // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
+    // on a unit target can leave relocation unresolved; provide an explicit
+    // front destination to mirror client cast payload semantics.
+    if (context.spellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
+    {
+        Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
+        player->CastSpell(CastSpellTargetArg(dest), context.spellId);
+    }
+    else
+        player->CastSpell(target, context.spellId, false);
+
+    bool hasTeleportEffect = false;
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        switch (spellInfo->GetEffect(SpellEffIndex(effectIndex)).Effect)
+        {
+            case SPELL_EFFECT_TELEPORT_UNITS:
+            case SPELL_EFFECT_TELEPORT_UNITS_FACE_CASTER:
+            case SPELL_EFFECT_LEAP:
+            case SPELL_EFFECT_JUMP:
+            case SPELL_EFFECT_JUMP_DEST:
+            case SPELL_EFFECT_LEAP_BACK:
+            case SPELL_EFFECT_CHARGE:
+            case SPELL_EFFECT_CHARGE_DEST:
+                hasTeleportEffect = true;
+                break;
+            default:
+                break;
+        }
+
+        if (hasTeleportEffect)
+            break;
+    }
+
+    // Bot players do not own a real game client to naturally ACK near teleports
+    // (for example Blink). If a teleport is still pending after cast, synthesize
+    // the teleport ACK immediately so other combat actions (like Charge) resolve
+    // against the post-Blink location.
+    if (hasTeleportEffect && player->IsBeingTeleportedNear())
+    {
+        WorldSession* session = player->GetSession();
+        if (session && session->IsVirtualSession())
+        {
+            TC_LOG_DEBUG("playerbots.pvp.class",
+                "Playerbot PvP teleport ACK synthesized: guid={} spell={} map={} x={} y={} z={}.",
+                player->GetGUID().ToString(), context.spellId, player->GetMapId(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+            WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+            teleportAck << player->GetPackGUID();
+            teleportAck << uint32(0);
+            teleportAck << uint32(0);
+            session->HandleMoveTeleportAck(teleportAck);
+        }
+    }
+
     return true;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -234,6 +234,36 @@ bool CanProcessPlayerLifecycle(Player const* player)
     return true;
 }
 
+void TryFinalizePendingVirtualBotTeleport(Player* player)
+{
+    if (!player || !playerbot::IsManagedRandomBot(player))
+        return;
+
+    WorldSession* session = player->GetSession();
+    if (!session || !session->IsVirtualSession())
+        return;
+
+    if (player->IsBeingTeleportedFar())
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check teleport finalization: guid={} type=far.",
+            player->GetGUID().ToString());
+        session->HandleMoveWorldportAck();
+    }
+
+    if (player->IsBeingTeleportedNear())
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check teleport finalization: guid={} type=near.",
+            player->GetGUID().ToString());
+        WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+        teleportAck << player->GetPackGUID();
+        teleportAck << uint32(0);
+        teleportAck << uint32(0);
+        session->HandleMoveTeleportAck(teleportAck);
+    }
+}
+
 void TryReviveManagedBotAfterStartup(Player* player)
 {
     if (!player || !playerbot::IsManagedRandomBot(player))
@@ -804,6 +834,7 @@ void RandomBotParticipationManager::OnPlayerLogout(Player const* player)
 void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
 {
     TryReviveManagedBotAfterStartup(player);
+    TryFinalizePendingVirtualBotTeleport(player);
 
     if (!CanProcessPlayerLifecycle(player))
         return;


### PR DESCRIPTION
### Motivation

- Virtual bot sessions do not have a real client to ACK near/far teleports, which can leave bot relocation unresolved and break follow-up combat actions.
- The Blink spell (1953) is a destination-based leap and casting it against a unit target for virtual sessions can fail to produce the expected relocation.
- Lifecycle processing should finalize any pending teleports for managed virtual bots before performing other lifecycle work.

### Description

- Added includes for `Protocol/Opcodes.h` and `WorldSession.h` to support constructing teleport ACK packets and session APIs.
- In `CastDirectSpell`, special-cased Blink (`1953`) to cast with an explicit front destination and added detection of teleport-like spell effects to synthesize `MSG_MOVE_TELEPORT_ACK` for virtual sessions when a near teleport is pending.
- Introduced `TryFinalizePendingVirtualBotTeleport` to finalize far teleports via `HandleMoveWorldportAck` and to synthesize near teleport ACKs, and invoked it from `ProcessPlayerLifecycle` before other lifecycle processing.
- Added debug logging to record when teleport ACKs are synthesized for playerbots.

### Testing

- Built the server (`make`) after changes and the build completed without compile errors.
- Ran the project's automated playerbot/pvp test targets and the server integration checks covering teleport and lifecycle paths, and they completed without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)