### PR TITLE
Playerbot PvP: ensure proper target/facing, cast checks, and duel notifications for virtual sessions

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -32,7 +32,7 @@ namespace
 {
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
 
-void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& context, bool casted)
+void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& context, bool casted, std::string const& failureReason)
 {
     if (!player || !player->duel)
         return;
@@ -47,8 +47,10 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
         message += GetTargetModeLabel(context.targetMode);
         message += " | success=";
         message += casted ? "yes" : "no";
-        message += " | reason=";
+        message += " | decision_reason=";
         message += context.reason ? context.reason : "none";
+        if (!casted && !failureReason.empty())
+            message += " | fail_reason=" + failureReason;
 
         player->Whisper(message, LANG_UNIVERSAL, opponent);
     }
@@ -120,31 +122,51 @@ Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& conte
     }
 }
 
-bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context)
+bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
 {
+    failureReason.clear();
+
     if (!player || !context.spellId || !player->HasSpell(context.spellId))
+    {
+        failureReason = "missing_spell";
         return false;
+    }
 
     SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(context.spellId);
     if (!spellInfo)
+    {
+        failureReason = "spell_info_missing";
         return false;
+    }
 
     if (player->GetSpellHistory()->HasCooldown(context.spellId) ||
         player->GetSpellHistory()->HasGlobalCooldown(spellInfo) ||
         player->IsNonMeleeSpellCast(false, false, true))
+    {
+        failureReason = "cooldown_or_casting";
         return false;
+    }
 
     Unit* target = ResolveTarget(player, context);
 
     if (!target || !target->IsAlive())
+    {
+        failureReason = "target_invalid_or_dead";
         return false;
+    }
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self && target != player)
+    {
+        failureReason = "self_target_mismatch";
         return false;
+    }
 
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
     {
         if (!player->IsValidAttackTarget(target, spellInfo))
+        {
+            failureReason = "invalid_enemy_target";
             return false;
+        }
 
         // Keep explicit enemy selection/victim linkage for virtual sessions so
         // cast checks and AI follow-up consistently reference the same hostile.
@@ -161,25 +183,43 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
     {
         if (!player->IsValidAssistTarget(target, spellInfo))
+        {
+            failureReason = "invalid_ally_target";
             return false;
+        }
     }
     else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::None)
+    {
+        failureReason = "target_mode_none";
         return false;
+    }
 
     if (!player->IsWithinLOSInMap(target))
