### PR TITLE
Playerbot PvP: preserve ranged kiting behavior under melee pressure

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -424,6 +424,29 @@ bool CanIssueBotMovement(Player const* player)
     return true;
 }
 
+bool IsMeleePressureTarget(Unit const* unit)
+{
+    Player const* player = unit ? unit->ToPlayer() : nullptr;
+    if (!player)
+        return false;
+
+    switch (player->GetClass())
+    {
+        case CLASS_WARRIOR:
+        case CLASS_ROGUE:
+            return true;
+        case CLASS_SHAMAN:
+        case CLASS_PALADIN:
+        {
+            Item const* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
+            ItemTemplate const* mainHandTemplate = mainHand ? mainHand->GetTemplate() : nullptr;
+            return mainHandTemplate && mainHandTemplate->InventoryType == INVTYPE_2HWEAPON;
+        }
+        default:
+            return false;
+    }
+}
+
 struct CombatPositioningProfile
 {
     float preferredMinRange = 0.0f;
@@ -725,6 +748,15 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
     if (profile.primarilyRanged)
     {
+        if (profile.createDistanceWhenCrowded && IsMeleePressureTarget(target) && distance < profile.preferredIdealRange)
+        {
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP distance band: bot={} profile={} decision=create-distance-vs-melee-pressure distance={} min={} ideal={} max={}.",
+                player->GetGUID().ToString(), profile.label, distance, profile.preferredMinRange, profile.preferredIdealRange,
+                profile.preferredMaxPressureRange);
+            return MoveAwayFromUnit(player, target, profile.preferredIdealRange);
+        }
+
         if (distance < profile.preferredMinRange && profile.createDistanceWhenCrowded)
         {
             TC_LOG_DEBUG("playerbots.pvp.lifecycle",


### PR DESCRIPTION
### Motivation
- Ranged playerbots (for example hunters) were remaining stationary inside the ranged "hold-band" while a melee opponent was very close, which prevented expected kiting movement and the jump/turn visuals used for instant casts.
- The intent is to restore generic run-away + instant-cast kiting behavior driven by combat role/pressure rather than adding any spell-specific exceptions.

### Description
- Added `IsMeleePressureTarget(Unit const*)` to detect melee pressure from player targets (warrior/rogue or paladin/shaman wielding a 2H weapon).
- Updated `DriveCombatPositioning` to trigger `MoveAwayFromUnit` toward the profile `preferredIdealRange` when a ranged bot is pressured by a melee target and the target is inside the ideal range.
- Added a debug log path for the new melee-pressure decision and kept all existing close/far distance behavior unchanged, avoiding any per-spell special-casing (no `Concussive Shot` exceptions).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55cc34e488327b7940c5a0ff18ea3)