### PR TITLE
Simplify PvP bot movement and tactical lifecycle: remove WSG lane steering and stall heuristics

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -34,7 +34,6 @@
 #include "MotionMaster.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
-#include "PathGenerator.h"
 #include "Item.h"
 #include "ItemTemplate.h"
 #include "Player.h"
@@ -98,159 +97,6 @@ TeamId ResolveBotTeamId(Player const* player)
     }
 
     return ResolveTeamId(player->GetTeam());
-}
-
-bool TryGetWarsongEnemyBasePosition(Player* player, Position& destination)
-{
-    if (!player || !IsWarsongGulch(player))
-        return false;
-
-    TeamId const botTeam = ResolveBotTeamId(player);
-
-    Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
-    Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
-
-    destination = (botTeam == TEAM_ALLIANCE) ? hordeFlagStand : allianceFlagStand;
-    return true;
-}
-
-struct WsgBattlePathNode
-{
-    Position point;
-    std::vector<uint32> neighbors;
-};
-
-std::vector<WsgBattlePathNode> const& GetWarsongBattlePathGraph()
-{
-    // Approximate battle-path graph with multiple route choices (mid/ramp/tunnel)
-    // and cross-links for recovery when one lane has poor navmesh probes.
-    static std::vector<WsgBattlePathNode> const graph =
-    {
-        { Position(1540.4f, 1481.3f, 351.8f, 0.0f), { 1, 2, 3 } },   // Alliance flag room
-        { Position(1496.0f, 1478.0f, 352.0f, 0.0f), { 0, 4 } },      // Alliance ramp
-        { Position(1504.0f, 1455.0f, 350.0f, 0.0f), { 0, 7 } },      // Alliance tunnel
-        { Position(1458.0f, 1470.0f, 351.0f, 0.0f), { 0, 10 } },     // Alliance roof exit
-        { Position(1410.0f, 1470.0f, 349.5f, 0.0f), { 1, 5, 10 } },
-        { Position(1340.0f, 1464.0f, 346.5f, 0.0f), { 4, 6, 11 } },
-        { Position(1260.0f, 1456.0f, 342.5f, 0.0f), { 5, 12, 13 } }, // Mid bridge hub
-        { Position(1418.0f, 1448.0f, 345.5f, 0.0f), { 2, 8, 11 } },
-        { Position(1325.0f, 1438.0f, 341.5f, 0.0f), { 7, 9, 12 } },
-        { Position(1232.0f, 1430.0f, 337.5f, 0.0f), { 8, 13 } },
-        { Position(1380.0f, 1488.0f, 351.5f, 0.0f), { 3, 4, 11 } },
-        { Position(1290.0f, 1480.0f, 347.5f, 0.0f), { 5, 7, 10, 12 } },
-        { Position(1198.0f, 1468.0f, 341.5f, 0.0f), { 6, 8, 11, 13 } },
-        { Position(1110.0f, 1452.0f, 338.5f, 0.0f), { 6, 9, 12, 14 } },
-        { Position(1020.0f, 1442.0f, 338.5f, 0.0f), { 13, 15, 16 } },
-        { Position(965.0f, 1437.0f, 343.0f, 0.0f), { 14, 17 } },
-        { Position(1006.0f, 1415.0f, 341.0f, 0.0f), { 14, 18 } },
-        { Position(934.0f, 1434.0f, 345.2f, 0.0f), { 15, 19 } },      // Horde ramp
-        { Position(944.0f, 1410.0f, 345.0f, 0.0f), { 16, 19 } },      // Horde tunnel
-        { Position(916.0f, 1434.4f, 345.4f, 0.0f), { 17, 18 } }       // Horde flag room
-    };
-
-    return graph;
-}
-
-uint32 FindClosestGraphNode(std::vector<WsgBattlePathNode> const& graph, Position const& origin)
-{
-    uint32 closestIndex = 0;
-    float closestDistance = std::numeric_limits<float>::max();
-
-    for (uint32 i = 0; i < graph.size(); ++i)
-    {
-        float const dx = graph[i].point.GetPositionX() - origin.GetPositionX();
-        float const dy = graph[i].point.GetPositionY() - origin.GetPositionY();
-        float const dz = graph[i].point.GetPositionZ() - origin.GetPositionZ();
-        float const distSq = dx * dx + dy * dy + dz * dz;
-        if (distSq < closestDistance)
-        {
-            closestDistance = distSq;
-            closestIndex = i;
-        }
-    }
-
-    return closestIndex;
-}
-
-bool TryBuildWarsongGraphPath(uint32 startNode, uint32 goalNode, std::vector<uint32>& pathOut)
-{
-    std::vector<WsgBattlePathNode> const& graph = GetWarsongBattlePathGraph();
-    if (startNode >= graph.size() || goalNode >= graph.size())
-        return false;
-
-    std::vector<float> bestDistance(graph.size(), std::numeric_limits<float>::max());
-    std::vector<int32> previous(graph.size(), -1);
-
-    using QueueEntry = std::pair<float, uint32>;
-    std::priority_queue<QueueEntry, std::vector<QueueEntry>, std::greater<QueueEntry>> queue;
-    bestDistance[startNode] = 0.0f;
-    queue.push({ 0.0f, startNode });
-
-    while (!queue.empty())
-    {
-        QueueEntry const current = queue.top();
-        queue.pop();
-
-        float const distanceSoFar = current.first;
-        uint32 const node = current.second;
-        if (distanceSoFar > bestDistance[node])
-            continue;
-
-        if (node == goalNode)
-            break;
-
-        Position const& nodePos = graph[node].point;
-        for (uint32 neighbor : graph[node].neighbors)
-        {
-            if (neighbor >= graph.size())
-                continue;
-
-            Position const& neighborPos = graph[neighbor].point;
-            float const edgeWeight = nodePos.GetExactDist(neighborPos);
-            float const candidateDistance = distanceSoFar + edgeWeight;
-            if (candidateDistance < bestDistance[neighbor])
-            {
-                bestDistance[neighbor] = candidateDistance;
-                previous[neighbor] = static_cast<int32>(node);
-                queue.push({ candidateDistance, neighbor });
-            }
-        }
-    }
-
-    if (bestDistance[goalNode] == std::numeric_limits<float>::max())
-        return false;
-
-    pathOut.clear();
-    for (int32 node = static_cast<int32>(goalNode); node >= 0; node = previous[node])
-        pathOut.push_back(static_cast<uint32>(node));
-
-    std::reverse(pathOut.begin(), pathOut.end());
-    return !pathOut.empty();
-}
-
-bool TryGetWarsongLaneWaypoint(Player* player, Position const& finalDestination, Position& waypointOut)
-{
-    if (!player || !IsWarsongGulch(player))
-        return false;
-
-    std::vector<WsgBattlePathNode> const& graph = GetWarsongBattlePathGraph();
-    if (graph.empty())
-        return false;
-
-    Position origin(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetOrientation());
-    uint32 const startNode = FindClosestGraphNode(graph, origin);
-    uint32 const goalNode = FindClosestGraphNode(graph, finalDestination);
-
-    std::vector<uint32> path;
-    if (!TryBuildWarsongGraphPath(startNode, goalNode, path))
-        return false;
-
-    uint32 nextNode = path.front();
-    if (path.size() > 1)
-        nextNode = path[1];
-
-    waypointOut = graph[nextNode].point;
-    return true;
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
@@ -361,8 +207,6 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     struct MoveOrderState
     {
         Position lastDestination;
-        Position lastPosition;
-        uint32 lastProgressMs = 0;
         uint32 lastIssueMs = 0;
     };
 
@@ -370,232 +214,27 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     MoveOrderState& state = stateByGuid[player->GetGUID().GetRawValue()];
     uint32 const nowMs = GameTime::GetGameTimeMS();
 
-    Position const currentPosition(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetOrientation());
-    if (state.lastProgressMs == 0 || state.lastPosition.GetExactDist(currentPosition) > 1.5f)
-    {
-        state.lastPosition = currentPosition;
-        state.lastProgressMs = nowMs;
-    }
-
-    bool const movementStalled = state.lastProgressMs != 0 && (nowMs - state.lastProgressMs) > 3500;
-
     bool const destinationChanged = state.lastIssueMs == 0 ||
         state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
-    if (!destinationChanged && !canReissueByTime && !movementStalled)
+    if (!destinationChanged && !canReissueByTime)
     {
-        std::ostringstream throttledDetail;
-        throttledDetail << "movepoint-skip reason=throttle"
-                        << " curr=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
-                        << " dest=(" << int32(destination.GetPositionX()) << "," << int32(destination.GetPositionY()) << "," << int32(destination.GetPositionZ()) << ")"
-                        << " lastIssuedMsAgo=" << (nowMs - state.lastIssueMs);
-        EmitBattlegroundGmDebug(player, throttledDetail.str(), 2000);
         return false;
-    }
-
-    if (movementStalled)
-    {
-        std::ostringstream stalledDetail;
-        stalledDetail << "movepoint-force-reissue reason=stalled"
-                      << " stalledMs=" << (nowMs - state.lastProgressMs);
-        EmitBattlegroundGmDebug(player, stalledDetail.str(), 1200);
     }
 
     MotionMaster* motionMaster = player->GetMotionMaster();
     MovementGeneratorType const currentMovement = motionMaster->GetCurrentMovementGeneratorType();
-    if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE || movementStalled)
+    if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)
     {
-        std::ostringstream overrideDetail;
-        overrideDetail << "movement generator override before MovePoint type=" << static_cast<uint32>(currentMovement);
-        EmitBattlegroundGmDebug(player, overrideDetail.str(), 5000);
         motionMaster->Clear();
-        if (movementStalled)
-            player->StopMoving();
     }
 
