### PR TITLE
Playerbot: restrict Curse of Tongues to true casters (exclude hunters/melee hybrids)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -354,6 +354,19 @@ bool IsCasterClass(Unit const* unit)
     }
 }
 
+bool ShouldUseCurseOfTongues(Unit const* unit)
+{
+    Player const* player = unit ? unit->ToPlayer() : nullptr;
+    if (!player)
+        return false;
+
+    // Curse of Tongues should focus on true caster targets and avoid hunters or melee hybrids.
+    if (player->GetClass() == CLASS_HUNTER)
+        return false;
+
+    return IsCasterClass(player) && !IsMeleeClass(player);
+}
+
 bool IsTargetInvalidByImmunity(Player const* player, Unit const* target);
 
 uint8 GetArmorPriority(Unit const* unit)
@@ -1426,7 +1439,7 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
     if (IsSpellReady(player, 6215))
         if (Unit const* fearTarget = SelectWarlockFearTarget(player, 20.0f))
             return { "warlock fear", "prioritize fear control on paladin/priest targets in range", 6215, playerbot::PvpClassSpellContext::TargetMode::Enemy, fearTarget->GetGUID() };
-    if (target->GetPowerType() == POWER_MANA && !HasAuraFromSpellChain(target, 11719) &&
+    if (target->GetPowerType() == POWER_MANA && ShouldUseCurseOfTongues(target) && !HasAuraFromSpellChain(target, 11719) &&
         !playerbot::PvpClassActions::IsWarlockCurseTargetCooldownActive(player, target, 11719) && IsSpellReady(player, 11719))
         return { "warlock curse of tongues", "slow enemy casting throughput", 11719, playerbot::PvpClassSpellContext::TargetMode::Enemy };
     if (!IsCasterClass(target) && !HasAuraFromSpellChain(target, 11713) && !HasAuraFromSpellChain(target, 11719) &&


### PR DESCRIPTION
### Motivation
- Demo warlock playerbots were casting `Curse of Tongues` on hunters and melee-oriented hybrid targets, which is suboptimal for PvP pressure allocation.
- The intent is to target true casters for `Curse of Tongues` while keeping `Curse of Agony` behavior for non-caster targets.

### Description
- Added a new helper `ShouldUseCurseOfTongues(Unit const* unit)` to encapsulate the target checks for `Curse of Tongues` usage.
- The helper explicitly excludes `CLASS_HUNTER` and returns `IsCasterClass(player) && !IsMeleeClass(player)` to avoid melee hybrids (including 2H shaman/paladin cases).
- Updated warlock PvP spell selection to require `ShouldUseCurseOfTongues(target)` before offering spell id `11719` (`Curse of Tongues`).

### Testing
- Ran repository diff/whitespace checks and no issues were reported.
- Performed a local repository consistency/status verification to confirm the change is present and isolated to `PlayerbotPvpCore.cpp`.
- Inspected the modified source to verify the new helper and the gate on `Curse of Tongues` were applied correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c806aebc83279182827781fffefa)