### PR TITLE
Improve inventory load logging and preserve problematic items in DB during Player::_LoadInventory

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -18681,8 +18681,21 @@ void Player::_LoadInventory(PreparedQueryResult result, uint32 timeDiff)
                     item->SetState(ITEM_UNCHANGED, this);
                 else
                 {
-                    TC_LOG_ERROR("entities.player", "Player::_LoadInventory: Player '{}' ({}) has item ({}, entry: {}) which can't be loaded into inventory (Bag {}, slot: {}) by reason {}. Item will be sent by mail.",
-                        GetName(), GetGUID().ToString(), item->GetGUID().ToString(), item->GetEntry(), bagGuid, slot, uint32(err));
+                    char const* slotType = "unknown";
+                    if (!bagGuid)
+                    {
+                        if (IsEquipmentPos(INVENTORY_SLOT_BAG_0, slot))
+                            slotType = "equipment";
+                        else if (IsInventoryPos(INVENTORY_SLOT_BAG_0, slot))
+                            slotType = "inventory";
+                        else if (IsBankPos(INVENTORY_SLOT_BAG_0, slot))
+                            slotType = "bank";
+                    }
+                    else
+                        slotType = "bag";
+
+                    TC_LOG_ERROR("entities.player", "Player::_LoadInventory: Player '{}' ({}) has item ({}, entry: {}) which can't be loaded (BagGuid {}, slot {}, slot type {}). InventoryResult {}. Item will be sent by mail.",
+                        GetName(), GetGUID().ToString(), item->GetGUID().ToString(), item->GetEntry(), bagGuid, slot, slotType, uint32(err));
                     item->DeleteFromInventoryDB(trans);
                     problematicItems.push_back(item);
                 }
@@ -18817,9 +18830,11 @@ Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint3
         }
         else
         {
-            TC_LOG_ERROR("entities.player", "Player::_LoadInventory: player ({}, name: '{}') has a broken item (GUID: {}, entry: {}) in inventory. Deleting item.",
+            TC_LOG_ERROR("entities.player", "Player::_LoadInventory: player ({}, name: '{}') has a broken item (GUID: {}, entry: {}) in inventory. Item is kept in DB for recovery and skipped during load.",
                 GetGUID().ToString(), GetName(), itemGuid, itemEntry);
-            remove = true;
+            delete item;
+            item = nullptr;
+            return nullptr;
         }
         // Remove item from inventory if necessary
         if (remove)
@@ -18832,10 +18847,8 @@ Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint3
     }
     else
     {
-        TC_LOG_ERROR("entities.player", "Player::_LoadInventory: player ({}, name: '{}') has an unknown item (entry: {}) in inventory. Deleting item.",
-            GetGUID().ToString(), GetName(), itemEntry);
-        Item::DeleteFromInventoryDB(trans, itemGuid);
-        Item::DeleteFromDB(trans, itemGuid);
+        TC_LOG_ERROR("entities.player", "Player::_LoadInventory: player ({}, name: '{}') has an unknown item (entry: {}, guid: {}) in inventory. Item is kept in DB for recovery and skipped during load.",
+            GetGUID().ToString(), GetName(), itemEntry, itemGuid);
     }
     return item;
 }


### PR DESCRIPTION
### Motivation
- Improve diagnostics when items fail to load by including slot type and result codes in logs.
- Avoid immediate deletion of broken or unknown items from the database so they can be recovered instead of being lost.

### Description
- Enhance error logging in `Player::_LoadInventory` to determine and include a `slotType` (using `IsEquipmentPos`, `IsInventoryPos`, `IsBankPos` and checking `bagGuid`) and to log the `InventoryResult` code when items cannot be loaded.
- Change handling of broken items so they are skipped during load, kept in the database for recovery, the in-memory `Item` object is deleted, and `nullptr` is returned instead of deleting the DB record.
- Stop deleting unknown items from the database during load and instead log that the item is kept in DB for recovery and skipped during load.
- Adjust log messages to include `bagGuid`, `slot`, `slot type`, and clearer descriptions of the new behavior.

### Testing
- Performed a local build to ensure the changes compile successfully.
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5dca19dd083278e0bf72f84ebf2cd)