### PR TITLE
Playerbot: Maintain movement after instant-cast jump and improve melee-pressure positioning

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -203,6 +203,7 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
         return;
 
     ObjectGuid const casterGuid = player->GetGUID();
+    ObjectGuid const targetGuid = target->GetGUID();
     player->SetFacingToObject(target);
     player->SetInFront(target);
 
@@ -212,7 +213,7 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
     float constexpr normalJumpSpeedZ = 7.95555f;
     player->JumpTo(jumpSpeedXY, normalJumpSpeedZ, false);
 
-    player->m_Events.AddEventAtOffset([casterGuid, resumeOrientation]()
+    player->m_Events.AddEventAtOffset([casterGuid, targetGuid, resumeOrientation]()
     {
         Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
         if (!caster || !caster->IsInWorld() || !caster->IsAlive())
@@ -222,6 +223,22 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
             return;
 
         caster->SetFacingTo(resumeOrientation);
+
+        // JumpTo can leave virtual-session bots briefly idle after landing.
+        // Re-issue a short forward MovePoint on the pre-cast heading to
+        // preserve run-and-cast flow instead of stopping in place.
+        if (caster->HasUnitState(UNIT_STATE_ROOT) || caster->HasUnitState(UNIT_STATE_STUNNED))
+            return;
+
+        Unit* resolvedTarget = ObjectAccessor::GetUnit(*caster, targetGuid);
+        if (!resolvedTarget || !resolvedTarget->IsAlive())
+            return;
+
+        float const stepDistance = std::max(4.0f, caster->GetSpeed(MOVE_RUN) * 0.65f);
+        Position destination(caster->GetPositionX() + std::cos(resumeOrientation) * stepDistance,
+            caster->GetPositionY() + std::sin(resumeOrientation) * stepDistance,
+            caster->GetPositionZ(), resumeOrientation);
+        caster->GetMotionMaster()->MovePoint(0, destination);
     }, 250ms);
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -424,6 +424,29 @@ bool CanIssueBotMovement(Player const* player)
     return true;
 }
 
+bool IsMeleePressureTarget(Unit const* unit)
+{
+    Player const* player = unit ? unit->ToPlayer() : nullptr;
+    if (!player)
+        return false;
+
+    switch (player->GetClass())
+    {
+        case CLASS_WARRIOR:
+        case CLASS_ROGUE:
+            return true;
+        case CLASS_SHAMAN:
+        case CLASS_PALADIN:
+        {
+            Item const* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
+            ItemTemplate const* mainHandTemplate = mainHand ? mainHand->GetTemplate() : nullptr;
+            return mainHandTemplate && mainHandTemplate->InventoryType == INVTYPE_2HWEAPON;
+        }
+        default:
+            return false;
+    }
+}
+
 struct CombatPositioningProfile
 {
     float preferredMinRange = 0.0f;
@@ -725,6 +748,15 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
     if (profile.primarilyRanged)
     {
+        if (profile.createDistanceWhenCrowded && IsMeleePressureTarget(target) && distance < profile.preferredIdealRange)
+        {
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP distance band: bot={} profile={} decision=create-distance-vs-melee-pressure distance={} min={} ideal={} max={}.",
+                player->GetGUID().ToString(), profile.label, distance, profile.preferredMinRange, profile.preferredIdealRange,
+                profile.preferredMaxPressureRange);
+            return MoveAwayFromUnit(player, target, profile.preferredIdealRange);
+        }
+
         if (distance < profile.preferredMinRange && profile.createDistanceWhenCrowded)
         {
             TC_LOG_DEBUG("playerbots.pvp.lifecycle",


### PR DESCRIPTION
### Motivation

- Prevent virtual-session bots from coming to a stop after using `JumpTo` for instant-cast visuals so they preserve run-and-cast flow.
- Improve PvP positioning so primarily-ranged bots react to melee-pressure targets (melee classes or 2H paladin/shaman) by creating distance when crowded.
- Provide clearer decision logging for distance-band behaviors to aid debugging and tuning.

### Description

- In `PlayerbotPvpClassActions.cpp` capture the `targetGuid` for the post-jump event and after restoring facing re-issue a short forward `MovePoint` toward a computed destination unless the bot is rooted or stunned, and only when the resolved target is still alive.
- The re-issue uses a `stepDistance` derived from run speed and preserves the pre-cast heading to avoid bots idling after landing.
- In `PlayerbotPvpLifecycleActions.cpp` add `IsMeleePressureTarget` to identify melee-pressure opponents based on class and main-hand weapon type for hybrids.
- Update `DriveCombatPositioning` to use `IsMeleePressureTarget` and create distance vs. melee pressure when `createDistanceWhenCrowded` is set, and add debug logging reflecting the new decision path.

### Testing

- Project built successfully after the changes without compiler errors.
- Ran automated playerbot unit tests including PvP lifecycle tests and they completed successfully.
- Verified PvP behavior logging appears for distance-band decisions during test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55cc34e488327b7940c5a0ff18ea3)