### PR TITLE
Include spell failure reasons in PvP duel notifications and logs

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -120,14 +120,17 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
         message += casted ? "yes" : "no";
         message += " | reason=";
         message += context.reason ? context.reason : "none";
+        message += " | fail_reason=";
+        message += failureReason.empty() ? "none" : failureReason;
 
         player->Whisper(message, LANG_UNIVERSAL, opponent);
     }
 
     TC_LOG_DEBUG("playerbots.pvp.class",
-        "[PvP duel] {} decision={} spell={} target={} success={} reason={}",
+        "[PvP duel] {} decision={} spell={} target={} success={} reason={} fail_reason={}",
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
-        GetTargetModeLabel(context.targetMode), casted ? "yes" : "no", context.reason ? context.reason : "none");
+        GetTargetModeLabel(context.targetMode), casted ? "yes" : "no", context.reason ? context.reason : "none",
+        failureReason.empty() ? "none" : failureReason);
 }
 
 void FinalizeVirtualNearTeleport(Player* player)
@@ -391,7 +394,11 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         castResult = player->CastSpell(target, context.spellId, false);
 
     if (castResult != SPELL_CAST_OK)
+    {
+        EnumText const reasonText = EnumUtils::ToString(castResult);
+        failureReason = reasonText.Title;
         return false;
+    }
 
     bool const isInstantCast = spellInfo->CalcCastTime() == 0;
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)


### PR DESCRIPTION
### Motivation
- Improve visibility into why automated PvP actions fail by surfacing cast failure reasons to duel opponents and logs.

### Description
- Append a `fail_reason` field to the duel whisper message so opponents receive the spell failure reason when a decision fails.
- Add `fail_reason` to the PvP debug log output to aid server-side debugging of bot decisions.
- Populate the `failureReason` string from the `SpellCastResult` enum when `CastSpell` does not return `SPELL_CAST_OK` so the textual reason is available for reporting.

### Testing
- Compiled the server with `cmake --build .` to ensure the code changes build cleanly and the modified file integrates without errors; build succeeded.
- Ran automated unit/test suite via `ctest` to exercise playerbot/PvP related tests and logging paths; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54ecd2be08327b14881bb2e43ab72)