### PR TITLE
Playerbots: run tactical movement during duels and use duel opponent as target

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -587,6 +587,12 @@ Unit* AcquireCombatTarget(Player* player, float scanDistance)
     Unit* target = player->GetVictim();
     if (!target || !target->IsAlive())
         target = player->GetSelectedUnit();
+    if ((!target || !target->IsAlive()) && player->duel && player->duel->State == DUEL_STATE_IN_PROGRESS)
+    {
+        Unit* duelOpponent = player->duel->Opponent;
+        if (duelOpponent && duelOpponent->IsAlive() && duelOpponent->GetMapId() == player->GetMapId())
+            target = duelOpponent;
+    }
     if ((!target || !target->IsAlive()) && player->InBattleground())
         target = FindNearestEnemyBattlegroundPlayer(player, scanDistance);
     if (!target || !target->IsAlive())
@@ -1076,5 +1082,16 @@ bool ArenaLifecycleActions::DeclineTeamInvitePrimitive(Player* player)
 
     player->SetArenaTeamIdInvited(0);
     return true;
+}
+
+bool DuelTacticalActions::Execute(Player* player)
+{
+    if (!player || !player->IsAlive() || !CanIssueBotMovement(player))
+        return false;
+
+    if (!player->duel || player->duel->State != DUEL_STATE_IN_PROGRESS)
+        return false;
+
+    return EngageNearestEnemyPlayer(player, 65.0f);
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
@@ -62,6 +62,12 @@ public:
     static bool AcceptTeamInvitePrimitive(Player* player);
     static bool DeclineTeamInvitePrimitive(Player* player);
 };
+
+class DuelTacticalActions
+{
+public:
+    static bool Execute(Player* player);
+};
 }
 
 #endif

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -952,6 +952,7 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     PvpValues const values = PvpCore::CollectValues(player);
     BattlegroundTacticalContext const tacticalContext = PvpCore::BuildBattlegroundTacticalContext(player, values);
     bool const didExecuteTactical = BattlegroundTacticalActions::Execute(player, tacticalContext);
+    bool const didExecuteDuelTactical = DuelTacticalActions::Execute(player);
     PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values);
     bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
 
@@ -962,7 +963,7 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         ObserveLifecycleReason(LifecycleObservationReason::GateDisabled, guid);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteTactical={}, didExecuteClassSpell={}.",
-            guid.ToString(), didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
+            guid.ToString(), (didExecuteTactical || didExecuteDuelTactical) ? 1 : 0, didExecuteClassSpell ? 1 : 0);
         return;
     }
 
@@ -972,7 +973,7 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         ObserveLifecycleReason(LifecycleObservationReason::NoLifecycleHooksActive, guid);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground=0, didExecuteArena=0, didExecuteTactical={}, didExecuteClassSpell={}.",
-            guid.ToString(), didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
+            guid.ToString(), (didExecuteTactical || didExecuteDuelTactical) ? 1 : 0, didExecuteClassSpell ? 1 : 0);
         return;
     }
 
@@ -1019,7 +1020,8 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
         "Playerbot PvP lifecycle dispatcher complete: guid={}, didExecuteBattleground={}, didExecuteArena={}, didExecuteTactical={}, didExecuteClassSpell={}.",
-        guid.ToString(), didExecuteBattleground ? 1 : 0, didExecuteArena ? 1 : 0, didExecuteTactical ? 1 : 0, didExecuteClassSpell ? 1 : 0);
+        guid.ToString(), didExecuteBattleground ? 1 : 0, didExecuteArena ? 1 : 0,
+        (didExecuteTactical || didExecuteDuelTactical) ? 1 : 0, didExecuteClassSpell ? 1 : 0);
 }
 
 bool RandomBotParticipationLifecycle::ProcessBattlegroundLifecycleEntryPoint(Player* player, PvpValues const& values,


### PR DESCRIPTION
### Motivation
- Ranged playerbots could stand still in 1v1 duels because tactical movement/positioning logic only ran through battleground flows and there was no duel-specific execution path.
- Combat positioning needed a reliable target during duels when the bot had no victim/selection so movement primitives can chase/kite appropriately.

### Description
- Added a new `DuelTacticalActions` hook by declaring `DuelTacticalActions::Execute` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h` and implementing it in the corresponding `.cpp` to run tactical movement when a duel is active.
- Extended `AcquireCombatTarget` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to fall back to the current duel opponent when no victim/selection exists.
- Wired the duel tactical execution into `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint` in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` and updated lifecycle debug output to include duel tactical execution in the tactical flag.

### Testing
- Ran a dry-run build graph check with `ninja -C build -n worldserver`, which succeeded.
- Started a full `worldserver` build with `cmake --build build --target worldserver -j2`, which began but was not completed in this environment due to overall build size and time constraints.
- No automated unit tests were executed in this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4f8705bec8327b9bc5459c7209f39)