### PR TITLE
Playerbot: defer hunter Auto Shot until class decisions complete

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -206,6 +206,51 @@ void FaceTargetForInstantCast(Player* player, Unit* target, SpellInfo const* spe
     player->SetInFront(target);
 }
 
+bool TryEnableHunterAutoShot(Player* player, Unit* preferredTarget, char const* triggerReason)
+{
+    if (!player || player->GetClass() != CLASS_HUNTER || !player->HasSpell(75))
+        return false;
+
+    Unit* target = preferredTarget;
+    if (!target || !target->IsAlive())
+        target = player->GetVictim();
+    if (!target || !target->IsAlive())
+        target = player->GetSelectedUnit();
+
+    if (!target || !target->IsAlive() || !player->IsValidAttackTarget(target))
+        return false;
+    if (player->IsWithinMeleeRange(target) || !player->IsWithinLOSInMap(target))
+        return false;
+
+    SpellInfo const* autoShotInfo = sSpellMgr->GetSpellInfo(75);
+    if (!autoShotInfo)
+        return false;
+
+    float const minRange = autoShotInfo->GetMinRange(false);
+    float const maxRange = autoShotInfo->GetMaxRange(false);
+    float const distance = player->GetDistance(target);
+    if (distance <= minRange || distance > maxRange)
+        return false;
+
+    Spell const* autoRepeatSpell = player->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
+    bool const autoShotActive = autoRepeatSpell && autoRepeatSpell->GetSpellInfo()->Id == 75;
+    if (autoShotActive)
+        return true;
+
+    player->SetSelection(target->GetGUID());
+    player->SetFacingToObject(target);
+    player->SetInFront(target);
+
+    SpellCastResult const castResult = player->CastSpell(target, 75, false);
+    if (castResult != SPELL_CAST_OK)
+        return false;
+
+    TC_LOG_DEBUG("playerbots.pvp.class",
+        "Playerbot PvP hunter auto shot primed: guid={} target={} reason={}.",
+        player->GetGUID().ToString(), target->GetGUID().ToString(), triggerReason ? triggerReason : "none");
+    return true;
+}
+
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
 {
     failureReason.clear();
@@ -571,8 +616,15 @@ void PvpClassActions::RegisterWarlockCurseTargetCooldown(Player const* player, U
 
 bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& context)
 {
-    if (!player || !context.classSpellsEnabled || !context.shouldExecute)
+    if (!player || !context.classSpellsEnabled)
         return false;
+
+    Unit* contextTarget = nullptr;
+    if (!context.targetGuid.IsEmpty())
+        contextTarget = ObjectAccessor::GetUnit(*player, context.targetGuid);
+
+    if (!context.shouldExecute)
+        return TryEnableHunterAutoShot(player, contextTarget, "decision-tree-complete");
 
     std::string failureReason;
     bool casted = false;
@@ -589,6 +641,10 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         context.targetGuid.ToString(),
         casted,
         context.reason ? context.reason : "none");
+
+    if (casted && (context.spellId == 20904 || context.spellId == 25294 || context.spellId == 5116))
+        TryEnableHunterAutoShot(player, contextTarget, context.actionName);
+
     return casted;
 }
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1179,14 +1179,6 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
     else if (!alreadyAttackingTarget)
         player->Attack(target, useMeleeAttack);
 
-    if (player->GetClass() == CLASS_HUNTER && profile.primarilyRanged && !player->IsWithinMeleeRange(target) && player->IsWithinLOSInMap(target))
-    {
-        Spell const* autoRepeatSpell = player->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
-        bool const autoShotActive = autoRepeatSpell && autoRepeatSpell->GetSpellInfo()->Id == 75;
-        if (!autoShotActive && player->HasSpell(75))
-            player->CastSpell(target, 75, false);
-    }
-
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
         "Playerbot PvP positioning profile: bot={} profile={} ranged={} createDistance={} meleeFallback={}.",
         player->GetGUID().ToString(), profile.label, profile.primarilyRanged, profile.createDistanceWhenCrowded,


### PR DESCRIPTION
### Motivation

- Prevent hunters from starting Auto Shot prematurely during movement/positioning so they properly face the intended target before autoshooting.
- Ensure Auto Shot is only enabled once the class decision tree finishes, while still enabling it after specific ranged spells (`Aimed Shot`, `Multi-Shot`, `Concussive Shot`).
- Avoid lifecycle movement code interfering with class spell logic and auto-repeat cycle timing for hunters.

### Description

- Added `TryEnableHunterAutoShot` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` which validates target, LOS, distance, facing and then primes Auto Shot (spell 75) by facing/selecting the target before casting. 
- Modified `PvpClassActions::Execute` to call the new helper when no class spell is chosen (decision tree complete), and to re-prime Auto Shot after successful casts of `Aimed Shot` (20904), `Multi-Shot` (25294), and `Concussive Shot` (5116).
- Removed the eager Auto Shot activation from `EngageNearestEnemyPlayer` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` so lifecycle movement no longer starts Auto Shot before class decision logic runs.
- Target/range/LOS checks and explicit facing (`SetFacingToObject` + `SetInFront`) are used to avoid facing/firing race conditions and to keep existing auto-repeat detection logic intact.

### Testing

- Ran a build invocation with `cmake --build build --target game -- -j4` and observed compilation progress through many translation units, but the full build was not completed due to environment/time constraints (partial build progress observed).
- Invoked the `scripts` build with `cmake --build build --target scripts -- -j4` which started script compilation successfully (process launched and compiling); it was interrupted before full completion for the same constraints.
- Attempted targeted object compilation and per-file compile via `ninja` and `compile_commands.json` entries which failed because the requested per-object targets/entries were not available in this environment.
- Per-file/diff style checks reported no whitespace/diff issues after the changes (`diff --check` style verification returned clean results).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e0a9dc6c8327afbe4db3e3a8ebb9)