### PR TITLE
Playerbot PvP: add Piercing Howl cooldown and improve auto-attack handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -504,6 +504,11 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (uint32 const resolvedSpellId = ResolveKnownSpellInChain(player, context.spellId))
             player->GetSpellHistory()->AddCooldown(resolvedSpellId, 0, std::chrono::seconds(12));
     }
+    if (context.spellId == 12323)
+    {
+        if (uint32 const resolvedSpellId = ResolveKnownSpellInChain(player, context.spellId))
+            player->GetSpellHistory()->AddCooldown(resolvedSpellId, 0, std::chrono::seconds(8));
+    }
 
     if ((context.spellId == 11719 || context.spellId == 11713) && target)
         playerbot::PvpClassActions::RegisterWarlockCurseTargetCooldown(player, target, context.spellId, std::chrono::seconds(12));

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1154,10 +1154,17 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
     CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     bool const useMeleeAttack = !profile.primarilyRanged || profile.meleeFallbackAcceptable;
     bool const isStealthedRogue = player->GetClass() == CLASS_ROGUE && player->HasStealthAura();
+    bool const targetInBreakableCrowdControl = target->HasBreakableByDamageCrowdControlAura();
     bool const alreadyAttackingTarget = player->GetVictim() && player->GetVictim()->GetGUID() == target->GetGUID();
+    bool const meleeAutoAttackActive = player->HasUnitState(UNIT_STATE_MELEE_ATTACKING);
     if (isStealthedRogue)
         player->AttackStop();
-    else if (!alreadyAttackingTarget)
+    else if (targetInBreakableCrowdControl)
+    {
+        if (alreadyAttackingTarget)
+            player->AttackStop();
+    }
+    else if (!alreadyAttackingTarget || !meleeAutoAttackActive)
         player->Attack(target, useMeleeAttack);
 
     if (player->GetClass() == CLASS_HUNTER && profile.primarilyRanged && !player->IsWithinMeleeRange(target) && player->IsWithinLOSInMap(target))


### PR DESCRIPTION
### Motivation
- Prevent warrior `Piercing Howl` (spell `12323`) from being repeatedly re-applied every decision tick by introducing a short tactical cooldown. 
- Make playerbot melee bots reliably maintain auto-attack on their chosen combat target while avoiding damage that would break crowd-control (breakable CC). 

### Description
- Add an 8-second tactical cooldown for `Piercing Howl` by resolving the known rank with `ResolveKnownSpellInChain(...)` and calling `player->GetSpellHistory()->AddCooldown(..., std::chrono::seconds(8))` in `PlayerbotPvpClassActions.cpp`. 
- Change engagement logic in `PlayerbotPvpLifecycleActions.cpp` to stop attacking if the `target` has breakable-by-damage crowd control by checking `target->HasBreakableByDamageCrowdControlAura()`. 
- Ensure bots (non-stealthed rogues) issue `player->Attack(...)` if they are not already attacking the target or if melee auto-attack state (`UNIT_STATE_MELEE_ATTACKING`) is not active. 
- Preserve existing special-case behavior for stealthed rogues and hunter auto-shot follow-up logic. 

### Testing
- Ran `git diff --check` with no issues reported. 
- Performed a local build attempt via `cmake --build build -j2 --target game`, which compiled and progressed into server targets successfully before being manually interrupted due to environment/runtime limits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f4c5cd4c8327af0ee56e551cf158)