### PR TITLE
Whisper duel decisions to opponent and ensure facing before enemy spell casts

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -37,6 +37,22 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
     if (!player || !player->duel)
         return;
 
+    Player* opponent = player->duel->Opponent;
+    if (opponent)
+    {
+        std::string message = "Decision: ";
+        message += context.actionName ? context.actionName : "none";
+        message += " | spell=" + std::to_string(context.spellId);
+        message += " | target=";
+        message += GetTargetModeLabel(context.targetMode);
+        message += " | success=";
+        message += casted ? "yes" : "no";
+        message += " | reason=";
+        message += context.reason ? context.reason : "none";
+
+        player->Whisper(message, LANG_UNIVERSAL, opponent);
+    }
+
     TC_LOG_DEBUG("playerbots.pvp.class",
         "[PvP duel] {} decision={} spell={} target={} success={} reason={}",
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
@@ -129,6 +145,12 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     {
         if (!player->IsValidAttackTarget(target, spellInfo))
             return false;
+
+        // Virtual playerbot sessions do not naturally rotate their character the
+        // same way a real client does while selecting/casting. Make sure the bot
+        // is facing its hostile target before casting so facing-sensitive spells
+        // do not fail in duels and other PvP contexts.
+        player->SetFacingToObject(target);
     }
     else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
     {


### PR DESCRIPTION
### Motivation

- Provide immediate feedback to a duel opponent about a bot's decision for easier debugging and transparency during PvP duels.
- Prevent facing-sensitive spells from failing when virtual playerbot sessions do not rotate the character like a real client.

### Description

- Extend `NotifyDuelDecision` to send a `Whisper` to the duel opponent with a compact decision message containing `actionName`, `spellId`, `targetMode`, `success`, and `reason`.
- In `CastDirectSpell`, call `player->SetFacingToObject(target)` when the `targetMode` is `Enemy` so the bot faces its hostile target before casting.
- Retain existing debug logging of duel decisions for server logs.

### Testing

- Project build completed successfully and automated test suite was executed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d487a73d388327bc5997205508d30f)