### PR TITLE
Playerbot: gate pet summon/revive and sync pet attack targeting

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -35,6 +35,27 @@ namespace
 {
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
 
+void CommandPetAttackTarget(Player* player, Unit* target)
+{
+    if (!player || !target || !target->IsAlive())
+        return;
+
+    Pet* pet = player->GetPet();
+    if (!pet || !pet->IsAlive() || !pet->IsValidAttackTarget(target))
+        return;
+
+    if (pet->GetVictim() != target)
+        pet->Attack(target, true);
+
+    if (CharmInfo* charmInfo = pet->GetCharmInfo())
+    {
+        charmInfo->SetIsCommandAttack(true);
+        charmInfo->SetIsAtStay(false);
+        charmInfo->SetIsCommandFollow(false);
+        charmInfo->SetCommandState(COMMAND_ATTACK);
+    }
+}
+
 void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& context, bool casted, std::string const& failureReason)
 {
     if (!player || !player->duel)
@@ -184,6 +205,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         player->SetSelection(target->GetGUID());
         if (player->GetVictim() != target)
             player->Attack(target, false);
+        CommandPetAttackTarget(player, target);
 
         // Virtual sessions can visually "turn" while server-side facing checks
         // still fail for the immediate cast tick. SetInFront updates orientation

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1045,6 +1045,10 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
     if (!HasHostileTarget(player, activeTarget))
         return decision;
 
+    Pet const* pet = player->GetPet();
+    bool const hasLivingPet = pet && pet->IsAlive();
+    bool const hasDeadPet = pet && !pet->IsAlive();
+
     Unit const* enemyOnTopTarget = SelectNearbyEnemyTarget(player, activeTarget, 5.0f);
     Unit const* nearbyCastingTarget = SelectEnemyCastingTarget(player, 20.0f, activeTarget);
     Unit const* closeMeleeThreat = SelectNearbyMeleeTarget(player, enemyOnTopTarget, 5.0f);
@@ -1087,7 +1091,9 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
         return { "hunter viper sting", "drain mana on mana users", 3034, playerbot::PvpClassSpellContext::TargetMode::Enemy, manaTarget->GetGUID() };
     if (!player->HasAura(19506) && IsSpellReady(player, 19506))
         return { "hunter trueshot aura", "maintain personal buff aura", 19506, playerbot::PvpClassSpellContext::TargetMode::Self };
-    if (!player->IsInCombat() && IsSpellReady(player, 982))
+    if (!hasLivingPet && !hasDeadPet && IsSpellReady(player, 883))
+        return { "hunter call pet", "summon active stable pet when no pet is present", 883, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (hasDeadPet && !player->IsInCombat() && IsSpellReady(player, 982))
         return { "hunter revive pet", "recover pet out of combat", 982, playerbot::PvpClassSpellContext::TargetMode::Self };
 
     return decision;
@@ -1291,10 +1297,13 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
     if (!HasHostileTarget(player, target))
         return decision;
 
+    Pet const* pet = player->GetPet();
+    bool const needsPetSummon = !pet || !pet->IsAlive();
+
     bool const closePressure = player->IsWithinDistInMap(target, 8.0f);
-    if (!player->IsInCombat() && IsSpellReady(player, 697))
+    if (!player->IsInCombat() && needsPetSummon && IsSpellReady(player, 697))
         return { "warlock summon voidwalker", "maintain voidwalker pet while out of combat", 697, playerbot::PvpClassSpellContext::TargetMode::Self };
-    if (player->IsInCombat() && IsSpellReady(player, 697))
+    if (player->IsInCombat() && needsPetSummon && IsSpellReady(player, 697))
         return { "warlock summon voidwalker", "recover voidwalker in combat when absent", 697, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (player->HealthBelowPct(45) && IsSpellReady(player, 7812))
         return { "warlock sacrifice", "consume voidwalker shield under low health pressure", 7812, playerbot::PvpClassSpellContext::TargetMode::Self };


### PR DESCRIPTION
### Motivation
- Prevent playerbots from repeatedly casting pet summon/revive when a usable pet is already present by gating those actions on actual pet state. 
- Ensure hunter/warlock pets follow the bot's kill intent by explicitly commanding living pets to attack the same enemy the bot targets. 

### Description
- In `SelectHunterSpell` added checks of `player->GetPet()` and only choose `Call Pet (883)` when no pet exists and `Revive Pet (982)` only when a pet exists but is dead (`hasDeadPet`). (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`) 
- In `SelectWarlockSpell` gate `Summon Voidwalker (697)` behind a `needsPetSummon` condition so summoning occurs only when no living pet is available. (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`) 
- Added `CommandPetAttackTarget(Player*, Unit*)` helper that validates the pet and issues `Attack` plus updates `CharmInfo` (`COMMAND_ATTACK`, `SetIsCommandAttack`, `SetIsAtStay`, `SetIsCommandFollow`) to synchronize pet behavior. (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`) 
- Call to `CommandPetAttackTarget` was added to `CastDirectSpell` after setting the bot's selection and `Attack` so living pets attack the same enemy target used for class PvP spells. (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`) 

### Testing
- Attempted an automated incremental build of the `worldserver` target via `cmake --build build --target worldserver -j2`, which started and compiled many translation units but was interrupted before completion due to environment execution limits. 
- No automated unit test suite or full build artifact was produced in this run, so runtime validation remains pending.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5106246e883278b924b3e9b49c1be)