-    bool generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
-    bool usedDirectLosFallback = false;
-    bool usedLaneGraphFallback = false;
+    bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
 
-    Position issuedDestination = destination;
-    if (IsWarsongGulch(player))
-    {
-        // Keep WSG movement path-safe for managed virtual bots: evaluate probes and
-        // reject unsafe navmesh modes early.
-        auto evaluatePath = [player](Position const& candidate, PathType& pathTypeOut, bool& calculateOkOut) -> bool
-        {
-            PathGenerator path(player);
-            calculateOkOut = path.CalculatePath(candidate.GetPositionX(), candidate.GetPositionY(), candidate.GetPositionZ(), false);
-            if (!calculateOkOut)
-            {
-                pathTypeOut = PATHFIND_NOPATH;
-                return true;
-            }
-
-            pathTypeOut = path.GetPathType();
-            if (pathTypeOut & PATHFIND_NOPATH)
-                return true;
-
-            return pathTypeOut & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT);
-        };
-
-        float const directDistance = player->GetDistance(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
-        constexpr float maxStepDistance = 45.0f;
-        if (directDistance > maxStepDistance)
-        {
-            // Prefer a graph waypoint when long direct probes are likely to cross
-            // navmesh trouble spots (tunnel/ramp transitions).
-            Position graphWaypoint;
-            if (TryGetWarsongLaneWaypoint(player, destination, graphWaypoint))
-            {
-                PathType graphPathType = PATHFIND_BLANK;
-                bool graphCalculated = false;
-                if (!evaluatePath(graphWaypoint, graphPathType, graphCalculated))
-                {
-                    issuedDestination = graphWaypoint;
-                    usedLaneGraphFallback = true;
-                    std::ostringstream laneGraphDetail;
-                    laneGraphDetail << "wsg-graph-step-selected"
-                                    << " pathType=" << uint32(graphPathType)
-                                    << " calc=" << (graphCalculated ? 1 : 0);
-                    EmitBattlegroundGmDebug(player, laneGraphDetail.str(), 1500);
-                }
-            }
-
-            if (!usedLaneGraphFallback)
-            {
-                float const ratio = maxStepDistance / directDistance;
-                issuedDestination.Relocate(
-                    player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
-                    player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
-                    player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
-                    player->GetOrientation());
-            }
-        }
-
-        PathType issuedPathType = PATHFIND_BLANK;
-        bool issuedCalculated = false;
-        bool unsafeIssuedPath = evaluatePath(issuedDestination, issuedPathType, issuedCalculated);
-        if (unsafeIssuedPath)
-        {
-            constexpr float fallbackSteps[] = { 32.0f, 24.0f, 16.0f, 10.0f };
-            bool foundSafeCandidate = false;
-            for (float stepDistance : fallbackSteps)
-            {
-                if (directDistance <= stepDistance)
-                    continue;
-
-                float const ratio = stepDistance / directDistance;
-                Position candidate(
-                    player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
-                    player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
-                    player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
-                    player->GetOrientation());
-
-                PathType candidatePathType = PATHFIND_BLANK;
-                bool candidateCalculated = false;
-                if (!evaluatePath(candidate, candidatePathType, candidateCalculated))
-                {
-                    issuedDestination = candidate;
-                    foundSafeCandidate = true;
-                    std::ostringstream safeStepDetail;
-                    safeStepDetail << "wsg-step-selected step=" << int32(stepDistance)
-                                   << " pathType=" << uint32(candidatePathType)
-                                   << " calc=" << (candidateCalculated ? 1 : 0);
-                    EmitBattlegroundGmDebug(player, safeStepDetail.str(), 1500);
-                    break;
-                }
-            }
-
-            if (!foundSafeCandidate)
-            {
-                Position laneWaypoint;
-                if (TryGetWarsongLaneWaypoint(player, destination, laneWaypoint))
-                {
-                    PathType lanePathType = PATHFIND_BLANK;
-                    bool laneCalculated = false;
-                    if (!evaluatePath(laneWaypoint, lanePathType, laneCalculated))
-                    {
-                        issuedDestination = laneWaypoint;
-                        foundSafeCandidate = true;
-                        usedLaneGraphFallback = true;
-                        std::ostringstream laneSafeDetail;
-                        laneSafeDetail << "wsg-graph-fallback-selected"
-                                       << " pathType=" << uint32(lanePathType)
-                                       << " calc=" << (laneCalculated ? 1 : 0);
-                        EmitBattlegroundGmDebug(player, laneSafeDetail.str(), 1500);
-                    }
-                }
-            }
-
-            if (!foundSafeCandidate)
-            {
-                std::ostringstream unsafeDetail;
-                unsafeDetail << "wsg-step-unsafe-all-candidates"
-                             << " directDist=" << int32(directDistance)
-                             << " issuedPathType=" << uint32(issuedPathType)
-                             << " calc=" << (issuedCalculated ? 1 : 0);
-                EmitBattlegroundGmDebug(player, unsafeDetail.str(), 1500);
-
-                // Final troubleshooting fallback: take a tiny direct-Los step so
-                // bots don't deadlock when navmesh flags all short probes unsafe.
-                float const emergencyStepDistance = std::min(8.0f, directDistance);
-                if (emergencyStepDistance > 0.0f)
-                {
-                    float const ratio = emergencyStepDistance / directDistance;
-                    Position emergencyDestination(
-                        player->GetPositionX() + (destination.GetPositionX() - player->GetPositionX()) * ratio,
-                        player->GetPositionY() + (destination.GetPositionY() - player->GetPositionY()) * ratio,
-                        player->GetPositionZ() + (destination.GetPositionZ() - player->GetPositionZ()) * ratio,
-                        player->GetOrientation());
-
-                    if (player->IsWithinLOS(emergencyDestination.GetPositionX(), emergencyDestination.GetPositionY(), emergencyDestination.GetPositionZ()))
-                    {
-                        issuedDestination = emergencyDestination;
-                        generatePath = false;
-                        usedDirectLosFallback = true;
-                        EmitBattlegroundGmDebug(player, "wsg-step-direct-los-fallback enabled", 1500);
-                    }
-                }
-            }
-        }
-    }
-
-    std::ostringstream moveDetail;
-    if (IsWarsongGulch(player) &&
-        !player->IsWithinLOS(issuedDestination.GetPositionX(), issuedDestination.GetPositionY(), issuedDestination.GetPositionZ()))
-    {
-        Position laneWaypoint;
-        if (TryGetWarsongLaneWaypoint(player, destination, laneWaypoint))
-        {
-            issuedDestination = laneWaypoint;
-            generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
-            usedLaneGraphFallback = true;
-            EmitBattlegroundGmDebug(player, "movepoint-lane-fallback reason=no-los-to-issued-destination", 1500);
-        }
-        else if (usedDirectLosFallback)
-        {
-            EmitBattlegroundGmDebug(player, "movepoint-skip reason=no-los-to-issued-destination", 1500);
-            return false;
-        }
-        else
-        {
-            EmitBattlegroundGmDebug(player, "movepoint-continue reason=no-los-and-no-lane-waypoint", 1500);
-        }
-    }
-
-    moveDetail << "movepoint-issue"
-               << " from=(" << int32(player->GetPositionX()) << "," << int32(player->GetPositionY()) << "," << int32(player->GetPositionZ()) << ")"
-               << " to=(" << int32(issuedDestination.GetPositionX()) << "," << int32(issuedDestination.GetPositionY()) << "," << int32(issuedDestination.GetPositionZ()) << ")"
-               << " movementType=" << static_cast<uint32>(currentMovement)
-               << " generatePath=" << (generatePath ? 1 : 0)
-               << " laneFallback=" << (usedLaneGraphFallback ? 1 : 0)
-               << " losFallback=" << (usedDirectLosFallback ? 1 : 0);
-    EmitBattlegroundGmDebug(player, moveDetail.str(), 2000);
-
-    // Reference-module parity: issue MovePoint directly and let MotionMaster handle path generation.
-    motionMaster->MovePoint(0, issuedDestination, generatePath);
-    state.lastDestination = issuedDestination;
+    // Reference parity: issue movement directly to resolved objective/start targets.
+    // Let core pathing own corridor/tunnel traversal instead of script-layer lane steering.
+    motionMaster->MovePoint(0, destination, generatePath);
+    state.lastDestination = destination;
     state.lastIssueMs = nowMs;
     return true;
 }
