### PR TITLE
Allow hunter PvP bots to cast abilities while Auto Shot is active

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1230,12 +1230,6 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
     if (!player)
         return decision;
 
-    // If Auto Shot is already active, avoid layering a separate spell decision
-    // that can interfere with the auto-repeat cycle.
-    Spell const* autoRepeatSpell = player->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
-    if (autoRepeatSpell && autoRepeatSpell->GetSpellInfo()->Id == 75)
-        return decision;
-
     Unit const* activeTarget = SelectCombatTarget(player);
     if (!HasHostileTarget(player, activeTarget))
         return decision;


### PR DESCRIPTION
### Motivation
- Hunter PvP bots were only firing Auto Shot and not evaluating or casting other class abilities while the auto-repeat spell was active, preventing use of stings, concussive/wing clip, cooldowns, pet actions, and utilities.

### Description
- Removed the early-return check for the current auto-repeat spell in `SelectHunterSpell` so hunter PvP spell selection continues even when Auto Shot (spell id `75`) is active; change made in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`.

### Testing
- Ran repository inspection commands including `nl -ba src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp | sed -n '1220,1265p'`, `git diff --check HEAD~1..HEAD && git show --stat --oneline --no-patch HEAD`, and `git status --short`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f4a57d3c8327a33e33d94f0b59bb)