### PR TITLE
playerbots: bypass lifecycle cadence after druid Nature's Swiftness

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -955,7 +955,9 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     bool const didExecuteDuelTactical = DuelTacticalActions::Execute(player);
     PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values);
     bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
-    if (didExecuteClassSpell && classSpellContext.spellId == 16166) // Elemental Mastery (off-GCD)
+    if (didExecuteClassSpell &&
+        (classSpellContext.spellId == 16166 || // Elemental Mastery (off-GCD)
+         classSpellContext.spellId == 17116)) // Nature's Swiftness (off-GCD)
     {
         std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
         g_NextRandomBotLifecycleProcessTimeByGuid[guid.GetRawValue()] = LifecycleCadenceClock::now();


### PR DESCRIPTION
### Motivation

- Resto druids use Nature's Swiftness (spell `17116`) as an off-GCD burst to enable an immediate follow-up heal, but the random-bot lifecycle previously waited for the 2s decision cadence before re-evaluating actions which delays the follow-up.

### Description

- Treat Nature's Swiftness (`17116`) as an off-GCD burst alongside Elemental Mastery (`16166`) in `RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint` by adding `17116` to the cadence-bypass condition in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` so the bot's next decision is processed immediately.

### Testing

- Ran `git diff --check` which completed without issues.
- Ran `git status --short` to verify only `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d526f2f4b483278b1f69975f2dfece)