### PR TITLE
Playerbot PvP: prevent Auto Shot conflicts and refine engage behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1202,6 +1202,12 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
     if (!player)
         return decision;
 
+    // If Auto Shot is already active, avoid layering a separate spell decision
+    // that can interfere with the auto-repeat cycle.
+    Spell const* autoRepeatSpell = player->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
+    if (autoRepeatSpell && autoRepeatSpell->GetSpellInfo()->Id == 75)
+        return decision;
+
     Unit const* activeTarget = SelectCombatTarget(player);
     if (!HasHostileTarget(player, activeTarget))
         return decision;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1120,10 +1120,19 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
     CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     bool const useMeleeAttack = !profile.primarilyRanged || profile.meleeFallbackAcceptable;
     bool const isStealthedRogue = player->GetClass() == CLASS_ROGUE && player->HasStealthAura();
+    bool const alreadyAttackingTarget = player->GetVictim() && player->GetVictim()->GetGUID() == target->GetGUID();
     if (isStealthedRogue)
         player->AttackStop();
-    else
+    else if (!alreadyAttackingTarget)
         player->Attack(target, useMeleeAttack);
+
+    if (player->GetClass() == CLASS_HUNTER && profile.primarilyRanged && !player->IsWithinMeleeRange(target) && player->IsWithinLOSInMap(target))
+    {
+        Spell const* autoRepeatSpell = player->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
+        bool const autoShotActive = autoRepeatSpell && autoRepeatSpell->GetSpellInfo()->Id == 75;
+        if (!autoShotActive && player->HasSpell(75))
+            player->CastSpell(target, 75, false);
+    }
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
         "Playerbot PvP positioning profile: bot={} profile={} ranged={} createDistance={} meleeFallback={}.",


### PR DESCRIPTION
### Motivation
- Prevent hunter AI from layering manual spell decisions on top of an active auto-repeat `Auto Shot` cycle (`spell 75`).
- Avoid redundant `Attack` calls when already attacking the same target and ensure hunters begin auto-shot when engaging at range.

### Description
- In `SelectHunterSpell`, short-circuit and return no decision if `CURRENT_AUTOREPEAT_SPELL` is active and its ID is `75` to avoid interfering with the auto-repeat cycle. 
- In `EngageNearestEnemyPlayer`, skip calling `Attack` when `GetVictim()` already matches the acquired target to avoid redundant attack calls.
- In `EngageNearestEnemyPlayer`, for hunters with a primarily ranged profile and a target in LOS but out of melee range, start `Auto Shot` by casting `spell 75` when it is available and not already active.
- Retain existing rogue stealth handling with `AttackStop()`.

### Testing
- Performed a full project build to verify compilation; the build completed successfully.
- No PvP-specific automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d717a58c83278d2ebeeb99ef75de)