### PR TITLE
Playerbot: include cast failure reason in duel whisper

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -120,14 +120,17 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
         message += casted ? "yes" : "no";
         message += " | reason=";
         message += context.reason ? context.reason : "none";
+        message += " | fail_reason=";
+        message += failureReason.empty() ? "none" : failureReason;
 
         player->Whisper(message, LANG_UNIVERSAL, opponent);
     }
 
     TC_LOG_DEBUG("playerbots.pvp.class",
-        "[PvP duel] {} decision={} spell={} target={} success={} reason={}",
+        "[PvP duel] {} decision={} spell={} target={} success={} reason={} fail_reason={}",
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
-        GetTargetModeLabel(context.targetMode), casted ? "yes" : "no", context.reason ? context.reason : "none");
+        GetTargetModeLabel(context.targetMode), casted ? "yes" : "no", context.reason ? context.reason : "none",
+        failureReason.empty() ? "none" : failureReason);
 }
 
 void FinalizeVirtualNearTeleport(Player* player)


### PR DESCRIPTION
### Motivation
- Expose the concrete cast failure cause when a playerbot fails a duel cast so the opponent (and server logs) can see the actual failure reason for easier debugging. 

### Description
- Added `fail_reason` to the whisper message composed in `NotifyDuelDecision` and populated it from the `failureReason` parameter, using `none` when empty. 
- Extended the PvP duel debug log format to include the `fail_reason` field for parity with the whisper output. 

### Testing
- No automated tests were run for this small, localized string/logging change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54ecd2be08327b14881bb2e43ab72)