### PR TITLE
Fix compile errors in Playerbot PvP lifecycle actions

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -28,6 +28,7 @@
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "CharacterCache.h"
+#include "Creature.h"
 #include "Chat.h"
 #include "Log.h"
 #include "Map.h"
@@ -38,6 +39,7 @@
 #include "ItemTemplate.h"
 #include "Player.h"
 #include "SpellMgr.h"
+#include "SpellInfo.h"
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
@@ -271,7 +273,7 @@ bool TryJumpOffWarsongGraveyard(Player* player)
 
     float const jumpSpeedXY = std::max(6.0f, player->GetSpeed(MOVE_RUN) * 1.1f);
     float const jumpSpeedZ = 8.0f;
-    player->SetFacingTo(player->GetAngle(nearest->landing.GetPositionX(), nearest->landing.GetPositionY()));
+    player->SetFacingTo(player->GetAbsoluteAngle(nearest->landing.GetPositionX(), nearest->landing.GetPositionY()));
     player->JumpTo(jumpSpeedXY, jumpSpeedZ, false);
     return true;
 }
@@ -1005,7 +1007,7 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
                 float const minAutoShotRange = autoShotInfo->GetMinRange(false);
                 float const maxAutoShotRange = autoShotInfo->GetMaxRange(false);
                 bool const canAutoShotWithoutDeadzone = distance > minAutoShotRange && distance <= maxAutoShotRange;
-                uint32 const autoShotTimerMs = player->GetAttackTimer(RANGED_ATTACK);
+                uint32 const autoShotTimerMs = player->getAttackTimer(RANGED_ATTACK);
                 if (canAutoShotWithoutDeadzone && autoShotTimerMs <= 600)
                 {
                     uint32 const pauseDurationMs = std::max<uint32>(autoShotTimerMs, 150);


### PR DESCRIPTION
### Motivation
- Resolve compiler errors caused by missing concrete type headers and incorrect member/function names used in the Playerbot PvP lifecycle script.
- Ensure the code uses the correct API available in this codebase so battleground/ghost handling and hunter auto-shot timing compile and work as intended.

### Description
- Added `#include "Creature.h"` to make `Creature` members available for spirit-guide handling in `PlayerbotPvpLifecycleActions.cpp`.
- Added `#include "SpellInfo.h"` so `SpellInfo` helpers like `GetMinRange`/`GetMaxRange` can be used without an incomplete-type error.
- Replaced the unavailable `player->GetAngle(...)` call with `player->GetAbsoluteAngle(...)` before calling `SetFacingTo(...)`.
- Replaced `player->GetAttackTimer(RANGED_ATTACK)` with the correct API `player->getAttackTimer(RANGED_ATTACK)`.
- Changes applied to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.

### Testing
- Verified symbol and usage changes with ripgrep using `rg "GetAngle\(|GetAttackTimer\(|#include \"Creature.h\"|#include \"SpellInfo.h\"|GetAbsoluteAngle\("` and confirmed the old usages were removed and new includes/identifiers present.
- Inspected the modified file with `nl -ba src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to confirm the new includes and replacements are in place; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c688c39083278a891d40d0705e6e)