### PR TITLE
Randomize playerbot battleground/arena queue ordering

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -39,12 +39,14 @@
 #include "WorldPacket.h"
 #include "WorldSession.h"
 #include "Util.h"
+#include "Containers.h"
 
 #include <cstring>
 #include <cmath>
 #include <limits>
 #include <sstream>
 #include <unordered_map>
+#include <array>
 
 namespace
 {
@@ -52,6 +54,22 @@ bool IsLifecycleGateEnabled()
 {
     playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
+}
+
+std::array<BattlegroundTypeId, 6> BuildRandomBattlegroundOrder()
+{
+    std::array<BattlegroundTypeId, 6> battlegroundTypes =
+    {
+        BATTLEGROUND_AV,
+        BATTLEGROUND_EY,
+        BATTLEGROUND_AB,
+        BATTLEGROUND_WS,
+        BATTLEGROUND_SA,
+        BATTLEGROUND_IC
+    };
+
+    Trinity::Containers::RandomShuffle(battlegroundTypes);
+    return battlegroundTypes;
 }
 
 void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string const& detail)
@@ -793,7 +811,13 @@ bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    return QueuePlayer(player, BattlegroundLifecycleActions::ManagedRandomBotQueueTarget(), 0);
+    for (BattlegroundTypeId bgTypeId : BuildRandomBattlegroundOrder())
+    {
+        if (QueuePlayer(player, bgTypeId, 0))
+            return true;
+    }
+
+    return false;
 }
 
 bool BattlegroundLifecycleActions::LeaveQueuePrimitive(Player* player)
@@ -1067,7 +1091,15 @@ bool ArenaLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    return QueuePlayer(player, BATTLEGROUND_AA, ARENA_TYPE_2v2);
+    std::array<uint8, 3> arenaTypes = { ARENA_TYPE_2v2, ARENA_TYPE_3v3, ARENA_TYPE_5v5 };
+    Trinity::Containers::RandomShuffle(arenaTypes);
+    for (uint8 arenaType : arenaTypes)
+    {
+        if (QueuePlayer(player, BATTLEGROUND_AA, arenaType))
+            return true;
+    }
+
+    return false;
 }
 
 bool ArenaLifecycleActions::LeaveQueuePrimitive(Player* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
@@ -27,8 +27,6 @@ namespace playerbot
 class BattlegroundLifecycleActions
 {
 public:
-    static constexpr BattlegroundTypeId ManagedRandomBotQueueTarget() { return BATTLEGROUND_WS; }
-
     static bool Execute(Player* player, BattlegroundLifecycleContext const& context);
 
     static bool JoinQueuePrimitive(Player* player);


### PR DESCRIPTION
### Motivation
- Reduce repeated identical playerbot team compositions by avoiding always queuing the same battleground or arena bracket every attempt.
- Make managed playerbot queue/arena selection behave more realistically by trying multiple valid options in a random order.

### Description
- Replace the fixed managed-bot battleground target with a randomized ordering by adding `BuildRandomBattlegroundOrder()` and attempting `QueuePlayer` for each shuffled `BattlegroundTypeId` instead of always using `BATTLEGROUND_WS`.
- Randomize arena bracket selection by shuffling `{ ARENA_TYPE_2v2, ARENA_TYPE_3v3, ARENA_TYPE_5v5 }` and attempting each bracket in `ArenaLifecycleActions::JoinQueuePrimitive` until one succeeds.
- Remove the static `ManagedRandomBotQueueTarget()` constant from `PlayerbotPvpLifecycleActions.h` and update `JoinQueuePrimitive` logic in `PlayerbotPvpLifecycleActions.cpp` to try shuffled options.
- Add `#include "Containers.h"` and use `Trinity::Containers::RandomShuffle` and `<array>` to perform shuffles.

### Testing
- Ran a local build attempt with `cmake --build build --target game -- -j4` to validate compilation in this environment; the build progressed substantially (compiled many translation units) but did not complete within the active run window.
- No additional automated unit tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d529d6e0988327a78a609b22381ef0)