@@ -1268,10 +907,12 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
     if (!battleground || !player)
         return false;
 
-    // WSG needs deterministic cross-map intent; base anchors can be missing or
-    // locally-biased in sparse managed-bot matches, which leaves bots stalling.
-    if (TryGetWarsongEnemyBasePosition(player, destination))
+    if (IsWarsongGulch(player))
     {
+        TeamId const botTeam = ResolveBotTeamId(player);
+        Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
+        Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
+        destination = (botTeam == TEAM_ALLIANCE) ? hordeFlagStand : allianceFlagStand;
         ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
@@ -1293,25 +934,6 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
     if (Position const* enemyStart = battleground->GetTeamStartPosition(Battleground::GetTeamIndexByTeamId(enemyTeam)))
     {
         destination = Position(*enemyStart);
-        ApplyDeterministicObjectiveOffset(battleground, player, destination);
-        return true;
-    }
-
-    // Fallback for sparse/invalid start-anchor states:
-    // WSG bots can otherwise idle in their own base graveyard when no objective
-    // anchor is resolved from battleground starts.
-    if (battleground->GetMapId() == 489) // Warsong Gulch
-    {
-        Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
-        Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
-
-        if (botTeam == TEAM_ALLIANCE)
-            destination = hordeFlagStand;
-        else if (botTeam == TEAM_HORDE)
-            destination = allianceFlagStand;
-        else
-            destination = hordeFlagStand;
-
         ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }
@@ -1432,43 +1054,9 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
         player->RemoveUnitFlag(UNIT_FLAG_PREPARATION);
     }
 
