### PR TITLE
Throttle BG MovePoint, add GM debug whispers, and adjust lifecycle cadence/teleport handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -70,6 +70,79 @@ void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string cons
         ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
 }
 
+void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs = 3000)
+{
+    if (!bot || !bot->InBattleground())
+        return;
+
+    static std::unordered_map<uint64, uint32> nextEmitTimeByBotGuid;
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint64 const botGuid = bot->GetGUID().GetRawValue();
+    uint32& nextEmitMs = nextEmitTimeByBotGuid[botGuid];
+    if (nowMs < nextEmitMs)
+        return;
+
+    nextEmitMs = nowMs + throttleMs;
+
+    Map* map = bot->GetMap();
+    if (!map)
+        return;
+
+    std::ostringstream whisper;
+    whisper << "[PBDBG] bot=" << bot->GetName() << " guid=" << bot->GetGUID().ToString()
+            << " map=" << bot->GetMapId() << " detail=" << detail;
+    std::string const message = whisper.str();
+
+    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
+    {
+        Player* observer = itr->GetSource();
+        if (!observer || !observer->IsGameMaster())
+            continue;
+
+        if (observer->GetBattlegroundId() != bot->GetBattlegroundId())
+            continue;
+
+        bot->Whisper(message, LANG_UNIVERSAL, observer);
+    }
+}
+
+bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 1200)
+{
+    if (!player)
+        return false;
+
+    struct MoveOrderState
+    {
+        Position lastDestination;
+        uint32 lastIssueMs = 0;
+    };
+
+    static std::unordered_map<uint64, MoveOrderState> stateByGuid;
+    MoveOrderState& state = stateByGuid[player->GetGUID().GetRawValue()];
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+
+    bool const destinationChanged = state.lastIssueMs == 0 ||
+        state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
+    bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
+    if (!destinationChanged && !canReissueByTime)
+        return false;
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    MovementGeneratorType const currentMovement = motionMaster->GetCurrentMovementGeneratorType();
+    if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == IDLE_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)
+    {
+        std::ostringstream overrideDetail;
+        overrideDetail << "movement generator override before MovePoint type=" << static_cast<uint32>(currentMovement);
+        EmitBattlegroundGmDebug(player, overrideDetail.str(), 5000);
+        motionMaster->Clear(false);
+    }
+
+    motionMaster->MovePoint(0, destination);
+    state.lastDestination = destination;
+    state.lastIssueMs = nowMs;
+    return true;
+}
+
 bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
 {
     if (!player || player->InBattleground())
@@ -833,6 +906,42 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (HandleBattlegroundDeathState(player))
         return true;
 
+    if (player->HasAura(SPELL_PREPARATION) || player->HasAura(SPELL_ARENA_PREPARATION) || player->HasUnitFlag(UNIT_FLAG_PREPARATION))
+    {
+        player->RemoveAurasDueToSpell(SPELL_PREPARATION);
+        player->RemoveAurasDueToSpell(SPELL_ARENA_PREPARATION);
+        player->RemoveUnitFlag(UNIT_FLAG_PREPARATION);
+    }
+
+    // Keep managed bots moving even when tactical decision hooks are disabled
+    // or when another behavior tree branch (e.g. buffing) wins the current tick.
+    // This prevents "stand still at gate-open" stalls in active battlegrounds.
+    if (!CanIssueBotMovement(player))
+    {
+        std::ostringstream blockedReason;
+        blockedReason << "movement-blocked alive=" << (player->IsAlive() ? 1 : 0)
+                      << " ghost=" << (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST) ? 1 : 0)
+                      << " rooted=" << (player->HasUnitState(UNIT_STATE_ROOT) ? 1 : 0)
+                      << " stunned=" << (player->HasUnitState(UNIT_STATE_STUNNED) ? 1 : 0);
+        EmitBattlegroundGmDebug(player, blockedReason.str());
+        return true;
+    }
+
+    if (EngageNearestEnemyPlayer(player, 65.0f))
+        return true;
+
+    if (Battleground* battleground = player->GetBattleground())
+    {
+        Position destination;
+        if (TryGetObjectivePosition(battleground, player, destination))
+        {
+            if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
+                IssueMovePointThrottled(player, destination);
+            return true;
+        }
+    }
+
+    EmitBattlegroundGmDebug(player, "no enemy target and no objective position resolved");
     return true;
 }
 
