### PR TITLE
Battleground: manually resurrect nearby virtual playerbot avatars during spirit guide waves

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -325,6 +325,29 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
                     player->CastSpell(player, SPELL_RESURRECTION_VISUAL, true);
                     m_ResurrectQueue.push_back(*itr2);
                 }
+
+                if (sh)
+                {
+                    // Managed playerbot avatars (virtual sessions) can occasionally miss the
+                    // regular resurrect queue registration. During each spirit guide wave,
+                    // manually include nearby dead playerbots so they resurrect reliably.
+                    for (BattlegroundPlayerMap::const_iterator bgPlayerItr = m_Players.begin(); bgPlayerItr != m_Players.end(); ++bgPlayerItr)
+                    {
+                        Player* nearbyPlayer = ObjectAccessor::FindPlayer(bgPlayerItr->first);
+                        if (!nearbyPlayer || nearbyPlayer->IsAlive() || !nearbyPlayer->IsInWorld() || !nearbyPlayer->IsWithinDistInMap(sh, 15.0f))
+                            continue;
+
+                        WorldSession* session = nearbyPlayer->GetSession();
+                        if (!session || !session->IsVirtualSession())
+                            continue;
+
+                        if (std::find(m_ResurrectQueue.begin(), m_ResurrectQueue.end(), nearbyPlayer->GetGUID()) != m_ResurrectQueue.end())
+                            continue;
+
+                        nearbyPlayer->CastSpell(nearbyPlayer, SPELL_RESURRECTION_VISUAL, true);
+                        m_ResurrectQueue.push_back(nearbyPlayer->GetGUID());
+                    }
+                }
                 (itr->second).clear();
             }
 


### PR DESCRIPTION
### Motivation
- Ensure managed playerbot avatars (virtual sessions) do not remain ghosted when they miss normal resurrect queue registration during battleground spirit guide waves.

### Description
- Add logic in `_ProcessResurrect` in `src/server/game/Battlegrounds/Battleground.cpp` to run when a spirit guide (`sh`) is present for the current wave.
- Iterate `m_Players` and for each dead, in-world player within `15.0f` yards of the spirit guide check for a virtual session via `session->IsVirtualSession()` and skip non-virtual or already-alive players.
- Prevent duplicate entries by checking `m_ResurrectQueue` with `std::find`, then apply `SPELL_RESURRECTION_VISUAL` and push the player's GUID into `m_ResurrectQueue` so they are resurrected with the same wave behavior.

### Testing
- Ran the whitespace/format check `git diff --check -- src/server/game/Battlegrounds/Battleground.cpp`, which reported no issues.
- No automated build or unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f8c2670c8327b6bc1963edda9ca3)