### PR TITLE
Playerbot: fallback warlock Fear target selection (random fallback if no paladin/priest)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -34,9 +34,11 @@
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"
+#include "Util.h"
 
 #include <array>
 #include <cmath>
+#include <vector>
 
 namespace
 {
@@ -807,20 +809,36 @@ Unit const* SelectWarlockFearTarget(Player const* player, float maxDistance)
     if (!player || !player->GetMap())
         return nullptr;
 
-    Unit const* best = nullptr;
-    float bestDistance = std::numeric_limits<float>::max();
     Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
     for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
     {
         Player* candidate = itr->GetSource();
         if (!HasHostileTarget(player, candidate))
             continue;
-        if (!(candidate->GetClass() == CLASS_PALADIN || candidate->GetClass() == CLASS_PRIEST))
+        if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, maxDistance))
+            continue;
+        if (candidate->HasAuraType(SPELL_AURA_MOD_FEAR))
+            return nullptr;
+    }
+
+    Unit const* best = nullptr;
+    float bestDistance = std::numeric_limits<float>::max();
+    std::vector<Unit const*> fallbackCandidates;
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!HasHostileTarget(player, candidate))
             continue;
         if (IsTargetInvalidByImmunity(player, candidate))
             continue;
         if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, maxDistance))
             continue;
+
+        if (!(candidate->GetClass() == CLASS_PALADIN || candidate->GetClass() == CLASS_PRIEST))
+        {
+            fallbackCandidates.push_back(candidate);
+            continue;
+        }
 
         float const distance = player->GetDistance(candidate);
         if (distance < bestDistance)
@@ -830,7 +848,13 @@ Unit const* SelectWarlockFearTarget(Player const* player, float maxDistance)
         }
     }
 
-    return best;
+    if (best)
+        return best;
+
+    if (fallbackCandidates.empty())
+        return nullptr;
+
+    return fallbackCandidates[urand(0u, static_cast<uint32>(fallbackCandidates.size() - 1))];
 }
 
 Unit const* SelectEnemyClassTarget(Player const* player, uint8 classId, float maxDistance)


### PR DESCRIPTION
### Motivation
- Ensure warlock playerbots can still use Fear when no paladin or priest target is available, while maintaining the existing rule to not cast Fear if any nearby hostile is already feared.

### Description
- Added an early scan of nearby hostile players to abort fear targeting if any hostile has `SPELL_AURA_MOD_FEAR`.
- Kept paladin/priest targets as the prioritized Fear targets and collected other valid hostile players into a `fallbackCandidates` `std::vector` when no priority class was present.
- Return the nearest paladin/priest if found, otherwise select a random fallback candidate using `urand(...)`.
- Added `#include "Util.h"` and `#include <vector>` and updated `SelectWarlockFearTarget` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` to implement the behavior.

### Testing
- Ran `git diff --check` which completed successfully and reported no whitespace or patch errors.
- Verified the modified logic by inspecting the updated file with `nl`/`sed` and `rg` to ensure the new scan, fallback collection, and random selection are present.
- Committed the change with message `Playerbot: fallback warlock fear target selection` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d701cf788327916b69713ed03a4a)