### PR TITLE
Fix rogue stealth not breaking on fully-absorbed hostile spell hits

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3924,6 +3924,13 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE;
     });
 
+    // Rogue - Stealth (all ranks)
+    ApplySpellFix({ 1784, 1785, 1786, 1787, 1788, 1789 }, [](SpellInfo* spellInfo)
+    {
+        // Break stealth when hit by hostile spells even if incoming damage is fully absorbed.
+        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_HITBYSPELL;
+    });
+
     // Death Knight T10 Tank 2P Bonus
     ApplySpellFix({ 70650 }, [](SpellInfo* spellInfo)
     {


### PR DESCRIPTION
### Motivation
* Rogues in stealth were not being brought out of stealth when hit by hostile spells if the incoming damage was fully absorbed (for example, `Power Word: Shield` absorbing `Frost Nova`), because the stealth aura lacked the `AURA_INTERRUPT_FLAG_HITBYSPELL` interrupt flag.

### Description
* Add a spell fix in `src/server/game/Spells/SpellMgr.cpp` that applies `AURA_INTERRUPT_FLAG_HITBYSPELL` to Rogue stealth spell ranks (`1784`–`1789`) so hostile spell hits break stealth even when damage is fully absorbed.

### Testing
* Ran `git diff --check` and `git status --short` to verify the change; both checks passed and the change is limited to `src/server/game/Spells/SpellMgr.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6fd660460832795f49b9c5d9955bc)