### PR TITLE
Fix Playerbot PvP class action compile regressions

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -164,6 +164,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         {
             failureReason = "invalid_enemy_target";
             return false;
+        }
 
         // Keep explicit enemy selection/victim linkage for virtual sessions so
         // cast checks and AI follow-up consistently reference the same hostile.
@@ -222,14 +223,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // attempting non-instant casts.
     if (spellInfo->CalcCastTime() > 0)
         player->StopMoving();
-
-    // Cast-time spells like Frostbolt fail while moving. Since playerbots do
-    // not have client-side stop-cast behavior, explicitly stop movement before
-    // attempting non-instant casts.
-    if (spellInfo->CalcCastTime() > 0)
-        player->StopMoving();
-
-    SpellCastResult castResult = SPELL_FAILED_ERROR;
 
     // Blink (1953) is a leap-forward spell with a destination target
     // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only


### PR DESCRIPTION
### Motivation
- Fix compile failures in `PlayerbotPvpClassActions.cpp` caused by a missing closing brace that produced downstream parsing errors and duplicate local declarations.

### Description
- Add the missing closing brace after the enemy-target validation in `CastDirectSpell`, and remove duplicated `player->StopMoving()` and the duplicate `SpellCastResult castResult` so the function has a single movement-stop check and one `castResult` definition.

### Testing
- Ran `cmake --build build --target game -- -j2`; the build configured and compiled and no new errors from `PlayerbotPvpClassActions.cpp` were observed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4a1dde8a88327901f8fba1d17433a)