### PR TITLE
Playerbot: face enemy targets before PvP class spell casts

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -129,6 +129,12 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     {
         if (!player->IsValidAttackTarget(target, spellInfo))
             return false;
+
+        // Virtual playerbot sessions do not naturally rotate their character the
+        // same way a real client does while selecting/casting. Make sure the bot
+        // is facing its hostile target before casting so facing-sensitive spells
+        // do not fail in duels and other PvP contexts.
+        player->SetFacingToObject(target);
     }
     else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
     {


### PR DESCRIPTION
### Motivation
- Playerbots in virtual sessions were not rotating to face hostile duel targets and therefore failed to cast facing-sensitive spells in PvP/duel scenarios.
- The change ensures bots behave more like real clients by orienting toward an enemy before attempting enemy-targeted class spell casts.

### Description
- Added a call to `player->SetFacingToObject(target)` in `CastDirectSpell` when `context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy` to force the bot to face its hostile target before casting.
- Change is localized to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` inside the enemy-target handling branch so self/ally/none flows are unchanged.

### Testing
- No automated tests or full server build/test suite were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d487a73d388327bc5997205508d30f)