### PR TITLE
playerbots: replace instant-cast jump-turn with face/pause cast

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -194,35 +194,66 @@ Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& conte
     }
 }
 
-void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const* spellInfo, float resumeOrientation)
+bool ScheduleFacingPauseInstantCast(Player* player, Unit* target, SpellInfo const* spellInfo, uint32 spellId)
 {
     if (!player || !target || !spellInfo)
-        return;
+        return false;
 
     if (spellInfo->CalcCastTime() > 0 || !player->isMoving())
-        return;
+        return false;
+
+    // If we're already in front enough for instant cast checks, proceed with
+    // the normal immediate cast path.
+    if (player->isInFrontInMap(target, 0.0f, float(M_PI) / 2.0f))
+        return false;
 
     ObjectGuid const casterGuid = player->GetGUID();
-    player->SetFacingToObject(target);
-    player->SetInFront(target);
+    ObjectGuid const targetGuid = target->GetGUID();
+    float const resumeOrientation = player->GetOrientation();
+    uint32 const resumeMovementFlags = player->GetUnitMovementFlags() & MOVEMENTFLAG_MASK_MOVING;
 
-    // Managed playerbots run as virtual sessions: use JumpTo directly for a
-    // short backward jump while temporarily facing the cast target.
-    float const jumpSpeedXY = std::max(2.5f, player->GetSpeed(MOVE_RUN));
-    float constexpr normalJumpSpeedZ = 7.95555f;
-    player->JumpTo(jumpSpeedXY, normalJumpSpeedZ, false);
+    player->StopMoving();
+    if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
+    {
+        player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+        player->SendMovementFlagUpdate();
+    }
 
-    player->m_Events.AddEventAtOffset([casterGuid, resumeOrientation]()
+    player->m_Events.AddEventAtOffset([casterGuid, targetGuid, spellId, resumeOrientation, resumeMovementFlags]()
     {
         Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
         if (!caster || !caster->IsInWorld() || !caster->IsAlive())
             return;
 
+        Unit* delayedTarget = ObjectAccessor::GetUnit(*caster, targetGuid);
+        if (!delayedTarget || !delayedTarget->IsAlive())
+            return;
+
         if (caster->IsNonMeleeSpellCast(false, false, true))
             return;
 
+        SpellInfo const* delayedSpellInfo = sSpellMgr->GetSpellInfo(spellId);
+        if (!delayedSpellInfo ||
+            caster->GetSpellHistory()->HasCooldown(spellId) ||
+            caster->GetSpellHistory()->HasGlobalCooldown(delayedSpellInfo))
+            return;
+
+        caster->SetFacingToObject(delayedTarget);
+        caster->SetInFront(delayedTarget);
+        SpellCastResult const delayedCastResult = caster->CastSpell(delayedTarget, spellId, false);
+        if (delayedCastResult != SPELL_CAST_OK)
+            return;
+
         caster->SetFacingTo(resumeOrientation);
+
+        if (resumeMovementFlags)
+        {
+            caster->AddUnitMovementFlag(resumeMovementFlags);
+            caster->SendMovementFlagUpdate();
+        }
     }, 250ms);
+
+    return true;
 }
 
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
@@ -320,8 +351,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
-    float preCastOrientation = player->GetOrientation();
-
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
     {
         if (!player->IsValidAttackTarget(target, spellInfo))
@@ -387,6 +416,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             return false;
         }
 
+    // If a moving bot is not facing enough for an instant enemy cast, pause
+    // briefly, face target, cast, then resume previous movement direction.
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
+        !itemTarget &&
+        ScheduleFacingPauseInstantCast(player, target, spellInfo, context.spellId))
+        return true;
+
     // Cast-time spells like Frostbolt fail while moving. Since playerbots do
     // not have client-side stop-cast behavior, explicitly stop movement before
     // attempting non-instant casts.
@@ -421,10 +457,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = reasonText.Title;
         return false;
     }
-
-    bool const isInstantCast = spellInfo->CalcCastTime() == 0;
-    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
-        JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,


### PR DESCRIPTION
### Motivation
- Remove the jump/180° visual workaround used by moving playerbots for instant enemy casts and replace it with a simpler, less intrusive approach that pauses movement, faces the target, performs the instant cast, and then resumes movement.
- Make instant-cast behavior work reliably when the enemy kites or the bot is not sufficiently facing the cast target without performing a physics-affecting jump.

### Description
- Replaced the `JumpTurnForInstantCastVisual` jump-based helper with `ScheduleFacingPauseInstantCast`, which stops the bot, checks facing, waits 250ms, faces the target, attempts the cast, then restores orientation and movement flags (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`).
- Integrated the new delayed face/pause path into `CastDirectSpell` for enemy-target instant casts when the bot is moving and not already sufficiently in front, short-circuiting the immediate cast path to schedule the delayed cast.
- Removed use of `Player::JumpTo` and instead safely manipulates movement flags for virtual sessions using `RemoveUnitMovementFlag`/`AddUnitMovementFlag` and `SendMovementFlagUpdate` so the bot resumes its previous movement state.
- Added checks to avoid scheduling when already in front (`isInFrontInMap`), and to re-check spell availability/cooldowns and target validity just before executing the delayed cast.

### Testing
- Started an incremental build using `cmake --build build --target worldserver -j2`, which began compiling project object files and progressed without immediate compiler errors in the observed output, though the full build did not complete within this run.
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5573d7d588327a33ffe9e2c720eaa)