### PR TITLE
Adjust WSG bot post-rez graveyard egress routing

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -224,43 +224,97 @@ bool TryJumpOffWarsongGraveyard(Player* player)
     if (!player || !player->IsAlive() || !IsWarsongGulch(player) || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
         return false;
 
-    struct JumpRoute
+    struct PostResurrectRouteState
     {
-        Position launch;
-        Position landing;
+        uint32 battlegroundInstanceId = 0;
+        bool wasAlive = true;
+        bool active = false;
+        uint8 phase = 0; // 0 = move to tip, 1 = run forward burst, 2 = move to mid
+        uint32 forwardBurstEndMs = 0;
     };
 
-    static std::array<JumpRoute, 2> const routes =
-    {{
-        { Position(957.20f, 1424.40f, 345.48f, 0.0f), Position(978.20f, 1427.10f, 335.20f, 0.0f) },      // Horde GY -> field
-        { Position(1517.60f, 1485.30f, 352.00f, 0.0f), Position(1498.60f, 1484.30f, 340.20f, 0.0f) }      // Alliance GY -> field
-    }};
+    static std::unordered_map<uint64, PostResurrectRouteState> stateByGuid;
+    PostResurrectRouteState& state = stateByGuid[player->GetGUID().GetRawValue()];
 
-    float nearestDist = std::numeric_limits<float>::max();
-    JumpRoute const* nearest = nullptr;
-    for (JumpRoute const& route : routes)
-    {
-        float const dist = player->GetDistance(route.launch.GetPositionX(), route.launch.GetPositionY(), route.launch.GetPositionZ());
-        if (dist < nearestDist)
-        {
-            nearestDist = dist;
-            nearest = &route;
-        }
-    }
-
-    if (!nearest || nearestDist > 22.0f)
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground)
         return false;
 
-    if (!player->IsWithinDist3d(nearest->launch.GetPositionX(), nearest->launch.GetPositionY(), nearest->launch.GetPositionZ(), 3.5f))
+    if (state.battlegroundInstanceId != battleground->GetInstanceID())
     {
-        IssueMovePointThrottled(player, nearest->launch, 1.5f, 500);
+        state = {};
+        state.battlegroundInstanceId = battleground->GetInstanceID();
+        state.wasAlive = player->IsAlive();
+    }
+
+    bool const justResurrected = !state.wasAlive && player->IsAlive();
+    state.wasAlive = player->IsAlive();
+    if (justResurrected)
+    {
+        state.active = true;
+        state.phase = 0;
+        state.forwardBurstEndMs = 0;
+    }
+
+    if (!state.active)
+        return false;
+
+    static Position const hordeGraveyardTip(1066.0946404f, 1380.843994f, 340.612305f, 0.0f);
+    static Position const allianceGraveyardTip(1406.597412f, 1553.099121f, 343.533295f, 0.0f);
+    static Position const midPoint(1258.810181f, 1463.801758f, 312.229401f, 0.0f);
+
+    TeamId const teamId = ResolveBotTeamId(player);
+    Position const& graveyardTip = (teamId == TEAM_HORDE) ? hordeGraveyardTip : allianceGraveyardTip;
+
+    if (state.phase == 0)
+    {
+        if (!player->IsWithinDist3d(graveyardTip.GetPositionX(), graveyardTip.GetPositionY(), graveyardTip.GetPositionZ(), 2.5f))
+        {
+            IssueMovePointThrottled(player, graveyardTip, 1.0f, 300);
+            return true;
+        }
+
+        state.phase = 1;
+    }
+
+    if (state.phase == 1)
+    {
+        uint32 const nowMs = GameTime::GetGameTimeMS();
+        if (!state.forwardBurstEndMs)
+            state.forwardBurstEndMs = nowMs + 1000;
+
+        float const dx = midPoint.GetPositionX() - graveyardTip.GetPositionX();
+        float const dy = midPoint.GetPositionY() - graveyardTip.GetPositionY();
+        float const len = std::sqrt(dx * dx + dy * dy);
+        if (len <= 0.001f)
+        {
+            state.phase = 2;
+            return true;
+        }
+
+        float const forwardDistance = player->GetSpeed(MOVE_RUN) * 1.0f;
+        Position forwardPoint(
+            graveyardTip.GetPositionX() + (dx / len) * forwardDistance,
+            graveyardTip.GetPositionY() + (dy / len) * forwardDistance,
+            graveyardTip.GetPositionZ(),
+            player->GetAbsoluteAngle(midPoint.GetPositionX(), midPoint.GetPositionY()));
+
+        IssueMovePointThrottled(player, forwardPoint, 0.5f, 100);
+
+        if (nowMs >= state.forwardBurstEndMs)
+            state.phase = 2;
         return true;
     }
 
-    float const jumpSpeedXY = std::max(6.0f, player->GetSpeed(MOVE_RUN) * 1.1f);
-    float const jumpSpeedZ = 8.0f;
-    player->SetFacingTo(player->GetAbsoluteAngle(nearest->landing.GetPositionX(), nearest->landing.GetPositionY()));
-    player->JumpTo(jumpSpeedXY, jumpSpeedZ, false);
+    if (state.phase == 2)
+    {
+        IssueMovePointThrottled(player, midPoint, 1.0f, 300);
+
+        if (player->IsWithinDist3d(midPoint.GetPositionX(), midPoint.GetPositionY(), midPoint.GetPositionZ(), 6.0f))
+            state.active = false;
+        return true;
+    }
+
     return true;
 }
 
@@ -1478,10 +1532,8 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
 
     if (player->IsInCombat())
         return EngageNearestEnemyPlayer(player, 100.0f);
-    /*
     if (TryJumpOffWarsongGraveyard(player))
         return true;
-        */
 
     if (context.objective.type == BattlegroundObjectiveType::None &&
         context.movement == BattlegroundMovementPrimitive::None &&


### PR DESCRIPTION
### Motivation
- Ensure Warsong Gulch playerbots that resurrect run to the correct graveyard tip for their faction, perform a short forward burst, then navigate to the midfield instead of getting stuck on the graveyard.

### Description
- Implemented a per-bot, per-battleground `PostResurrectRouteState` tracked in `TryJumpOffWarsongGraveyard` to detect dead→alive transitions and drive a 3-phase egress routine.
- Added explicit faction-specific graveyard tip coordinates `Horde(1066.0946404, 1380.843994, 340.612305)` and `Alliance(1406.597412, 1553.099121, 343.533295)` and the midfield anchor `Position(1258.810181, 1463.801758, 312.229401)`.
- Phase behavior: phase 0 moves the bot to the faction graveyard tip, phase 1 issues a timed 1-second forward movement burst away from the tip, and phase 2 routes the bot to the midfield anchor; routing state resets when the battleground instance changes.
- Re-enabled invocation of the post-rez routine in `MoveToObjectivePrimitive` so the new egress routine runs before normal objective movement.

### Testing
- Ran a parallel build with `cmake --build build --target worldserver -j2`; the build started and compilation output streamed without errors for the changed file, but the full build did not complete within the session window.
- No automated unit tests were executed in this run; no compile-time errors for the modified translation unit were observed in the partial build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7281a0f9883278d8e11a24ac81b9b)