### PR TITLE
Improve mage playerbot mana/item actions and interrupt targeting

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -288,6 +288,11 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         }
     }
 
+    // Avoid immediate re-polymorph loops after quick dispels by imposing a
+    // short tactical cooldown on the playerbot's polymorph decision path.
+    if (context.spellId == 112826)
+        player->GetSpellHistory()->AddCooldown(context.spellId, 0, std::chrono::seconds(15));
+
     return true;
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -22,6 +22,7 @@
 #include "Log.h"
 #include "Player.h"
 #include "Protocol/Opcodes.h"
+#include "Spell.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
@@ -289,6 +290,34 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     return true;
 }
+
+bool UseDirectItem(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
+{
+    failureReason.clear();
+    if (!player || !context.itemEntry)
+    {
+        failureReason = "missing_item_entry";
+        return false;
+    }
+
+    Item* item = player->GetItemByEntry(context.itemEntry);
+    if (!item)
+    {
+        failureReason = "item_missing";
+        return false;
+    }
+
+    if (player->CanUseItem(item) != EQUIP_ERR_OK)
+    {
+        failureReason = "item_unusable";
+        return false;
+    }
+
+    SpellCastTargets targets;
+    targets.SetUnitTarget(player);
+    player->CastItemUseSpell(item, targets, 1, 0);
+    return true;
+}
 }
 
 namespace playerbot
@@ -299,7 +328,11 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         return false;
 
     std::string failureReason;
-    bool const casted = CastDirectSpell(player, context, failureReason);
+    bool casted = false;
+    if (context.itemEntry)
+        casted = UseDirectItem(player, context, failureReason);
+    else
+        casted = CastDirectSpell(player, context, failureReason);
     NotifyDuelDecision(player, context, casted, failureReason);
     TC_LOG_DEBUG("playerbots.pvp.class",
         "Playerbot PvP class execution: action={} spell={} target_mode={} target_guid={} success={} reason={}.",

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -114,6 +114,8 @@ struct SpellDecision
     char const* reason = nullptr;
     uint32 spellId = 0;
     playerbot::PvpClassSpellContext::TargetMode targetMode = playerbot::PvpClassSpellContext::TargetMode::None;
+    ObjectGuid targetGuid = ObjectGuid::Empty;
+    uint32 itemEntry = 0;
 };
 
 struct TacticalDecision
@@ -341,6 +343,43 @@ Unit const* SelectClosestEnemyTarget(Player const* player, bool requireReachable
     return best;
 }
 
