### PR TITLE
Deterministic objective offsets and cadence/throttle tuning for PvP bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -124,7 +124,7 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
     }
 }
 
-bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 1200)
+bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)
 {
     if (!player)
         return false;
@@ -796,6 +796,19 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
     return DriveCombatPositioning(player, target, profile);
 }
 
+void ApplyDeterministicObjectiveOffset(Battleground const* battleground, Player const* player, Position& destination)
+{
+    if (!battleground || !player)
+        return;
+
+    // Keep each bot slightly spread out, but stable across updates, to avoid
+    // objective destination churn that causes oscillating movement.
+    uint64 const seed = player->GetGUID().GetRawValue() ^ (uint64(battleground->GetMapId()) << 32) ^ battleground->GetInstanceID();
+    float const angle = float(seed % 6283) / 1000.0f;
+    float const radius = 2.0f + float((seed / 6283) % 600) / 100.0f; // [2.0, 8.0)
+    destination.RelocateOffset(Position(std::cos(angle) * radius, std::sin(angle) * radius, 0.0f, 0.0f));
+}
+
 bool TryGetObjectivePosition(Battleground* battleground, Player* player, Position& destination)
 {
     if (!battleground || !player)
@@ -809,7 +822,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
         float const distanceToAllianceStart = player->GetDistance(allianceStart->GetPositionX(), allianceStart->GetPositionY(), allianceStart->GetPositionZ());
         float const distanceToHordeStart = player->GetDistance(hordeStart->GetPositionX(), hordeStart->GetPositionY(), hordeStart->GetPositionZ());
         destination = (distanceToAllianceStart > distanceToHordeStart) ? Position(*allianceStart) : Position(*hordeStart);
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 
@@ -819,7 +832,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
     if (Position const* enemyStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(enemyTeam)))
     {
         destination = Position(*enemyStart);
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 
@@ -838,7 +851,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
         else
             destination = hordeFlagStand;
 
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -64,7 +64,7 @@ using LifecycleCadenceClock = std::chrono::steady_clock;
 using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 
 constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
-constexpr std::chrono::milliseconds BattlegroundActiveCadenceInterval(250);
+constexpr std::chrono::milliseconds BattlegroundActiveCadenceInterval(2000);
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;
@@ -293,11 +293,8 @@ bool CanProcessPlayerLifecycle(Player const* player)
     bool const inActiveBattleground = player->InBattleground() &&
         player->GetBattleground() &&
         player->GetBattleground()->GetStatus() == STATUS_IN_PROGRESS;
-    if (inActiveBattleground)
-    {
-        nextProcessTime = now + BattlegroundActiveCadenceInterval;
-        return true;
-    }
+    std::chrono::milliseconds const cadenceInterval = inActiveBattleground ?
+        BattlegroundActiveCadenceInterval : RandomBotLifecycleCadenceInterval;
 
     if (nextProcessTime > now)
     {
@@ -306,7 +303,7 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    nextProcessTime = now + RandomBotLifecycleCadenceInterval;
+    nextProcessTime = now + cadenceInterval;
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Reduce movement-command churn and oscillation by making objective offsets stable per-bot instead of random each tick.
- Lower the frequency of lifecycle processing for active battlegrounds to reduce CPU load and spurious re-evaluations.
- Reduce move-command resend rate to avoid over-issuing movement orders.

### Description

- Increased the move-reissue throttle in `IssueMovePointThrottled` by changing the default `minReissueMs` from `1200` to `2000`.
- Added `ApplyDeterministicObjectiveOffset`, which derives a stable per-bot offset from the bot GUID, map id, and instance id and applies it to objective `Position`.
- Replaced calls to `RelocateOffset` with random `urand` jitter in `TryGetObjectivePosition` with `ApplyDeterministicObjectiveOffset` for all objective branches.
- Changed `BattlegroundActiveCadenceInterval` from `250ms` to `2000ms` and updated `CanProcessPlayerLifecycle` to select a cadence interval based on whether the player is in an active battleground.

### Testing

- Successfully built the server to verify there are no compile-time errors after the changes.
- Executed PvP lifecycle smoke tests with simulated battlegrounds to confirm bots use stable objective offsets and reduced movement oscillation (smoke tests passed).
- Ran the automated unit/integration test suite and confirmed there were no regressions in the tested areas (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54ca153b48327a4f64520cd9b16af)