### PR TITLE
Prevent playerbot direct-heal spam on full-health targets

### DIFF
--- a/playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/GenericSpellActions.cpp
+++ b/playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/GenericSpellActions.cpp
@@ -209,7 +209,14 @@ CastHealingSpellAction::CastHealingSpellAction(PlayerbotAI* botAI, std::string c
     range = botAI->GetRange("heal");
 }
 
-bool CastHealingSpellAction::isUseful() { return CastAuraSpellAction::isUseful(); }
+bool CastHealingSpellAction::isUseful()
+{
+    Unit* target = GetTarget();
+    if (!target || target->IsFullHealth())
+        return false;
+
+    return CastSpellAction::isUseful();
+}
 
 bool CastAoeHealSpellAction::isUseful() { return CastSpellAction::isUseful(); }
 


### PR DESCRIPTION
### Motivation
- Player healer bots (priests) were repeatedly casting instant direct heals (e.g. `flash heal`) on themselves at full HP because the previous usefulness check relied on aura-based logic that does not apply to direct heals.

### Description
- Updated `CastHealingSpellAction::isUseful()` in `playerbot reference/mod-playerbots-master/src/Ai/Base/Actions/GenericSpellActions.cpp` to early-return `false` when `GetTarget()` is null or `GetTarget()->IsFullHealth()`.
- Switched the usefulness fallback for direct heals to call `CastSpellAction::isUseful()` instead of `CastAuraSpellAction::isUseful()`, so direct heals are evaluated by general cast conditions rather than aura presence.
- Left AoE/heal-party checks unchanged by keeping `CastAoeHealSpellAction::isUseful()` as `CastSpellAction::isUseful()`.

### Testing
- Ran `cmake --build build --target worldserver -j 2`, which configured and started a build successfully but was not waited to full completion in this environment (progress observed). 
- Attempted a targeted `ninja` invocation for the specific object file, which failed because that exact target name is not present in the generated build graph. 
- Source change compiled as part of the in-progress build session and the modified file was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c2e3caac8327ae748f2ce2e3f788)