+Unit const* SelectEnemyCastingTarget(Player const* player, float maxDistance, Unit const* preferredTarget = nullptr)
+{
+    if (!player || !player->GetMap())
+        return nullptr;
+
+    auto isCandidateUsable = [&](Unit const* candidate)
+    {
+        return HasHostileTarget(player, candidate) &&
+            !IsTargetInvalidByImmunity(player, candidate) &&
+            candidate->HasUnitState(UNIT_STATE_CASTING) &&
+            player->IsWithinLOSInMap(candidate) &&
+            player->IsWithinDistInMap(candidate, maxDistance);
+    };
+
+    if (isCandidateUsable(preferredTarget))
+        return preferredTarget;
+
+    Unit const* best = nullptr;
+    float bestDistance = std::numeric_limits<float>::max();
+    Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!isCandidateUsable(candidate))
+            continue;
+
+        float const distance = player->GetDistance(candidate);
+        if (distance < bestDistance)
+        {
+            best = candidate;
+            bestDistance = distance;
+        }
+    }
+
+    return best;
+}
+
 Unit const* SelectCombatTarget(Player const* player)
 {
     if (!player)
@@ -438,9 +477,14 @@ SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inM
         return decision;
 
     bool const closePressure = player->IsWithinDistInMap(target, 8.0f);
+    float const manaPct = player->GetPowerPct(POWER_MANA);
 
     if (player->HealthBelowPct(20) && IsSpellReady(player, 11958))
         return { "mage ice block", "self-preservation emergency", 11958, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (manaPct < 25.0f && IsSpellReady(player, 12051))
+        return { "mage evocation", "recover mana below 25 percent", 12051, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (manaPct < 50.0f && player->HasItemCount(8008))
+        return { "use mana ruby", "consume mana ruby below 50 percent mana", 22044, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID(), 8008 };
     if (player->HasUnitState(UNIT_STATE_STUNNED) && IsSpellReady(player, 1953))
         return { "mage blink", "break stun pressure when possible", 1953, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (!IsSpellReady(player, 11958) && IsSpellReady(player, 12472))
@@ -451,8 +495,9 @@ SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inM
         return { "mage cone of cold", "defensive snare versus nearby melee", 120, playerbot::PvpClassSpellContext::TargetMode::Enemy };
     if (closePressure && IsSpellReady(player, 1953))
         return { "mage blink", "escape melee pressure", 1953, playerbot::PvpClassSpellContext::TargetMode::Self };
-    if (target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 2139))
-        return { "mage counterspell", "interrupt enemy cast at range", 2139, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (IsSpellReady(player, 2139))
+        if (Unit const* castingTarget = SelectEnemyCastingTarget(player, 30.0f, target))
+            return { "mage counterspell", "interrupt any enemy cast in range", 2139, playerbot::PvpClassSpellContext::TargetMode::Enemy, castingTarget->GetGUID() };
     if (!player->HasAura(11426) && IsSpellReady(player, 11426))
         return { "mage ice barrier", "maintain defensive absorb shield", 11426, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (target->HealthBelowPct(10) && IsSpellReady(player, 2136))
@@ -466,7 +511,7 @@ SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inM
         return { "arcane intellect", "arcane intellect", 10157, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (!player->IsInCombat() && IsSpellReady(player, 10220) && !player->HasAura(10220))
         return { "arcane intellect", "arcane intellect", 10220, playerbot::PvpClassSpellContext::TargetMode::Self };
-    if (!player->IsInCombat() && IsSpellReady(player, 10054) && !player->HasItemCount(8008))
+    if (IsSpellReady(player, 10054) && !player->HasItemCount(8008))
         return { "create mana ruby", "create mana ruby", 10054, playerbot::PvpClassSpellContext::TargetMode::Self };
 
     return decision;
@@ -939,8 +984,11 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     context.spellId = decision.spellId;
     context.targetMode = decision.targetMode;
     context.selfCast = context.targetMode == PvpClassSpellContext::TargetMode::Self;
+    context.itemEntry = decision.itemEntry;
     context.targetGuid = hasValidTarget ? target->GetGUID() : ObjectGuid::Empty;
     context.allyTargetGuid = allyTarget ? allyTarget->GetGUID() : ObjectGuid::Empty;
+    if (!decision.targetGuid.IsEmpty())
+        context.targetGuid = decision.targetGuid;
     if (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
         context.targetGuid = context.allyTargetGuid;
     else if (context.targetMode == PvpClassSpellContext::TargetMode::Self)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -292,6 +292,20 @@ bool HasBreakableCrowdControl(Unit const* unit)
     return HasAnyAura(unit, { 118, 12824, 12825, 12826, 28272, 28271, 61305, 61721, 6770, 2070, 11297, 1776, 2094, 5782, 6213, 6215, 5484, 5246 });
 }
 
+bool IsPolymorphed(Unit const* unit)
+{
+    return HasAnyAura(unit, { 118, 12824, 12825, 12826, 28272, 28271, 61305, 61721 });
+}
+
+bool HasDotAura(Unit const* unit)
+{
+    if (!unit)
+        return false;
+
+    return unit->HasAuraType(SPELL_AURA_PERIODIC_DAMAGE) ||
+        unit->HasAuraType(SPELL_AURA_PERIODIC_DAMAGE_PERCENT);
+}
+
 bool IsTargetInvalidByImmunity(Player const* player, Unit const* target)
 {
     if (!player || !target)
@@ -367,6 +381,111 @@ Unit const* SelectEnemyCastingTarget(Player const* player, float maxDistance, Un
     {
         Player* candidate = itr->GetSource();
         if (!isCandidateUsable(candidate))
+            continue;
+
+        float const distance = player->GetDistance(candidate);
+        if (distance < bestDistance)
+        {
+            best = candidate;
+            bestDistance = distance;
+        }
+    }
+
+    return best;
+}
+
+bool AnyEnemyPolymorphed(Player const* player, float maxDistance)
+{
+    if (!player || !player->GetMap())
+        return false;
+
+    Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!HasHostileTarget(player, candidate))
+            continue;
+        if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, maxDistance))
+            continue;
+        if (IsPolymorphed(candidate))
+            return true;
+    }
+
+    return false;
+}
+
+Unit const* SelectPolymorphTarget(Player const* player, float maxDistance)
+{
+    if (!player || !player->GetMap())
+        return nullptr;
+
+    Unit const* best = nullptr;
+    uint8 bestPriority = std::numeric_limits<uint8>::max();
+    float bestDistance = std::numeric_limits<float>::max();
+    Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!HasHostileTarget(player, candidate))
+            continue;
+        if (candidate->GetClass() == CLASS_DRUID)
+            continue;
+        if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, maxDistance))
+            continue;
+        if (HasDotAura(candidate) || IsPolymorphed(candidate))
+            continue;
+        if (IsTargetInvalidByImmunity(player, candidate))
+            continue;
+
+        uint8 priority = 2;
+        if (candidate->GetClass() == CLASS_PALADIN || candidate->GetClass() == CLASS_PRIEST)
+            priority = 0;
+        else if (candidate->GetPowerType() == POWER_MANA)
+            priority = 1;
+
+        float const distance = player->GetDistance(candidate);
+        if (priority < bestPriority || (priority == bestPriority && distance < bestDistance))
+        {
+            best = candidate;
+            bestPriority = priority;
+            bestDistance = distance;
+        }
+    }
+
+    return best;
+}
+
+Unit const* SelectFriendlyCurseTarget(Player const* player, float maxDistance)
+{
+    if (!player || !player->GetMap())
+        return nullptr;
+
+    auto hasDispellableCurse = [&](Unit const* target)
+    {
+        if (!target || !target->IsAlive())
+            return false;
+
+        DispelChargesList dispelList;
+        target->GetDispellableAuraList(player, (1 << DISPEL_CURSE), dispelList);
+        return !dispelList.empty();
+    };
+
+    if (hasDispellableCurse(player))
+        return player;
+
+    Unit const* best = nullptr;
+    float bestDistance = std::numeric_limits<float>::max();
+    Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!candidate || candidate == player || !candidate->IsAlive())
+            continue;
+        if (!player->IsValidAssistTarget(candidate))
+            continue;
+        if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, maxDistance))
+            continue;
+        if (!hasDispellableCurse(candidate))
             continue;
 
         float const distance = player->GetDistance(candidate);
