### PR TITLE
Qualify playerbot types in battleground tactical tick

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -330,16 +330,16 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     if (player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear())
         return;
 
-    PvpValues const values = PvpCore::CollectValues(player);
-    BattlegroundTacticalContext const tacticalContext = PvpCore::BuildBattlegroundTacticalContext(player, values);
-    BattlegroundTacticalActions::Execute(player, tacticalContext);
+    playerbot::PvpValues const values = playerbot::PvpCore::CollectValues(player);
+    playerbot::BattlegroundTacticalContext const tacticalContext = playerbot::PvpCore::BuildBattlegroundTacticalContext(player, values);
+    playerbot::BattlegroundTacticalActions::Execute(player, tacticalContext);
 
-    BattlegroundLifecycleContext inProgressContext;
+    playerbot::BattlegroundLifecycleContext inProgressContext;
     inProgressContext.lifecycleEnabled = true;
-    inProgressContext.queueOperation = QueueOperationType::None;
-    inProgressContext.invitationResponse = InvitationResponseType::None;
+    inProgressContext.queueOperation = playerbot::QueueOperationType::None;
+    inProgressContext.invitationResponse = playerbot::InvitationResponseType::None;
     inProgressContext.shouldHandleInProgressStatus = true;
-    BattlegroundLifecycleActions::Execute(player, inProgressContext);
+    playerbot::BattlegroundLifecycleActions::Execute(player, inProgressContext);
 }
 
 void TryFinalizePendingVirtualBotTeleport(Player* player)


### PR DESCRIPTION
### Motivation
- Fix compiler errors in `ProcessActiveBattlegroundTacticalTick` where several PvP types and helpers declared in the `playerbot` namespace were referenced without qualification so the compiler could not resolve symbols.

### Description
- Prefix calls and types with `playerbot::` in `PlayerbotRandomBotParticipation.cpp`, including `PvpValues`, `PvpCore::CollectValues`, `PvpCore::BuildBattlegroundTacticalContext`, `BattlegroundTacticalContext`, and `BattlegroundTacticalActions::Execute`.
- Qualify lifecycle types and enum values by changing `BattlegroundLifecycleContext`, `QueueOperationType::None`, and `InvitationResponseType::None` to `playerbot::BattlegroundLifecycleContext`, `playerbot::QueueOperationType::None`, and `playerbot::InvitationResponseType::None` respectively, and call `playerbot::BattlegroundLifecycleActions::Execute`.
- All edits are confined to `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` around the active battleground tactical tick handling.

### Testing
- No automated build or unit tests were executed in this environment, so compilation and runtime verification were not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d590e4edc88327b03ecd0fd1d79e2e)