### PR TITLE
Improve Playerbot PvP movement (WSG) and virtual-session path handling

### DIFF
--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -20,10 +20,12 @@
 #include "MoveSpline.h"
 #include "MovementPacketBuilder.h"
 #include "Unit.h"
+#include "Player.h"
 #include "PathGenerator.h"
 #include "Transport.h"
 #include "Opcodes.h"
 #include "WorldPacket.h"
+#include "WorldSession.h"
 
 namespace Movement
 {
@@ -257,20 +259,38 @@ namespace Movement
             {
                 PathType const pathType = path.GetPathType();
                 bool const playerControlled = unit->IsControlledByPlayer() || unit->GetOwnerGUID().IsPlayer();
+                bool virtualSessionControlled = false;
+                if (Player const* moverPlayer = unit->ToPlayer())
+                    if (WorldSession const* session = moverPlayer->GetSession())
+                        virtualSessionControlled = session->IsVirtualSession();
                 bool const navmeshAvailable = path.HasNavigationData();
+                bool const usesUnsafePathMode = navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT));
 
                 if (!(pathType & PATHFIND_NOPATH))
                 {
-                    if (!(playerControlled && ((pathType & PATHFIND_INCOMPLETE) ||
-                        (navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))))
+                    bool const strictPlayerRejectPath = playerControlled && !virtualSessionControlled &&
+                        ((pathType & PATHFIND_INCOMPLETE) || usesUnsafePathMode);
+                    bool const virtualPlayerRejectPath = virtualSessionControlled && usesUnsafePathMode;
+
+                    if (!(strictPlayerRejectPath || virtualPlayerRejectPath))
                     {
                         MovebyPath(path.GetPath());
                         return;
                     }
                 }
 
-                if (playerControlled && ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
-                    (navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT)))))
+                if (virtualSessionControlled && ((pathType & PATHFIND_NOPATH) || usesUnsafePathMode))
+                {
+                    args.path_Idx_offset = 0;
+                    args.path.resize(2);
+                    TransportPathTransform transform(unit, args.TransformForTransport);
+                    Vector3 stay(unit->GetPositionX(), unit->GetPositionY(), unit->GetPositionZ());
+                    args.path[1] = transform(stay);
+                    return;
+                }
+
+                if ((playerControlled && !virtualSessionControlled) && ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+                    usesUnsafePathMode))
                 {
                     args.path_Idx_offset = 0;
                     args.path.resize(2);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -34,6 +34,7 @@
 #include "MotionMaster.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
+#include "PathGenerator.h"
 #include "Item.h"
 #include "ItemTemplate.h"
 #include "Player.h"
@@ -49,6 +50,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <array>
+#include <algorithm>
 
 namespace
 {
@@ -59,6 +61,21 @@ bool IsWarsongGulch(Player const* player)
 
     Battleground const* battleground = player->GetBattleground();
     return battleground && battleground->GetMapId() == 489;
+}
+
+bool TryGetWarsongEnemyBasePosition(Player* player, Position& destination)
+{
+    if (!player || !IsWarsongGulch(player))
+        return false;
+
+    uint32 const bgTeam = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
+    TeamId const botTeam = (bgTeam == ALLIANCE) ? TEAM_ALLIANCE : TEAM_HORDE;
+
+    Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
+    Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
+
+    destination = (botTeam == TEAM_ALLIANCE) ? hordeFlagStand : allianceFlagStand;
+    return true;
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
@@ -155,6 +172,10 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
 
         bot->Whisper(message, LANG_UNIVERSAL, observer);
     }
+
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "PBDBG bot={} guid={} map={} detail={}",
+        bot->GetName(), bot->GetGUID().ToString(), bot->GetMapId(), detail);
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)
@@ -196,19 +217,119 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         motionMaster->Clear();
     }
 
