### PR TITLE
Playerbot: use max-rank classic spells, bypass EM cadence, and improve WSG movement

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -29,6 +29,7 @@
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "SpellAuras.h"
+#include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
 
@@ -234,7 +235,24 @@ ClassicProfileSelection DetectClassicClassProfile(Player const* player)
 
 bool IsSpellReady(Player const* player, uint32 spellId)
 {
-    return player && spellId && player->HasSpell(spellId) && !player->GetSpellHistory()->HasCooldown(spellId);
+    if (!player || !spellId)
+        return false;
+
+    SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!baseSpellInfo)
+        return false;
+
+    uint32 resolvedSpellId = 0;
+    for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
+    {
+        if (player->HasSpell(chainSpellId))
+            resolvedSpellId = chainSpellId;
+    }
+
+    if (!resolvedSpellId)
+        return false;
+
+    return !player->GetSpellHistory()->HasCooldown(resolvedSpellId);
 }
 
 bool HasHostileTarget(Player const* player, Unit const* target)
@@ -1744,6 +1762,21 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     context.actionName = decision.actionName;
     context.reason = decision.reason;
     context.spellId = decision.spellId;
+    if (context.spellId)
+    {
+        if (SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(context.spellId))
+        {
+            uint32 resolvedSpellId = 0;
+            for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
+            {
+                if (player->HasSpell(chainSpellId))
+                    resolvedSpellId = chainSpellId;
+            }
+
+            if (resolvedSpellId)
+                context.spellId = resolvedSpellId;
+        }
+    }
     context.targetMode = decision.targetMode;
     context.selfCast = context.targetMode == PvpClassSpellContext::TargetMode::Self;
     context.itemEntry = decision.itemEntry;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -903,6 +903,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
                 return true;
             }
 
+            // WSG can enter sparse states where objective anchors are unavailable.
+            // In those windows, force a large-radius enemy scan before falling
+            // back to local graveyard movement so bots keep crossing the map.
+            if (EngageNearestEnemyPlayer(player, 500.0f))
+                return true;
+
             if (WorldSafeLocsEntry const* graveyard = battleground->GetClosestGraveyard(player))
             {
                 Position destination(graveyard->Loc.X, graveyard->Loc.Y, graveyard->Loc.Z, player->GetOrientation());

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -955,6 +955,14 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     bool const didExecuteDuelTactical = DuelTacticalActions::Execute(player);
     PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values);
     bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
+    if (didExecuteClassSpell && classSpellContext.spellId == 16166) // Elemental Mastery (off-GCD)
+    {
+        std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
+        g_NextRandomBotLifecycleProcessTimeByGuid[guid.GetRawValue()] = LifecycleCadenceClock::now();
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP cadence bypass applied: guid={} spell={} reason=off-gcd-burst-window.",
+            guid.ToString(), classSpellContext.spellId);
+    }
 
     RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
     if (!hooks.lifecycleEnabled)


### PR DESCRIPTION
### Motivation
- Classic-class playerbots were evaluating and casting spell IDs without resolving to the highest learned rank in a spell chain, causing bots to attempt rank-1 IDs they don't have instead of using their max rank. 
- Elemental Shaman burst (Elemental Mastery) is off the global cooldown and should allow immediate follow-up casts instead of waiting the lifecycle's ~2s cadence. 
- In Warsong Gulch (WSG) some bots idled at base when objective anchors were unavailable; they need a fallback that makes them still cross the map and engage enemies.

### Description
- Resolve requested spell IDs to the highest learned rank in a spell chain for readiness checks by updating `IsSpellReady` to walk the spell chain and check the highest rank the player knows (adds `SpellMgr` include and chain traversal). 
- Normalize the `PvpClassSpellContext::spellId` selected by PvP decision code to the player’s highest learned rank before execution so class spells cast the max available classic rank. 
- After a successful Elemental Mastery execution (spell id `16166`), immediately advance the player’s lifecycle next-process timestamp to `now` to bypass the usual cadence throttle so elemental shamans can follow with burst spells. 
- Improve WSG objective movement by adding a large-radius enemy engagement scan (`EngageNearestEnemyPlayer(player, 500.0f)`) when objective anchors are unavailable so bots do not remain parked at base. 
- Files changed: `PlayerbotPvpCore.cpp`, `PlayerbotPvpLifecycleActions.cpp`, `PlayerbotRandomBotParticipation.cpp`.

### Testing
- Started an automated build with `cmake --build build --target worldserver -j2`, which began configuration and compilation successfully in this environment (full build takes longer than this run). 
- Ran automated code checks (`git diff --check`) and repository status inspection (`git status --short`) which reported no tracked-file issues related to the changes. 
- Local compile run proceeded (build jobs spawned) without compilation errors observed in the initial phase; no unit tests are enabled in this build configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50efb745c8327a7576da62c33e965)