### PR TITLE
Fix playerbot shaman Windfury self-cast by targeting weapon item for temporary imbues

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -265,6 +265,15 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
+    bool const isTemporaryWeaponImbue = [&spellInfo]()
+    {
+        for (SpellEffectInfo const& effectInfo : spellInfo->GetEffects())
+            if (effectInfo.Effect == SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY)
+                return true;
+
+        return false;
+    }();
+
     Item* itemTarget = nullptr;
     if (context.spellId == 11202 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
     {
@@ -281,6 +290,24 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (!itemTarget)
         {
             failureReason = "weapon_already_poisoned";
+            return false;
+        }
+    }
+    else if (isTemporaryWeaponImbue && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
+    {
+        Item* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
+        if (mainHand && !mainHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+            itemTarget = mainHand;
+        else
+        {
+            Item* offHand = player->GetWeaponForAttack(OFF_ATTACK, true);
+            if (offHand && !offHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+                itemTarget = offHand;
+        }
+
+        if (!itemTarget)
+        {
+            failureReason = "weapon_already_imbued";
             return false;
         }
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -323,6 +323,17 @@ bool HasAuraFromSpellChain(Unit const* unit, uint32 baseSpellId)
     return false;
 }
 
+bool HasTemporaryWeaponImbue(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Item* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
+    Item* offHand = player->GetWeaponForAttack(OFF_ATTACK, true);
+    return (mainHand && mainHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT)) ||
+        (offHand && offHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT));
+}
+
 bool IsCasterClass(Unit const* unit)
 {
     Player const* player = unit ? unit->ToPlayer() : nullptr;
@@ -1494,7 +1505,7 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target)
 
     if (!player->IsInCombat())
     {
-        if (!HasAuraFromSpellChain(player, 8232) && IsSpellReady(player, 8232))
+        if (!HasTemporaryWeaponImbue(player) && IsSpellReady(player, 8232))
             return { "shaman windfury weapon", "maintain weapon imbue out of combat", 8232, playerbot::PvpClassSpellContext::TargetMode::Self };
         if (!HasAuraFromSpellChain(player, 10432) && IsSpellReady(player, 10432))
             return { "shaman lightning shield", "maintain shield buff out of combat", 10432, playerbot::PvpClassSpellContext::TargetMode::Self };


### PR DESCRIPTION
### Motivation
- Playerbot shamans were choosing Windfury Weapon but casting it as a self-target without an item target, which can fail with `SPELL_FAILED_ITEM_NOT_FOUND` when no temporary weapon enchant is present on an equipped weapon. 
- The previous upkeep check used `HasAuraFromSpellChain`, which does not reflect temporary item enchants on weapons.

### Description
- Added `HasTemporaryWeaponImbue` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` to detect temporary enchants on main/off-hand weapons. 
- Updated shaman upkeep logic in `SelectShamanSpell` to use `HasTemporaryWeaponImbue` when deciding to cast Windfury (`8232`). 
- Extended `CastDirectSpell` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` to detect spells with `SPELL_EFFECT_ENCHANT_ITEM_TEMPORARY` and automatically select an unequipped weapon (`GetWeaponForAttack`) as the item target for self-targeted temporary weapon imbues. 
- Added an explicit failure reason `weapon_already_imbued` when no eligible weapon is available for a temporary imbue.

### Testing
- Started a full build with `cmake --build build --target worldserver -j4`, which began but did not complete within the session (incomplete). 
- Invoked `cmake --build build --target scripts -j4`, which progressed during the session without a final error report (in-progress). 
- Attempted a targeted `ninja` compile of the two modified object files which failed due to an invalid/unknown target in the local build graph (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55189646883279079e457a48fb1f7)