### PR TITLE
Fix Playerbot PvP namespace and steady_clock type

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -61,7 +61,7 @@ struct WarlockCurseCooldownKeyHash
     }
 };
 
-std::unordered_map<WarlockCurseCooldownKey, GameTime::steady_clock::time_point, WarlockCurseCooldownKeyHash> g_WarlockCurseTargetCooldowns;
+std::unordered_map<WarlockCurseCooldownKey, std::chrono::steady_clock::time_point, WarlockCurseCooldownKeyHash> g_WarlockCurseTargetCooldowns;
 
 uint32 ResolveKnownSpellInChain(Player const* player, uint32 baseSpellId)
 {

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1371,10 +1371,10 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
         if (Unit const* fearTarget = SelectWarlockFearTarget(player, 20.0f))
             return { "warlock fear", "prioritize fear control on paladin/priest targets in range", 5782, playerbot::PvpClassSpellContext::TargetMode::Enemy, fearTarget->GetGUID() };
     if (target->GetPowerType() == POWER_MANA && !HasAuraFromSpellChain(target, 1714) &&
-        !PvpClassActions::IsWarlockCurseTargetCooldownActive(player, target, 1714) && IsSpellReady(player, 1714))
+        !playerbot::PvpClassActions::IsWarlockCurseTargetCooldownActive(player, target, 1714) && IsSpellReady(player, 1714))
         return { "warlock curse of tongues", "slow enemy casting throughput", 1714, playerbot::PvpClassSpellContext::TargetMode::Enemy };
     if (!IsCasterClass(target) && !HasAuraFromSpellChain(target, 980) &&
-        !PvpClassActions::IsWarlockCurseTargetCooldownActive(player, target, 11713) && IsSpellReady(player, 11713))
+        !playerbot::PvpClassActions::IsWarlockCurseTargetCooldownActive(player, target, 11713) && IsSpellReady(player, 11713))
         return { "warlock curse of agony", "apply curse of agony pressure to non-caster players", 11713, playerbot::PvpClassSpellContext::TargetMode::Enemy };
     if (!target->HasAura(25311) && IsSpellReady(player, 25311))
         return { "warlock corruption", "maintain corruption dot", 25311, playerbot::PvpClassSpellContext::TargetMode::Enemy };


### PR DESCRIPTION
### Motivation
- Fix compilation errors when building Playerbot PvP scripts caused by an unqualified class reference and an incorrect clock type.

### Description
- Qualify warlock curse cooldown checks with `playerbot::PvpClassActions::IsWarlockCurseTargetCooldownActive` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`.
- Replace `GameTime::steady_clock::time_point` with `std::chrono::steady_clock::time_point` for the cooldown map in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`.

### Testing
- Ran an incremental build with `ninja -C build scripts -j2`; the modified scripts compiled as part of the build, but a subsequent full build stopped due to an unrelated PCH allocation failure (`sorry, unimplemented: PCH allocation failure`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d523a162cc83279e104f447a7f361a)