### PR TITLE
Fix playerbot duel movement speed to honor snares

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8942,7 +8942,18 @@ void Unit::SetSpeedRate(UnitMoveType mtype, float rate)
 
     float newSpeedFlat = rate * (IsControlledByPlayer() ? playerBaseMoveSpeed[mtype] : baseMoveSpeed[mtype]);
     if (IsMovedByClient() && IsInWorld())
-        MovementPacketSender::SendSpeedChangeToMover(this, mtype, newSpeedFlat);
+    {
+        // Virtual sessions (for example managed playerbots) do not emit client-side
+        // movement change ACKs. Apply speed updates immediately so server-side motion
+        // generators (MovePoint/MoveFollow/etc.) use the correct aura-adjusted speed.
+        if (GameClient* controller = GetGameClientMovingMe(); controller && controller->GetWorldSession() && controller->GetWorldSession()->IsVirtualSession())
+        {
+            SetSpeedRateReal(mtype, rate);
+            MovementPacketSender::SendSpeedChangeToObservers(this, mtype, newSpeedFlat);
+        }
+        else
+            MovementPacketSender::SendSpeedChangeToMover(this, mtype, newSpeedFlat);
+    }
     else if (IsMovedByClient() && !IsInWorld()) // (1)
         SetSpeedRateReal(mtype, rate);
     else // <=> if(!IsMovedByPlayer())


### PR DESCRIPTION
### Motivation
- Player-controlled virtual sessions (managed playerbots) were ignoring aura-based slows during server-side movement (duels like Hamstring) because speed changes were left pending for client ACKs instead of being applied immediately.

### Description
- Apply speed updates immediately for virtual movers by updating `Unit::SetSpeedRate` to call `SetSpeedRateReal` and broadcast observer speed changes when `GameClient::GetWorldSession()->IsVirtualSession()` is true, instead of waiting for client-side ACK packets.

### Testing
- Built the modified translation unit with `cmake --build /workspace/TrinityCore112/build --target src/server/game/CMakeFiles/game.dir/Entities/Unit/Unit.cpp.o -- -j4`, which completed successfully.
- Started a full `game` target build with `cmake --build /workspace/TrinityCore112/build --target game -- -j4`; the build was initiated (output shown) but the full graph was not waited-through to completion in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4fb9eb1d083278c3095330d08d177)