### PR TITLE
Playerbot PvP: improve in-battleground lifecycle handling and add GM debug emits

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -70,6 +70,43 @@ void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string cons
         ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
 }
 
+void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs = 3000)
+{
+    if (!bot || !bot->InBattleground())
+        return;
+
+    static std::unordered_map<uint64, uint32> nextEmitTimeByBotGuid;
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint64 const botGuid = bot->GetGUID().GetRawValue();
+    uint32& nextEmitMs = nextEmitTimeByBotGuid[botGuid];
+    if (nowMs < nextEmitMs)
+        return;
+
+    nextEmitMs = nowMs + throttleMs;
+
+    Map* map = bot->GetMap();
+    if (!map)
+        return;
+
+    std::ostringstream whisper;
+    whisper << "[PBDBG] bot=" << bot->GetName() << " guid=" << bot->GetGUID().ToString()
+            << " map=" << bot->GetMapId() << " detail=" << detail;
+    std::string const message = whisper.str();
+
+    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
+    {
+        Player* observer = itr->GetSource();
+        if (!observer || !observer->IsGameMaster())
+            continue;
+
+        if (observer->GetBattlegroundId() != bot->GetBattlegroundId())
+            continue;
+
+        if (WorldSession* observerSession = observer->GetSession())
+            ChatHandler(observerSession).PSendSysMessage("%s", message.c_str());
+    }
+}
+
 bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
 {
     if (!player || player->InBattleground())
@@ -833,6 +870,53 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (HandleBattlegroundDeathState(player))
         return true;
 
+    if (player->HasAura(SPELL_PREPARATION) || player->HasAura(SPELL_ARENA_PREPARATION) || player->HasUnitFlag(UNIT_FLAG_PREPARATION))
+    {
+        player->RemoveAurasDueToSpell(SPELL_PREPARATION);
+        player->RemoveAurasDueToSpell(SPELL_ARENA_PREPARATION);
+        player->RemoveUnitFlag(UNIT_FLAG_PREPARATION);
+        EmitBattlegroundGmDebug(player, "removed lingering preparation state in STATUS_IN_PROGRESS");
+    }
+
+    // Keep managed bots moving even when tactical decision hooks are disabled
+    // or when another behavior tree branch (e.g. buffing) wins the current tick.
+    // This prevents "stand still at gate-open" stalls in active battlegrounds.
+    if (!CanIssueBotMovement(player))
+    {
+        std::ostringstream blockedReason;
+        blockedReason << "movement-blocked alive=" << (player->IsAlive() ? 1 : 0)
+                      << " ghost=" << (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST) ? 1 : 0)
+                      << " rooted=" << (player->HasUnitState(UNIT_STATE_ROOT) ? 1 : 0)
+                      << " stunned=" << (player->HasUnitState(UNIT_STATE_STUNNED) ? 1 : 0);
+        EmitBattlegroundGmDebug(player, blockedReason.str());
+        return true;
+    }
+
+    if (EngageNearestEnemyPlayer(player, 65.0f))
+    {
+        EmitBattlegroundGmDebug(player, "engaging nearest enemy (65y)");
+        return true;
+    }
+
+    if (Battleground* battleground = player->GetBattleground())
+    {
+        Position destination;
+        if (TryGetObjectivePosition(battleground, player, destination))
+        {
+            if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
+            {
+                player->GetMotionMaster()->MovePoint(0, destination);
+                std::ostringstream movementDetail;
+                movementDetail << "issued MovePoint to objective x=" << destination.GetPositionX()
+                               << " y=" << destination.GetPositionY()
+                               << " z=" << destination.GetPositionZ();
+                EmitBattlegroundGmDebug(player, movementDetail.str());
+            }
+            return true;
+        }
+    }
+
+    EmitBattlegroundGmDebug(player, "no enemy target and no objective position resolved");
     return true;
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -214,10 +214,29 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    if (!player->IsInWorld() || player->IsBeingTeleported())
+    if (!player->IsInWorld())
     {
         ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
         return false;
+    }
+
+    if (player->IsBeingTeleported())
+    {
+        // Managed random bots can occasionally retain the generic teleport flag
+        // after a battleground transition (especially when start countdowns are
+        // skipped). If near/far teleport semaphores are clear and the bot is
+        // already placed in a battleground map, continue lifecycle processing so
+        // tactical movement does not deadlock at match start.
+        bool const hasPendingTeleportAck = player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear();
+        if (hasPendingTeleportAck || !player->InBattleground())
+        {
+            ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
+            return false;
+        }
+
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check tolerated stale teleport flag: guid={} battlegroundId={}.",
+            guid.ToString(), player->GetBattlegroundId());
     }
 
     uint64 const playerGuid = guid.GetRawValue();


### PR DESCRIPTION
### Motivation

- Prevent managed bots from stalling at battleground start by clearing lingering preparation state and ensuring movement/engagement behavior continues.  
- Provide GMs with throttled per-battleground debug messages to observe bot decisions without spamming chat.  
- Allow lifecycle processing to continue for managed virtual bots that retain stale teleport flags after battleground transitions when it is safe to do so.

### Description

- Add `EmitBattlegroundGmDebug` helper to send throttled debug messages to game masters present in the same battleground.  
- In `HandleInProgressStatusPrimitive` remove lingering `SPELL_PREPARATION`/`SPELL_ARENA_PREPARATION` auras and `UNIT_FLAG_PREPARATION`, early-return if `CanIssueBotMovement` is false and emit a debug message, attempt `EngageNearestEnemyPlayer` within `65.0f`, and resolve objective positions to issue `MovePoint` when needed while emitting debug detail for actions or when no target/objective is found.  
- Update `CanProcessPlayerLifecycle` to separate the `IsInWorld` and `IsBeingTeleported` checks and tolerate a stale generic teleport flag for managed bots already in a battleground when no pending near/far teleport is present, with a debug log emitted when the stale flag is tolerated.

### Testing

- Performed an automated CI build which compiled the modified code successfully.  
- Executed the project's automated test suite in CI; all tests (including PvP-related tests in the suite) completed without failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52754e2308327b962d865e08b62f3)