-    // Keep managed bots moving even when tactical decision hooks are disabled
-    // or when another behavior tree branch (e.g. buffing) wins the current tick.
-    // This prevents "stand still at gate-open" stalls in active battlegrounds.
-    if (!CanIssueBotMovement(player))
-    {
-        std::ostringstream blockedReason;
-        blockedReason << "movement-blocked alive=" << (player->IsAlive() ? 1 : 0)
-                      << " ghost=" << (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST) ? 1 : 0)
-                      << " rooted=" << (player->HasUnitState(UNIT_STATE_ROOT) ? 1 : 0)
-                      << " stunned=" << (player->HasUnitState(UNIT_STATE_STUNNED) ? 1 : 0);
-        EmitBattlegroundGmDebug(player, blockedReason.str());
-        return true;
-    }
-
-    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 65.0f;
-    if (EngageNearestEnemyPlayer(player, engageDistance))
-        return true;
-
-    if (Battleground* battleground = player->GetBattleground())
-    {
-        Position destination;
-        if (TryGetObjectivePosition(battleground, player, destination))
-        {
-            bool const withinObjectiveRange = player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f);
-            if (!withinObjectiveRange)
-                IssueMovePointThrottled(player, destination);
-            else
-                EmitBattlegroundGmDebug(player, "objective-skip reason=already-near-objective range=12");
-            return true;
-        }
-    }
-
-    if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
-
-    EmitBattlegroundGmDebug(player, "no enemy target and no objective position resolved");
-    return true;
+    // Reference module parity: in-progress movement/combat are handled by
+    // tactical actions (move to objective / check objective), not lifecycle.
+    return false;
 }
 
 bool BattlegroundTacticalActions::Execute(Player* player, BattlegroundTacticalContext const& context)
