### PR TITLE
Allow six participants in Stockades PvPvE instance entry checks

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3859,6 +3859,11 @@ Map::EnterState InstanceMap::CannotEnter(Player* player)
 
     // cannot enter if the instance is full (player cap), GMs don't count
     uint32 maxPlayers = GetMaxPlayers();
+    // Stockades PvPvE custom mode supports three 2-player teams (6 total),
+    // while the base Stockades map cap is five players.
+    if (GetId() == 34 && GetScriptName() == "instance_the_stockade_pvpve")
+        maxPlayers = std::max<uint32>(maxPlayers, 6u);
+
     if (GetPlayersCountExceptGMs() >= maxPlayers)
     {
         TC_LOG_WARN("maps", "MAP: Instance '{}' of map '{}' cannot have more than '{}' players. Player '{}' rejected", GetInstanceId(), GetMapName(), maxPlayers, player->GetName());


### PR DESCRIPTION
### Motivation
- Fix a test-case where the third team's second player was denied zone-in because the Stockades instance player cap (5) blocked the sixth participant in the custom PvPvE mode.

### Description
- Adjusted `InstanceMap::CannotEnter` in `src/server/game/Maps/Map.cpp` to raise the effective `maxPlayers` to at least `6` when `GetId() == 34` and `GetScriptName() == "instance_the_stockade_pvpve"`, and added an inline comment explaining the override.

### Testing
- Invoked `cmake --build build --target game -j2` to validate compilation; the build progressed and no compilation errors were observed during the session, and no additional automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d729c408cc8327bd07d218b3f6a1f1)