### PR TITLE
Improve battleground bot movement: WSG path safety, virtual session handling, and tactical tick

### DIFF
--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -20,10 +20,12 @@
 #include "MoveSpline.h"
 #include "MovementPacketBuilder.h"
 #include "Unit.h"
+#include "Player.h"
 #include "PathGenerator.h"
 #include "Transport.h"
 #include "Opcodes.h"
 #include "WorldPacket.h"
+#include "WorldSession.h"
 
 namespace Movement
 {
@@ -257,20 +259,38 @@ namespace Movement
             {
                 PathType const pathType = path.GetPathType();
                 bool const playerControlled = unit->IsControlledByPlayer() || unit->GetOwnerGUID().IsPlayer();
+                bool virtualSessionControlled = false;
+                if (Player const* moverPlayer = unit->ToPlayer())
+                    if (WorldSession const* session = moverPlayer->GetSession())
+                        virtualSessionControlled = session->IsVirtualSession();
                 bool const navmeshAvailable = path.HasNavigationData();
+                bool const usesUnsafePathMode = navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT));
 
                 if (!(pathType & PATHFIND_NOPATH))
                 {
-                    if (!(playerControlled && ((pathType & PATHFIND_INCOMPLETE) ||
-                        (navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))))
+                    bool const strictPlayerRejectPath = playerControlled && !virtualSessionControlled &&
+                        ((pathType & PATHFIND_INCOMPLETE) || usesUnsafePathMode);
+                    bool const virtualPlayerRejectPath = virtualSessionControlled && usesUnsafePathMode;
+
+                    if (!(strictPlayerRejectPath || virtualPlayerRejectPath))
                     {
                         MovebyPath(path.GetPath());
                         return;
                     }
                 }
 
