### PR TITLE
Improve PvP bot movement: preserve run-and-cast flow and avoid melee pressure for ranged bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -203,6 +203,7 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
         return;
 
     ObjectGuid const casterGuid = player->GetGUID();
+    ObjectGuid const targetGuid = target->GetGUID();
     player->SetFacingToObject(target);
     player->SetInFront(target);
 
@@ -212,16 +213,29 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
     float constexpr normalJumpSpeedZ = 7.95555f;
     player->JumpTo(jumpSpeedXY, normalJumpSpeedZ, false);
 
-    player->m_Events.AddEventAtOffset([casterGuid, resumeOrientation]()
+    player->m_Events.AddEventAtOffset([casterGuid, targetGuid, resumeOrientation]()
     {
         Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
         if (!caster || !caster->IsInWorld() || !caster->IsAlive())
             return;
 
-        if (caster->IsNonMeleeSpellCast(false, false, true))
+        caster->SetFacingTo(resumeOrientation);
+
+        // JumpTo can leave virtual-session bots briefly idle after landing.
+        // Re-issue a short forward MovePoint on the pre-cast heading to
+        // preserve run-and-cast flow instead of stopping in place.
+        if (caster->HasUnitState(UNIT_STATE_ROOT) || caster->HasUnitState(UNIT_STATE_STUNNED))
             return;
 
-        caster->SetFacingTo(resumeOrientation);
+        Unit* resolvedTarget = ObjectAccessor::GetUnit(*caster, targetGuid);
+        if (!resolvedTarget || !resolvedTarget->IsAlive())
+            return;
+
+        float const stepDistance = std::max(8.0f, caster->GetSpeed(MOVE_RUN) * 1.35f);
+        Position destination(caster->GetPositionX() + std::cos(resumeOrientation) * stepDistance,
+            caster->GetPositionY() + std::sin(resumeOrientation) * stepDistance,
+            caster->GetPositionZ(), resumeOrientation);
+        caster->GetMotionMaster()->MovePoint(0, destination);
     }, 250ms);
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -424,6 +424,29 @@ bool CanIssueBotMovement(Player const* player)
     return true;
 }
 
+bool IsMeleePressureTarget(Unit const* unit)
+{
+    Player const* player = unit ? unit->ToPlayer() : nullptr;
+    if (!player)
+        return false;
+
+    switch (player->GetClass())
+    {
+        case CLASS_WARRIOR:
+        case CLASS_ROGUE:
+            return true;
+        case CLASS_SHAMAN:
+        case CLASS_PALADIN:
+        {
+            Item const* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
+            ItemTemplate const* mainHandTemplate = mainHand ? mainHand->GetTemplate() : nullptr;
+            return mainHandTemplate && mainHandTemplate->InventoryType == INVTYPE_2HWEAPON;
+        }
+        default:
+            return false;
+    }
+}
+
 struct CombatPositioningProfile
 {
     float preferredMinRange = 0.0f;
@@ -725,6 +748,15 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
     if (profile.primarilyRanged)
     {
+        if (profile.createDistanceWhenCrowded && IsMeleePressureTarget(target) && distance < profile.preferredIdealRange)
+        {
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP distance band: bot={} profile={} decision=create-distance-vs-melee-pressure distance={} min={} ideal={} max={}.",
+                player->GetGUID().ToString(), profile.label, distance, profile.preferredMinRange, profile.preferredIdealRange,
+                profile.preferredMaxPressureRange);
+            return MoveAwayFromUnit(player, target, profile.preferredIdealRange);
+        }
+
         if (distance < profile.preferredMinRange && profile.createDistanceWhenCrowded)
         {
             TC_LOG_DEBUG("playerbots.pvp.lifecycle",


### PR DESCRIPTION
### Motivation
- Prevent managed playerbots from briefly standing idle after a zero-cast-time `JumpTo` visual so they preserve run-and-cast flow. 
- Make ranged/combat positioning aware of melee-pressure targets so ranged bots create distance versus hard-melee opponents.

### Description
- In `JumpTurnForInstantCastVisual` capture the target GUID and schedule a post-jump lambda that restores facing and re-issues a short forward `MovePoint` toward the pre-cast heading to avoid stopping after `JumpTo`, with an early return for rooted or stunned bots. 
- Resolve the captured target inside the scheduled event and compute a forward `destination` using `resumeOrientation` and a `stepDistance` based on `MOVE_RUN` speed, then call `GetMotionMaster()->MovePoint`. 
- Add `IsMeleePressureTarget` helper to classify melee-pressure opponents (Warrior and Rogue always, and Shamans/Paladins wielding 2H weapons). 
- Update `DriveCombatPositioning` to make ranged profiles create distance when crowded specifically versus melee-pressure targets when closer than the profile's ideal range.

### Testing
- Built the server sources with the changes and the build completed successfully. 
- Ran the test-suite for playerbot PvP lifecycle codepaths and smoke-tested AI movement scenarios; automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55cc34e488327b7940c5a0ff18ea3)