### PR TITLE
Playerbot: tolerate stale teleport flag in active battlegrounds

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -214,10 +214,29 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    if (!player->IsInWorld() || player->IsBeingTeleported())
+    if (!player->IsInWorld())
     {
         ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
         return false;
+    }
+
+    if (player->IsBeingTeleported())
+    {
+        // Managed random bots can occasionally retain the generic teleport flag
+        // after a battleground transition (especially when start countdowns are
+        // skipped). If near/far teleport semaphores are clear and the bot is
+        // already placed in a battleground map, continue lifecycle processing so
+        // tactical movement does not deadlock at match start.
+        bool const hasPendingTeleportAck = player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear();
+        if (hasPendingTeleportAck || !player->InBattleground())
+        {
+            ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
+            return false;
+        }
+
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check tolerated stale teleport flag: guid={} battlegroundId={}.",
+            guid.ToString(), player->GetBattlegroundId());
     }
 
     uint64 const playerGuid = guid.GetRawValue();


### PR DESCRIPTION
### Motivation
- Prevent managed random bots from deadlocking and "standing still" at battleground start (e.g., WSG) when a stale `IsBeingTeleported()` flag blocks lifecycle processing.

### Description
- Relaxed the lifecycle gate in `CanProcessPlayerLifecycle` so `IsBeingTeleported()` no longer immediately rejects processing; instead it only blocks when `IsBeingTeleportedFar()` or `IsBeingTeleportedNear()` are true or the player is not `InBattleground()` and logs a debug message when a stale teleport flag is tolerated (`src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`).

### Testing
- Ran `cmake --build build --target game -j2` (compilation started) and a dry-run `cmake --build build --target game -j2 -- -n` which completed successfully, and observed no compiler errors during this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52754e2308327b962d865e08b62f3)