### PR TITLE
Fix playerbot battleground spirit guide resurrection queueing

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -625,15 +625,20 @@ bool HandleBattlegroundDeathState(Player* player)
     if (!spiritEntry)
         return true;
 
-    Creature* spiritGuide = player->FindNearestCreature(spiritEntry, 90.0f, false);
+    // Mirror player core BG death handling behavior: once ghosted at a battleground
+    // graveyard, register at a nearby spirit guide and wait for the periodic wave rez.
+    // Avoid script-driven ghost movement because missed/path-blocked moves can prevent
+    // ever getting queued for resurrection.
+    Creature* spiritGuide = player->FindNearestCreature(spiritEntry, 30.0f, false);
     if (!spiritGuide)
-        return true;
-
-    if (!player->IsWithinDist3d(spiritGuide->GetPositionX(), spiritGuide->GetPositionY(), spiritGuide->GetPositionZ(), 8.0f))
     {
-        Position destination(spiritGuide->GetPositionX(), spiritGuide->GetPositionY(), spiritGuide->GetPositionZ(), player->GetOrientation());
-        IssueMovePointThrottled(player, destination, 3.0f, 700);
-        return true;
+        // Rare fallback: if team resolution and nearby search disagree (e.g. after team
+        // swaps or delayed map state), use any nearby spirit guide so bots still rez.
+        spiritGuide = player->FindNearestCreature(BG_CREATURE_ENTRY_A_SPIRITGUIDE, 30.0f, false);
+        if (!spiritGuide)
+            spiritGuide = player->FindNearestCreature(BG_CREATURE_ENTRY_H_SPIRITGUIDE, 30.0f, false);
+        if (!spiritGuide)
+            return true;
     }
 
     battleground->AddPlayerToResurrectQueue(spiritGuide->GetGUID(), player->GetGUID());


### PR DESCRIPTION
### Motivation
- Playerbots could release in battlegrounds (notably Warsong) but fail to enter the spirit-guide resurrection queue because script-driven ghost movement to the guide could be missed or blocked.

### Description
- Adjusted `HandleBattlegroundDeathState` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to stop issuing ghost movement and instead locate a spirit guide with `FindNearestCreature(..., 30.0f, false)` and queue the player directly for resurrection.
- Added a fallback search that attempts `BG_CREATURE_ENTRY_A_SPIRITGUIDE` and `BG_CREATURE_ENTRY_H_SPIRITGUIDE` if the resolved team-specific entry is not found.

### Testing
- No automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d6bf94dc8327b07222116f0d13d7)