### PR TITLE
playerbot: auto-cancel druid shapeshift when spell blocked by form

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -140,6 +140,16 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
+    // Druids can intentionally swap into Bear Form under melee pressure, but
+    // many follow-up heals/utility spells are not castable in Bear/Cat forms.
+    // The random bot cadence evaluates roughly every 2 seconds, so waiting for
+    // the next tick to leave form makes bots appear locked out. If the selected
+    // spell is blocked only by current shapeshift state, immediately cancel the
+    // form and continue with the same cast attempt in this tick.
+    if (player->GetClass() == CLASS_DRUID && player->HasAuraType(SPELL_AURA_MOD_SHAPESHIFT))
+        if (spellInfo->CheckShapeshift(player->GetShapeshiftForm()) == SPELL_FAILED_NOT_SHAPESHIFT)
+            player->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+
     if (player->GetSpellHistory()->HasCooldown(context.spellId) ||
         player->GetSpellHistory()->HasGlobalCooldown(spellInfo) ||
         player->IsNonMeleeSpellCast(false, false, true))


### PR DESCRIPTION
### Motivation
- Bots that shift into Bear (or Cat) form under melee pressure can get stuck because many heals/utility spells are not castable while shapeshifted and the PvP cadence only reevaluates every ~2 seconds. 
- The change aims to let a druid bot shift back out and cast the intended spell in the same decision tick instead of waiting for the next cadence pass.

### Description
- Added a targeted check inside `CastDirectSpell` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` to detect when a druid has a shapeshift aura and the chosen spell fails only due to shapeshift (`SPELL_FAILED_NOT_SHAPESHIFT`).
- If that condition is met the code calls `player->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT)` to cancel the form immediately so the same cast attempt can proceed in this tick.
- Behavior is strictly scoped to `CLASS_DRUID` and only triggers when the spell is specifically blocked by the current shapeshift state.

### Testing
- Performed an automated build invocation with `cmake --build build --target worldserver -j2`, which started successfully and compiled many translation units without error before the run was stopped due to environment time/size limits. 
- No unit test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50dae2e348327902d1304ea600457)