### PR TITLE
Stabilize battleground bot movement and throttle/cadence behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -124,7 +124,7 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
     }
 }
 
-bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 1200)
+bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)
 {
     if (!player)
         return false;
@@ -168,11 +168,11 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
                << " from=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
                << " to=(" << int32(destination.GetPositionX()) << "," << int32(destination.GetPositionY()) << "," << int32(destination.GetPositionZ()) << ")"
                << " movementType=" << static_cast<uint32>(currentMovement)
-               << " forceDirect=1";
+               << " generatePath=1";
     EmitBattlegroundGmDebug(player, moveDetail.str(), 2000);
 
-    // Use direct point movement for battleground objective travel diagnostics.
-    motionMaster->MovePoint(0, destination, false);
+    // Use pathfinding for battleground objective travel to avoid wall clipping.
+    motionMaster->MovePoint(0, destination, true);
     state.lastDestination = destination;
     state.lastIssueMs = nowMs;
     return true;
@@ -796,6 +796,19 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
     return DriveCombatPositioning(player, target, profile);
 }
 
+void ApplyDeterministicObjectiveOffset(Battleground const* battleground, Player const* player, Position& destination)
+{
+    if (!battleground || !player)
+        return;
+
+    // Keep each bot slightly spread out, but stable across updates, to avoid
+    // objective destination churn that causes oscillating movement.
+    uint64 const seed = player->GetGUID().GetRawValue() ^ (uint64(battleground->GetMapId()) << 32) ^ battleground->GetInstanceID();
+    float const angle = float(seed % 6283) / 1000.0f;
+    float const radius = 2.0f + float((seed / 6283) % 600) / 100.0f; // [2.0, 8.0)
+    destination.RelocateOffset(Position(std::cos(angle) * radius, std::sin(angle) * radius, 0.0f, 0.0f));
+}
+
 bool TryGetObjectivePosition(Battleground* battleground, Player* player, Position& destination)
 {
     if (!battleground || !player)
@@ -809,7 +822,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
         float const distanceToAllianceStart = player->GetDistance(allianceStart->GetPositionX(), allianceStart->GetPositionY(), allianceStart->GetPositionZ());
         float const distanceToHordeStart = player->GetDistance(hordeStart->GetPositionX(), hordeStart->GetPositionY(), hordeStart->GetPositionZ());
         destination = (distanceToAllianceStart > distanceToHordeStart) ? Position(*allianceStart) : Position(*hordeStart);
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 
@@ -819,7 +832,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
     if (Position const* enemyStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(enemyTeam)))
     {
         destination = Position(*enemyStart);
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 
@@ -838,7 +851,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
         else
             destination = hordeFlagStand;
 
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -64,7 +64,7 @@ using LifecycleCadenceClock = std::chrono::steady_clock;
 using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 
 constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
-constexpr std::chrono::milliseconds BattlegroundActiveCadenceInterval(250);
+constexpr std::chrono::milliseconds BattlegroundActiveCadenceInterval(2000);
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;
@@ -293,11 +293,8 @@ bool CanProcessPlayerLifecycle(Player const* player)
     bool const inActiveBattleground = player->InBattleground() &&
         player->GetBattleground() &&
         player->GetBattleground()->GetStatus() == STATUS_IN_PROGRESS;
-    if (inActiveBattleground)
-    {
-        nextProcessTime = now + BattlegroundActiveCadenceInterval;
-        return true;
-    }
+    std::chrono::milliseconds const cadenceInterval = inActiveBattleground ?
+        BattlegroundActiveCadenceInterval : RandomBotLifecycleCadenceInterval;
 
     if (nextProcessTime > now)
     {
@@ -306,7 +303,7 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    nextProcessTime = now + RandomBotLifecycleCadenceInterval;
+    nextProcessTime = now + cadenceInterval;
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Reduce movement churn and wall-clipping for managed bots when navigating battleground objectives.  
- Prevent rapid reissue of move orders and over-frequent lifecycle processing in active battlegrounds.  
- Ensure objective offsets are stable and deterministic per-bot to avoid oscillating destination updates.  

### Description

- Increase default reissue throttle in `IssueMovePointThrottled` from `1200` to `2000` ms and update the throttled debug emit to match.  
- Switch `MotionMaster::MovePoint` to use pathfinding (`true`) instead of direct movement to avoid wall clipping and change the debug token from `forceDirect=1` to `generatePath=1`.  
- Add `ApplyDeterministicObjectiveOffset` to compute a stable per-bot offset based on bot GUID, map id and instance id and replace previous random `RelocateOffset` uses in `TryGetObjectivePosition` with deterministic offsets.  
- Increase `BattlegroundActiveCadenceInterval` from `250` ms to `2000` ms and refactor lifecycle cadence logic to apply a per-bot `cadenceInterval` (active vs idle) when scheduling the next processing time.  

### Testing

- Performed a full server build (compile) after changes and the build completed successfully.  
- Ran automated unit/integration tests covering playerbot PvP lifecycle and movement behavior and the test suite completed with no failures.  
- Observed expected debug emissions and reduced movepoint reissues and more stable objective destinations in battleground simulation runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54ca153b48327a4f64520cd9b16af)