### PR TITLE
Playerbot PvP: improve pet handling and instant warlock pet recovery

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -21,6 +21,7 @@
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"
+#include "Pet.h"
 #include "Protocol/Opcodes.h"
 #include "Spell.h"
 #include "SpellInfo.h"
@@ -34,6 +35,27 @@
 namespace
 {
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
+
+void CommandPetAttackTarget(Player* player, Unit* target)
+{
+    if (!player || !target || !target->IsAlive())
+        return;
+
+    Pet* pet = player->GetPet();
+    if (!pet || !pet->IsAlive() || !pet->IsValidAttackTarget(target))
+        return;
+
+    if (pet->GetVictim() != target)
+        pet->Attack(target, true);
+
+    if (CharmInfo* charmInfo = pet->GetCharmInfo())
+    {
+        charmInfo->SetIsCommandAttack(true);
+        charmInfo->SetIsAtStay(false);
+        charmInfo->SetIsCommandFollow(false);
+        charmInfo->SetCommandState(COMMAND_ATTACK);
+    }
+}
 
 void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& context, bool casted, std::string const& failureReason)
 {
@@ -184,6 +206,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         player->SetSelection(target->GetGUID());
         if (player->GetVictim() != target)
             player->Attack(target, false);
+        CommandPetAttackTarget(player, target);
 
         // Virtual sessions can visually "turn" while server-side facing checks
         // still fail for the immediate cast tick. SetInFront updates orientation
@@ -253,6 +276,23 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
         return false;
+
+    // Fel Domination is off the global cooldown. When used mid-fight to recover
+    // a missing warlock pet, immediately follow with Summon Voidwalker so the
+    // bot does not wait for the next class-decision cadence tick.
+    if (context.spellId == 18708 && player->GetClass() == CLASS_WARLOCK && player->HasSpell(697))
+    {
+        Pet* pet = player->GetPet();
+        if (!pet || !pet->IsAlive())
+        {
+            SpellInfo const* summonVoidwalkerInfo = sSpellMgr->GetSpellInfo(697);
+            if (summonVoidwalkerInfo &&
+                !player->GetSpellHistory()->HasCooldown(697) &&
+                !player->GetSpellHistory()->HasGlobalCooldown(summonVoidwalkerInfo) &&
+                !player->IsNonMeleeSpellCast(false, false, true))
+                player->CastSpell(player, 697, false);
+        }
+    }
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -28,6 +28,7 @@
 #include "Map.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "Pet.h"
 #include "SpellAuras.h"
 #include "SpellHistory.h"
 #include "Unit.h"
@@ -1045,6 +1046,10 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
     if (!HasHostileTarget(player, activeTarget))
         return decision;
 
+    Pet const* pet = player->GetPet();
+    bool const hasLivingPet = pet && pet->IsAlive();
+    bool const hasDeadPet = pet && !pet->IsAlive();
+
     Unit const* enemyOnTopTarget = SelectNearbyEnemyTarget(player, activeTarget, 5.0f);
     Unit const* nearbyCastingTarget = SelectEnemyCastingTarget(player, 20.0f, activeTarget);
     Unit const* closeMeleeThreat = SelectNearbyMeleeTarget(player, enemyOnTopTarget, 5.0f);
@@ -1087,7 +1092,9 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
         return { "hunter viper sting", "drain mana on mana users", 3034, playerbot::PvpClassSpellContext::TargetMode::Enemy, manaTarget->GetGUID() };
     if (!player->HasAura(19506) && IsSpellReady(player, 19506))
         return { "hunter trueshot aura", "maintain personal buff aura", 19506, playerbot::PvpClassSpellContext::TargetMode::Self };
-    if (!player->IsInCombat() && IsSpellReady(player, 982))
+    if (!hasLivingPet && !hasDeadPet && IsSpellReady(player, 883))
+        return { "hunter call pet", "summon active stable pet when no pet is present", 883, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (hasDeadPet && !player->IsInCombat() && IsSpellReady(player, 982))
         return { "hunter revive pet", "recover pet out of combat", 982, playerbot::PvpClassSpellContext::TargetMode::Self };
 
     return decision;
@@ -1291,10 +1298,15 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
     if (!HasHostileTarget(player, target))
         return decision;
 
+    Pet const* pet = player->GetPet();
+    bool const needsPetSummon = !pet || !pet->IsAlive();
+
     bool const closePressure = player->IsWithinDistInMap(target, 8.0f);
-    if (!player->IsInCombat() && IsSpellReady(player, 697))
+    if (player->IsInCombat() && needsPetSummon && !player->HasAura(18708) && IsSpellReady(player, 18708))
+        return { "warlock fel domination", "prepare instant pet recovery before voidwalker summon", 18708, playerbot::PvpClassSpellContext::TargetMode::Self };
+    if (!player->IsInCombat() && needsPetSummon && IsSpellReady(player, 697))
         return { "warlock summon voidwalker", "maintain voidwalker pet while out of combat", 697, playerbot::PvpClassSpellContext::TargetMode::Self };
-    if (player->IsInCombat() && IsSpellReady(player, 697))
+    if (player->IsInCombat() && needsPetSummon && IsSpellReady(player, 697))
         return { "warlock summon voidwalker", "recover voidwalker in combat when absent", 697, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (player->HealthBelowPct(45) && IsSpellReady(player, 7812))
         return { "warlock sacrifice", "consume voidwalker shield under low health pressure", 7812, playerbot::PvpClassSpellContext::TargetMode::Self };


### PR DESCRIPTION
### Motivation

- Improve bot pet behavior during PvP so pets follow the player's attack decisions and warlocks can recover pets immediately when using Fel Domination during combat.
- Fix incorrect hunter pet-summon/revive selection so bots summon a stable pet when none exists and revive a dead pet out of combat.

### Description

- Add `Pet.h` includes and introduce `CommandPetAttackTarget(Player*, Unit*)` helper to command the player's pet to attack and set charm command flags.
- Call the new `CommandPetAttackTarget` when a player selects/attacks an enemy in `CastDirectSpell` so the pet follows the bot's explicit attack target and orientation is set for casts.
- After casting Fel Domination (spell `18708`) for warlocks, immediately attempt to cast Summon Voidwalker (`697`) when appropriate by checking spell info, cooldowns and that the player is not mid-cast.
- Update hunter logic to explicitly call stable pet (`883`) when no pet exists, and only use revive pet (`982`) when a dead pet is present and the player is out of combat; update warlock logic to only attempt summons when a pet is missing and insert a pre-summon Fel Domination decision during combat when applicable.

### Testing

- Performed a project build (`make`) which completed successfully without compile errors.
- Executed the automated server/unit test suite related to playerbot PvP where available and observed no test failures.
- No automated regressions were detected in the PvP bot tests after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5106246e883278b924b3e9b49c1be)