### PR TITLE
Stabilize battleground bot movement: throttle reissues, deterministic offsets, and cadence tuning

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -124,7 +124,7 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
     }
 }
 
-bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 1200)
+bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)
 {
     if (!player)
         return false;
@@ -163,16 +163,18 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         motionMaster->Clear();
     }
 
+    bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
+
     std::ostringstream moveDetail;
     moveDetail << "movepoint-issue"
                << " from=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
                << " to=(" << int32(destination.GetPositionX()) << "," << int32(destination.GetPositionY()) << "," << int32(destination.GetPositionZ()) << ")"
                << " movementType=" << static_cast<uint32>(currentMovement)
-               << " forceDirect=1";
+               << " generatePath=" << (generatePath ? 1 : 0);
     EmitBattlegroundGmDebug(player, moveDetail.str(), 2000);
 
-    // Use direct point movement for battleground objective travel diagnostics.
-    motionMaster->MovePoint(0, destination, false);
+    // Reference-module parity: issue MovePoint directly and let MotionMaster handle path generation.
+    motionMaster->MovePoint(0, destination, generatePath);
     state.lastDestination = destination;
     state.lastIssueMs = nowMs;
     return true;
@@ -796,6 +798,19 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
     return DriveCombatPositioning(player, target, profile);
 }
 
+void ApplyDeterministicObjectiveOffset(Battleground const* battleground, Player const* player, Position& destination)
+{
+    if (!battleground || !player)
+        return;
+
+    // Keep each bot slightly spread out, but stable across updates, to avoid
+    // objective destination churn that causes oscillating movement.
+    uint64 const seed = player->GetGUID().GetRawValue() ^ (uint64(battleground->GetMapId()) << 32) ^ battleground->GetInstanceID();
+    float const angle = float(seed % 6283) / 1000.0f;
+    float const radius = 2.0f + float((seed / 6283) % 600) / 100.0f; // [2.0, 8.0)
+    destination.RelocateOffset(Position(std::cos(angle) * radius, std::sin(angle) * radius, 0.0f, 0.0f));
+}
+
 bool TryGetObjectivePosition(Battleground* battleground, Player* player, Position& destination)
 {
     if (!battleground || !player)
@@ -809,7 +824,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
         float const distanceToAllianceStart = player->GetDistance(allianceStart->GetPositionX(), allianceStart->GetPositionY(), allianceStart->GetPositionZ());
         float const distanceToHordeStart = player->GetDistance(hordeStart->GetPositionX(), hordeStart->GetPositionY(), hordeStart->GetPositionZ());
         destination = (distanceToAllianceStart > distanceToHordeStart) ? Position(*allianceStart) : Position(*hordeStart);
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 
@@ -819,7 +834,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
     if (Position const* enemyStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(enemyTeam)))
     {
         destination = Position(*enemyStart);
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 
@@ -838,7 +853,7 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
         else
             destination = hordeFlagStand;
 
-        destination.RelocateOffset(Position(float(urand(0, 16)) - 8.0f, float(urand(0, 16)) - 8.0f, 0.0f, 0.0f));
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -64,7 +64,7 @@ using LifecycleCadenceClock = std::chrono::steady_clock;
 using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 
 constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
-constexpr std::chrono::milliseconds BattlegroundActiveCadenceInterval(250);
+constexpr std::chrono::milliseconds BattlegroundActiveCadenceInterval(2000);
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;
@@ -293,11 +293,8 @@ bool CanProcessPlayerLifecycle(Player const* player)
     bool const inActiveBattleground = player->InBattleground() &&
         player->GetBattleground() &&
         player->GetBattleground()->GetStatus() == STATUS_IN_PROGRESS;
-    if (inActiveBattleground)
-    {
-        nextProcessTime = now + BattlegroundActiveCadenceInterval;
-        return true;
-    }
+    std::chrono::milliseconds const cadenceInterval = inActiveBattleground ?
+        BattlegroundActiveCadenceInterval : RandomBotLifecycleCadenceInterval;
 
     if (nextProcessTime > now)
     {
@@ -306,7 +303,7 @@ bool CanProcessPlayerLifecycle(Player const* player)
         return false;
     }
 
-    nextProcessTime = now + RandomBotLifecycleCadenceInterval;
+    nextProcessTime = now + cadenceInterval;
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- Reduce frequent movement reissues and oscillating movement for bots in battlegrounds by increasing reissue throttling and avoiding churn from random destination jitter. 
- Allow MotionMaster to decide whether to generate a path rather than always forcing direct movement, respecting flying/swimming state. 
- Lower CPU/logic churn by relaxing the active-battleground lifecycle processing cadence.

### Description
- Increase the default movement reissue throttle in `IssueMovePointThrottled` from `1200`ms to `2000`ms and use a per-GUID `MoveOrderState` to track `lastDestination` and `lastIssueMs` so identical destinations are suppressed until allowed. 
- Compute `generatePath` as `!player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING)` and call `motionMaster->MovePoint(0, destination, generatePath)` instead of forcing a direct move, and update debug output to show `generatePath`. 
- Add `ApplyDeterministicObjectiveOffset(Battleground const*, Player const*, Position&)` and replace ad-hoc `urand` offsets in `TryGetObjectivePosition` with a stable per-bot deterministic offset derived from the bot GUID, map id, and instance id so bots spread out but keep stable destinations. 
- Increase `BattlegroundActiveCadenceInterval` from `250`ms to `2000`ms and unify cadence handling in `CanProcessPlayerLifecycle` so the next processing time uses the appropriate interval for active battlegrounds or idle cadence.

### Testing
- Project compiled successfully (`make -j`) after changes with no build errors. 
- Ran automated playerbot/pvp unit tests related to movement and lifecycle processing and they passed. 
- Verified the adjusted lifecycle cadence logic by running the automated battleground lifecycle integration tests, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54ca153b48327a4f64520cd9b16af)