### PR TITLE
End Warsong Gulch when no human players remain

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -26,6 +26,7 @@
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "WorldPacket.h"
+#include "WorldSession.h"
 #include "WorldStatePackets.h"
 #include "World.h"
 #include <iomanip>
@@ -211,6 +212,27 @@ void BattlegroundWS::PostUpdateImpl(uint32 diff)
 {
     if (GetStatus() == STATUS_IN_PROGRESS)
     {
+        bool hasHumanPlayer = false;
+        for (BattlegroundPlayerMap::const_iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+        {
+            Player* player = ObjectAccessor::FindPlayer(itr->first);
+            if (!player)
+                continue;
+
+            WorldSession* session = player->GetSession();
+            if (!session || session->IsVirtualSession())
+                continue;
+
+            hasHumanPlayer = true;
+            break;
+        }
+
+        if (!hasHumanPlayer)
+        {
+            TC_LOG_INFO("bg.warsong", "BattlegroundWS::PostUpdateImpl: Ending WSG instance {} because no human players remain.", GetInstanceID());
+            EndNow();
+            return;
+        }
 
         if (_flagState[TEAM_ALLIANCE] == BG_WS_FLAG_STATE_WAIT_RESPAWN)
         {


### PR DESCRIPTION
### Motivation
- Prevent Warsong Gulch instances from being held open by playerbot virtual sessions after all human players leave. 
- Ensure battleground instances are cleaned up promptly so playerbots do not get hogged into stale matches. 
- Use session type discrimination to shut down only when no real (non-virtual) players remain.

### Description
- Added `#include "WorldSession.h"` and a human-player presence check in `BattlegroundWS::PostUpdateImpl` that iterates `m_Players` and ignores virtual sessions via `IsVirtualSession()`.
- If no non-virtual session is found the code logs an info line with `TC_LOG_INFO("bg.warsong", ...)` and calls `EndNow()` to terminate the WSG instance immediately.
- The early shutdown path returns before the regular Warsong update logic so no further per-frame processing occurs for that instance.

### Testing
- Ran `cmake --build build --target worldserver -j4` to validate compile impact and observed the build progress without compilation errors for the modified file during the captured run (build is large and the session captured partial progress). 
- Executed `git diff --check` and verified the commit with `git show`/status to ensure the change is clean and committed successfully. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d728e7a11c8327b70261335fb041d8)