### PR TITLE
Emit jump visual and restore facing for instant PvP casts by playerbots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -29,6 +29,8 @@
 #include "Unit.h"
 #include "WorldSession.h"
 
+#include <algorithm>
+#include <cmath>
 #include <chrono>
 
 namespace
@@ -123,6 +125,54 @@ Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& conte
     }
 }
 
+void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const* spellInfo, float resumeOrientation)
+{
+    if (!player || !target || !spellInfo)
+        return;
+
+    if (spellInfo->CalcCastTime() > 0 || !player->isMoving())
+        return;
+
+    ObjectGuid const casterGuid = player->GetGUID();
+    player->SetFacingToObject(target);
+    player->SetInFront(target);
+
+    // Emit a normal jump movement opcode so observers see the same jump flow as
+    // a player-generated jump packet instead of knockback/spline movement.
+    float const jumpSpeedXY = std::max(2.5f, player->GetSpeed(MOVE_RUN));
+    float constexpr normalJumpSpeedZ = 8.2f;
+    float constexpr backwardAngle = 3.14159265f;
+    float const jumpDirection = player->GetOrientation() + backwardAngle;
+
+    MovementInfo movementInfo;
+    movementInfo.guid = player->GetGUID();
+    movementInfo.flags = player->GetUnitMovementFlags() | MOVEMENTFLAG_FALLING;
+    movementInfo.flags2 = static_cast<uint16>(player->GetExtraUnitMovementFlags());
+    movementInfo.pos.Relocate(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetOrientation());
+    movementInfo.time = GameTime::GetGameTimeMS();
+    movementInfo.fallTime = 0;
+    movementInfo.jump.sinAngle = std::sin(jumpDirection);
+    movementInfo.jump.cosAngle = std::cos(jumpDirection);
+    movementInfo.jump.xyspeed = jumpSpeedXY;
+    movementInfo.jump.zspeed = normalJumpSpeedZ;
+
+    WorldPacket jumpPacket(MSG_MOVE_JUMP, 66);
+    WorldSession::WriteMovementInfo(&jumpPacket, &movementInfo);
+    player->SendMessageToSet(&jumpPacket, false);
+
+    player->m_Events.AddEventAtOffset([casterGuid, resumeOrientation]()
+    {
+        Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
+        if (!caster || !caster->IsInWorld() || !caster->IsAlive())
+            return;
+
+        if (caster->GetCurrentSpell(CURRENT_GENERIC_SPELL) || caster->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
+            return;
+
+        caster->SetFacingTo(resumeOrientation);
+    }, 250ms);
+}
+
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
 {
     failureReason.clear();
@@ -170,6 +220,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "self_target_mismatch";
         return false;
     }
+
+    float preCastOrientation = player->GetOrientation();
 
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
     {
@@ -236,7 +288,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // not have client-side stop-cast behavior, explicitly stop movement before
     // attempting non-instant casts.
     if (spellInfo->CalcCastTime() > 0)
+    {
         player->StopMoving();
+        if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
+        {
+            player->SetFacingToObject(target);
+            player->SetInFront(target);
+        }
+    }
 
     // Blink (1953) is a leap-forward spell with a destination target
     // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
@@ -253,6 +312,10 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
         return false;
+
+    bool const isInstantCast = spellInfo->CalcCastTime() == 0;
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
+        JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,


### PR DESCRIPTION
### Motivation

- Fix visual/facing discrepancies for virtual bot sessions when casting instant enemy-targeted spells so observers see a natural jump/turn flow and the bot resumes its original orientation.
- Ensure cast-time spells stop movement and preserve facing for immediate server-side facing checks to pass.

### Description

- Add `JumpTurnForInstantCastVisual` which emits a `MSG_MOVE_JUMP` movement packet and schedules restoring the caster orientation after 250ms to emulate client jump/turn visuals for instant casts.
- Capture pre-cast orientation in `CastDirectSpell` and invoke the jump/turn helper for enemy-targeted instant spells.  
- Ensure `player->StopMoving()` for non-instant casts is followed by `SetFacingToObject`/`SetInFront` when targeting enemies so facing-sensitive checks succeed.  
- Add necessary includes (`<algorithm>`, `<cmath>`) and preserve existing special-case handling for `Blink (1953)`.

### Testing

- Built the server (`make`) with the changes and the build completed successfully.  
- Ran the automated unit test suite (`ctest` / project test runner) and all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50fabe3948327a4b3c312b96a0d02)