### PR TITLE
Restore movement after instant-cast jump turns for playerbots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -213,6 +213,7 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
 
     ObjectGuid const casterGuid = player->GetGUID();
     ObjectGuid const targetGuid = target->GetGUID();
+    uint32 const preJumpMovementFlags = player->GetUnitMovementFlags() & MOVEMENTFLAG_MASK_MOVING;
     float destinationX = 0.0f;
     float destinationY = 0.0f;
     float destinationZ = 0.0f;
@@ -226,7 +227,7 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
     float constexpr normalJumpSpeedZ = 7.95555f;
     player->JumpTo(jumpSpeedXY, normalJumpSpeedZ, false);
 
-    player->m_Events.AddEventAtOffset([casterGuid, targetGuid, resumeOrientation, hadDestination, destinationX, destinationY, destinationZ]()
+    player->m_Events.AddEventAtOffset([casterGuid, targetGuid, resumeOrientation, hadDestination, destinationX, destinationY, destinationZ, preJumpMovementFlags]()
     {
         Player* caster = ObjectAccessor::FindConnectedPlayer(casterGuid);
         if (!caster || !caster->IsInWorld() || !caster->IsAlive())
@@ -248,6 +249,16 @@ void JumpTurnForInstantCastVisual(Player* player, Unit* target, SpellInfo const*
         {
             Position destination(destinationX, destinationY, destinationZ, resumeOrientation);
             caster->GetMotionMaster()->MovePoint(0, destination);
+            return;
+        }
+
+        // Some kiting movement modes use direct movement flags rather than an
+        // active motion-master destination. Restore those flags after landing
+        // so instant-cast jump turns do not leave the bot standing still.
+        if (preJumpMovementFlags)
+        {
+            caster->AddUnitMovementFlag(MovementFlags(preJumpMovementFlags));
+            caster->SendMovementFlagUpdate();
         }
     }, 250ms);
 }


### PR DESCRIPTION
### Motivation
- Prevent virtual-session playerbots from becoming stationary after using the instant-cast jump-turn visual when they were previously moving.
- Ensure bots that were following a `MotionMaster` destination continue that destination after the jump, while other movement modes that rely on movement flags are restored appropriately.
- Avoid regressions for classes like Rogues that use a different instant-cast handling path.

### Description
- Capture pre-jump movement flags (`player->GetUnitMovementFlags() & MOVEMENTFLAG_MASK_MOVING`) before calling `JumpTo` and include them in the delayed event lambda.
- Re-issue a previously active `MotionMaster` destination via `GetMotionMaster()->MovePoint` when `hadDestination` is true and return immediately to avoid altering movement intent.
- Restore direct movement modes by re-applying the saved movement flags with `AddUnitMovementFlag` and calling `SendMovementFlagUpdate` when there was no `MotionMaster` destination.
- Keep existing special-case handling for Rogues and the early exits for roots/stuns and dead/missing targets.

### Testing
- Built the server with the changes and the build completed successfully.
- Executed the project's automated test suite and relevant unit tests, and all ran successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ccec1bd083278cb1850b99e154ad)