@@ -1478,6 +1066,18 @@ bool BattlegroundTacticalActions::Execute(Player* player, BattlegroundTacticalCo
 
     if (!player->IsAlive())
         return false;
+
+    if (Battleground* battleground = player->GetBattleground())
+    {
+        // During prep phase only process the explicit start-position action.
+        // This prevents competing tactical actions from pulling bots back/forth.
+        if (battleground->GetStatus() == STATUS_WAIT_JOIN)
+        {
+            if (IsTacticalAction(context.actionName, "bg move to start"))
+                return MoveToStartPrimitive(player);
+            return false;
+        }
+    }
 
     if (IsTacticalAction(context.actionName, "bg move to start"))
         return MoveToStartPrimitive(player);
@@ -1502,26 +1102,83 @@ bool BattlegroundTacticalActions::MoveToStartPrimitive(Player* player)
     if (!player || !player->InBattleground())
         return false;
 
-    if (Battleground* battleground = player->GetBattleground())
-        return battleground->GetStatus() == STATUS_WAIT_JOIN;
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground || battleground->GetStatus() != STATUS_WAIT_JOIN)
+        return false;
 
-    return false;
+    uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
+    TeamId const teamId = ResolveTeamId(assignedTeam ? assignedTeam : player->GetBGTeam());
+    TeamId const startTeam = (teamId == TEAM_NEUTRAL) ? player->GetTeamId() : teamId;
+    Position const* start = battleground->GetTeamStartPosition(startTeam);
+    if (!start)
+        return false;
+
+    Position destination;
+    if (IsWarsongGulch(player))
+    {
+        Position const wsHorde1(944.981f, 1423.478f, 345.434f, 6.18f);
+        Position const wsHorde2(948.488f, 1459.834f, 343.066f, 6.27f);
+        Position const wsHorde3(933.484f, 1433.726f, 345.535f, 0.08f);
+        Position const wsAlliance1(1510.502f, 1493.385f, 351.995f, 3.1f);
+        Position const wsAlliance2(1496.578f, 1457.900f, 344.442f, 3.1f);
+        Position const wsAlliance3(1521.235f, 1480.951f, 352.007f, 3.2f);
+
+        uint32 const role = uint32(player->GetGUID().GetRawValue() % 10);
+        Position const base = (startTeam == TEAM_HORDE)
+            ? ((role < 4) ? wsHorde2 : (role > 6 ? wsHorde1 : wsHorde3))
+            : ((role < 4) ? wsAlliance2 : (role > 6 ? wsAlliance1 : wsAlliance3));
+        float const spread = (role < 4 || role > 6) ? 4.0f : 10.0f;
+        destination.Relocate(
+            base.GetPositionX() + frand(-spread, spread),
+            base.GetPositionY() + frand(-spread, spread),
+            base.GetPositionZ(),
+            base.GetOrientation());
+    }
+    else
+    {
+        destination = *start;
+        destination.Relocate(
+            start->GetPositionX() + frand(-7.0f, 7.0f),
+            start->GetPositionY() + frand(-7.0f, 7.0f),
+            start->GetPositionZ(),
+            start->GetOrientation());
+    }
+
+    IssueMovePointThrottled(player, destination, 2.5f, 800);
+
+    return true;
 }
 
 bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context)
 {
     if (!player || !player->InBattleground())
         return false;
+
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground || battleground->GetStatus() == STATUS_WAIT_JOIN)
+        return false;
+
     if (!CanIssueBotMovement(player))
         return false;
 