@@ -918,7 +1027,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
             if (TryGetObjectivePosition(battleground, player, destination))
             {
                 if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
-                    player->GetMotionMaster()->MovePoint(0, destination);
+                    IssueMovePointThrottled(player, destination);
                 return true;
             }
 
@@ -932,7 +1041,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
             {
                 Position destination(graveyard->Loc.X, graveyard->Loc.Y, graveyard->Loc.Z, player->GetOrientation());
                 if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
-                    player->GetMotionMaster()->MovePoint(0, destination);
+                    IssueMovePointThrottled(player, destination);
                 return true;
             }
         }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -60,6 +60,7 @@ using LifecycleCadenceClock = std::chrono::steady_clock;
 using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 
 constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
+constexpr std::chrono::milliseconds BattlegroundActiveCadenceInterval(250);
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;
@@ -214,16 +215,45 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    if (!player->IsInWorld() || player->IsBeingTeleported())
+    if (!player->IsInWorld())
     {
         ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
         return false;
+    }
+
+    if (player->IsBeingTeleported())
+    {
+        // Managed random bots can occasionally retain the generic teleport flag
+        // after a battleground transition (especially when start countdowns are
+        // skipped). If near/far teleport semaphores are clear and the bot is
+        // already placed in a battleground map, continue lifecycle processing so
+        // tactical movement does not deadlock at match start.
+        bool const hasPendingTeleportAck = player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear();
+        if (hasPendingTeleportAck || !player->InBattleground())
+        {
+            ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
+            return false;
+        }
+
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot lifecycle pre-check tolerated stale teleport flag: guid={} battlegroundId={}.",
+            guid.ToString(), player->GetBattlegroundId());
     }
 
     uint64 const playerGuid = guid.GetRawValue();
     LifecycleCadenceTimePoint const now = LifecycleCadenceClock::now();
     std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
     LifecycleCadenceTimePoint& nextProcessTime = g_NextRandomBotLifecycleProcessTimeByGuid[playerGuid];
+
+    bool const inActiveBattleground = player->InBattleground() &&
+        player->GetBattleground() &&
+        player->GetBattleground()->GetStatus() == STATUS_IN_PROGRESS;
+    if (inActiveBattleground)
+    {
+        nextProcessTime = now + BattlegroundActiveCadenceInterval;
+        return true;
+    }
+
     if (nextProcessTime > now)
     {
         ObserveLifecycleReason(LifecycleObservationReason::CadenceThrottled, guid);


### PR DESCRIPTION
### Motivation

- Reduce movement spam and stalled bots in active battlegrounds by throttling repeated `MovePoint` orders and ensuring bots continue to move when tactical hooks are inactive. 
- Provide battlefield-visible debug messages for GMs to observe managed bot behavior in battlegrounds. 
- Tighten lifecycle cadence for active matches and relax teleport gating for bots that already transitioned into battleground maps to avoid startup deadlocks.

### Description

- Added `EmitBattlegroundGmDebug` to whisper diagnostic messages to GMs in the same battleground and introduced a per-bot emission throttle. 
- Implemented `IssueMovePointThrottled` which rate-limits `MotionMaster->MovePoint`, coalesces repeated destinations, and can clear blocking movement generators before issuing a new move. 
- Replaced direct `MovePoint` calls with `IssueMovePointThrottled` in tactical movement code paths (`MoveToObjectivePrimitive` and other in-progress handling). 
- In `HandleInProgressStatusPrimitive` removed lingering preparation auras/flags, added movement-block diagnostics, and attempt to engage nearby enemies or move toward objective positions when appropriate. 
- Introduced `BattlegroundActiveCadenceInterval` and updated `CanProcessPlayerLifecycle` to run managed bots at a higher cadence while `STATUS_IN_PROGRESS`. 
- Relaxed teleport gating when `IsBeingTeleported()` is set but the bot is already placed in a battleground and teleport ack semaphores are clear to avoid blocking lifecycle processing. 

### Testing

- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52754e2308327b962d865e08b62f3)