### PR TITLE
Emit jump visual and restore facing for instant PvP spells

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -29,6 +29,8 @@
 #include "Unit.h"
 #include "WorldSession.h"
 
+#include <algorithm>
+#include <cmath>
 #include <chrono>
 
 namespace
@@ -123,6 +125,54 @@ Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& conte
     }
 }
 
+void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const* spellInfo, float resumeOrientation)
+{
+    if (!player || !target || !spellInfo)
+        return;
+
+    if (spellInfo->CalcCastTime() > 0 || !player->isMoving())
+        return;
+
+    ObjectGuid const casterGuid = player->GetGUID();
+    player->SetFacingToObject(target);
+    player->SetInFront(target);
+
+    // Emit a normal jump movement opcode so observers see the same jump flow as
+    // a player-generated jump packet instead of knockback/spline movement.
+    float const jumpSpeedXY = std::max(2.5f, player->GetSpeed(MOVE_RUN));
+    float constexpr normalJumpSpeedZ = 7.95555f;
+    float constexpr backwardAngle = 3.14159265f;
+    float const jumpDirection = player->GetOrientation() + backwardAngle;
+
+    MovementInfo movementInfo;
+    movementInfo.guid = player->GetGUID();
+    movementInfo.flags = player->GetUnitMovementFlags() | MOVEMENTFLAG_FALLING;
+    movementInfo.flags2 = static_cast<uint16>(player->GetExtraUnitMovementFlags());
+    movementInfo.pos.Relocate(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetOrientation());
+    movementInfo.time = GameTime::GetGameTimeMS();
+    movementInfo.fallTime = 0;
+    movementInfo.jump.sinAngle = std::sin(jumpDirection);
+    movementInfo.jump.cosAngle = std::cos(jumpDirection);
+    movementInfo.jump.xyspeed = jumpSpeedXY;
+    movementInfo.jump.zspeed = normalJumpSpeedZ;
+
+    WorldPacket jumpPacket(MSG_MOVE_JUMP, 66);
+    WorldSession::WriteMovementInfo(&jumpPacket, &movementInfo);
+    player->SendMessageToSet(&jumpPacket, false);
+
+    player->m_Events.AddEventAtOffset([casterGuid, resumeOrientation]()
+    {
+        Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
+        if (!caster || !caster->IsInWorld() || !caster->IsAlive())
+            return;
+
+        if (caster->IsNonMeleeSpellCast(false, false, true))
+            return;
+
+        caster->SetFacingTo(resumeOrientation);
+    }, 250ms);
+}
+
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
 {
     failureReason.clear();
@@ -170,6 +220,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "self_target_mismatch";
         return false;
     }
+
+    float preCastOrientation = player->GetOrientation();
 
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
     {
@@ -253,6 +305,10 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
         return false;
+
+    bool const isInstantCast = spellInfo->CalcCastTime() == 0;
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
+        JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,


### PR DESCRIPTION
### Motivation

- Improve visual parity for virtual bot sessions when casting instant, facing-sensitive spells on enemy targets so observers see a natural jump/turn instead of no movement or knockback-style motion.

### Description

- Add `JumpTurnForInstantCastVisual` to emit a scripted jump movement packet, set immediate facing toward the target, and schedule a resume of the original orientation after 250ms. 
- Capture and restore pre-cast orientation (`preCastOrientation`) for instant enemy-targeted casts and invoke the new helper when `CalcCastTime() == 0`.
- Add includes for `<algorithm>` and `<cmath>` required by the new math usage and adjust relevant cast flow to call the helper only for instant casts on enemies.
- Preserve existing special-case handling for Blink (`1953`) and existing shapeshift/cooldown checks; no changes to non-instant cast behavior.

### Testing

- Built the project with `make` which completed successfully.
- Ran the automated unit test suite with `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50fabe3948327a4b3c312b96a0d02)