### PR TITLE
Improve PvP bot casting/facing/target handling and duel decision notification

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -37,6 +37,22 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
     if (!player || !player->duel)
         return;
 
+    Player* opponent = player->duel->Opponent;
+    if (opponent)
+    {
+        std::string message = "Decision: ";
+        message += context.actionName ? context.actionName : "none";
+        message += " | spell=" + std::to_string(context.spellId);
+        message += " | target=";
+        message += GetTargetModeLabel(context.targetMode);
+        message += " | success=";
+        message += casted ? "yes" : "no";
+        message += " | reason=";
+        message += context.reason ? context.reason : "none";
+
+        player->Whisper(message, LANG_UNIVERSAL, opponent);
+    }
+
     TC_LOG_DEBUG("playerbots.pvp.class",
         "[PvP duel] {} decision={} spell={} target={} success={} reason={}",
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
@@ -129,6 +145,17 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     {
         if (!player->IsValidAttackTarget(target, spellInfo))
             return false;
+
+        // Keep explicit enemy selection/victim linkage for virtual sessions so
+        // cast checks and AI follow-up consistently reference the same hostile.
+        player->SetSelection(target->GetGUID());
+        if (player->GetVictim() != target)
+            player->Attack(target, false);
+
+        // Virtual sessions can visually "turn" while server-side facing checks
+        // still fail for the immediate cast tick. SetInFront updates orientation
+        // instantly, so facing-sensitive spells pass UNIT_NOT_INFRONT checks.
+        player->SetInFront(target);
     }
     else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
     {
@@ -153,6 +180,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
             return false;
 
+    // Cast-time spells like Frostbolt fail while moving. Since playerbots do
+    // not have client-side stop-cast behavior, explicitly stop movement before
+    // attempting non-instant casts.
+    if (spellInfo->CalcCastTime() > 0)
+        player->StopMoving();
+
+    SpellCastResult castResult = SPELL_FAILED_ERROR;
+
     // Blink (1953) is a leap-forward spell with a destination target
     // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
     // on a unit target can leave relocation unresolved; provide an explicit
@@ -160,10 +195,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     if (context.spellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
     {
         Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
-        player->CastSpell(CastSpellTargetArg(dest), context.spellId);
+        castResult = player->CastSpell(CastSpellTargetArg(dest), context.spellId);
     }
     else
-        player->CastSpell(target, context.spellId, false);
+        castResult = player->CastSpell(target, context.spellId, false);
+
+    if (castResult != SPELL_CAST_OK)
+        return false;
 
     bool hasTeleportEffect = false;
     for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)


### PR DESCRIPTION
### Motivation

- Make PvP bot spell casting more reliable in virtual sessions by ensuring consistent target selection, facing, and movement state for casts. 
- Provide opponents feedback in duels about bot decision attempts for easier debugging. 
- Ensure casts fail early when server-side checks prevent them, instead of proceeding as if they succeeded.

### Description

- Send a duel `Whisper` to the opponent with a short decision message including action, spell id, target mode, success and reason in `NotifyDuelDecision` when a player is in a duel. 
- In `CastDirectSpell` ensure enemy targets are explicitly selected and set as the player victim via `SetSelection` and `Attack`, and immediately align facing with `SetInFront` so facing checks accept the cast. 
- Stop movement before attempting non-instant casts via `StopMoving` when `CalcCastTime() > 0`. 
- Capture `CastSpell`'s `SpellCastResult` (including special-case `Blink` destination cast) and return failure if the cast result is not `SPELL_CAST_OK`. 

### Testing

- Compiled the server code and confirmed the build succeeds with the changes. 
- Exercised PvP bot casting paths in automated integration runs covering enemy/ally/self target modes and `Blink`, and observed expected cast acceptance/rejection behavior. 
- Ran available unit/regression tests and observed no failures after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d487a73d388327bc5997205508d30f)