-                if (playerControlled && ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
-                    (navmeshAvailable && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT)))))
+                if (virtualSessionControlled && ((pathType & PATHFIND_NOPATH) || usesUnsafePathMode))
+                {
+                    args.path_Idx_offset = 0;
+                    args.path.resize(2);
+                    TransportPathTransform transform(unit, args.TransformForTransport);
+                    Vector3 stay(unit->GetPositionX(), unit->GetPositionY(), unit->GetPositionZ());
+                    args.path[1] = transform(stay);
+                    return;
+                }
+
+                if ((playerControlled && !virtualSessionControlled) && ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+                    usesUnsafePathMode))
                 {
                     args.path_Idx_offset = 0;
                     args.path.resize(2);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -34,6 +34,7 @@
 #include "MotionMaster.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
+#include "PathGenerator.h"
 #include "Item.h"
 #include "ItemTemplate.h"
 #include "Player.h"
@@ -49,6 +50,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <array>
+#include <algorithm>
 
 namespace
 {
@@ -59,6 +61,69 @@ bool IsWarsongGulch(Player const* player)
 
     Battleground const* battleground = player->GetBattleground();
     return battleground && battleground->GetMapId() == 489;
+}
+
+bool TryGetWarsongEnemyBasePosition(Player* player, Position& destination)
+{
+    if (!player || !IsWarsongGulch(player))
+        return false;
+
+    uint32 const bgTeam = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
+    TeamId const botTeam = (bgTeam == ALLIANCE) ? TEAM_ALLIANCE : TEAM_HORDE;
+
+    Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
+    Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
+
+    destination = (botTeam == TEAM_ALLIANCE) ? hordeFlagStand : allianceFlagStand;
+    return true;
+}
+
+bool TryGetWarsongLaneWaypoint(Player* player, Position& waypointOut)
+{
+    if (!player || !IsWarsongGulch(player))
+        return false;
+
+    uint32 const bgTeam = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
+    bool const allianceToHorde = (bgTeam == ALLIANCE);
+
+    static std::array<Position, 5> const kAllianceToHorde =
+    {
+        Position(1450.0f, 1470.0f, 350.0f, 0.0f),
+        Position(1320.0f, 1460.0f, 345.0f, 0.0f),
+        Position(1180.0f, 1450.0f, 340.0f, 0.0f),
+        Position(1040.0f, 1440.0f, 338.0f, 0.0f),
+        Position(950.0f, 1438.0f, 344.0f, 0.0f)
+    };
+
+    static std::array<Position, 5> const kHordeToAlliance =
+    {
+        Position(1000.0f, 1438.0f, 344.0f, 0.0f),
+        Position(1120.0f, 1444.0f, 339.0f, 0.0f),
+        Position(1260.0f, 1453.0f, 341.0f, 0.0f),
+        Position(1390.0f, 1466.0f, 346.0f, 0.0f),
+        Position(1510.0f, 1478.0f, 351.0f, 0.0f)
+    };
+
+    std::array<Position, 5> const& lane = allianceToHorde ? kAllianceToHorde : kHordeToAlliance;
+
+    int closestIndex = -1;
+    float closestDistance = std::numeric_limits<float>::max();
+    for (uint32 i = 0; i < lane.size(); ++i)
+    {
+        float const dist = player->GetDistance(lane[i].GetPositionX(), lane[i].GetPositionY(), lane[i].GetPositionZ());
+        if (dist < closestDistance)
+        {
+            closestDistance = dist;
+            closestIndex = int(i);
+        }
+    }
+
+    if (closestIndex < 0)
+        return false;
+
+    uint32 const nextIndex = std::min<uint32>(closestIndex + 1, lane.size() - 1);
+    waypointOut = lane[nextIndex];
+    return true;
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
@@ -139,22 +204,9 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
     if (!map)
         return;
 
-    std::ostringstream whisper;
-    whisper << "[PBDBG] bot=" << bot->GetName() << " guid=" << bot->GetGUID().ToString()
-            << " map=" << bot->GetMapId() << " detail=" << detail;
-    std::string const message = whisper.str();
-
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        if (observer->GetBattlegroundId() != bot->GetBattlegroundId())
-            continue;
-
-        bot->Whisper(message, LANG_UNIVERSAL, observer);
-    }
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "PBDBG bot={} guid={} map={} detail={}",
+        bot->GetName(), bot->GetGUID().ToString(), bot->GetMapId(), detail);
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)
@@ -196,19 +248,138 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         motionMaster->Clear();
     }
 
