### PR TITLE
Playerbot: make WSG bots fight at midfield (ignore objectives)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2112,6 +2112,11 @@ BattlegroundObjectiveSelection PvpCore::SelectObjectiveSkeleton(PvpValues const&
 {
     BattlegroundObjectiveSelection objective;
 
+    // WSG brawl mode: ignore flag/objective play and let tactical movement
+    // converge bots to the shared midfield fight anchor.
+    if (values.battlegroundTypeId == BATTLEGROUND_WS)
+        return objective;
+
     if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierNear, values))
         objective.type = BattlegroundObjectiveType::AttackFlagCarrier;
     else if ((!values.battlegroundTeamHasHumans && IsTriggerActive(PvpTrigger::PlayerHasFlag, values)) ||
@@ -2144,6 +2149,9 @@ BattlegroundMovementPrimitive PvpCore::SelectMovementPrimitiveSkeleton(PvpValues
 
 FlagCarrierDirective PvpCore::SelectFlagCarrierDirectiveSkeleton(PvpValues const& values)
 {
+    if (values.battlegroundTypeId == BATTLEGROUND_WS)
+        return FlagCarrierDirective::None;
+
     if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierNear, values))
         return FlagCarrierDirective::AttackEnemyCarrier;
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1158,10 +1158,9 @@ bool TryGetObjectivePosition(Battleground* battleground, Player* player, Positio
 
     if (IsWarsongGulch(player))
     {
-        TeamId const botTeam = ResolveBotTeamId(player);
-        Position const allianceFlagStand(1540.423f, 1481.325f, 351.8284f, 3.089233f);
-        Position const hordeFlagStand(916.0226f, 1434.405f, 345.413f, 0.01745329f);
-        destination = (botTeam == TEAM_ALLIANCE) ? hordeFlagStand : allianceFlagStand;
+        // Midfield brawl behavior for WSG: collapse both teams toward center map.
+        Position const midfieldAnchor(1239.40f, 1543.60f, 306.00f, 0.0f);
+        destination = midfieldAnchor;
         ApplyDeterministicObjectiveOffset(battleground, player, destination);
         return true;
     }


### PR DESCRIPTION
### Motivation
- Force managed playerbots in Warsong Gulch to converge on a central fight rather than pursue flag/objectives to produce consistent mid-map brawls.
- Simplify WSG-specific objective/flag-carrier handling so tactical combat behavior drives engagements instead of objective routing.
- Modified the playerbot PvP code in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and no external skills were used.

### Description
- Short-circuited `PvpCore::SelectObjectiveSkeleton` for `BATTLEGROUND_WS` so the returned objective is empty, preventing bots from selecting flag-carrier attack/protect objectives.
- Made `PvpCore::SelectFlagCarrierDirectiveSkeleton` return `FlagCarrierDirective::None` for `BATTLEGROUND_WS` to avoid entering carrier-targeting directives on WSG.
- Changed `TryGetObjectivePosition` behavior for WSG to set a shared midfield anchor at `Position(1239.40f, 1543.60f, 306.00f, 0.0f)` and preserved the existing `ApplyDeterministicObjectiveOffset` to spread bots deterministically.
- These changes direct WSG tactical movement to a common midfield destination while leaving other battleground types unchanged.

### Testing
- Invoked a targeted build with `cmake --build build --target worldserver -j2`; CMake reconfiguration completed and compilation progressed across files.
- The build was manually stopped in this environment before full completion due to runtime/size constraints, so no full binary or integration run was produced.
- No automated unit tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6db08b63c8327819a7d652252200f)