### PR TITLE
Playerbots: cast Warlock Curse of Agony on non-casters and add per-target curse cooldowns

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -32,10 +32,53 @@
 #include "WorldSession.h"
 
 #include <chrono>
+#include <unordered_map>
 
 namespace
 {
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
+
+struct WarlockCurseCooldownKey
+{
+    ObjectGuid casterGuid;
+    ObjectGuid targetGuid;
+    uint32 spellId = 0;
+
+    bool operator==(WarlockCurseCooldownKey const& other) const
+    {
+        return casterGuid == other.casterGuid && targetGuid == other.targetGuid && spellId == other.spellId;
+    }
+};
+
+struct WarlockCurseCooldownKeyHash
+{
+    std::size_t operator()(WarlockCurseCooldownKey const& key) const
+    {
+        std::size_t const casterHash = std::hash<uint64>{}(key.casterGuid.GetRawValue());
+        std::size_t const targetHash = std::hash<uint64>{}(key.targetGuid.GetRawValue());
+        std::size_t const spellHash = std::hash<uint32>{}(key.spellId);
+        return casterHash ^ (targetHash << 1) ^ (spellHash << 2);
+    }
+};
+
+std::unordered_map<WarlockCurseCooldownKey, GameTime::steady_clock::time_point, WarlockCurseCooldownKeyHash> g_WarlockCurseTargetCooldowns;
+
+uint32 ResolveKnownSpellInChain(Player const* player, uint32 baseSpellId)
+{
+    if (!player || !baseSpellId)
+        return 0;
+
+    SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(baseSpellId);
+    if (!baseSpellInfo)
+        return 0;
+
+    uint32 resolvedSpellId = 0;
+    for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
+        if (player->HasSpell(chainSpellId))
+            resolvedSpellId = chainSpellId;
+
+    return resolvedSpellId;
+}
 
 void CommandPetAttackTarget(Player* player, Unit* target)
 {
@@ -411,8 +454,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // short tactical cooldowns on selected PvP debuffs.
     if (context.spellId == 112826)
         player->GetSpellHistory()->AddCooldown(context.spellId, 0, std::chrono::seconds(15));
-    if (context.spellId == 3034 || context.spellId == 1714)
-        player->GetSpellHistory()->AddCooldown(context.spellId, 0, std::chrono::seconds(12));
+    if (context.spellId == 3034 || context.spellId == 1714 || context.spellId == 11713)
+    {
+        if (uint32 const resolvedSpellId = ResolveKnownSpellInChain(player, context.spellId))
+            player->GetSpellHistory()->AddCooldown(resolvedSpellId, 0, std::chrono::seconds(12));
+    }
+
+    if ((context.spellId == 1714 || context.spellId == 11713) && target)
+        PvpClassActions::RegisterWarlockCurseTargetCooldown(player, target, context.spellId, std::chrono::seconds(12));
 
     return true;
 }
@@ -448,6 +497,33 @@ bool UseDirectItem(Player* player, playerbot::PvpClassSpellContext const& contex
 
 namespace playerbot
 {
+bool PvpClassActions::IsWarlockCurseTargetCooldownActive(Player const* player, Unit const* target, uint32 spellId)
+{
+    if (!player || !target || !spellId)
+        return false;
+
+    WarlockCurseCooldownKey const key{ player->GetGUID(), target->GetGUID(), spellId };
+    auto const itr = g_WarlockCurseTargetCooldowns.find(key);
+    if (itr == g_WarlockCurseTargetCooldowns.end())
+        return false;
+
+    if (GameTime::GetGameTimeSteadyPoint() >= itr->second)
+    {
+        g_WarlockCurseTargetCooldowns.erase(itr);
+        return false;
+    }
+
+    return true;
+}
+
+void PvpClassActions::RegisterWarlockCurseTargetCooldown(Player const* player, Unit const* target, uint32 spellId, std::chrono::seconds cooldown)
+{
+    if (!player || !target || !spellId || cooldown <= std::chrono::seconds::zero())
+        return;
+
+    g_WarlockCurseTargetCooldowns[{ player->GetGUID(), target->GetGUID(), spellId }] = GameTime::GetGameTimeSteadyPoint() + cooldown;
+}
+
 bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& context)
 {
     if (!player || !context.classSpellsEnabled || !context.shouldExecute)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
@@ -20,7 +20,10 @@
 
 #include "PlayerbotPvpCore.h"
 
+#include <chrono>
+
 class Player;
+class Unit;
 
 namespace playerbot
 {
@@ -28,6 +31,8 @@ class PvpClassActions
 {
 public:
     static bool Execute(Player* player, PvpClassSpellContext const& context);
+    static bool IsWarlockCurseTargetCooldownActive(Player const* player, Unit const* target, uint32 spellId);
+    static void RegisterWarlockCurseTargetCooldown(Player const* player, Unit const* target, uint32 spellId, std::chrono::seconds cooldown);
 };
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "PlayerbotPvpCore.h"
+#include "PlayerbotPvpClassActions.h"
 #include "PlayerbotRandomBotParticipation.h"
 
 #include "Battleground.h"
@@ -301,6 +302,42 @@ bool IsMeleeClass(Unit const* unit)
         case CLASS_SHAMAN:
         case CLASS_PALADIN:
             return IsUsingTwoHander(player);
+        default:
+            return false;
+    }
+}
+
+bool HasAuraFromSpellChain(Unit const* unit, uint32 baseSpellId)
+{
+    if (!unit || !baseSpellId)
+        return false;
+
+    SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(baseSpellId);
+    if (!baseSpellInfo)
+        return false;
+
+    for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
+        if (unit->HasAura(chainSpellId))
+            return true;
+
+    return false;
+}
+
+bool IsCasterClass(Unit const* unit)
+{
+    Player const* player = unit ? unit->ToPlayer() : nullptr;
+    if (!player)
+        return false;
+
+    switch (player->GetClass())
+    {
+        case CLASS_MAGE:
+        case CLASS_PRIEST:
+        case CLASS_WARLOCK:
+        case CLASS_DRUID:
+        case CLASS_SHAMAN:
+        case CLASS_PALADIN:
+            return true;
         default:
             return false;
     }
@@ -1333,8 +1370,12 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
     if (IsSpellReady(player, 5782))
         if (Unit const* fearTarget = SelectWarlockFearTarget(player, 20.0f))
             return { "warlock fear", "prioritize fear control on paladin/priest targets in range", 5782, playerbot::PvpClassSpellContext::TargetMode::Enemy, fearTarget->GetGUID() };
-    if (target->GetPowerType() == POWER_MANA && !target->HasAura(1714) && IsSpellReady(player, 1714))
+    if (target->GetPowerType() == POWER_MANA && !HasAuraFromSpellChain(target, 1714) &&
+        !PvpClassActions::IsWarlockCurseTargetCooldownActive(player, target, 1714) && IsSpellReady(player, 1714))
         return { "warlock curse of tongues", "slow enemy casting throughput", 1714, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+    if (!IsCasterClass(target) && !HasAuraFromSpellChain(target, 980) &&
+        !PvpClassActions::IsWarlockCurseTargetCooldownActive(player, target, 11713) && IsSpellReady(player, 11713))
+        return { "warlock curse of agony", "apply curse of agony pressure to non-caster players", 11713, playerbot::PvpClassSpellContext::TargetMode::Enemy };
     if (!target->HasAura(25311) && IsSpellReady(player, 25311))
         return { "warlock corruption", "maintain corruption dot", 25311, playerbot::PvpClassSpellContext::TargetMode::Enemy };
     if ((target->HealthBelowPct(20) || (closePressure && IsMeleeClass(target))) && IsSpellReady(player, 6789))


### PR DESCRIPTION
### Motivation
- Prevent warlock playerbots from repeatedly reapplying curses after quick decurses by introducing a short throttle per caster+target for curses.
- Extend warlock PvP pressure by applying `Curse of Agony (11713)` to non-caster player targets in addition to existing curses.

### Description
- Added per-target cooldown tracking stored in an `unordered_map` keyed by caster GUID, target GUID and `spellId`, and exposed `PvpClassActions::IsWarlockCurseTargetCooldownActive` and `PvpClassActions::RegisterWarlockCurseTargetCooldown` in `PlayerbotPvpClassActions`.
- Added `ResolveKnownSpellInChain` and changed tactical cooldown application to resolve the caster's known spell rank so cooldowns are applied to the correct known rank when adding to `SpellHistory`.
- Added `HasAuraFromSpellChain` and `IsCasterClass` helpers and updated `SelectWarlockSpell` to check per-target cooldowns and auras across spell chains, and to return `Curse of Agony (11713)` for non-caster player targets when appropriate.
- Registered a 12-second per-target cooldown after casting `Curse of Tongues (1714)` or `Curse of Agony (11713)` and included `11713` in the tactical cooldown resolution path.

### Testing
- Ran `git diff --check` to validate whitespace and simple diff issues, which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d522215150832782858444fe333125)