-    bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
+    bool generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
+    bool usedDirectLosFallback = false;
+
+    Position issuedDestination = destination;
+    if (IsWarsongGulch(player))
+    {
+        float const directDistance = player->GetDistance(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
+        constexpr float maxStepDistance = 45.0f;
+        if (directDistance > maxStepDistance)
+        {
+            float const ratio = maxStepDistance / directDistance;
+            issuedDestination.Relocate(
+                player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
+                player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
+                player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
+                player->GetOrientation());
+        }
+
+        // Keep WSG movement path-safe for managed virtual bots: if the local step
+        // still resolves to unsafe navmesh modes, iteratively shorten the step.
+        auto evaluatePath = [player](Position const& candidate, PathType& pathTypeOut, bool& calculateOkOut) -> bool
+        {
+            PathGenerator path(player);
+            calculateOkOut = path.CalculatePath(candidate.GetPositionX(), candidate.GetPositionY(), candidate.GetPositionZ(), false);
+            if (!calculateOkOut)
+            {
+                pathTypeOut = PATHFIND_NOPATH;
+                return true;
+            }
+
+            pathTypeOut = path.GetPathType();
+            if (pathTypeOut & PATHFIND_NOPATH)
+                return true;
+
+            return pathTypeOut & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT);
+        };
+
+        PathType issuedPathType = PATHFIND_BLANK;
+        bool issuedCalculated = false;
+        bool unsafeIssuedPath = evaluatePath(issuedDestination, issuedPathType, issuedCalculated);
+        if (unsafeIssuedPath)
+        {
+            constexpr float fallbackSteps[] = { 32.0f, 24.0f, 16.0f, 10.0f };
+            bool foundSafeCandidate = false;
+            for (float stepDistance : fallbackSteps)
+            {
+                if (directDistance <= stepDistance)
+                    continue;
+
+                float const ratio = stepDistance / directDistance;
+                Position candidate(
+                    player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
+                    player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
+                    player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
+                    player->GetOrientation());
+
+                PathType candidatePathType = PATHFIND_BLANK;
+                bool candidateCalculated = false;
+                if (!evaluatePath(candidate, candidatePathType, candidateCalculated))
+                {
+                    issuedDestination = candidate;
+                    foundSafeCandidate = true;
+                    std::ostringstream safeStepDetail;
+                    safeStepDetail << "wsg-step-selected step=" << int32(stepDistance)
+                                   << " pathType=" << uint32(candidatePathType)
+                                   << " calc=" << (candidateCalculated ? 1 : 0);
+                    EmitBattlegroundGmDebug(player, safeStepDetail.str(), 1500);
+                    break;
+                }
+            }
+
+            if (!foundSafeCandidate)
+            {
+                std::ostringstream unsafeDetail;
+                unsafeDetail << "wsg-step-unsafe-all-candidates"
+                             << " directDist=" << int32(directDistance)
+                             << " issuedPathType=" << uint32(issuedPathType)
+                             << " calc=" << (issuedCalculated ? 1 : 0);
+                EmitBattlegroundGmDebug(player, unsafeDetail.str(), 1500);
+
+                // Final troubleshooting fallback: take a tiny direct-Los step so
+                // bots don't deadlock when navmesh flags all short probes unsafe.
+                float const emergencyStepDistance = std::min(8.0f, directDistance);
+                if (emergencyStepDistance > 0.0f)
+                {
+                    float const ratio = emergencyStepDistance / directDistance;
+                    Position emergencyDestination(
+                        player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
+                        player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
+                        player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
+                        player->GetOrientation());
+
+                    if (player->IsWithinLOS(emergencyDestination.GetPositionX(), emergencyDestination.GetPositionY(), emergencyDestination.GetPositionZ()))
+                    {
+                        issuedDestination = emergencyDestination;
+                        generatePath = false;
+                        usedDirectLosFallback = true;
+                        EmitBattlegroundGmDebug(player, "wsg-step-direct-los-fallback enabled", 1500);
+                    }
+                }
+            }
+        }
+    }
 
     std::ostringstream moveDetail;
+    if (usedDirectLosFallback &&
+        !player->IsWithinLOS(issuedDestination.GetPositionX(), issuedDestination.GetPositionY(), issuedDestination.GetPositionZ()))
+    {
+        Position laneWaypoint;
+        if (TryGetWarsongLaneWaypoint(player, laneWaypoint))
+        {
+            issuedDestination = laneWaypoint;
+            generatePath = false;
+            EmitBattlegroundGmDebug(player, "movepoint-lane-fallback reason=no-los-to-issued-destination", 1500);
+        }
+        else
+        {
+            EmitBattlegroundGmDebug(player, "movepoint-skip reason=no-los-to-issued-destination", 1500);
+            return false;
+        }
+    }
+
     moveDetail << "movepoint-issue"
                << " from=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
-               << " to=(" << int32(destination.GetPositionX()) << "," << int32(destination.GetPositionY()) << "," << int32(destination.GetPositionZ()) << ")"
+               << " to=(" << int32(issuedDestination.GetPositionX()) << "," << int32(issuedDestination.GetPositionY()) << "," << int32(issuedDestination.GetPositionZ()) << ")"
                << " movementType=" << static_cast<uint32>(currentMovement)
                << " generatePath=" << (generatePath ? 1 : 0);
     EmitBattlegroundGmDebug(player, moveDetail.str(), 2000);
 
     // Reference-module parity: issue MovePoint directly and let MotionMaster handle path generation.
-    motionMaster->MovePoint(0, destination, generatePath);
-    state.lastDestination = destination;
+    motionMaster->MovePoint(0, issuedDestination, generatePath);
+    state.lastDestination = issuedDestination;
     state.lastIssueMs = nowMs;
     return true;
 }
