### PR TITLE
Improve Warsong Gulch bot behavior by adding WSG detection and expanding enemy scan range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -52,6 +52,15 @@
 
 namespace
 {
+bool IsWarsongGulch(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Battleground const* battleground = player->GetBattleground();
+    return battleground && battleground->GetMapId() == 489;
+}
+
 bool IsLifecycleGateEnabled()
 {
     playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
@@ -1021,6 +1030,9 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
         return true;
     }
 
+    if (IsWarsongGulch(player))
+        return EngageNearestEnemyPlayer(player, 2000.0f);
+
     if (EngageNearestEnemyPlayer(player, 65.0f))
         return true;
 
@@ -1086,6 +1098,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!CanIssueBotMovement(player))
         return false;
 
+    if (IsWarsongGulch(player))
+        return EngageNearestEnemyPlayer(player, 2000.0f);
+
     bool const teamHasHumans = PvpCore::TeamHasHumanPlayers(player);
     if (teamHasHumans && TryReturnDroppedFriendlyFlagWithHumanPriority(player))
         return true;
@@ -1134,7 +1149,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
             // WSG can enter sparse states where objective anchors are unavailable.
             // In those windows, force a large-radius enemy scan before falling
             // back to local graveyard movement so bots keep crossing the map.
-            if (EngageNearestEnemyPlayer(player, 500.0f))
+            if (EngageNearestEnemyPlayer(player, 2000.0f))
                 return true;
 
             if (WorldSafeLocsEntry const* graveyard = battleground->GetClosestGraveyard(player))
@@ -1162,6 +1177,9 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
 {
     if (!player || !player->InBattleground())
         return false;
+
+    if (IsWarsongGulch(player))
+        return EngageNearestEnemyPlayer(player, 2000.0f);
 
     if (EngageNearestEnemyPlayer(player, 60.0f))
         return true;


### PR DESCRIPTION
### Motivation
- Reduce stalled or overly-localized bot behavior in Warsong Gulch (WSG) by forcing broad enemy engagement when objective anchors are sparse.
- Provide a clear battleground-specific check to apply WSG heuristics only where intended.

### Description
- Added a helper `IsWarsongGulch(Player const* player)` that returns true when the player's battleground map id equals `489`.
- In `HandleInProgressStatusPrimitive`, `MoveToObjectivePrimitive`, and `CheckObjectivePrimitive`, added an early WSG branch that calls `EngageNearestEnemyPlayer(player, 2000.0f)` to force a long-range enemy scan on WSG.
- Increased the fallback `EngageNearestEnemyPlayer` radius from `500.0f` to `2000.0f` in the WSG objective-position branch so bots will search across the map before moving to the graveyard.

### Testing
- Project was built successfully after the changes (`make`/build completed without errors). 
- Existing automated unit/integration tests were executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56392b284832797bcd3d95ea1f837)