### PR TITLE
Fix Warsong playerbot resurrection and graveyard movement behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -227,6 +227,51 @@ bool MoveToClosestBattlegroundGraveyard(Player* player)
     return false;
 }
 
+bool TryJumpOffWarsongGraveyard(Player* player)
+{
+    if (!player || !player->IsAlive() || !IsWarsongGulch(player) || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
+        return false;
+
+    struct JumpRoute
+    {
+        Position launch;
+        Position landing;
+    };
+
+    static std::array<JumpRoute, 2> const routes =
+    {{
+        { Position(957.20f, 1424.40f, 345.48f, 0.0f), Position(978.20f, 1427.10f, 335.20f, 0.0f) },      // Horde GY -> field
+        { Position(1517.60f, 1485.30f, 352.00f, 0.0f), Position(1498.60f, 1484.30f, 340.20f, 0.0f) }      // Alliance GY -> field
+    }};
+
+    float nearestDist = std::numeric_limits<float>::max();
+    JumpRoute const* nearest = nullptr;
+    for (JumpRoute const& route : routes)
+    {
+        float const dist = player->GetDistance(route.launch.GetPositionX(), route.launch.GetPositionY(), route.launch.GetPositionZ());
+        if (dist < nearestDist)
+        {
+            nearestDist = dist;
+            nearest = &route;
+        }
+    }
+
+    if (!nearest || nearestDist > 22.0f)
+        return false;
+
+    if (!player->IsWithinDist3d(nearest->launch.GetPositionX(), nearest->launch.GetPositionY(), nearest->launch.GetPositionZ(), 3.5f))
+    {
+        IssueMovePointThrottled(player, nearest->launch, 1.5f, 500);
+        return true;
+    }
+
+    float const jumpSpeedXY = std::max(6.0f, player->GetSpeed(MOVE_RUN) * 1.1f);
+    float const jumpSpeedZ = 8.0f;
+    player->SetFacingTo(player->GetAngle(nearest->landing.GetPositionX(), nearest->landing.GetPositionY()));
+    player->JumpTo(jumpSpeedXY, jumpSpeedZ, false);
+    return true;
+}
+
 bool IsLifecycleGateEnabled()
 {
     playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
@@ -555,9 +600,6 @@ bool HandleBattlegroundDeathState(Player* player)
 
     if (!player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
     {
-        if (player->getDeathState() == JUST_DIED)
-            player->KillPlayer();
-
         player->BuildPlayerRepop();
         player->RepopAtGraveyard();
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
@@ -566,6 +608,33 @@ bool HandleBattlegroundDeathState(Player* player)
         return true;
     }
 
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground)
+        return true;
+
+    if (battleground->IsPlayerInResurrectQueue(player->GetGUID()))
+        return true;
+
+    uint32 const spiritEntry = ResolveBotTeamId(player) == TEAM_ALLIANCE ? BG_CREATURE_ENTRY_A_SPIRITGUIDE : BG_CREATURE_ENTRY_H_SPIRITGUIDE;
+    if (!spiritEntry)
+        return true;
+
+    Creature* spiritGuide = player->FindNearestCreature(spiritEntry, 90.0f, false);
+    if (!spiritGuide)
+        return true;
+
+    if (!player->IsWithinDist3d(spiritGuide->GetPositionX(), spiritGuide->GetPositionY(), spiritGuide->GetPositionZ(), 8.0f))
+    {
+        Position destination(spiritGuide->GetPositionX(), spiritGuide->GetPositionY(), spiritGuide->GetPositionZ(), player->GetOrientation());
+        IssueMovePointThrottled(player, destination, 3.0f, 700);
+        return true;
+    }
+
+    battleground->AddPlayerToResurrectQueue(spiritGuide->GetGUID(), player->GetGUID());
+    sBattlegroundMgr->SendAreaSpiritHealerQueryOpcode(player, battleground, spiritGuide->GetGUID());
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP death handling: guid={} action=queue-resurrect spiritGuide={}.",
+        player->GetGUID().ToString(), spiritGuide->GetGUID().ToString());
     return true;
 }
 
@@ -1305,6 +1374,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
 
     if (player->IsInCombat())
         return EngageNearestEnemyPlayer(player, 80.0f);
+
+    if (TryJumpOffWarsongGraveyard(player))
+        return true;
 
     if (context.objective.type == BattlegroundObjectiveType::None &&
         context.movement == BattlegroundMovementPrimitive::None &&


### PR DESCRIPTION
### Motivation
- Playerbots in Warsong Gulch were failing to rez at spirit guides, exhibiting odd graveyard pathing (not jumping off cliffs naturally), and interfering with normal corpse/insignia flow.  
- The change aims to restore normal battleground resurrection/loot behavior and make graveyard exits look natural for bots.

### Description
- Stop forcing an extra `KillPlayer()` during immediate death handling and instead release spirit normally by using `BuildPlayerRepop()`/`RepopAtGraveyard()` (fixes corpse/insignia interaction).  
- Add ghost-phase spirit guide handling: ghosts will locate the nearest team spirit guide, move toward it, be queued via `AddPlayerToResurrectQueue()`, and trigger `SendAreaSpiritHealerQueryOpcode()` when in range.  
- Add `TryJumpOffWarsongGraveyard()` with faction-specific launch/landing anchors and a jump/facing sequence so alive bots leave the Warsong graveyard via natural jump routes.  
- Hook the new jump helper into `BattlegroundTacticalActions::MoveToObjectivePrimitive()` so Warsong graveyard jump behavior is evaluated before normal objective routing.

### Testing
- Started a full build with `cmake --build build --target worldserver -j4`; configuration and compilation began and progressed in this environment (long full rebuild).  
- Attempted a focused build for the modified script object with `ninja -C build ...PlayerbotPvpLifecycleActions.cpp.o`, which failed due to an unknown ninja target path (environment target discovery issue).  
- No automated unit tests were run; build attempts above are the automated validations performed and indicate compilation work started but a full verification build was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c3f8159c83278cdec8a4cb64cbbf)