@@ -881,6 +1052,14 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
     if (!battleground || !player)
         return false;
 
+    // WSG needs deterministic cross-map intent; base anchors can be missing or
+    // locally-biased in sparse managed-bot matches, which leaves bots stalling.
+    if (TryGetWarsongEnemyBasePosition(player, destination))
+    {
+        ApplyDeterministicObjectiveOffset(battleground, player, destination);
+        return true;
+    }
+
     Position const* allianceStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(TEAM_ALLIANCE));
     Position const* hordeStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(TEAM_HORDE));
 
@@ -1052,10 +1231,8 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
         return true;
     }
 
-    if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
-
-    if (EngageNearestEnemyPlayer(player, 65.0f))
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 65.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
     if (Battleground* battleground = player->GetBattleground())
@@ -1071,6 +1248,9 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
             return true;
         }
     }
+
+    if (IsWarsongGulch(player))
+        return MoveToClosestBattlegroundGraveyard(player);
 
     EmitBattlegroundGmDebug(player, "no enemy target and no objective position resolved");
     return true;
@@ -1120,14 +1300,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!CanIssueBotMovement(player))
         return false;
 
-    if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
-
     bool const teamHasHumans = PvpCore::TeamHasHumanPlayers(player);
     if (teamHasHumans && TryReturnDroppedFriendlyFlagWithHumanPriority(player))
         return true;
 
-    if (EngageNearestEnemyPlayer(player, 80.0f))
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 80.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
     if (context.objective.type == BattlegroundObjectiveType::None &&
@@ -1187,6 +1365,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     bool const fallbackEngage = EngageNearestEnemyPlayer(player, 55.0f);
     if (!fallbackEngage)
     {
+        if (IsWarsongGulch(player))
+            return MoveToClosestBattlegroundGraveyard(player);
+
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP movement skipped: bot={} reason=no-objective-movement-and-no-fallback-target.",
             player->GetGUID().ToString());
@@ -1200,11 +1381,12 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (!player || !player->InBattleground())
         return false;
 
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 60.0f;
+    if (EngageNearestEnemyPlayer(player, engageDistance))
+        return true;
+
     if (IsWarsongGulch(player))
         return MoveToClosestBattlegroundGraveyard(player);
-
-    if (EngageNearestEnemyPlayer(player, 60.0f))
-        return true;
 
     return context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None;
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -64,7 +64,6 @@ using LifecycleCadenceClock = std::chrono::steady_clock;
 using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 
 constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
-constexpr std::chrono::milliseconds BattlegroundActiveCadenceInterval(2000);
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;
@@ -293,18 +292,53 @@ bool CanProcessPlayerLifecycle(Player const* player)
     bool const inActiveBattleground = player->InBattleground() &&
         player->GetBattleground() &&
         player->GetBattleground()->GetStatus() == STATUS_IN_PROGRESS;
-    std::chrono::milliseconds const cadenceInterval = inActiveBattleground ?
-        BattlegroundActiveCadenceInterval : RandomBotLifecycleCadenceInterval;
+    std::chrono::milliseconds const cadenceInterval = RandomBotLifecycleCadenceInterval;
 
     if (nextProcessTime > now)
     {
         ObserveLifecycleReason(LifecycleObservationReason::CadenceThrottled, guid);
-        EmitLifecycleGmDebug(player, "can-process=no cadence-throttled");
+        auto const waitRemainingMs = std::chrono::duration_cast<std::chrono::milliseconds>(nextProcessTime - now).count();
+        std::ostringstream cadenceDetail;
+        cadenceDetail << "can-process=no cadence-throttled wait_ms=" << waitRemainingMs
+                      << " cadence_ms=" << cadenceInterval.count()
+                      << " bg_active=" << (inActiveBattleground ? 1 : 0)
+                      << " model=bg-fasttick-v3";
+        EmitLifecycleGmDebug(player, cadenceDetail.str());
         return false;
     }
 
     nextProcessTime = now + cadenceInterval;
     return true;
+}
+
+void ProcessActiveBattlegroundTacticalTick(Player* player)
+{
+    if (!player || !IsLifecycleGateEnabled())
+        return;
+
+    if (!playerbot::IsManagedRandomBot(player))
+        return;
+
+    if (!player->IsInWorld() || !player->InBattleground())
+        return;
+
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground || battleground->GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    if (player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear())
+        return;
+
+    playerbot::PvpValues const values = playerbot::PvpCore::CollectValues(player);
+    playerbot::BattlegroundTacticalContext const tacticalContext = playerbot::PvpCore::BuildBattlegroundTacticalContext(player, values);
+    playerbot::BattlegroundTacticalActions::Execute(player, tacticalContext);
+
+    playerbot::BattlegroundLifecycleContext inProgressContext;
+    inProgressContext.lifecycleEnabled = true;
+    inProgressContext.queueOperation = playerbot::QueueOperationType::None;
+    inProgressContext.invitationResponse = playerbot::InvitationResponseType::None;
+    inProgressContext.shouldHandleInProgressStatus = true;
+    playerbot::BattlegroundLifecycleActions::Execute(player, inProgressContext);
 }
 
 void TryFinalizePendingVirtualBotTeleport(Player* player)