+    {
+        failureReason = "no_los";
         return false;
+    }
 
     float const maxRange = spellInfo->GetMaxRange(false);
     if (maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
+    {
+        failureReason = "out_of_range";
         return false;
+    }
 
     float const minRange = spellInfo->GetMinRange(false);
     if (minRange > 0.0f && player->IsWithinDistInMap(target, minRange))
+    {
+        failureReason = "too_close";
         return false;
+    }
 
     if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
+        {
+            failureReason = "insufficient_power";
             return false;
+        }
 
     // Cast-time spells like Frostbolt fail while moving. Since playerbots do
     // not have client-side stop-cast behavior, explicitly stop movement before
@@ -202,7 +242,10 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         castResult = player->CastSpell(target, context.spellId, false);
 
     if (castResult != SPELL_CAST_OK)
+    {
+        failureReason = "cast_result_" + std::to_string(static_cast<uint32>(castResult));
         return false;
+    }
 
     bool hasTeleportEffect = false;
     for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
@@ -261,8 +304,9 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
     if (!player || !context.classSpellsEnabled || !context.shouldExecute)
         return false;
 
-    bool const casted = CastDirectSpell(player, context);
-    NotifyDuelDecision(player, context, casted);
+    std::string failureReason;
+    bool const casted = CastDirectSpell(player, context, failureReason);
+    NotifyDuelDecision(player, context, casted, failureReason);
     TC_LOG_DEBUG("playerbots.pvp.class",
         "Playerbot PvP class execution: action={} spell={} target_mode={} target_guid={} success={} reason={}.",
         context.actionName ? context.actionName : "none",

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -37,6 +37,22 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
     if (!player || !player->duel)
         return;
 
+    Player* opponent = player->duel->Opponent;
+    if (opponent)
+    {
+        std::string message = "Decision: ";
+        message += context.actionName ? context.actionName : "none";
+        message += " | spell=" + std::to_string(context.spellId);
+        message += " | target=";
+        message += GetTargetModeLabel(context.targetMode);
+        message += " | success=";
+        message += casted ? "yes" : "no";
+        message += " | reason=";
+        message += context.reason ? context.reason : "none";
+
+        player->Whisper(message, LANG_UNIVERSAL, opponent);
+    }
+
     TC_LOG_DEBUG("playerbots.pvp.class",
         "[PvP duel] {} decision={} spell={} target={} success={} reason={}",
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
@@ -129,6 +145,18 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     {
         if (!player->IsValidAttackTarget(target, spellInfo))
             return false;
+
+        // Keep explicit enemy selection/victim linkage for virtual sessions so
+        // cast checks and AI follow-up consistently reference the same hostile.
+        player->SetSelection(target->GetGUID());
+        if (player->GetVictim() != target)
+            player->Attack(target, false);
+
+        // Virtual playerbot sessions do not naturally rotate their character the
+        // same way a real client does while selecting/casting. Make sure the bot
+        // is facing its hostile target before casting so facing-sensitive spells
+        // do not fail in duels and other PvP contexts.
+        player->SetFacingToObject(target);
     }
     else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
     {
@@ -153,6 +181,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
             return false;
 
+    // Cast-time spells like Frostbolt fail while moving. Since playerbots do
+    // not have client-side stop-cast behavior, explicitly stop movement before
+    // attempting non-instant casts.
+    if (spellInfo->CalcCastTime() > 0)
+        player->StopMoving();
+
+    SpellCastResult castResult = SPELL_FAILED_ERROR;
+
     // Blink (1953) is a leap-forward spell with a destination target
     // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
     // on a unit target can leave relocation unresolved; provide an explicit
@@ -160,10 +196,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     if (context.spellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
     {
         Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
-        player->CastSpell(CastSpellTargetArg(dest), context.spellId);
+        castResult = player->CastSpell(CastSpellTargetArg(dest), context.spellId);
     }
     else
-        player->CastSpell(target, context.spellId, false);
+        castResult = player->CastSpell(target, context.spellId, false);
+
+    if (castResult != SPELL_CAST_OK)
+        return false;
 
     bool hasTeleportEffect = false;
     for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)


### PR DESCRIPTION
### Motivation

- Improve reliability of PvP spell casts for virtual playerbot sessions by ensuring target selection, facing, and movement state match client semantics. 
- Provide duel opponents with a brief decision notification so duel flow is easier to observe and debug.

### Description

- Add duel opponent notification using `Player::Whisper` to send action name, `spellId`, target mode, success flag, and `reason` when a decision is made. 
- Ensure explicit enemy selection and engagement by setting selection (`Player::SetSelection`) and linking the victim via `Player::Attack` for enemy-targeted casts. 
- Force the bot to face the hostile target using `Player::SetFacingToObject` before casting to avoid facing-sensitive spell failures. 
- Stop movement prior to attempting non-instant casts with `Player::StopMoving` and capture `SpellCastResult` from `Player::CastSpell`, returning early on non-`SPELL_CAST_OK`. 
- Handle `Blink` (1953) by passing an explicit front destination and checking the returned cast result to mirror client cast payload semantics.

### Testing

- Project was built locally with `make` and the server binary compiled successfully. 
- Ran available test suite with `make test`, and unit tests completed without failures. 
- Performed a basic local integration check of duel whisper and PvP cast behavior which exhibited the intended improvements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d487a73d388327bc5997205508d30f)