-    bool const teamHasHumans = PvpCore::TeamHasHumanPlayers(player);
-    if (teamHasHumans && TryReturnDroppedFriendlyFlagWithHumanPriority(player))
-        return true;
+    if (player->isMoving())
+        return false;
 
-    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 80.0f;
-    if (EngageNearestEnemyPlayer(player, engageDistance))
-        return true;
+    if (!player->IsStopped())
+        return false;
+
+    switch (player->GetMotionMaster()->GetCurrentMovementGeneratorType())
+    {
+        case IDLE_MOTION_TYPE:
+        case CHASE_MOTION_TYPE:
+        case POINT_MOTION_TYPE:
+            break;
+        default:
+            return true;
+    }
+
+    if (player->IsInCombat())
+        return false;
 
     if (context.objective.type == BattlegroundObjectiveType::None &&
         context.movement == BattlegroundMovementPrimitive::None &&
@@ -1548,7 +1205,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
 
     if (context.movement == BattlegroundMovementPrimitive::MoveToObjectivePosition)
     {
-        if (Battleground* battleground = player->GetBattleground())
+        if (battleground)
         {
             Position destination;
             if (TryGetObjectivePosition(battleground, player, destination))
@@ -1561,34 +1218,11 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
                 return true;
             }
 
-            // WSG can enter sparse states where objective anchors are unavailable.
-            // In those windows, force a large-radius enemy scan before falling
-            // back to local graveyard movement so bots keep crossing the map.
-            if (EngageNearestEnemyPlayer(player, 2000.0f))
-                return true;
-
-            if (WorldSafeLocsEntry const* graveyard = battleground->GetClosestGraveyard(player))
-            {
-                Position destination(graveyard->Loc.X, graveyard->Loc.Y, graveyard->Loc.Z, player->GetOrientation());
-                if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
-                    IssueMovePointThrottled(player, destination);
-                return true;
-            }
+            return false;
         }
     }
 
