### PR TITLE
playerbots: avoid clearing idle movement before BG MovePoint

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -147,7 +147,7 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     MotionMaster* motionMaster = player->GetMotionMaster();
     MovementGeneratorType const currentMovement = motionMaster->GetCurrentMovementGeneratorType();
-    if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == IDLE_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)
+    if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)
     {
         std::ostringstream overrideDetail;
         overrideDetail << "movement generator override before MovePoint type=" << static_cast<uint32>(currentMovement);


### PR DESCRIPTION
### Motivation
- Bots in battlegrounds repeatedly logged `movement generator override before MovePoint type=0` and remained stationary at base due to clearing the motion stack while already idle.

### Description
- Adjust the movement-override check in `IssueMovePointThrottled` to stop treating `IDLE_MOTION_TYPE` as an override and only clear for `FOLLOW_MOTION_TYPE` and `DISTRACT_MOTION_TYPE`.
- This change is contained in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and prevents unnecessary `motionMaster->Clear()` calls when the bot is already idle.

### Testing
- Ran `git diff --check` and it returned clean with no warnings (success).
- Ran `git status --short` to verify only the intended file changed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53b5fc7848327a0c3be0935371426)