### PR TITLE
Playerbot: cast Freezing Trap immediately after Feign Death

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -242,6 +242,33 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     if (castResult != SPELL_CAST_OK)
         return false;
 
+    // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
+    // threat, immediately attempt Freezing Trap in the same lifecycle tick
+    // rather than waiting for the next cadence pass.
+    if (context.spellId == 5384)
+    {
+        Unit* pressureTarget = nullptr;
+        if (!context.targetGuid.IsEmpty())
+            pressureTarget = ObjectAccessor::GetUnit(*player, context.targetGuid);
+        if (!pressureTarget)
+            pressureTarget = player->GetVictim();
+
+        bool const closeMeleePressure = pressureTarget && pressureTarget->IsAlive() && player->IsWithinDistInMap(pressureTarget, 5.0f);
+        if (closeMeleePressure && player->HasSpell(1499))
+        {
+            SpellInfo const* freezingTrapInfo = sSpellMgr->GetSpellInfo(1499);
+            if (freezingTrapInfo &&
+                !player->GetSpellHistory()->HasCooldown(1499) &&
+                !player->GetSpellHistory()->HasGlobalCooldown(freezingTrapInfo) &&
+                !player->IsNonMeleeSpellCast(false, false, true))
+            {
+                SpellCastResult const trapCastResult = player->CastSpell(player, 1499, false);
+                if (trapCastResult != SPELL_CAST_OK)
+                    TC_LOG_DEBUG("playerbots.pvp.class", "Hunter trap follow-up failed after feign death: guid={}, result={}.", player->GetGUID().ToString(), uint32(trapCastResult));
+            }
+        }
+    }
+
     bool hasTeleportEffect = false;
     for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
     {


### PR DESCRIPTION
### Motivation
- Improve hunter playerbot responsiveness by attempting `Freezing Trap` (spell id `1499`) immediately when `Feign Death` (`5384`) succeeds against a nearby melee threat instead of waiting for the next lifecycle cadence.

### Description
- Add an immediate follow-up in `CastDirectSpell` (file `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`) that runs when `context.spellId == 5384`.
- Resolve the pressure target from `context.targetGuid` or `player->GetVictim()` and require the target be alive and within `5.0f` distance before attempting the trap.
- Gate the follow-up by normal spell availability checks (player `HasSpell(1499)`, spell info exists, no per-spell cooldown, no global cooldown and not already casting) and perform `player->CastSpell(player, 1499, false)`; log a debug message if the trap cast fails.

### Testing
- Ran `git diff --check` to verify there are no whitespace/diff issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50047eea083278f99b5e1a34e7187)