-    bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
+    bool generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
+
+    Position issuedDestination = destination;
+    if (IsWarsongGulch(player))
+    {
+        float const directDistance = player->GetDistance(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
+        constexpr float maxStepDistance = 45.0f;
+        if (directDistance > maxStepDistance)
+        {
+            float const ratio = maxStepDistance / directDistance;
+            issuedDestination.Relocate(
+                player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
+                player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
+                player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
+                player->GetOrientation());
+        }
+
+        // Keep WSG movement path-safe for managed virtual bots: if the local step
+        // still resolves to unsafe navmesh modes, iteratively shorten the step.
+        auto evaluatePath = [player](Position const& candidate, PathType& pathTypeOut, bool& calculateOkOut) -> bool
+        {
+            PathGenerator path(player);
+            calculateOkOut = path.CalculatePath(candidate.GetPositionX(), candidate.GetPositionY(), candidate.GetPositionZ(), false);
+            if (!calculateOkOut)
+            {
+                pathTypeOut = PATHFIND_NOPATH;
+                return true;
+            }
+
+            pathTypeOut = path.GetPathType();
+            if (pathTypeOut & PATHFIND_NOPATH)
+                return true;
+
+            return pathTypeOut & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT);
+        };
+
+        PathType issuedPathType = PATHFIND_BLANK;
+        bool issuedCalculated = false;
+        bool unsafeIssuedPath = evaluatePath(issuedDestination, issuedPathType, issuedCalculated);
+        if (unsafeIssuedPath)
+        {
+            constexpr float fallbackSteps[] = { 32.0f, 24.0f, 16.0f, 10.0f };
+            bool foundSafeCandidate = false;
+            for (float stepDistance : fallbackSteps)
+            {
+                if (directDistance <= stepDistance)
+                    continue;
+
+                float const ratio = stepDistance / directDistance;
+                Position candidate(
+                    player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
+                    player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
+                    player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
+                    player->GetOrientation());
+
+                PathType candidatePathType = PATHFIND_BLANK;
+                bool candidateCalculated = false;
+                if (!evaluatePath(candidate, candidatePathType, candidateCalculated))
+                {
+                    issuedDestination = candidate;
+                    foundSafeCandidate = true;
+                    std::ostringstream safeStepDetail;
+                    safeStepDetail << "wsg-step-selected step=" << int32(stepDistance)
+                                   << " pathType=" << uint32(candidatePathType)
+                                   << " calc=" << (candidateCalculated ? 1 : 0);
+                    EmitBattlegroundGmDebug(player, safeStepDetail.str(), 1500);
+                    break;
+                }
+            }
+
+            if (!foundSafeCandidate)
+            {
+                std::ostringstream unsafeDetail;
+                unsafeDetail << "wsg-step-unsafe-all-candidates"
+                             << " directDist=" << int32(directDistance)
+                             << " issuedPathType=" << uint32(issuedPathType)
+                             << " calc=" << (issuedCalculated ? 1 : 0);
+                EmitBattlegroundGmDebug(player, unsafeDetail.str(), 1500);
+
+                // Final troubleshooting fallback: take a tiny direct-Los step so
+                // bots don't deadlock when navmesh flags all short probes unsafe.
+                float const emergencyStepDistance = std::min(8.0f, directDistance);
+                if (emergencyStepDistance > 0.0f)
+                {
+                    float const ratio = emergencyStepDistance / directDistance;
+                    Position emergencyDestination(
+                        player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
+                        player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
+                        player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
+                        player->GetOrientation());
+
+                    if (player->IsWithinLOS(emergencyDestination.GetPositionX(), emergencyDestination.GetPositionY(), emergencyDestination.GetPositionZ()))
+                    {
+                        issuedDestination = emergencyDestination;
+                        generatePath = false;
+                        EmitBattlegroundGmDebug(player, "wsg-step-direct-los-fallback enabled", 1500);
+                    }
+                }
+            }
+        }
+    }
 
     std::ostringstream moveDetail;
     moveDetail << "movepoint-issue"
                << " from=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
-               << " to=(" << int32(destination.GetPositionX()) << "," << int32(destination.GetPositionY()) << "," << int32(destination.GetPositionZ()) << ")"
+               << " to=(" << int32(issuedDestination.GetPositionX()) << "," << int32(issuedDestination.GetPositionY()) << "," << int32(issuedDestination.GetPositionZ()) << ")"
                << " movementType=" << static_cast<uint32>(currentMovement)
                << " generatePath=" << (generatePath ? 1 : 0);
     EmitBattlegroundGmDebug(player, moveDetail.str(), 2000);
 
     // Reference-module parity: issue MovePoint directly and let MotionMaster handle path generation.