-    bool const fallbackEngage = EngageNearestEnemyPlayer(player, 55.0f);
-    if (!fallbackEngage)
-    {
-        if (IsWarsongGulch(player))
-            return MoveToClosestBattlegroundGraveyard(player);
-
-        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP movement skipped: bot={} reason=no-objective-movement-and-no-fallback-target.",
-            player->GetGUID().ToString());
-    }
-
-    return fallbackEngage;
+    return false;
 }
 
 bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -71,60 +71,6 @@ std::mutex g_RandomBotLifecycleCadenceLock;
 std::unordered_set<uint64> g_StartupRevivedManagedBotGuids;
 std::mutex g_StartupReviveLock;
 bool g_StartupRevivePending = false;
-std::unordered_map<uint64, std::pair<Position, uint32>> g_FastTickMotionByGuid;
-std::unordered_map<uint64, uint8> g_FastTickStallAttemptsByGuid;
-std::mutex g_FastTickMotionLock;
-
-bool TryForceWarsongAdvanceMove(Player* player)
-{
-    if (!player || !player->InBattleground())
-        return false;
-
-    Battleground* battleground = player->GetBattleground();
-    if (!battleground || battleground->GetMapId() != 489 || battleground->GetStatus() != STATUS_IN_PROGRESS)
-        return false;
-
-    uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
-    Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
-    Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
-
-    Position destination = (assignedTeam == HORDE) ? allianceFlagStand : hordeFlagStand;
-    float const dist = player->GetDistance(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
-    if (dist < 18.0f)
-        destination = (assignedTeam == HORDE) ? Position(1410.0f, 1470.0f, 349.5f, 0.0f) : Position(1020.0f, 1442.0f, 338.5f, 0.0f);
-
-    player->GetMotionMaster()->Clear();
-    player->GetMotionMaster()->MovePoint(0, destination, false);
-    return true;
-}
-
-bool TryNudgeWarsongStalledBot(Player* player)
-{
-    if (!player || !player->InBattleground())
-        return false;
-
-    Battleground* battleground = player->GetBattleground();
-    if (!battleground || battleground->GetMapId() != 489 || battleground->GetStatus() != STATUS_IN_PROGRESS)
-        return false;
-
-    uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
-    Position const allianceMid(1260.0f, 1456.0f, 342.5f, 0.0f);
-    Position const hordeMid(1198.0f, 1468.0f, 341.5f, 0.0f);
-    Position const target = (assignedTeam == HORDE) ? allianceMid : hordeMid;
-
-    float const distance = player->GetDistance(target.GetPositionX(), target.GetPositionY(), target.GetPositionZ());
-    if (distance < 3.0f)
-        return false;
-
-    float const step = std::min(12.0f, distance);
-    float const ratio = step / distance;
-    Position nudged(player->GetPositionX() + (target.GetPositionX() - player->GetPositionX()) * ratio,
-                    player->GetPositionY() + (target.GetPositionY() - player->GetPositionY()) * ratio,
-                    player->GetPositionZ() + (target.GetPositionZ() - player->GetPositionZ()) * ratio,
-                    player->GetOrientation());
-
-    return player->UpdatePosition(nudged, true);
-}
 
 void EmitLifecycleGmDebug(Player const* player, std::string const& detail, uint32 throttleMs = 5000)
 {
@@ -395,52 +341,6 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     inProgressContext.shouldHandleInProgressStatus = true;
     bool const didExecuteLifecycle = playerbot::BattlegroundLifecycleActions::Execute(player, inProgressContext);
 
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-    uint64 const botGuid = player->GetGUID().GetRawValue();
-    Position const currentPosition(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetOrientation());
-    bool movementStalled = false;
-    {
-        std::lock_guard<std::mutex> motionLock(g_FastTickMotionLock);
-        auto& progressState = g_FastTickMotionByGuid[botGuid];
-        if (progressState.second == 0 || progressState.first.GetExactDist(currentPosition) > 3.0f)
-        {
-            progressState.first = currentPosition;
-            progressState.second = nowMs;
-        }
-
-        movementStalled = progressState.second != 0 && (nowMs - progressState.second) > 4500;
-    }
-    bool didForceObjectiveMove = false;
-    if (movementStalled && !player->IsInCombat() &&
-        !player->HasUnitState(UNIT_STATE_ROOT) && !player->HasUnitState(UNIT_STATE_STUNNED))
-    {
-        didForceObjectiveMove = playerbot::BattlegroundTacticalActions::MoveToObjectivePrimitive(player, tacticalContext);
-        if (!didForceObjectiveMove)
-            didForceObjectiveMove = playerbot::BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(player);
-        if (!didForceObjectiveMove)
-            didForceObjectiveMove = TryForceWarsongAdvanceMove(player);
-
-        uint8 stallAttempts = 0;
-        {
-            std::lock_guard<std::mutex> motionLock(g_FastTickMotionLock);
-            uint8& attemptRef = g_FastTickStallAttemptsByGuid[botGuid];
-            attemptRef = std::min<uint8>(attemptRef + 1, 10);
-            stallAttempts = attemptRef;
-        }
-
-        if (stallAttempts >= 3 && TryNudgeWarsongStalledBot(player))
-        {
-            didForceObjectiveMove = true;
-            std::lock_guard<std::mutex> motionLock(g_FastTickMotionLock);
-            g_FastTickStallAttemptsByGuid[botGuid] = 0;
-        }
-    }
-    else
-    {
-        std::lock_guard<std::mutex> motionLock(g_FastTickMotionLock);
-        g_FastTickStallAttemptsByGuid[botGuid] = 0;
-    }
-
     std::ostringstream tickDetail;
     uint32 const bgTeam = player->GetBGTeam();
     uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
@@ -449,8 +349,6 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
                << " alive=" << (player->IsAlive() ? 1 : 0)
                << " rooted=" << (player->HasUnitState(UNIT_STATE_ROOT) ? 1 : 0)
                << " stunned=" << (player->HasUnitState(UNIT_STATE_STUNNED) ? 1 : 0)
-               << " stalled=" << (movementStalled ? 1 : 0)
-               << " forceMove=" << (didForceObjectiveMove ? 1 : 0)
                << " bgTeam=" << bgTeam
                << " assignedTeam=" << assignedTeam
                << " x=" << int32(player->GetPositionX())
@@ -1078,9 +976,6 @@ void RandomBotParticipationManager::OnPlayerLogout(Player const* player)
 
     std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
     g_NextRandomBotLifecycleProcessTimeByGuid.erase(player->GetGUID().GetRawValue());
-    std::lock_guard<std::mutex> motionLock(g_FastTickMotionLock);
-    g_FastTickMotionByGuid.erase(player->GetGUID().GetRawValue());
-    g_FastTickStallAttemptsByGuid.erase(player->GetGUID().GetRawValue());
 }
 
 void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)


