### PR TITLE
Playerbot PvP: chase stealth openers and start auto-attack after Cheap Shot

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -348,6 +348,11 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     float const maxRange = spellInfo->GetMaxRange(false);
     if (!itemTarget && maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
     {
+        // Stealthed rogue openers (e.g., Cheap Shot) should actively close to
+        // melee instead of idling on repeated out-of-range cast attempts.
+        if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
+            player->GetMotionMaster()->MoveChase(target);
+
         failureReason = "out_of_range";
         return false;
     }
@@ -404,6 +409,12 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = reasonText.Title;
         return false;
     }
+
+    // Cheap Shot opener flow: after a successful stealth stun, immediately
+    // start melee auto attack so white swings begin without waiting for a
+    // later lifecycle tick to issue Attack().
+    if (context.spellId == 1833 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && target && target->IsAlive())
+        player->Attack(target, true);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,


### PR DESCRIPTION
### Motivation
- Rogue playerbots in stealth could repeatedly attempt openers like `Cheap Shot` from out of range and not close the gap to get into melee.  
- After landing a stealth opener the bot sometimes did not enable melee auto-attacks immediately, delaying white-swing damage.

### Description
- When an enemy-targeted class spell attempt fails with `out_of_range`, the code now issues `player->GetMotionMaster()->MoveChase(target)` so bots actively close to melee range before returning failure, applied in `CastDirectSpell`.  
- After a successful cast of `Cheap Shot` (`spellId == 1833`) the bot now invokes `player->Attack(target, true)` to immediately start melee auto-attack so white swings begin without waiting for a later lifecycle tick.  
- Change made in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` within the `CastDirectSpell` flow.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e13af4b883278ee8782478d6cc06)