### PR TITLE
Add jump-turn visual to preserve retreat motion for instant enemy casts

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -20,6 +20,7 @@
 #include "GameTime.h"
 #include "ObjectAccessor.h"
 #include "Log.h"
+#include "MotionMaster.h"
 #include "Player.h"
 #include "Protocol/Opcodes.h"
 #include "Spell.h"
@@ -29,6 +30,7 @@
 #include "Unit.h"
 #include "WorldSession.h"
 
+#include <algorithm>
 #include <chrono>
 
 namespace
@@ -123,6 +125,39 @@ Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& conte
     }
 }
 
+void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const* spellInfo, float resumeOrientation)
+{
+    if (!player || !target || !spellInfo)
+        return;
+
+    if (spellInfo->CalcCastTime() > 0 || !player->isMoving())
+        return;
+
+    ObjectGuid const casterGuid = player->GetGUID();
+    player->SetFacingToObject(target);
+    player->SetInFront(target);
+
+    // Use MotionMaster jump spline (not Unit::JumpTo knockback) so movement
+    // keeps a regular jump arc while preserving retreat momentum.
+    float const jumpSpeedXY = std::max(2.5f, player->GetSpeed(MOVE_RUN));
+    float constexpr backwardAngle = 3.14159265f;
+    Position const jumpDest = player->GetFirstCollisionPosition(4.0f, player->GetOrientation() + backwardAngle);
+    player->GetMotionMaster()->MoveJump(jumpDest.GetPositionX(), jumpDest.GetPositionY(), jumpDest.GetPositionZ(),
+        player->GetOrientation(), jumpSpeedXY, 4.5f);
+
+    player->m_Events.AddEventAtOffset([casterGuid, resumeOrientation]()
+    {
+        Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
+        if (!caster || !caster->IsInWorld() || !caster->IsAlive())
+            return;
+
+        if (caster->IsNonMeleeSpellCast(false, false, true))
+            return;
+
+        caster->SetFacingTo(resumeOrientation);
+    }, 250ms);
+}
+
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
 {
     failureReason.clear();
@@ -170,6 +205,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "self_target_mismatch";
         return false;
     }
+
+    float preCastOrientation = player->GetOrientation();
 
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
     {
@@ -253,6 +290,10 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
         return false;
+
+    bool const isInstantCast = spellInfo->CalcCastTime() == 0;
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
+        JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,


### PR DESCRIPTION
### Motivation

- Improve visual fidelity for playerbots when casting instant offensive spells while moving by preserving retreat momentum and providing a visible turn-back animation. 
- Prevent immediate server-side facing checks from rejecting instant casts by briefly adjusting orientation and restoring prior facing after the visual.

### Description

- Added `JumpTurnForInstantCastVisual` which uses `MotionMaster::MoveJump` to perform a short backward jump and schedules an event to restore the player's facing after 250ms if the player is still valid and not casting. 
- Store pre-cast orientation (`preCastOrientation`) and call the new helper for instant casts on enemy targets to perform the jump-turn visual. 
- Included `MotionMaster.h` and `<algorithm>` headers required by the new logic and adjusted a few placement points in `CastDirectSpell` to capture orientation and invoke the visual. 

### Testing

- Compiled the server code successfully using the project build (`cmake`/`make`) with no build errors. 
- Ran automated test suite (`ctest`/`make test`) and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50fabe3948327a4b3c312b96a0d02)