### PR TITLE
Skip jump-turn visual for Rogues on instant-cast while moving

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -202,6 +202,15 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
     if (spellInfo->CalcCastTime() > 0 || !player->isMoving())
         return;
 
+    // Rogues should not use the jump-turn visual while kiting/chasing.
+    // For instant casts, only face the target and keep normal movement flow.
+    if (player->GetClass() == CLASS_ROGUE)
+    {
+        player->SetFacingToObject(target);
+        player->SetInFront(target);
+        return;
+    }
+
     ObjectGuid const casterGuid = player->GetGUID();
     ObjectGuid const targetGuid = target->GetGUID();
     player->SetFacingToObject(target);


### PR DESCRIPTION
### Motivation
- Rogues should not perform the jump-turn visual when casting instant spells while moving or kiting, and instead should simply face the target and continue normal movement flow.

### Description
- Add an early `CLASS_ROGUE` check in `JumpTurnForInstantCastVisual` to call `SetFacingToObject` and `SetInFront` and return immediately, preventing the backward `JumpTo` and temporary movement interruption for rogues.

### Testing
- Built the server (`make`) and ran the automated test suite (`make test`), with the relevant playerbot/unit tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c717b3e48327b347b54430bbc8d5)