### PR TITLE
Include Item.h in PlayerbotPvpClassActions to fix incomplete-type error

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -18,6 +18,7 @@
 #include "PlayerbotPvpClassActions.h"
 
 #include "GameTime.h"
+#include "Item.h"
 #include "ObjectAccessor.h"
 #include "Log.h"
 #include "Player.h"


### PR DESCRIPTION
### Motivation
- Resolve a compile error where `Item` was only forward-declared and member access (`GetEnchantmentId`) on `Item*` caused an incomplete-type error in PvP bot logic.

### Description
- Add the missing include `#include "Item.h"` to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` so `Item` is a complete type where weapon enchantment checks are performed.

### Testing
- Ran `cmake --build build --target game -- -j2` to validate the change, the build started and progressed through compilation without any further compile errors related to the modified file observed in the captured output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d518c31f4083278f839020307cc85f)