### PR TITLE
Fix Playerbot PvP namespace and GameTime API usage

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -461,7 +461,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     }
 
     if ((context.spellId == 1714 || context.spellId == 11713) && target)
-        PvpClassActions::RegisterWarlockCurseTargetCooldown(player, target, context.spellId, std::chrono::seconds(12));
+        playerbot::PvpClassActions::RegisterWarlockCurseTargetCooldown(player, target, context.spellId, std::chrono::seconds(12));
 
     return true;
 }
@@ -507,7 +507,7 @@ bool PvpClassActions::IsWarlockCurseTargetCooldownActive(Player const* player, U
     if (itr == g_WarlockCurseTargetCooldowns.end())
         return false;
 
-    if (GameTime::GetGameTimeSteadyPoint() >= itr->second)
+    if (GameTime::Now() >= itr->second)
     {
         g_WarlockCurseTargetCooldowns.erase(itr);
         return false;
@@ -521,7 +521,7 @@ void PvpClassActions::RegisterWarlockCurseTargetCooldown(Player const* player, U
     if (!player || !target || !spellId || cooldown <= std::chrono::seconds::zero())
         return;
 
-    g_WarlockCurseTargetCooldowns[{ player->GetGUID(), target->GetGUID(), spellId }] = GameTime::GetGameTimeSteadyPoint() + cooldown;
+    g_WarlockCurseTargetCooldowns[{ player->GetGUID(), target->GetGUID(), spellId }] = GameTime::Now() + cooldown;
 }
 
 bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& context)


### PR DESCRIPTION
### Motivation
- Resolve compile errors caused by an unqualified call to `PvpClassActions::RegisterWarlockCurseTargetCooldown` and by references to a removed `GameTime::GetGameTimeSteadyPoint()` API.
- Ensure the warlock curse tactical cooldown logic uses the current `GameTime` API so cooldown lookups and registrations compare against a valid steady time point.

### Description
- Qualify the registration call as `playerbot::PvpClassActions::RegisterWarlockCurseTargetCooldown(...)` to match the class namespace and fix the undeclared identifier error in `CastDirectSpell`.
- Replace `GameTime::GetGameTimeSteadyPoint()` with `GameTime::Now()` in `IsWarlockCurseTargetCooldownActive` to perform cooldown expiry checks using the current API.
- Replace `GameTime::GetGameTimeSteadyPoint()` with `GameTime::Now()` when storing the cooldown expiry in `RegisterWarlockCurseTargetCooldown`.

### Testing
- No automated tests, builds, or compilation were executed in this environment; changes were verified by source edits and a diff only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5264075888327ab656ad4e76f7390)