@@ -933,6 +967,7 @@ void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
 {
     TryReviveManagedBotAfterStartup(player);
     TryFinalizePendingVirtualBotTeleport(player);
+    ProcessActiveBattlegroundTacticalTick(player);
 
     if (!CanProcessPlayerLifecycle(player))
         return;


### PR DESCRIPTION
### Motivation

- Reduce managed-bot deadlocks and unsafe navmesh behavior in Warsong Gulch (WSG) by making movement more tolerant and deterministic for sparse/multi-step map crossings.  
- Avoid rejecting or misrouting bots running in virtual sessions and ensure tactical decisions are applied more frequently during active battlegrounds.  
- Improve debugging output for battleground lifecycle and remove noisy GM whisper behavior.

### Description

- Add virtual session detection to `MoveSplineInit::MoveTo` and relax/adjust path acceptance rules for player-controlled vs virtual-session-controlled movers, ensuring correct fallback to a short-stay path when appropriate.  
- Introduce WSG-specific helpers: `TryGetWarsongEnemyBasePosition` and `TryGetWarsongLaneWaypoint` to provide deterministic objective anchors and lane waypoints.  
- Overhaul `IssueMovePointThrottled` to chunk long WSG moves into safe step distances, probe navmesh safety with `PathGenerator`, try progressively smaller steps, and use a small direct-LOS fallback if all short probes are considered unsafe; also select a lane waypoint when direct-LOS fallback lacks visibility.  
- Increase WSG engagement scan distances and re-order graveyard fallback logic so bots continue crossing the map even when objective anchors are sparse.  
- Replace GM whisper fanout with structured `TC_LOG_DEBUG` in `EmitBattlegroundGmDebug` to reduce chat spam and keep diagnostics in logs.  
- Add `ProcessActiveBattlegroundTacticalTick` and invoke it from `RandomBotParticipationManager::ProcessPlayerLifecycle` to run tactical and lifecycle actions for managed bots during active battlegrounds.  
- Simplify lifecycle cadence logic to a single cadence and improve cadence debug logging with extra context.  
- Minor includes and small refactors across `MoveSplineInit.cpp`, `PlayerbotPvpLifecycleActions.cpp`, and `PlayerbotRandomBotParticipation.cpp`.

### Testing

- Performed a full project build (server) which completed successfully.  
- Ran the repository's automated unit/integration test suite where available and observed no regressions in existing tests.  
- Executed local battleground smoke tests with managed bots in WSG to validate multi-step movement, navmesh fallback behavior, and tactical tick execution; the bots progressed across the map and did not deadlock during short runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56c159df8832790d44f72609c6930)