### PR TITLE
Fix MotionMaster::Clear invocation in Playerbot PvP lifecycle

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -152,7 +152,7 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         std::ostringstream overrideDetail;
         overrideDetail << "movement generator override before MovePoint type=" << static_cast<uint32>(currentMovement);
         EmitBattlegroundGmDebug(player, overrideDetail.str(), 5000);
-        motionMaster->Clear(false);
+        motionMaster->Clear();
     }
 
     motionMaster->MovePoint(0, destination);


### PR DESCRIPTION
### Motivation
- Fix a Jenkins/Clang compile error caused by calling `motionMaster->Clear(false);` which no longer matches any `MotionMaster::Clear` overload.

### Description
- Replace `motionMaster->Clear(false);` with `motionMaster->Clear();` in `IssueMovePointThrottled` located at `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to align with the current `MotionMaster` API.

### Testing
- Applied the patch successfully and ran `rg -n -- "->Clear\\(false\\)" src/server` to confirm no remaining `Clear(false)` usages, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53a38c46483278269570247ad026a)