### PR TITLE
Finalize virtual-session teleports and synthesize ACKs for bots (summon/recall, PvP, lifecycle)

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -615,9 +615,45 @@ public:
             if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
                 return false;
 
-            if (target->IsBeingTeleportedFar())
-                if (WorldSession* targetSession = target->GetSession(); targetSession && targetSession->IsVirtualSession())
+            if (WorldSession* targetSession = target->GetSession(); targetSession && targetSession->IsVirtualSession())
+            {
+                if (target->IsBeingTeleportedFar())
                     targetSession->HandleMoveWorldportAck();
+
+                if (target->IsBeingTeleportedNear())
+                {
+                    WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+                    teleportAck << target->GetPackGUID();
+                    teleportAck << uint32(0);
+                    teleportAck << uint32(0);
+                    targetSession->HandleMoveTeleportAck(teleportAck);
+
+                    if (target->IsBeingTeleportedNear())
+                    {
+                        uint32 const oldZone = target->GetZoneId();
+                        WorldLocation const& dest = target->GetTeleportDest();
+                        target->SetSemaphoreTeleportNear(false);
+                        target->UpdatePosition(dest, true);
+                        target->SetFallInformation(0, target->GetPositionZ());
+
+                        uint32 newZone = 0;
+                        uint32 newArea = 0;
+                        target->GetZoneAndAreaId(newZone, newArea);
+                        target->UpdateZone(newZone, newArea);
+
+                        if (oldZone != newZone)
+                        {
+                            if (target->pvpInfo.IsHostile)
+                                target->CastSpell(target, 2479, true);
+                            else if (target->IsPvP() && !target->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP))
+                                target->UpdatePvP(false, false);
+                        }
+
+                        target->ResummonPetTemporaryUnSummonedIfAny();
+                        target->ProcessDelayedOperations();
+                    }
+                }
+            }
 
             if (target->IsBeingTeleported())
             {
@@ -945,6 +981,46 @@ public:
         // check online security
         if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
             return false;
+
+        if (WorldSession* targetSession = target->GetSession(); targetSession && targetSession->IsVirtualSession())
+        {
+            if (target->IsBeingTeleportedFar())
+                targetSession->HandleMoveWorldportAck();
+
+            if (target->IsBeingTeleportedNear())
+            {
+                WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+                teleportAck << target->GetPackGUID();
+                teleportAck << uint32(0);
+                teleportAck << uint32(0);
+                targetSession->HandleMoveTeleportAck(teleportAck);
+
+                if (target->IsBeingTeleportedNear())
+                {
+                    uint32 const oldZone = target->GetZoneId();
+                    WorldLocation const& dest = target->GetTeleportDest();
+                    target->SetSemaphoreTeleportNear(false);
+                    target->UpdatePosition(dest, true);
+                    target->SetFallInformation(0, target->GetPositionZ());
+
+                    uint32 newZone = 0;
+                    uint32 newArea = 0;
+                    target->GetZoneAndAreaId(newZone, newArea);
+                    target->UpdateZone(newZone, newArea);
+
+                    if (oldZone != newZone)
+                    {
+                        if (target->pvpInfo.IsHostile)
+                            target->CastSpell(target, 2479, true);
+                        else if (target->IsPvP() && !target->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP))
+                            target->UpdatePvP(false, false);
+                    }
+
+                    target->ResummonPetTemporaryUnSummonedIfAny();
+                    target->ProcessDelayedOperations();
+                }
+            }
+        }
 
         if (target->IsBeingTeleported())
         {

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -20,13 +20,44 @@
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "Protocol/Opcodes.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
+#include "WorldSession.h"
 
 namespace
 {
+void FinalizeVirtualNearTeleport(Player* player)
+{
+    if (!player || !player->IsBeingTeleportedNear())
+        return;
+
+    uint32 const oldZone = player->GetZoneId();
+    WorldLocation const& dest = player->GetTeleportDest();
+
+    player->SetSemaphoreTeleportNear(false);
+    player->UpdatePosition(dest, true);
+    player->SetFallInformation(0, player->GetPositionZ());
+
+    uint32 newZone = 0;
+    uint32 newArea = 0;
+    player->GetZoneAndAreaId(newZone, newArea);
+    player->UpdateZone(newZone, newArea);
+
+    if (oldZone != newZone)
+    {
+        if (player->pvpInfo.IsHostile)
+            player->CastSpell(player, 2479, true);
+        else if (player->IsPvP() && !player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP))
+            player->UpdatePvP(false, false);
+    }
+
+    player->ResummonPetTemporaryUnSummonedIfAny();
+    player->ProcessDelayedOperations();
+}
+
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
 {
     switch (mode)
@@ -108,7 +139,64 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
             return false;
 
-    player->CastSpell(target, context.spellId, false);
+    // Blink (1953) is a leap-forward spell with a destination target
+    // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
+    // on a unit target can leave relocation unresolved; provide an explicit
+    // front destination to mirror client cast payload semantics.
+    if (context.spellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
+    {
+        Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
+        player->CastSpell(CastSpellTargetArg(dest), context.spellId);
+    }
+    else
+        player->CastSpell(target, context.spellId, false);
+
+    bool hasTeleportEffect = false;
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        switch (spellInfo->GetEffect(SpellEffIndex(effectIndex)).Effect)
+        {
+            case SPELL_EFFECT_TELEPORT_UNITS:
+            case SPELL_EFFECT_TELEPORT_UNITS_FACE_CASTER:
+            case SPELL_EFFECT_LEAP:
+            case SPELL_EFFECT_JUMP:
+            case SPELL_EFFECT_JUMP_DEST:
+            case SPELL_EFFECT_LEAP_BACK:
+            case SPELL_EFFECT_CHARGE:
+            case SPELL_EFFECT_CHARGE_DEST:
+                hasTeleportEffect = true;
+                break;
+            default:
+                break;
+        }
+
+        if (hasTeleportEffect)
+            break;
+    }
+
+    // Bot players do not own a real game client to naturally ACK near teleports
+    // (for example Blink). If a teleport is still pending after cast, synthesize
+    // the teleport ACK immediately so other combat actions (like Charge) resolve
+    // against the post-Blink location.
+    if (hasTeleportEffect && player->IsBeingTeleportedNear())
+    {
+        WorldSession* session = player->GetSession();
+        if (session && session->IsVirtualSession())
+        {
+            TC_LOG_DEBUG("playerbots.pvp.class",
+                "Playerbot PvP teleport ACK synthesized: guid={} spell={} map={} x={} y={} z={}.",
+                player->GetGUID().ToString(), context.spellId, player->GetMapId(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+            WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+            teleportAck << player->GetPackGUID();
+            teleportAck << uint32(0);
+            teleportAck << uint32(0);
+            session->HandleMoveTeleportAck(teleportAck);
+
+            if (player->IsBeingTeleportedNear())
+                FinalizeVirtualNearTeleport(player);
+        }
+    }
+
     return true;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -234,6 +234,61 @@ bool CanProcessPlayerLifecycle(Player const* player)
     return true;
 }
 
+void TryFinalizePendingVirtualBotTeleport(Player* player)
+{
+    if (!player || !playerbot::IsManagedRandomBot(player))
+        return;
+
+    WorldSession* session = player->GetSession();
+    if (!session || !session->IsVirtualSession())
+        return;
+
+    if (player->IsBeingTeleportedFar())
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check teleport finalization: guid={} type=far.",
+            player->GetGUID().ToString());
+        session->HandleMoveWorldportAck();
+    }
+
+    if (player->IsBeingTeleportedNear())
+    {
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check teleport finalization: guid={} type=near.",
+            player->GetGUID().ToString());
+        WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+        teleportAck << player->GetPackGUID();
+        teleportAck << uint32(0);
+        teleportAck << uint32(0);
+        session->HandleMoveTeleportAck(teleportAck);
+
+        if (player->IsBeingTeleportedNear())
+        {
+            uint32 const oldZone = player->GetZoneId();
+            WorldLocation const& dest = player->GetTeleportDest();
+            player->SetSemaphoreTeleportNear(false);
+            player->UpdatePosition(dest, true);
+            player->SetFallInformation(0, player->GetPositionZ());
+
+            uint32 newZone = 0;
+            uint32 newArea = 0;
+            player->GetZoneAndAreaId(newZone, newArea);
+            player->UpdateZone(newZone, newArea);
+
+            if (oldZone != newZone)
+            {
+                if (player->pvpInfo.IsHostile)
+                    player->CastSpell(player, 2479, true);
+                else if (player->IsPvP() && !player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP))
+                    player->UpdatePvP(false, false);
+            }
+
+            player->ResummonPetTemporaryUnSummonedIfAny();
+            player->ProcessDelayedOperations();
+        }
+    }
+}
+
 void TryReviveManagedBotAfterStartup(Player* player)
 {
     if (!player || !playerbot::IsManagedRandomBot(player))
@@ -804,6 +859,7 @@ void RandomBotParticipationManager::OnPlayerLogout(Player const* player)
 void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
 {
     TryReviveManagedBotAfterStartup(player);
+    TryFinalizePendingVirtualBotTeleport(player);
 
     if (!CanProcessPlayerLifecycle(player))
         return;


### PR DESCRIPTION
### Motivation
- Virtual sessions (managed bot players) do not have a real client to ACK near teleports (e.g., Blink) or worldport transitions, leaving bots in a pending teleport state and breaking subsequent actions like PvP moves, summons, and recalls.
- Summon and recall commands must finalize pending virtual teleports when targeting virtual sessions to avoid leaving target bots in inconsistent positions.
- Playerbot PvP actions that cause movement effects need immediate teleport finalization to ensure follow-up actions resolve against the correct location.

### Description
- Added explicit handling for virtual sessions in `cs_misc.cpp` for the Summon and Recall commands to call `HandleMoveWorldportAck` and synthesize `MSG_MOVE_TELEPORT_ACK`, and to finalize near-teleport state (position, zone, PvP flags, pet resummon, delayed ops).
- Introduced `FinalizeVirtualNearTeleport` in `PlayerbotPvpClassActions.cpp` and enhanced `CastDirectSpell` to special-case `Blink (1953)` with an explicit destination and to detect teleport-like spell effects, synthesize `MSG_MOVE_TELEPORT_ACK` for virtual sessions, and finalize the near-teleport state with logging.
- Added `TryFinalizePendingVirtualBotTeleport` in `PlayerbotRandomBotParticipation.cpp` and invoked it from `ProcessPlayerLifecycle` so pending teleports are finalized during lifecycle processing for managed random bots.
- Added necessary includes (`Protocol/Opcodes.h`, `WorldSession.h`) and debug logging entries to trace synthesized ACKs and lifecycle finalization events.

### Testing
- Performed a debug build with `cmake --build .` which completed successfully.
- Executed automated test suite via `ctest --output-on-failure` and all tests passed.
- Ran existing playerbot-related unit tests to validate that synthesized teleport ACKs do not regress PvP action resolution and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4446d15bc8327b7d5fc64ba9d34af)