### PR TITLE
playerbots: add WSG objective fallback to leave base

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -711,6 +711,25 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
         return true;
     }
 
+    // Fallback for sparse/invalid start-anchor states:
+    // WSG bots can otherwise idle in their own base graveyard when no objective
+    // anchor is resolved from battleground starts.
+    if (battleground->GetMapId() == 489) // Warsong Gulch
+    {
+        Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
+        Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
+
+        if (botTeam == TEAM_ALLIANCE)
+            destination = hordeFlagStand;
+        else if (botTeam == TEAM_HORDE)
+            destination = allianceFlagStand;
+        else
+            destination = hordeFlagStand;
+
+        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        return true;
+    }
+
     return false;
 }
 }


### PR DESCRIPTION
### Motivation
- Bots in Warsong Gulch can idle at their base graveyards when battleground start anchors are unavailable, causing them not to move toward objectives.

### Description
- Added a Warsong Gulch-specific fallback in `TryGetObjectivePosition` to return an enemy flag-stand position when battleground start anchors cannot be resolved. 
- The fallback uses the enemy flag stand coordinates and applies the same random `RelocateOffset` jitter used elsewhere so bots still traverse the map toward the objective. 
- Change is implemented in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` inside `TryGetObjectivePosition` with a `mapId == 489` guard.

### Testing
- Ran `cmake --build build -j4 --target worldserver` to validate configuration and start a compile, which reconfigured successfully and began compiling the project but was not completed in this environment due to the full rebuild size.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5228a09688327ba00b643317e6f56)