### PR TITLE
Playerbot PvP: safer WSG movement, deterministic WSG anchors, and virtual-session path handling

### DIFF
--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -20,10 +20,12 @@
 #include "MoveSpline.h"
 #include "MovementPacketBuilder.h"
 #include "Unit.h"
+#include "Player.h"
 #include "PathGenerator.h"
 #include "Transport.h"
 #include "Opcodes.h"
 #include "WorldPacket.h"
+#include "WorldSession.h"
 
 namespace Movement
 {
@@ -257,20 +259,38 @@ namespace Movement
             {
                 PathType const pathType = path.GetPathType();
                 bool const playerControlled = unit->IsControlledByPlayer() || unit->GetOwnerGUID().IsPlayer();
+                bool virtualSessionControlled = false;
+                if (Player const* moverPlayer = unit->ToPlayer())
+                    if (WorldSession const* session = moverPlayer->GetSession())
+                        virtualSessionControlled = session->IsVirtualSession();
                 bool const navmeshAvailable = path.HasNavigationData();
+                bool const usesUnsafePathMode = navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT));
 
                 if (!(pathType & PATHFIND_NOPATH))
                 {
-                    if (!(playerControlled && ((pathType & PATHFIND_INCOMPLETE) ||
-                        (navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))))
+                    bool const strictPlayerRejectPath = playerControlled && !virtualSessionControlled &&
+                        ((pathType & PATHFIND_INCOMPLETE) || usesUnsafePathMode);
+                    bool const virtualPlayerRejectPath = virtualSessionControlled && usesUnsafePathMode;
+
+                    if (!(strictPlayerRejectPath || virtualPlayerRejectPath))
                     {
                         MovebyPath(path.GetPath());
                         return;
                     }
                 }
 
-                if (playerControlled && ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
-                    (navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT)))))
+                if (virtualSessionControlled && ((pathType & PATHFIND_NOPATH) || usesUnsafePathMode))
+                {
+                    args.path_Idx_offset = 0;
+                    args.path.resize(2);
+                    TransportPathTransform transform(unit, args.TransformForTransport);
+                    Vector3 stay(unit->GetPositionX(), unit->GetPositionY(), unit->GetPositionZ());
+                    args.path[1] = transform(stay);
+                    return;
+                }
+
+                if ((playerControlled && !virtualSessionControlled) && ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+                    usesUnsafePathMode))
                 {
                     args.path_Idx_offset = 0;
                     args.path.resize(2);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -34,6 +34,7 @@
 #include "MotionMaster.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
+#include "PathGenerator.h"
 #include "Item.h"
 #include "ItemTemplate.h"
 #include "Player.h"
@@ -59,6 +60,21 @@ bool IsWarsongGulch(Player const* player)
 
     Battleground const* battleground = player->GetBattleground();
     return battleground && battleground->GetMapId() == 489;
+}
+
+bool TryGetWarsongEnemyBasePosition(Player* player, Position& destination)
+{
+    if (!player || !IsWarsongGulch(player))
+        return false;
+
+    uint32 const bgTeam = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
+    TeamId const botTeam = (bgTeam == ALLIANCE) ? TEAM_ALLIANCE : TEAM_HORDE;
+
+    Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
+    Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
+
+    destination = (botTeam == TEAM_ALLIANCE) ? hordeFlagStand : allianceFlagStand;
+    return true;
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
@@ -198,17 +214,71 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
 
+    Position issuedDestination = destination;
+    if (IsWarsongGulch(player))
+    {
+        float const directDistance = player->GetDistance(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
+        constexpr float maxStepDistance = 45.0f;
+        if (directDistance > maxStepDistance)
+        {
+            float const ratio = maxStepDistance / directDistance;
+            issuedDestination.Relocate(
+                player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
+                player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
+                player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
+                player->GetOrientation());
+        }
+
+        // Keep WSG movement path-safe for managed virtual bots: if the local step
+        // still resolves to unsafe navmesh modes, iteratively shorten the step.
+        auto isUnsafePath = [player](Position const& candidate) -> bool
+        {
+            PathGenerator path(player);
+            if (!path.CalculatePath(candidate.GetPositionX(), candidate.GetPositionY(), candidate.GetPositionZ(), false))
+                return true;
+
+            PathType const pathType = path.GetPathType();
+            if (pathType & PATHFIND_NOPATH)
+                return true;
+
+            return pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT);
+        };
+
+        if (isUnsafePath(issuedDestination))
+        {
+            constexpr float fallbackSteps[] = { 32.0f, 24.0f, 16.0f, 10.0f };
+            for (float stepDistance : fallbackSteps)
+            {
+                if (directDistance <= stepDistance)
+                    continue;
+
+                float const ratio = stepDistance / directDistance;
+                Position candidate(
+                    player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
+                    player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
+                    player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
+                    player->GetOrientation());
+
+                if (!isUnsafePath(candidate))
+                {
+                    issuedDestination = candidate;
+                    break;
+                }
+            }
+        }
+    }
+
     std::ostringstream moveDetail;
     moveDetail << "movepoint-issue"
                << " from=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
-               << " to=(" << int32(destination.GetPositionX()) << "," << int32(destination.GetPositionY()) << "," << int32(destination.GetPositionZ()) << ")"
+               << " to=(" << int32(issuedDestination.GetPositionX()) << "," << int32(issuedDestination.GetPositionY()) << "," << int32(issuedDestination.GetPositionZ()) << ")"
                << " movementType=" << static_cast<uint32>(currentMovement)
                << " generatePath=" << (generatePath ? 1 : 0);
     EmitBattlegroundGmDebug(player, moveDetail.str(), 2000);
 
     // Reference-module parity: issue MovePoint directly and let MotionMaster handle path generation.
-    motionMaster->MovePoint(0, destination, generatePath);
-    state.lastDestination = destination;
+    motionMaster->MovePoint(0, issuedDestination, generatePath);
+    state.lastDestination = issuedDestination;
     state.lastIssueMs = nowMs;
     return true;
 }
