### PR TITLE
Playerbot PvP: tolerate stale teleports, resume movement in battlegrounds, and add GM debug whispers

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -70,6 +70,42 @@ void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string cons
         ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
 }
 
+void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs = 3000)
+{
+    if (!bot || !bot->InBattleground())
+        return;
+
+    static std::unordered_map<uint64, uint32> nextEmitTimeByBotGuid;
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint64 const botGuid = bot->GetGUID().GetRawValue();
+    uint32& nextEmitMs = nextEmitTimeByBotGuid[botGuid];
+    if (nowMs < nextEmitMs)
+        return;
+
+    nextEmitMs = nowMs + throttleMs;
+
+    Map* map = bot->GetMap();
+    if (!map)
+        return;
+
+    std::ostringstream whisper;
+    whisper << "[PBDBG] bot=" << bot->GetName() << " guid=" << bot->GetGUID().ToString()
+            << " map=" << bot->GetMapId() << " detail=" << detail;
+    std::string const message = whisper.str();
+
+    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
+    {
+        Player* observer = itr->GetSource();
+        if (!observer || !observer->IsGameMaster())
+            continue;
+
+        if (observer->GetBattlegroundId() != bot->GetBattlegroundId())
+            continue;
+
+        bot->Whisper(message, LANG_UNIVERSAL, observer);
+    }
+}
+
 bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
 {
     if (!player || player->InBattleground())
@@ -833,6 +869,42 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (HandleBattlegroundDeathState(player))
         return true;
 
+    if (player->HasAura(SPELL_PREPARATION) || player->HasAura(SPELL_ARENA_PREPARATION) || player->HasUnitFlag(UNIT_FLAG_PREPARATION))
+    {
+        player->RemoveAurasDueToSpell(SPELL_PREPARATION);
+        player->RemoveAurasDueToSpell(SPELL_ARENA_PREPARATION);
+        player->RemoveUnitFlag(UNIT_FLAG_PREPARATION);
+    }
+
+    // Keep managed bots moving even when tactical decision hooks are disabled
+    // or when another behavior tree branch (e.g. buffing) wins the current tick.
+    // This prevents "stand still at gate-open" stalls in active battlegrounds.
+    if (!CanIssueBotMovement(player))
+    {
+        std::ostringstream blockedReason;
+        blockedReason << "movement-blocked alive=" << (player->IsAlive() ? 1 : 0)
+                      << " ghost=" << (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST) ? 1 : 0)
+                      << " rooted=" << (player->HasUnitState(UNIT_STATE_ROOT) ? 1 : 0)
+                      << " stunned=" << (player->HasUnitState(UNIT_STATE_STUNNED) ? 1 : 0);
+        EmitBattlegroundGmDebug(player, blockedReason.str());
+        return true;
+    }
+
+    if (EngageNearestEnemyPlayer(player, 65.0f))
+        return true;
+
+    if (Battleground* battleground = player->GetBattleground())
+    {
+        Position destination;
+        if (TryGetObjectivePosition(battleground, player, destination))
+        {
+            if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
+                player->GetMotionMaster()->MovePoint(0, destination);
+            return true;
+        }
+    }
+
+    EmitBattlegroundGmDebug(player, "no enemy target and no objective position resolved");
     return true;
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -214,10 +214,29 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    if (!player->IsInWorld() || player->IsBeingTeleported())
+    if (!player->IsInWorld())
     {
         ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
         return false;
+    }
+
+    if (player->IsBeingTeleported())
+    {
+        // Managed random bots can occasionally retain the generic teleport flag
+        // after a battleground transition (especially when start countdowns are
+        // skipped). If near/far teleport semaphores are clear and the bot is
+        // already placed in a battleground map, continue lifecycle processing so
+        // tactical movement does not deadlock at match start.
+        bool const hasPendingTeleportAck = player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear();
+        if (hasPendingTeleportAck || !player->InBattleground())
+        {
+            ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
+            return false;
+        }
+
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check tolerated stale teleport flag: guid={} battlegroundId={}.",
+            guid.ToString(), player->GetBattlegroundId());
     }
 
     uint64 const playerGuid = guid.GetRawValue();


### PR DESCRIPTION
### Motivation
- Prevent managed random bots from stalling at battleground start due to lingering preparation auras, movement blockade, or stale teleport flags.
- Provide targeted, throttled diagnostics to GMs in the same battleground to simplify debugging of bot lifecycle and movement stalls.
- Allow lifecycle processing to continue for virtual/managed bots placed in battleground maps even when a generic teleport flag remains set.

### Description
- Add `EmitBattlegroundGmDebug` which throttles per-bot debug whispers and sends formatted debug messages to GMs in the same battleground.
- In `HandleInProgressStatusPrimitive` remove preparation auras and unit preparation flag, short-circuit when movement is blocked while emitting GM debug, attempt to engage the nearest enemy, and fall back to moving to a resolved objective position.
- Update `CanProcessPlayerLifecycle` to separate the `IsInWorld` and `IsBeingTeleported` checks and tolerate stale teleport flags for managed random bots already in a battleground, while still rejecting genuine pending teleports; include a debug log when the stale flag is tolerated.
- Preserve existing cadence throttling and other lifecycle guards while narrowing the conditions that cause bots to be skipped so tactical movement doesn't deadlock.

### Testing
- Built the server and ran the PvP/playerbot related unit and integration tests connected to battleground lifecycle logic, and they completed successfully.
- Verified lifecycle cadence throttling and teleport-gate conditions through automated lifecycle tests with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52754e2308327b962d865e08b62f3)