### PR TITLE
playerbots: prevent rogue stealth from being broken by auto-attack

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -268,7 +268,10 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         // Keep explicit enemy selection/victim linkage for virtual sessions so
         // cast checks and AI follow-up consistently reference the same hostile.
         player->SetSelection(target->GetGUID());
-        if (player->GetVictim() != target)
+        bool const preserveStealthForOpener = player->HasStealthAura();
+        if (preserveStealthForOpener)
+            player->AttackStop();
+        else if (player->GetVictim() != target)
             player->Attack(target, false);
         CommandPetAttackTarget(player, target);
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -674,7 +674,11 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
 
     CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     bool const useMeleeAttack = !profile.primarilyRanged || profile.meleeFallbackAcceptable;
-    player->Attack(target, useMeleeAttack);
+    bool const isStealthedRogue = player->GetClass() == CLASS_ROGUE && player->HasStealthAura();
+    if (isStealthedRogue)
+        player->AttackStop();
+    else
+        player->Attack(target, useMeleeAttack);
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
         "Playerbot PvP positioning profile: bot={} profile={} ranged={} createDistance={} meleeFallback={}.",


### PR DESCRIPTION
### Motivation
- Rogue playerbots were starting/continuing melee auto-attack while stealthed which broke stealth openers like `Cheap Shot`; the change preserves stealth for opener logic.
- Lifecycle engagement logic could also trigger an immediate `Attack(...)` and unintentionally reveal stealthed rogues during PvP positioning.

### Description
- In `CastDirectSpell` (PvP class spell execution) keep the explicit target selection but, when the player `HasStealthAura()`, call `AttackStop()` instead of initiating `Attack(...)` so stealth is preserved for opener spells; non-stealthed behavior is unchanged.
- In `EngageNearestEnemyPlayer` (PvP lifecycle engage) suppress `player->Attack(...)` for rogues with `HasStealthAura()` and call `AttackStop()` instead, while preserving normal attack behavior for other cases.
- No changes to spell selection logic or cheap-shot conditions; only the pre-attack/engage linkage was adjusted to avoid breaking stealth early.

### Testing
- Ran `cmake --build build --target worldserver -j2` to configure and start a full build; CMake configured successfully and compilation progressed without visible compile errors during the session but the full rebuild was long-running and not waited to completion in this environment.
- No automated unit tests were executed in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5280942f883279b72f8424278f621)