### PR TITLE
Spells: make classic fear/shout/roar spells ignore miss

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -5007,6 +5007,21 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(5); // 40yd
     });
 
+    // Intimidating Shout / Demoralizing Shout / Demoralizing Roar / Psychic Scream (Classic ranks)
+    // should not miss hit checks (still can be resisted)
+    ApplySpellFix({
+        5246,                   // Intimidating Shout
+        1160, 6190, 11554,      // Demoralizing Shout (Ranks 1-3)
+        11555, 11556, 25202,    // Demoralizing Shout (Ranks 4-6)
+        25203,                  // Demoralizing Shout (Rank 7)
+        99, 1735, 9490,         // Demoralizing Roar (Ranks 1-3)
+        9747, 9898,             // Demoralizing Roar (Ranks 4-5)
+        8122, 8124, 10888, 10890// Psychic Scream (Ranks 1-4)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {
         SpellInfo* spellInfo = mSpellInfoMap[i];


### PR DESCRIPTION
### Motivation
- Ensure Classic-rank Intimidating Shout, Demoralizing Shout, Demoralizing Roar, and Psychic Scream do not fail on miss-style hit checks while keeping normal resist behaviour (they should still be resistible). 

### Description
- Added an `ApplySpellFix` block in `SpellMgr::LoadSpellInfoCorrections()` (file `src/server/game/Spells/SpellMgr.cpp`) that sets `AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT` for the classic ranks of Intimidating Shout (`5246`), Demoralizing Shout (`1160, 6190, 11554, 11555, 11556, 25202, 25203`), Demoralizing Roar (`99, 1735, 9490, 9747, 9898`), and Psychic Scream (`8122, 8124, 10888, 10890`).

### Testing
- Ran `git diff --check`, `git status --short`, and `git show --stat --oneline -1` to validate the patch format and commit, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c45ef88c83278bc0f9fcfe064b41)