@@ -473,10 +592,11 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
 SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inMelee)
 {
     SpellDecision decision;
-    if (!HasHostileTarget(player, target))
+    if (!player)
         return decision;
 
-    bool const closePressure = player->IsWithinDistInMap(target, 8.0f);
+    bool const hasHostileTarget = HasHostileTarget(player, target);
+    bool const closePressure = hasHostileTarget && player->IsWithinDistInMap(target, 8.0f);
     float const manaPct = player->GetPowerPct(POWER_MANA);
 
     if (player->HealthBelowPct(20) && IsSpellReady(player, 11958))
@@ -485,6 +605,9 @@ SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inM
         return { "mage evocation", "recover mana below 25 percent", 12051, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (manaPct < 50.0f && player->HasItemCount(8008))
         return { "use mana ruby", "consume mana ruby below 50 percent mana", 22044, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID(), 8008 };
+    if (IsSpellReady(player, 475))
+        if (Unit const* cursedTarget = SelectFriendlyCurseTarget(player, 40.0f))
+            return { "remove lesser curse", "dispel curse from friendly target", 475, cursedTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, cursedTarget->GetGUID() };
     if (player->HasUnitState(UNIT_STATE_STUNNED) && IsSpellReady(player, 1953))
         return { "mage blink", "break stun pressure when possible", 1953, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (!IsSpellReady(player, 11958) && IsSpellReady(player, 12472))
@@ -500,11 +623,12 @@ SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inM
             return { "mage counterspell", "interrupt any enemy cast in range", 2139, playerbot::PvpClassSpellContext::TargetMode::Enemy, castingTarget->GetGUID() };
     if (!player->HasAura(11426) && IsSpellReady(player, 11426))
         return { "mage ice barrier", "maintain defensive absorb shield", 11426, playerbot::PvpClassSpellContext::TargetMode::Self };
-    if (target->HealthBelowPct(10) && IsSpellReady(player, 2136))
+    if (hasHostileTarget && target->HealthBelowPct(10) && IsSpellReady(player, 2136))
         return { "mage fire blast", "instant execute pressure on low health target", 2136, playerbot::PvpClassSpellContext::TargetMode::Enemy };
-    if (!target->HasAura(112826) && !closePressure && target->GetClass() != CLASS_DRUID && IsSpellReady(player, 112826))
-        return { "mage polymorph", "safe ranged crowd control", 112826, playerbot::PvpClassSpellContext::TargetMode::Enemy };
-    if (IsSpellReady(player, 25304))
+    if (IsSpellReady(player, 112826) && !AnyEnemyPolymorphed(player, 40.0f))
+        if (Unit const* polymorphTarget = SelectPolymorphTarget(player, 30.0f))
+            return { "mage polymorph", "priority crowd control on non-dotted paladin/priest targets", 112826, playerbot::PvpClassSpellContext::TargetMode::Enemy, polymorphTarget->GetGUID() };
+    if (hasHostileTarget && IsSpellReady(player, 25304))
         return { "mage frostbolt", "default ranged pressure", 25304, playerbot::PvpClassSpellContext::TargetMode::Enemy };
 
     if (!player->IsInCombat() && IsSpellReady(player, 10157) && !player->HasAura(10157))

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -156,6 +156,7 @@ struct PvpClassSpellContext
     TargetMode targetMode = TargetMode::None;
     ObjectGuid targetGuid = ObjectGuid::Empty;
     ObjectGuid allyTargetGuid = ObjectGuid::Empty;
+    uint32 itemEntry = 0;
 };
 
 struct BattlegroundLifecycleContext


### PR DESCRIPTION
### Motivation
- Make mage playerbots manage mana more effectively by using Evocation and mana rubies at configurable thresholds and enable bots to act on more than their single primary target. 
- Allow PvP class logic to trigger item-based actions (consumables) and target spells at explicit secondary targets so bots can react to nearby threats (interrupts) and use consumables.

### Description
- Extend `PvpClassSpellContext` with an `itemEntry` field to carry item-driven actions from decision to execution. 
- Add `UseDirectItem` and wire `PvpClassActions::Execute` to call it when `context.itemEntry` is set so consumables are used via `CastItemUseSpell` instead of only spellbook casts. 
- Add `SelectEnemyCastingTarget` to scan nearby valid enemies that are currently casting and return the closest usable caster (accepts an optional preferred target). 
- Update mage decision logic in `SelectMageSpell` to: cast `Evocation (12051)` when mana < 25%, consume a Mana Ruby (item `8008` / spell `22044`) when mana < 50% if available, and allow `Create Mana Ruby (10054)` whenever missing and the spell is ready; make `Counterspell (2139)` target any nearby casting enemy by setting an explicit `targetGuid` in the decision. 
- Preserve explicit decision `targetGuid` and `itemEntry` when assembling `PvpClassSpellContext` so multi-target and item-based decisions flow through execution.

### Testing
- Ran a CMake-based build invocation: `cmake --build build --target worldserver -j2` which reconfigured the build and began compilation (CMake configured successfully in this environment). (partial/ongoing). 
- Attempted a targeted Ninja invocation to build specific object targets which failed because the attempted object targets were not present in the generated Ninja graph; no full scripts/worldserver link verification completed here. 
- No automated runtime/gameplay tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4fa78a100832799de8349f525a6aa)