### PR TITLE
Improve PvP bot movement diagnostics and refine MovePoint behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -143,11 +143,19 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
     if (!destinationChanged && !canReissueByTime)
+    {
+        std::ostringstream throttledDetail;
+        throttledDetail << "movepoint-skip reason=throttle"
+                        << " curr=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
+                        << " dest=(" << int32(destination.GetPositionX()) << "," << int32(destination.GetPositionY()) << "," << int32(destination.GetPositionZ()) << ")"
+                        << " lastIssuedMsAgo=" << (nowMs - state.lastIssueMs);
+        EmitBattlegroundGmDebug(player, throttledDetail.str(), 2000);
         return false;
+    }
 
     MotionMaster* motionMaster = player->GetMotionMaster();
     MovementGeneratorType const currentMovement = motionMaster->GetCurrentMovementGeneratorType();
-    if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == IDLE_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)
+    if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)
     {
         std::ostringstream overrideDetail;
         overrideDetail << "movement generator override before MovePoint type=" << static_cast<uint32>(currentMovement);
@@ -155,7 +163,16 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         motionMaster->Clear();
     }
 
-    motionMaster->MovePoint(0, destination);
+    std::ostringstream moveDetail;
+    moveDetail << "movepoint-issue"
+               << " from=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
+               << " to=(" << int32(destination.GetPositionX()) << "," << int32(destination.GetPositionY()) << "," << int32(destination.GetPositionZ()) << ")"
+               << " movementType=" << static_cast<uint32>(currentMovement)
+               << " forceDirect=1";
+    EmitBattlegroundGmDebug(player, moveDetail.str(), 2000);
+
+    // Use direct point movement for battleground objective travel diagnostics.
+    motionMaster->MovePoint(0, destination, false);
     state.lastDestination = destination;
     state.lastIssueMs = nowMs;
     return true;
@@ -963,8 +980,11 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
         Position destination;
         if (TryGetObjectivePosition(battleground, player, destination))
         {
-            if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
+            bool const withinObjectiveRange = player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f);
+            if (!withinObjectiveRange)
                 IssueMovePointThrottled(player, destination);
+            else
+                EmitBattlegroundGmDebug(player, "objective-skip reason=already-near-objective range=12");
             return true;
         }
     }
@@ -1054,8 +1074,11 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
             Position destination;
             if (TryGetObjectivePosition(battleground, player, destination))
             {
-                if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
+                bool const withinObjectiveRange = player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f);
+                if (!withinObjectiveRange)
                     IssueMovePointThrottled(player, destination);
+                else
+                    EmitBattlegroundGmDebug(player, "objective-skip reason=already-near-objective range=12");
                 return true;
             }
 


### PR DESCRIPTION
### Motivation

- Add richer diagnostics to troubleshoot why bots skip `MovePoint` reissues and to log movement directives for battleground objectives.
- Avoid unnecessarily clearing motion state for bots that are idle so existing idle movement isn't overridden by objective moves. 
- Ensure battleground objective movement uses a direct point invocation to aid travel diagnostics and reduce ambiguous movement behavior.

### Description

- Added detailed throttling logs in `IssueMovePointThrottled` via `EmitBattlegroundGmDebug` that include current and destination coordinates and time since the last issue. 
- Removed `IDLE_MOTION_TYPE` from the movement-generator override check so only `FOLLOW_MOTION_TYPE` and `DISTRACT_MOTION_TYPE` trigger `motionMaster->Clear()`, and emitted debug when clearing occurs. 
- Emit a pre-move debug message with from/to coordinates and movement type, and call `motionMaster->MovePoint(0, destination, false)` to use direct point movement for battleground objective travel. 
- Introduced `withinObjectiveRange` checks and emit `objective-skip reason=already-near-objective range=12` when the bot is within 12 units of an objective in both in-progress and tactical move flows. 

### Testing

- Built the server sources after the change and the build completed successfully. 
- Ran automated unit tests including the `playerbots` PvP-related tests and they passed. 
- Verified automated movement and objective proximity checks did not report regressions in CI test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53b5fc7848327a0c3be0935371426)