### PR TITLE
Playerbot PvP: stop ranged bots in firing band to fix Hunter Auto Shot

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1075,6 +1075,16 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
             "Playerbot PvP distance band: bot={} profile={} decision=hold-band distance={} min={} ideal={} max={}.",
             player->GetGUID().ToString(), profile.label, distance, profile.preferredMinRange, profile.preferredIdealRange,
             profile.preferredMaxPressureRange);
+
+        // Ranged bots should fully settle once they are inside their preferred
+        // firing band. Continuously following in-band keeps movement active and
+        // can suppress Auto Shot firing windows for hunters.
+        player->StopMoving();
+        if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
+        {
+            player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+            player->SendMovementFlagUpdate();
+        }
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Hunter playerbots were continuing residual follow movement while already inside their preferred ranged firing band, which kept movement active and suppressed Auto Shot firing windows.
- Virtual (managed) bot sessions can retain movement flags after a `StopMoving`, so movement state must be cleared server-side to ensure a true stationary firing posture.

### Description
- When the positioning decision is `hold-band` in `DriveCombatPositioning`, call `player->StopMoving()` so ranged bots fully settle instead of continuing in-band movement.
- For virtual sessions, clear movement flags with `player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING)` and call `player->SendMovementFlagUpdate()` to synchronize the server-side stationary state.
- The change is implemented in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and includes a short comment explaining the Auto Shot suppression rationale.

### Testing
- Invoked `cmake --build build --target worldserver -j4`, and configuration plus compilation began successfully and compiled multiple translation units with no errors observed in the portion executed.
- No automated unit tests were run as part of this change; a full build and runtime verification are recommended to validate in-game Auto Shot behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cd5586908327844ad1e1d747a39b)