### PR TITLE
Keep managed bots moving in active battlegrounds and tolerate stale teleport flag during lifecycle checks

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -833,6 +833,26 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (HandleBattlegroundDeathState(player))
         return true;
 
+    // Keep managed bots moving even when tactical decision hooks are disabled
+    // or when another behavior tree branch (e.g. buffing) wins the current tick.
+    // This prevents "stand still at gate-open" stalls in active battlegrounds.
+    if (CanIssueBotMovement(player))
+    {
+        if (EngageNearestEnemyPlayer(player, 65.0f))
+            return true;
+
+        if (Battleground* battleground = player->GetBattleground())
+        {
+            Position destination;
+            if (TryGetObjectivePosition(battleground, player, destination))
+            {
+                if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
+                    player->GetMotionMaster()->MovePoint(0, destination);
+                return true;
+            }
+        }
+    }
+
     return true;
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -214,10 +214,29 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    if (!player->IsInWorld() || player->IsBeingTeleported())
+    if (!player->IsInWorld())
     {
         ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
         return false;
+    }
+
+    if (player->IsBeingTeleported())
+    {
+        // Managed random bots can occasionally retain the generic teleport flag
+        // after a battleground transition (especially when start countdowns are
+        // skipped). If near/far teleport semaphores are clear and the bot is
+        // already placed in a battleground map, continue lifecycle processing so
+        // tactical movement does not deadlock at match start.
+        bool const hasPendingTeleportAck = player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear();
+        if (hasPendingTeleportAck || !player->InBattleground())
+        {
+            ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
+            return false;
+        }
+
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check tolerated stale teleport flag: guid={} battlegroundId={}.",
+            guid.ToString(), player->GetBattlegroundId());
     }
 
     uint64 const playerGuid = guid.GetRawValue();


### PR DESCRIPTION
### Motivation
- Prevent managed playerbots from standing still at gate-open or stalling in active battlegrounds when tactical hooks are disabled or another behavior branch wins the tick.  
- Avoid lifecycle deadlocks caused by stale generic teleport flags after battleground transitions while the bot is already placed in the battleground map.

### Description
- Add a fallback movement path in `HandleInProgressStatusPrimitive` that, when `CanIssueBotMovement` is true, first tries `EngageNearestEnemyPlayer(player, 65.0f)` and then falls back to obtaining an objective via `TryGetObjectivePosition` and issuing `MovePoint` when farther than `12.0f`.  
- Split the early lifecycle pre-check in `CanProcessPlayerLifecycle` to reject only when not `IsInWorld()`, and add handling for `IsBeingTeleported()` that tolerates a stale generic teleport flag when no pending near/far teleport is present and the player is already in a battleground, while logging a debug message.  
- Preserve cadence throttling and other lifecycle observation paths while improving movement continuity for managed random bots.

### Testing
- Built the project and executed the automated test suite via `make test`, and all tests completed successfully.  
- Ran the PvP lifecycle/integration scenario tests for playerbots that exercise battleground transitions, and the scenarios passed without introducing new failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52754e2308327b962d865e08b62f3)