### PR TITLE
Adjust Stockades honor token rewards after first invasion

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
+++ b/src/server/scripts/EasternKingdoms/Stormwind/instance_the_stockade_pvpve.cpp
@@ -406,6 +406,8 @@ namespace
     // Honor token helpers (bosses / minibosses -> team-wide honor on kill)
     // ---------------------------------------------------------------------------
 
+    std::unordered_set<uint32> s_StockadesInvasionBonusInstances;
+
     // Return how many honor tokens this creature entry should award per kill.
     uint32 GetHonorTokensForCreatureEntry(uint32 entry)
     {
@@ -432,6 +434,22 @@ namespace
         }
 
         return 0;
+    }
+
+    void SetStockadesInvasionBonusActive(uint32 instanceId, bool active)
+    {
+        if (!instanceId)
+            return;
+
+        if (active)
+            s_StockadesInvasionBonusInstances.insert(instanceId);
+        else
+            s_StockadesInvasionBonusInstances.erase(instanceId);
+    }
+
+    bool IsStockadesInvasionBonusActive(uint32 instanceId)
+    {
+        return instanceId && s_StockadesInvasionBonusInstances.find(instanceId) != s_StockadesInvasionBonusInstances.end();
     }
 
     // Find the killer's team inside its current run
@@ -513,7 +531,11 @@ namespace
         if (!tokens)
             return; // this mob doesn't award tokens
 
-        AwardHonorTokensToKillerTeam(killer, tokens);
+        uint32 adjustedTokens = std::max<uint32>(1, tokens / 2);
+        if (IsStockadesInvasionBonusActive(killed->GetInstanceId()))
+            adjustedTokens *= 2;
+
+        AwardHonorTokensToKillerTeam(killer, adjustedTokens);
 
         // Also treat boss kills as the Stockades completion trigger so teleport
         // spells unlock even if the instance death hook misses the GUID match.
@@ -556,6 +578,7 @@ public:
             _bigBadWolves("Big Bad Wolves", StockadesPvPvE::GetBigBadWolfEntries()),
             _wrathboneSkeletons("Wrathbone Skeletons", StockadesPvPvE::GetWrathboneSkeletonEntries())
         {
+            SetStockadesInvasionBonusActive(instance->GetInstanceId(), false);
         }
 
         void OnPlayerEnter(Player* player) override
@@ -829,6 +852,12 @@ public:
             // Only if we actually found opponents do we tell the invading player.
             if (hasOpponents)
             {
+                if (!_invasionTriggered)
+                {
+                    _invasionTriggered = true;
+                    SetStockadesInvasionBonusActive(instance->GetInstanceId(), true);
+                }
+
                 if (WorldSession* invSession = invadingPlayer->GetSession())
                 {
                     invSession->SendNotification("You sense an evil presence");
@@ -878,6 +907,7 @@ public:
         KeyDropGroup _bigBadWolves;
         KeyDropGroup _wrathboneSkeletons;
         bool         _bossSpawned = false;
+        bool         _invasionTriggered = false;
         ObjectGuid   _bossGuid = ObjectGuid::Empty;
     };
 };


### PR DESCRIPTION
### Motivation
- Ensure Stockades PvPvE honor tokens are halved as a baseline and then restored (x2) for the remainder of the instance once the instance is invaded for the first time.

### Description
- Add a per-instance tracking set `s_StockadesInvasionBonusInstances` and helper functions `SetStockadesInvasionBonusActive` and `IsStockadesInvasionBonusActive` to toggle/query the invasion bonus by instance ID.
- Change token awarding in `HandleStockadesPveHonorKill` to compute `adjustedTokens = std::max<uint32>(1, tokens / 2)` and then double `adjustedTokens` when the invasion bonus is active for the instance before calling `AwardHonorTokensToKillerTeam`.
- Initialize the per-instance bonus to disabled in the instance script constructor and activate it once on first detection inside `NotifyOpposingPlayersOfInvasion`, guarded by a new `_invasionTriggered` member to prevent repeated activation.

### Testing
- No automated build or unit tests were executed in this environment; this is a code-only change and requires CI/build verification.
- Recommend running a full build and functional PvPvE scenario tests to validate token amounts before and after the first invasion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cda8b11c8327b9482f7610add363)