### PR TITLE
Fix Playerbot PvP compile errors in battleground checks and class spell selector

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1568,48 +1568,6 @@ SpellDecision SelectClassicClassSpell(Player const* player, Unit const* target, 
     }
 }
 
-SpellDecision SelectClassicClassSpell(Player const* player, Unit const* target, Unit const* allyTarget, ClassicProfileSelection const& profileSelection)
-{
-    SpellDecision decision;
-    if (!player)
-    {
-        decision.reason = "missing-player";
-        return decision;
-    }
-
-    if (profileSelection.unsupportedClass)
-    {
-        decision.reason = "unsupported-class";
-        return decision;
-    }
-
-    bool const inMelee = target && player->IsWithinMeleeRange(target);
-    switch (player->GetClass())
-    {
-        case CLASS_HUNTER:
-            return SelectHunterSpell(player, target, inMelee);
-        case CLASS_MAGE:
-            return SelectMageSpell(player, target, inMelee);
-        case CLASS_PRIEST:
-            return SelectPriestSpell(player, target, allyTarget, profileSelection);
-        case CLASS_PALADIN:
-            return SelectPaladinSpell(player, target);
-        case CLASS_WARLOCK:
-            return SelectWarlockSpell(player, target);
-        case CLASS_DRUID:
-            return SelectDruidSpell(player, target);
-        case CLASS_WARRIOR:
-            return SelectWarriorSpell(player, target, profileSelection);
-        case CLASS_ROGUE:
-            return SelectRogueSpell(player, target);
-        case CLASS_SHAMAN:
-            return SelectShamanSpell(player, target);
-        default:
-            decision.reason = "class-not-in-this-pass";
-            return decision;
-    }
-}
-
 char const* GetClassLabel(uint8 classId)
 {
     switch (classId)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -22,6 +22,7 @@
 #include "PlayerbotPvpLifecycleActions.h"
 
 #include "AccountMgr.h"
+#include "Battleground.h"
 #include "Configuration/Config.h"
 #include "CharacterCache.h"
 #include "Chat.h"


### PR DESCRIPTION
### Motivation
- Resolve compiler errors observed in CI caused by accessing `Battleground` members from a translation unit that only had a forward declaration and by a duplicated function definition causing a redefinition error.

### Description
- Added `#include "Battleground.h"` to `PlayerbotRandomBotParticipation.cpp` so `Battleground::GetStatus()` and `STATUS_IN_PROGRESS` are declared at compile time.
- Removed the duplicated `SelectClassicClassSpell(...)` definition from `PlayerbotPvpCore.cpp`, leaving the single intended implementation.

### Testing
- Ran `git diff --check` to ensure no whitespace/style issues and it succeeded.
- Verified there is a single declaration by running `rg -n "SpellDecision SelectClassicClassSpell\(" src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` which returned one occurrence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d536ef329c8327a0bc3990b60bc35a)