### PR TITLE
Finalize virtual-session teleports for bots and synthesize teleport ACKs on casts (Blink/teleports)

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -615,9 +615,20 @@ public:
             if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
                 return false;
 
-            if (target->IsBeingTeleportedFar())
-                if (WorldSession* targetSession = target->GetSession(); targetSession && targetSession->IsVirtualSession())
+            if (WorldSession* targetSession = target->GetSession(); targetSession && targetSession->IsVirtualSession())
+            {
+                if (target->IsBeingTeleportedFar())
                     targetSession->HandleMoveWorldportAck();
+
+                if (target->IsBeingTeleportedNear())
+                {
+                    WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+                    teleportAck << target->GetPackGUID();
+                    teleportAck << uint32(0);
+                    teleportAck << uint32(0);
+                    targetSession->HandleMoveTeleportAck(teleportAck);
+                }
+            }
 
             if (target->IsBeingTeleported())
             {
@@ -945,6 +956,21 @@ public:
         // check online security
         if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
             return false;
+
+        if (WorldSession* targetSession = target->GetSession(); targetSession && targetSession->IsVirtualSession())
+        {
+            if (target->IsBeingTeleportedFar())
+                targetSession->HandleMoveWorldportAck();
+
+            if (target->IsBeingTeleportedNear())
+            {
+                WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+                teleportAck << target->GetPackGUID();
+                teleportAck << uint32(0);
+                teleportAck << uint32(0);
+                targetSession->HandleMoveTeleportAck(teleportAck);
+            }
+        }
 
         if (target->IsBeingTeleported())
         {

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -20,10 +20,12 @@
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "Protocol/Opcodes.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
+#include "WorldSession.h"
 
 namespace
 {
@@ -108,7 +110,61 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
             return false;
 
-    player->CastSpell(target, context.spellId, false);
+    // Blink (1953) is a leap-forward spell with a destination target
+    // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
+    // on a unit target can leave relocation unresolved; provide an explicit
+    // front destination to mirror client cast payload semantics.
+    if (context.spellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
+    {
+        Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
+        player->CastSpell(CastSpellTargetArg(dest), context.spellId);
+    }
+    else
+        player->CastSpell(target, context.spellId, false);
+
+    bool hasTeleportEffect = false;
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        switch (spellInfo->GetEffect(SpellEffIndex(effectIndex)).Effect)
+        {
+            case SPELL_EFFECT_TELEPORT_UNITS:
+            case SPELL_EFFECT_TELEPORT_UNITS_FACE_CASTER:
+            case SPELL_EFFECT_LEAP:
+            case SPELL_EFFECT_JUMP:
+            case SPELL_EFFECT_JUMP_DEST:
+            case SPELL_EFFECT_LEAP_BACK:
+            case SPELL_EFFECT_CHARGE:
+            case SPELL_EFFECT_CHARGE_DEST:
+                hasTeleportEffect = true;
+                break;
+            default:
+                break;
+        }
+
+        if (hasTeleportEffect)
+            break;
+    }
+
+    // Bot players do not own a real game client to naturally ACK near teleports
+    // (for example Blink). If a teleport is still pending after cast, synthesize
+    // the teleport ACK immediately so other combat actions (like Charge) resolve
+    // against the post-Blink location.
+    if (hasTeleportEffect && player->IsBeingTeleportedNear())
+    {
+        WorldSession* session = player->GetSession();
+        if (session && session->IsVirtualSession())
+        {
+            TC_LOG_DEBUG("playerbots.pvp.class",
+                "Playerbot PvP teleport ACK synthesized: guid={} spell={} map={} x={} y={} z={}.",
+                player->GetGUID().ToString(), context.spellId, player->GetMapId(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+            WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+            teleportAck << player->GetPackGUID();
+            teleportAck << uint32(0);
+            teleportAck << uint32(0);
+            session->HandleMoveTeleportAck(teleportAck);
+        }
+    }
+
     return true;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -234,6 +234,36 @@ bool CanProcessPlayerLifecycle(Player const* player)
     return true;
 }
 
+void TryFinalizePendingVirtualBotTeleport(Player* player)
+{
+    if (!player || !playerbot::IsManagedRandomBot(player))
+        return;
+
+    WorldSession* session = player->GetSession();
+    if (!session || !session->IsVirtualSession())
+        return;
+
+    if (player->IsBeingTeleportedFar())
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check teleport finalization: guid={} type=far.",
+            player->GetGUID().ToString());
+        session->HandleMoveWorldportAck();
+    }
+
+    if (player->IsBeingTeleportedNear())
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check teleport finalization: guid={} type=near.",
+            player->GetGUID().ToString());
+        WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+        teleportAck << player->GetPackGUID();
+        teleportAck << uint32(0);
+        teleportAck << uint32(0);
+        session->HandleMoveTeleportAck(teleportAck);
+    }
+}
+
 void TryReviveManagedBotAfterStartup(Player* player)
 {
     if (!player || !playerbot::IsManagedRandomBot(player))
@@ -804,6 +834,7 @@ void RandomBotParticipationManager::OnPlayerLogout(Player const* player)
 void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
 {
     TryReviveManagedBotAfterStartup(player);
+    TryFinalizePendingVirtualBotTeleport(player);
 
     if (!CanProcessPlayerLifecycle(player))
         return;


### PR DESCRIPTION
### Motivation
- Virtual (bot) sessions do not have a real client to ACK teleports, which can leave teleportation states unresolved and break follow-up actions or lifecycle processing.
- Casting leap/teleport spells (e.g. Blink) from playerbots can leave their location inconsistent for subsequent logic unless an ACK is synthesized.
- Summon/recall commands should finalize pending teleports for virtual sessions to avoid leaving bots in a teleporting state.

### Description
- In `cs_misc.cpp` enhanced `HandleSummonCommand` and `HandleRecallCommand` to finalize pending virtual-session teleports by calling `HandleMoveWorldportAck()` for far teleports and sending a `MSG_MOVE_TELEPORT_ACK` packet for near teleports before checking `IsBeingTeleported()`.
- In `PlayerbotPvpClassActions.cpp` added includes for opcode/session headers, special-cased Blink (spell id `1953`) to provide a front destination when casting, and added detection of teleport-like spell effects to synthesize a `MSG_MOVE_TELEPORT_ACK` for virtual bot sessions when a near teleport remains pending after cast, with debug logging.
- In `PlayerbotRandomBotParticipation.cpp` added `TryFinalizePendingVirtualBotTeleport()` to finalize pending teleports for managed random bots (far and near) and invoked it from `ProcessPlayerLifecycle()` before lifecycle processing.

### Testing
- Performed a full project build (`cmake` + `make`) to verify compile-time correctness, which completed successfully.
- Ran the playerbot-related test suite via `ctest -R playerbot` and the targeted playerbot/unit tests covering PvP/cast and lifecycle paths passed.
- Executed basic automated script-based checks that exercise `HandleSummonCommand`, `HandleRecallCommand`, and bot Blink casts under virtual sessions and verified no teleport state leaks (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)