### PR TITLE
Add Item and ItemTemplate includes to PlayerbotPvpLifecycleActions.cpp

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -34,6 +34,8 @@
 #include "MotionMaster.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
+#include "Item.h"
+#include "ItemTemplate.h"
 #include "Player.h"
 #include "World.h"
 #include "WorldPacket.h"


### PR DESCRIPTION
### Motivation
- Resolve compile errors caused by member access on forward-declared `Item`/`ItemTemplate` and the missing `INVTYPE_2HWEAPON` identifier by providing full type definitions.

### Description
- Added `#include "Item.h"` and `#include "ItemTemplate.h"` to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` so `mainHand->GetTemplate()` and `INVTYPE_2HWEAPON` resolve against the full definitions.

### Testing
- Ran `git diff --check` to verify no whitespace/style issues were introduced, and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55db305f483278c882c6de1006a11)