@@ -881,6 +951,14 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
     if (!battleground || !player)
         return false;
 
+    // WSG needs deterministic cross-map intent; base anchors can be missing or
+    // locally-biased in sparse managed-bot matches, which leaves bots stalling.
+    if (TryGetWarsongEnemyBasePosition(player, destination))
+    {
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
+        return true;
+    }
+
     Position const* allianceStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(TEAM_ALLIANCE));
     Position const* hordeStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(TEAM_HORDE));
 
@@ -1052,10 +1130,8 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
         return true;
     }
 
-    if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
-
-    if (EngageNearestEnemyPlayer(player, 65.0f))
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 65.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
     if (Battleground* battleground = player->GetBattleground())
@@ -1071,6 +1147,9 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
             return true;
         }
     }
+
+    if (IsWarsongGulch(player))
+        return MoveToClosestBattlegroundGraveyard(player);
 
     EmitBattlegroundGmDebug(player, "no enemy target and no objective position resolved");
     return true;
@@ -1120,14 +1199,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!CanIssueBotMovement(player))
         return false;
 
-    if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
-
     bool const teamHasHumans = PvpCore::TeamHasHumanPlayers(player);
     if (teamHasHumans && TryReturnDroppedFriendlyFlagWithHumanPriority(player))
         return true;
 
-    if (EngageNearestEnemyPlayer(player, 80.0f))
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 80.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
     if (context.objective.type == BattlegroundObjectiveType::None &&
@@ -1187,6 +1264,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     bool const fallbackEngage = EngageNearestEnemyPlayer(player, 55.0f);
     if (!fallbackEngage)
     {
+        if (IsWarsongGulch(player))
+            return MoveToClosestBattlegroundGraveyard(player);
+
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP movement skipped: bot={} reason=no-objective-movement-and-no-fallback-target.",
             player->GetGUID().ToString());
@@ -1200,11 +1280,12 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (!player || !player->InBattleground())
         return false;
 
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 60.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
+        return true;
+
     if (IsWarsongGulch(player))
         return MoveToClosestBattlegroundGraveyard(player);
-
-    if (EngageNearestEnemyPlayer(player, 60.0f))
-        return true;
 
     return context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None;
 }


### PR DESCRIPTION
### Motivation

- Avoid bots getting stuck or taking unsafe navmesh shortcuts during Warsong Gulch (WSG) and improve movement decisions for managed/virtual sessions.
- Ensure bots have deterministic enemy-base anchors in WSG when battleground start anchors are missing to prevent stalling in sparse matches.
- Treat virtual (disconnected) sessions differently when deciding to accept or reject generated paths so managed bots can continue moving in constrained environments.

### Description

- In `MoveSplineInit.cpp` detect `Player` virtual sessions via `WorldSession::IsVirtualSession()` and refine path-accept/reject logic so virtual sessions are not rejected by the same strict rules as live player-controlled units, and add a fallback short-stay path for rejected cases.
- In `PlayerbotPvpLifecycleActions.cpp` add `PathGenerator` usage and implement `TryGetWarsongEnemyBasePosition()` to provide deterministic WSG enemy-base anchors as an objective fallback.
- Update `IssueMovePointThrottled()` to compute a stepped `issuedDestination` for WSG (max per-step distance) and validate local steps using `PathGenerator::CalculatePath()`, with progressively shorter fallback step distances to avoid unsafe navmesh modes before issuing the move.
- Adjust battleground movement logic to prefer larger enemy scans in WSG (long-range engage) and reorder graveyard/objective fallbacks so WSG bots cross the map reliably while relying on the deterministic anchors and safer local steps.

### Testing

- Performed a full project build which completed without compile errors.
- Executed the repository's automated test harness where present and observed no regressions related to movement or playerbot PvP code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56c159df8832790d44f72609c6930)