### PR TITLE
Playerbots: increase PvP engagement radius to 100 yards

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1470,7 +1470,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     }
 
     if (player->IsInCombat())
-        return EngageNearestEnemyPlayer(player, 80.0f);
+        return EngageNearestEnemyPlayer(player, 100.0f);
     /*
     if (TryJumpOffWarsongGraveyard(player))
         return true;
@@ -1530,7 +1530,7 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (!player || !player->InBattleground())
         return false;
 
-    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 60.0f;
+    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 100.0f;
     if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
@@ -1705,6 +1705,6 @@ bool DuelTacticalActions::Execute(Player* player)
     if (!player->duel || player->duel->State != DUEL_STATE_IN_PROGRESS)
         return false;
 
-    return EngageNearestEnemyPlayer(player, 65.0f);
+    return EngageNearestEnemyPlayer(player, 100.0f);
 }
 }


### PR DESCRIPTION
### Motivation
- Make playerbot PvP behavior match the requirement to engage players within 100 yards by increasing tactical scan distances used for acquiring nearby enemy players.

### Description
- Updated engagement distance in `BattlegroundTacticalActions::MoveToObjectivePrimitive` to call `EngageNearestEnemyPlayer(player, 100.0f)` instead of `80.0f` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.
- Updated the non-WSG objective-check engagement distance from `60.0f` to `100.0f` in the same file by changing `float const engageDistance = IsWarsongGulch(player) ? 2000.0f : 100.0f`.
- Updated `DuelTacticalActions::Execute` to call `EngageNearestEnemyPlayer(player, 100.0f)` instead of `65.0f` to align duel behavior with the new radius.

### Testing
- Ran `cmake --build build --target worldserver -j2`, which started configuration and compilation successfully but was stopped before completion due to build duration.
- Ran `cmake --build build --target scripts -j2`, which began and progressed through script compilation (including the modified script) but was stopped before completion due to build duration.
- No automated test failures were observed during the partial builds, but full builds were not completed in this session so no end-to-end binary verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f42fa03c832795ee4786c1ccb1ff)