### PR TITLE
Playerbot: apply Crippling Poison to unpoisoned rogue weapons

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -179,9 +179,29 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
+    Item* itemTarget = nullptr;
+    if (context.spellId == 11202 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
+    {
+        Item* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
+        if (mainHand && !mainHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+            itemTarget = mainHand;
+        else
+        {
+            Item* offHand = player->GetWeaponForAttack(OFF_ATTACK, true);
+            if (offHand && !offHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+                itemTarget = offHand;
+        }
+
+        if (!itemTarget)
+        {
+            failureReason = "weapon_already_poisoned";
+            return false;
+        }
+    }
+
     Unit* target = ResolveTarget(player, context);
 
-    if (!target || !target->IsAlive())
+    if ((!target || !target->IsAlive()) && !itemTarget)
     {
         failureReason = "target_invalid_or_dead";
         return false;
@@ -227,21 +247,21 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
-    if (!player->IsWithinLOSInMap(target))
+    if (!itemTarget && !player->IsWithinLOSInMap(target))
     {
         failureReason = "no_los";
         return false;
     }
 
     float const maxRange = spellInfo->GetMaxRange(false);
-    if (maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
+    if (!itemTarget && maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
     {
         failureReason = "out_of_range";
         return false;
     }
 
     float const minRange = spellInfo->GetMinRange(false);
-    if (minRange > 0.0f && player->IsWithinDistInMap(target, minRange))
+    if (!itemTarget && minRange > 0.0f && player->IsWithinDistInMap(target, minRange))
     {
         failureReason = "too_close";
         return false;
@@ -270,6 +290,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
         castResult = player->CastSpell(CastSpellTargetArg(dest), context.spellId);
     }
+    else if (itemTarget)
+        castResult = player->CastSpell(CastSpellTargetArg(itemTarget), context.spellId);
     else
         castResult = player->CastSpell(target, context.spellId, false);
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1407,6 +1407,16 @@ SpellDecision SelectRogueSpell(Player const* player, Unit const* target)
     if (!HasHostileTarget(player, target))
         return decision;
 
+    if (!player->IsInCombat() && IsSpellReady(player, 11202))
+    {
+        Item* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
+        Item* offHand = player->GetWeaponForAttack(OFF_ATTACK, true);
+        bool const mainHandMissingPoison = mainHand && !mainHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT);
+        bool const offHandMissingPoison = offHand && !offHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT);
+        if (mainHandMissingPoison || offHandMissingPoison)
+            return { "rogue crippling poison", "apply crippling poison to unpoisoned weapons out of combat", 11202, playerbot::PvpClassSpellContext::TargetMode::Self };
+    }
+
     if (!player->IsInCombat() && !player->HasAura(1784) && IsSpellReady(player, 1784))
         return { "rogue stealth", "enter stealth before engagement", 1784, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 1766))


### PR DESCRIPTION
### Motivation
- Ensure rogue playerbots keep their weapons poisoned by automatically applying `11202` (Crippling Poison) to any unpoisoned weapon so they maintain expected PvP behavior.

### Description
- Add out-of-combat decision in `SelectRogueSpell` to request `11202` when either main-hand or off-hand lacks a temporary enchant (checks `TEMP_ENCHANTMENT_SLOT`).
- Extend `CastDirectSpell` in `PlayerbotPvpClassActions.cpp` to support item-targeted casts by selecting an unpoisoned weapon (main hand first, then off hand) and casting `11202` on the `Item` via `CastSpell(CastSpellTargetArg(itemTarget), ...)`.
- Bypass unit LOS/range/min-range checks for valid item-targeted poison casts while preserving existing validation and behavior for normal unit-targeted spells and special cases (e.g., Blink and hunter trap follow-up).
- Fail gracefully with `failureReason = "weapon_already_poisoned"` when both weapon slots are already poisoned to avoid redundant casts.

### Testing
- Ran a build invocation: `cmake --build build --target worldserver -j2`, which started successfully and progressed through compilation of many translation units in this environment. 
- The build was manually interrupted due to runtime constraints; no automated tests were executed in this session and no compilation errors were observed before the manual stop.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5122e4a408327a77fd0060302ec37)