### PR TITLE
Preserve playerbot movement destination across instant-cast jump-turn

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -204,6 +204,10 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
 
     ObjectGuid const casterGuid = player->GetGUID();
     ObjectGuid const targetGuid = target->GetGUID();
+    float destinationX = 0.0f;
+    float destinationY = 0.0f;
+    float destinationZ = 0.0f;
+    bool const hadDestination = player->GetMotionMaster()->GetDestination(destinationX, destinationY, destinationZ);
     player->SetFacingToObject(target);
     player->SetInFront(target);
 
@@ -213,7 +217,7 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
     float constexpr normalJumpSpeedZ = 7.95555f;
     player->JumpTo(jumpSpeedXY, normalJumpSpeedZ, false);
 
-    player->m_Events.AddEventAtOffset([casterGuid, targetGuid, resumeOrientation]()
+    player->m_Events.AddEventAtOffset([casterGuid, targetGuid, resumeOrientation, hadDestination, destinationX, destinationY, destinationZ]()
     {
         Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
         if (!caster || !caster->IsInWorld() || !caster->IsAlive())
@@ -222,8 +226,8 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
         caster->SetFacingTo(resumeOrientation);
 
         // JumpTo can leave virtual-session bots briefly idle after landing.
-        // Re-issue a short forward MovePoint on the pre-cast heading to
-        // preserve run-and-cast flow instead of stopping in place.
+        // If there was already an active destination before the jump, re-issue
+        // that same destination so the jump does not alter movement intent.
         if (caster->HasUnitState(UNIT_STATE_ROOT) || caster->HasUnitState(UNIT_STATE_STUNNED))
             return;
 
@@ -231,11 +235,11 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
         if (!resolvedTarget || !resolvedTarget->IsAlive())
             return;
 
-        float const stepDistance = std::max(8.0f, caster->GetSpeed(MOVE_RUN) * 1.35f);
-        Position destination(caster->GetPositionX() + std::cos(resumeOrientation) * stepDistance,
-            caster->GetPositionY() + std::sin(resumeOrientation) * stepDistance,
-            caster->GetPositionZ(), resumeOrientation);
-        caster->GetMotionMaster()->MovePoint(0, destination);
+        if (hadDestination)
+        {
+            Position destination(destinationX, destinationY, destinationZ, resumeOrientation);
+            caster->GetMotionMaster()->MovePoint(0, destination);
+        }
     }, 250ms);
 }
 


### PR DESCRIPTION
### Motivation
- Playerbot rogues could overshoot their intended path after the 180° jump-turn visual because the post-jump recovery always issued a new forward `MovePoint`, changing the bot's original movement intent.

### Description
- Capture the bot's active movement destination before performing the instant-cast jump via `MotionMaster::GetDestination` and record `hadDestination` plus coordinates.
- Replace the unconditional short forward `MovePoint` issued after the jump with a conditional re-issue of the original destination using `MovePoint(0, destination)` when `hadDestination` is true, while preserving the existing orientation restore and root/stun checks.

### Testing
- Ran `cmake --build build --target scripts -j4` to build the scripts; the build started and compiled script targets in this environment (build progress observed, environment output captured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c717b3e48327b347b54430bbc8d5)