-    motionMaster->MovePoint(0, destination, generatePath);
-    state.lastDestination = destination;
+    motionMaster->MovePoint(0, issuedDestination, generatePath);
+    state.lastDestination = issuedDestination;
     state.lastIssueMs = nowMs;
     return true;
 }
@@ -881,6 +1002,14 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
     if (!battleground || !player)
         return false;
 
+    // WSG needs deterministic cross-map intent; base anchors can be missing or
+    // locally-biased in sparse managed-bot matches, which leaves bots stalling.
+    if (TryGetWarsongEnemyBasePosition(player, destination))
+    {
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
+        return true;
+    }
+
     Position const* allianceStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(TEAM_ALLIANCE));
     Position const* hordeStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(TEAM_HORDE));
 
@@ -1052,10 +1181,8 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
         return true;
     }
 
-    if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
-
-    if (EngageNearestEnemyPlayer(player, 65.0f))
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 65.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
     if (Battleground* battleground = player->GetBattleground())
@@ -1071,6 +1198,9 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
             return true;
         }
     }
+
+    if (IsWarsongGulch(player))
+        return MoveToClosestBattlegroundGraveyard(player);
 
     EmitBattlegroundGmDebug(player, "no enemy target and no objective position resolved");
     return true;
@@ -1120,14 +1250,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!CanIssueBotMovement(player))
         return false;
 
-    if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
-
     bool const teamHasHumans = PvpCore::TeamHasHumanPlayers(player);
     if (teamHasHumans && TryReturnDroppedFriendlyFlagWithHumanPriority(player))
         return true;
 
-    if (EngageNearestEnemyPlayer(player, 80.0f))
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 80.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
     if (context.objective.type == BattlegroundObjectiveType::None &&
@@ -1187,6 +1315,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     bool const fallbackEngage = EngageNearestEnemyPlayer(player, 55.0f);
     if (!fallbackEngage)
     {
+        if (IsWarsongGulch(player))
+            return MoveToClosestBattlegroundGraveyard(player);
+
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP movement skipped: bot={} reason=no-objective-movement-and-no-fallback-target.",
             player->GetGUID().ToString());
@@ -1200,11 +1331,12 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (!player || !player->InBattleground())
         return false;
 
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 60.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
+        return true;
+
     if (IsWarsongGulch(player))
         return MoveToClosestBattlegroundGraveyard(player);
-
-    if (EngageNearestEnemyPlayer(player, 60.0f))
-        return true;
 
     return context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None;
 }


### PR DESCRIPTION
### Motivation
- Fix bot movement deadlocks and unsafe navmesh usages in Warsong Gulch (WSG) and make managed/virtual bot sessions handle pathfinding differently from live players.
- Prevent bots from repeatedly requesting long or unsafe navmesh paths and provide deterministic objective anchors for sparse WSG matches.
- Ensure virtual/disconnected sessions (managed bots) can use safer fallback movement behavior without blocking live player movement logic.

### Description
- Update `MoveSplineInit::MoveTo` to detect `WorldSession::IsVirtualSession()` for `Player`-controlled units and separate rejection logic for live vs virtual sessions, preserving path usage when appropriate and falling back to a short-stay path when needed. (changes in `MoveSplineInit.cpp`)
- Add WSG-specific movement heuristics in `IssueMovePointThrottled`: cap per-step distance, probe navmesh with `PathGenerator`, iteratively shorten steps (`32,24,16,10`) to find a safe local step, and use a small LOS-only emergency step if all candidates are unsafe; track and issue `MovePoint` using the chosen `issuedDestination`. (changes in `PlayerbotPvpLifecycleActions.cpp`)
- Add `TryGetWarsongEnemyBasePosition` to return deterministic enemy base anchors for WSG and apply a small deterministic offset via `ApplyDeterministicObjectiveOffset` when computing objective positions.
- Adjust battleground movement decision flow and engage ranges for WSG (use large scan radius `2000.0f` where appropriate) and reposition some WSG graveyard fallback logic to avoid stalls.
- Enhance debug emission by logging to the server log via `TC_LOG_DEBUG` in addition to whispering GMs. Added required includes (`Player`, `WorldSession`, `PathGenerator`, etc.).

### Testing
- Performed a full project build and verified the server compiles with the changes (no compile errors observed). 
- No automated unit test suite was included or executed for these changes; no automated tests failed during the build validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56c159df8832790d44f72609c6930)