### PR DESCRIPTION
### Motivation

- Reduce brittle, script-layer Warsong Gulch (WSG) lane-steering and emergency fallbacks which duplicated core pathing and caused stalls or complex heuristics.  
- Shift movement responsibilities to tactical actions and core pathing to improve parity with reference behavior and reduce lifecycle/tactical overlap.  
- Remove fast-tick stall detection and nudging logic that forced movement from the lifecycle manager.  

### Description

- Removed WSG-specific path graph, pathfinder probes, multi-step fallbacks, direct-LOS emergency steps, and related helpers, and eliminated the `PathGenerator` include.  
- Simplified `IssueMovePointThrottled` to always issue a direct `MovePoint` to the resolved target and removed movement-stalled logic, forced motion overrides, and many debug fallbacks.  
- Consolidated WSG objective resolution into `TryGetObjectivePosition` (inline check for WSG and deterministic base anchor) and removed separate lane/graph functions.  
- Reworked lifecycle vs tactical responsibilities: `HandleInProgressStatusPrimitive` now defers to tactical modules (returns false), and `BattlegroundTacticalActions` now gates prep-phase start movement and implements `MoveToStartPrimitive` with deterministic WSG start placements and spread.  
- Simplified `MoveToObjectivePrimitive` and other tactical primitives to add stricter preconditions (movement generator/state checks, prep-phase gating, combat checks) and removed many fallback behaviors (large enemy scans, graveyard nudges).  
- Removed fast-tick motion tracking, stall attempt counters, `TryForceWarsongAdvanceMove`, and `TryNudgeWarsongStalledBot` from the random-bot participation manager and updated fast-tick debug output accordingly.  

### Testing

- Built the server (project build) after the change using the usual build system and verify the build succeeds.  
- Ran the repository test suite / `ctest` where available and confirmed the tests completed without regressions.  
- Executed the Playerbot PvP tactical/lifecycle fast-tick path (automated lifecycle tick) to ensure no crashes and that bots continue to receive movement orders (observed via existing debug hooks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5dfa2dd948327afd709dd2479b205)