### PR TITLE
Playerbot: remove instant-cast jump-turn and strafe while casting

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -194,7 +194,7 @@ Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& conte
     }
 }
 
-void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const* spellInfo, float resumeOrientation)
+void StrafeAwayForInstantCastVisual(Player* player, Unit* target, SpellInfo const* spellInfo)
 {
     if (!player || !target || !spellInfo)
         return;
@@ -202,27 +202,17 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
     if (spellInfo->CalcCastTime() > 0 || !player->isMoving())
         return;
 
-    ObjectGuid const casterGuid = player->GetGUID();
     player->SetFacingToObject(target);
     player->SetInFront(target);
 
-    // Managed playerbots run as virtual sessions: use JumpTo directly for a
-    // short backward jump while temporarily facing the cast target.
-    float const jumpSpeedXY = std::max(2.5f, player->GetSpeed(MOVE_RUN));
-    float constexpr normalJumpSpeedZ = 7.95555f;
-    player->JumpTo(jumpSpeedXY, normalJumpSpeedZ, false);
-
-    player->m_Events.AddEventAtOffset([casterGuid, resumeOrientation]()
+    // Keep moving without jump-turn visuals: strafe while maintaining a valid
+    // facing direction for instant kiting casts.
+    if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
     {
-        Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
-        if (!caster || !caster->IsInWorld() || !caster->IsAlive())
-            return;
-
-        if (caster->IsNonMeleeSpellCast(false, false, true))
-            return;
-
-        caster->SetFacingTo(resumeOrientation);
-    }, 250ms);
+        player->RemoveUnitMovementFlag(MOVEMENTFLAG_STRAFE_LEFT | MOVEMENTFLAG_STRAFE_RIGHT);
+        player->AddUnitMovementFlag(MOVEMENTFLAG_BACKWARD | MOVEMENTFLAG_STRAFE_LEFT);
+        player->SendMovementFlagUpdate();
+    }
 }
 
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
@@ -319,8 +309,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "self_target_mismatch";
         return false;
     }
-
-    float preCastOrientation = player->GetOrientation();
 
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
     {
@@ -424,7 +412,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     bool const isInstantCast = spellInfo->CalcCastTime() == 0;
     if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && isInstantCast)
-        JumpTurnForInstantCastVisual(player, target, spellInfo, preCastOrientation);
+        StrafeAwayForInstantCastVisual(player, target, spellInfo);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,


### PR DESCRIPTION
### Motivation
- The previous instant-cast visual used a short backward `JumpTo` and a delayed orientation restore which produced unreliable 180° jump-turn behavior for managed playerbots. 
- Bots should be able to cast instant enemy spells while still kiting, without performing a jump animation that breaks behavior. 
- Replace the jump-based visual with a strafing movement so bots keep moving while maintaining facing toward the cast target.

### Description
- Replaced `JumpTurnForInstantCastVisual` with `StrafeAwayForInstantCastVisual` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`. 
- The new helper keeps `SetFacingToObject`/`SetInFront` and, for virtual sessions, clears existing strafe flags then applies `MOVEMENTFLAG_BACKWARD | MOVEMENTFLAG_STRAFE_LEFT` followed by `SendMovementFlagUpdate`. 
- Updated the instant enemy-cast path to call `StrafeAwayForInstantCastVisual` for instant casts and removed the previous pre-cast orientation restore logic.

### Testing
- Ran symbol searches with `rg` to verify `JumpTurnForInstantCastVisual` references were removed and `StrafeAwayForInstantCastVisual` is wired into the instant-cast flow, which succeeded. 
- Inspected the produced `diff` to confirm only the intended changes in `PlayerbotPvpClassActions.cpp`, which matched expectations. 
- No full build/ runtime tests were executed in this patch; integration/ runtime verification is recommended to validate in-game strafing visuals and movement flag interactions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55ae4ce448327b4a770df078adb60)