### PR TITLE
Simulate visual turn for instant PvP casts and preserve player orientation

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -29,6 +29,7 @@
 #include "Unit.h"
 #include "WorldSession.h"
 
+#include <algorithm>
 #include <chrono>
 
 namespace
@@ -123,6 +124,38 @@ Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& conte
     }
 }
 
+void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const* spellInfo, float resumeOrientation)
+{
+    if (!player || !target || !spellInfo)
+        return;
+
+    if (spellInfo->CalcCastTime() > 0 || !player->isMoving())
+        return;
+
+    ObjectGuid const casterGuid = player->GetGUID();
+    player->SetFacingToObject(target);
+    player->SetInFront(target);
+
+    // Simulate a quick jump-180 instant cast while preserving retreat momentum:
+    // face target, perform a backward jump (relative to that facing), then
+    // restore original run orientation.
+    float const jumpSpeedXY = std::max(2.5f, player->GetSpeed(MOVE_RUN));
+    float constexpr normalJumpSpeedZ = 8.2f;
+    player->JumpTo(jumpSpeedXY, normalJumpSpeedZ, false);
+
+    player->m_Events.AddEventAtOffset([casterGuid, resumeOrientation]()
+    {
+        Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
+        if (!caster || !caster->IsInWorld() || !caster->IsAlive())
+            return;
+
+        if (caster->GetCurrentSpell(CURRENT_GENERIC_SPELL) || caster->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
+            return;
+
+        caster->SetFacingTo(resumeOrientation);
+    }, 250ms);
+}
+
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
 {
     failureReason.clear();
@@ -170,6 +203,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "self_target_mismatch";
         return false;
     }
+
+    float preCastOrientation = player->GetOrientation();
 
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
     {
@@ -236,7 +271,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // not have client-side stop-cast behavior, explicitly stop movement before
     // attempting non-instant casts.
     if (spellInfo->CalcCastTime() > 0)
+    {
         player->StopMoving();
+        if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
+        {
+            player->SetFacingToObject(target);
+            player->SetInFront(target);
+        }
+    }
 
     // Blink (1953) is a leap-forward spell with a destination target
     // (TARGET_DEST_CASTER_FRONT_LEAP). For virtual bot sessions, casting only
@@ -253,6 +295,10 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
         return false;
+
+    bool const isInstantCast = spellInfo->CalcCastTime() == 0;
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
+        JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,


### PR DESCRIPTION
### Motivation
- Improve visual fidelity for virtual bot sessions by ensuring instant-cast PvP spells show an immediate turn while preserving the bot's original movement/resume orientation.
- Ensure facing checks pass for enemy-targeted casts and avoid bots appearing locked out when shapeshifted or moving.

### Description
- Add `JumpTurnForInstantCastVisual` which performs a quick jump and temporarily sets facing to the target, then restores the previous orientation after 250ms, using `std::max` for jump speed calculations.
- Save pre-cast orientation in `CastDirectSpell` and call the new visual function for enemy-targeted instant casts to simulate a turn without interrupting retreat momentum.
- Ensure `player->SetFacingToObject`/`SetInFront` is applied after `StopMoving()` for non-instant casts to satisfy server-side facing checks.
- Add `#include <algorithm>` to support `std::max` used by the new logic.

### Testing
- Project build (`make`) completed successfully without compilation errors.
- Automated test suite (`make test`) ran and returned success for the existing tests covering server build and playerbot scripts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50fabe3948327a4b3c312b96a0d02)