### PR TITLE
Playerbot hunter: delay Freezing Trap 500ms after Feign Death

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -29,6 +29,8 @@
 #include "Unit.h"
 #include "WorldSession.h"
 
+#include <chrono>
+
 namespace
 {
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
@@ -243,8 +245,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
-    // threat, immediately attempt Freezing Trap in the same lifecycle tick
-    // rather than waiting for the next cadence pass.
+    // threat, pause movement, clear explicit target selection for visual parity,
+    // then cast Freezing Trap exactly 500ms later before resuming chase.
     if (context.spellId == 5384)
     {
         Unit* pressureTarget = nullptr;
@@ -256,16 +258,33 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         bool const closeMeleePressure = pressureTarget && pressureTarget->IsAlive() && player->IsWithinDistInMap(pressureTarget, 5.0f);
         if (closeMeleePressure && player->HasSpell(1499))
         {
-            SpellInfo const* freezingTrapInfo = sSpellMgr->GetSpellInfo(1499);
-            if (freezingTrapInfo &&
-                !player->GetSpellHistory()->HasCooldown(1499) &&
-                !player->GetSpellHistory()->HasGlobalCooldown(freezingTrapInfo) &&
-                !player->IsNonMeleeSpellCast(false, false, true))
+            ObjectGuid const hunterGuid = player->GetGUID();
+            ObjectGuid const pressureTargetGuid = pressureTarget->GetGUID();
+
+            player->StopMoving();
+            player->SetSelection(ObjectGuid::Empty);
+
+            player->m_Events.AddEventAtOffset([hunterGuid, pressureTargetGuid]()
             {
-                SpellCastResult const trapCastResult = player->CastSpell(player, 1499, false);
-                if (trapCastResult != SPELL_CAST_OK)
-                    TC_LOG_DEBUG("playerbots.pvp.class", "Hunter trap follow-up failed after feign death: guid={}, result={}.", player->GetGUID().ToString(), uint32(trapCastResult));
-            }
+                Player* hunter = ObjectAccessor::FindConnectedPlayer(hunterGuid);
+                if (!hunter || !hunter->IsInWorld() || !hunter->IsAlive())
+                    return;
+
+                SpellInfo const* freezingTrapInfo = sSpellMgr->GetSpellInfo(1499);
+                if (freezingTrapInfo &&
+                    !hunter->GetSpellHistory()->HasCooldown(1499) &&
+                    !hunter->GetSpellHistory()->HasGlobalCooldown(freezingTrapInfo) &&
+                    !hunter->IsNonMeleeSpellCast(false, false, true))
+                {
+                    SpellCastResult const trapCastResult = hunter->CastSpell(hunter, 1499, false);
+                    if (trapCastResult != SPELL_CAST_OK)
+                        TC_LOG_DEBUG("playerbots.pvp.class", "Hunter trap follow-up failed after feign death delay: guid={}, result={}.", hunter->GetGUID().ToString(), uint32(trapCastResult));
+                }
+
+                if (Unit* resumedTarget = ObjectAccessor::GetUnit(*hunter, pressureTargetGuid))
+                    if (resumedTarget->IsAlive())
+                        hunter->Attack(resumedTarget, false);
+            }, std::chrono::milliseconds(500));
         }
     }
 


### PR DESCRIPTION
### Motivation
- Make hunter playerbot PvP trap setup visually match player sequencing by ensuring Feign Death causes the bot to stop and drop target before the trap is placed 500 ms later.
- Avoid casting Freezing Trap in the same lifecycle tick where Feign Death is applied so the bot appears to actually "feign death" during the trap loop.

### Description
- Added `#include <chrono>` and updated the Feign Death follow-up in `CastDirectSpell` to schedule the trap cast using `m_Events.AddEventAtOffset(..., std::chrono::milliseconds(500))` instead of casting immediately.
- Before scheduling the delayed cast the bot now calls `StopMoving()` and clears selection with `SetSelection(ObjectGuid::Empty)` to visually drop the target.
- The delayed lambda retrieves the player via `ObjectAccessor::FindConnectedPlayer`, re-checks cooldowns/casting state, attempts `CastSpell(..., 1499, false)`, and if successful (or after attempt) re-engages the original pressure target with `Attack` if it is still valid.
- Changes are contained in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` (replaced same-tick cast with event-scheduled cast and target resume logic).

### Testing
- Ran `git diff --check` and it completed with no output (no whitespace/errors found). 
- Created a commit `Playerbot hunter: delay trap 500ms after feign death` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5069e0f74832796a06dfa75120707)