### PR TITLE
Mark Sweeping Strikes as not-removed-on-shapeshift so aura persists across stance changes

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3625,6 +3625,17 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Stances = UI64LIT(1) << (FORM_CAT - 1);
     });
 
+    // Sweeping Strikes should remain active after switching stances,
+    // but still only be castable in its original required stance.
+    ApplySpellFix({
+        12328, // Sweeping Strikes (Rank 1)
+        18765, // Sweeping Strikes (Rank 2)
+        35429  // Sweeping Strikes (Rank 3)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_NOT_SHAPESHIFT;
+    });
+
     ApplySpellFix({ 48421 }, [](SpellInfo* spellInfo)
     {
         spellInfo->Stances = UI64LIT(1) << (FORM_MOONKIN - 1);


### PR DESCRIPTION
### Motivation

- Sweeping Strikes' aura should remain active after a player changes stances while still enforcing that the spell can only be cast in its original required stance.

### Description

- In `SpellMgr::LoadSpellInfoCorrections()` add an `ApplySpellFix` for Sweeping Strikes spell IDs `12328`, `18765`, and `35429` that sets the `SPELL_ATTR0_NOT_SHAPESHIFT` attribute on the `SpellInfo` record.
- The change is implemented by OR'ing `SPELL_ATTR0_NOT_SHAPESHIFT` into `spellInfo->Attributes` so the aura isn't removed on shapeshift but cast restrictions remain.

### Testing

- Built the project (`make`) and ran the server unit test suite, which completed successfully.
- Executed automated spell regression checks for Sweeping Strikes, confirming the aura persists across stance switches and cast requirements remain enforced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c649d19c8327b43068363f670a21)