### PR TITLE
Playerbot PvP: ensure facing/stop movement before casts, validate cast result, and notify duel opponent

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -37,6 +37,22 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
     if (!player || !player->duel)
         return;
 
+    Player* opponent = player->duel->Opponent;
+    if (opponent)
+    {
+        std::string message = "Decision: ";
+        message += context.actionName ? context.actionName : "none";
+        message += " | spell=" + std::to_string(context.spellId);
+        message += " | target=";
+        message += GetTargetModeLabel(context.targetMode);
+        message += " | success=";
+        message += casted ? "yes" : "no";
+        message += " | reason=";
+        message += context.reason ? context.reason : "none";
+
+        player->Whisper(message, LANG_UNIVERSAL, opponent);
+    }
+
     TC_LOG_DEBUG("playerbots.pvp.class",
         "[PvP duel] {} decision={} spell={} target={} success={} reason={}",
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
@@ -129,6 +145,12 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     {
         if (!player->IsValidAttackTarget(target, spellInfo))
             return false;
+
+        // Virtual playerbot sessions do not naturally rotate their character the
+        // same way a real client does while selecting/casting. Make sure the bot
+        // is facing its hostile target before casting so facing-sensitive spells
+        // do not fail in duels and other PvP contexts.
+        player->SetFacingToObject(target);
     }
     else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
     {
@@ -153,6 +175,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
             return false;
 
+    // Cast-time spells like Frostbolt fail while moving. Since playerbots do
+    // not have client-side stop-cast behavior, explicitly stop movement before
+    // attempting non-instant casts.
+    if (spellInfo->CalcCastTime() > 0)
+        player->StopMoving();
+
+    SpellCastResult castResult = SPELL_FAILED_ERROR;
+
     // Blink (1953) is a leap-forward spell with a destination target
     // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
     // on a unit target can leave relocation unresolved; provide an explicit
@@ -160,10 +190,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     if (context.spellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
     {
         Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
-        player->CastSpell(CastSpellTargetArg(dest), context.spellId);
+        castResult = player->CastSpell(CastSpellTargetArg(dest), context.spellId);
     }
     else
-        player->CastSpell(target, context.spellId, false);
+        castResult = player->CastSpell(target, context.spellId, false);
+
+    if (castResult != SPELL_CAST_OK)
+        return false;
 
     bool hasTeleportEffect = false;
     for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)


### PR DESCRIPTION
### Motivation

- Prevent spells from failing for virtual playerbots in PvP because of incorrect facing or moving during cast. 
- Ensure blink-like teleport spells include an explicit destination for virtual sessions. 
- Make duel decisions visible to the opponent for easier debugging of bot behavior. 

### Description

- Send a whisper to the duel opponent with the action name, spell id, target mode, success flag, and reason by updating `NotifyDuelDecision`. 
- Ensure enemy targets are faced before casting by calling `player->SetFacingToObject(target)` for `TargetMode::Enemy`. 
- Stop bot movement before attempting non-instant casts when `spellInfo->CalcCastTime() > 0` by calling `player->StopMoving()`. 
- Capture and check the `SpellCastResult` returned from `player->CastSpell(...)` (including special-case handling for Blink `1953`) and fail the cast flow if the result is not `SPELL_CAST_OK`. 

### Testing

- Built the project with the updated code using the normal build system (`cmake`/`make`) and the build completed successfully. 
- Ran automated unit tests/CI test suite (`ctest`/project tests) covering spell-casting and PvP scenarios and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d487a73d388327bc5997205508d30f)