### PR TITLE
Fix duplicate isInstantCast redeclarations in Playerbot PvP cast handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -399,14 +399,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
         JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
 
-    bool const isInstantCast = spellInfo->CalcCastTime() == 0;
-    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
-        JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
-
-    bool const isInstantCast = spellInfo->CalcCastTime() == 0;
-    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
-        JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
-
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,
     // then cast Freezing Trap exactly 500ms later before resuming chase.


### PR DESCRIPTION
### Motivation
- Remove redundant `isInstantCast` redeclarations in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` to resolve compiler errors caused by variable redefinition and keep a single instant-cast visual handling after a successful cast.

### Description
- Deleted two duplicated `bool const isInstantCast = spellInfo->CalcCastTime() == 0;` blocks and left a single instant-cast check and `JumpTurnForInstantCastVisual(...)` invocation immediately after the successful `CastSpell` path.

### Testing
- No full build/test was run; automated verification consisted of file inspection (`nl | sed`) and repository checks (`git commit` / `git show`) to confirm the change was applied, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55499c10c832782c7e3ddee174be0)