### PR TITLE
Notify GMs of bot spell-cast failures and reduce GM whisper spam from lifecycle debug

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <sstream>
 #include <unordered_map>
 
 namespace
@@ -131,6 +132,36 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
         GetTargetModeLabel(context.targetMode), casted ? "yes" : "no", context.reason ? context.reason : "none",
         failureReason.empty() ? "none" : failureReason);
+}
+
+void NotifySpellCastFailureToGameMasters(Player* bot, playerbot::PvpClassSpellContext const& context, SpellCastResult castResult)
+{
+    if (!bot || castResult == SPELL_CAST_OK || castResult == SPELL_FAILED_SPELL_IN_PROGRESS)
+        return;
+
+    Map* map = bot->GetMap();
+    if (!map)
+        return;
+
+    EnumText const resultText = EnumUtils::ToString(castResult);
+    std::ostringstream os;
+    os << "[Playerbot spell-fail] bot=" << bot->GetName()
+       << " guid=" << bot->GetGUID().ToString()
+       << " map=" << bot->GetMapId()
+       << " spell=" << context.spellId
+       << " action=" << (context.actionName ? context.actionName : "none")
+       << " target=" << GetTargetModeLabel(context.targetMode)
+       << " result=" << resultText.Title;
+    std::string const message = os.str();
+
+    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
+    {
+        Player* observer = itr->GetSource();
+        if (!observer || !observer->IsGameMaster())
+            continue;
+
+        bot->Whisper(message, LANG_UNIVERSAL, observer);
+    }
 }
 
 void FinalizeVirtualNearTeleport(Player* player)
@@ -400,6 +431,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
     {
+        NotifySpellCastFailureToGameMasters(player, context, castResult);
         EnumText const reasonText = EnumUtils::ToString(castResult);
         failureReason = reasonText.Title;
         return false;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -370,8 +370,7 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
 
     nextEmitMs = nowMs + throttleMs;
 
-    Map* map = bot->GetMap();
-    if (!map)
+    if (!bot->GetMap())
         return;
 
     std::ostringstream os;
@@ -383,17 +382,6 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
 
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        if (observer->GetBattlegroundId() != bot->GetBattlegroundId())
-            continue;
-
-        bot->Whisper(message, LANG_UNIVERSAL, observer);
-    }
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -86,28 +86,13 @@ void EmitLifecycleGmDebug(Player const* player, std::string const& detail, uint3
 
     nextEmitMs = nowMs + throttleMs;
 
-    Map const* map = player->GetMap();
-    if (!map)
-        return;
-
     std::ostringstream os;
     os << "[PBDBG lifecycle] bot=" << player->GetName()
        << " guid=" << player->GetGUID().ToString()
        << " bgId=" << player->GetBattlegroundId()
        << " detail=" << detail;
     std::string const message = os.str();
-
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        if (observer->GetBattlegroundId() != player->GetBattlegroundId())
-            continue;
-
-        const_cast<Player*>(player)->Whisper(message, LANG_UNIVERSAL, observer);
-    }
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
 }
 
 enum class LifecycleObservationReason : uint8


### PR DESCRIPTION
### Motivation

- Provide Game Masters with actionable visibility when a playerbot fails to cast a PvP spell. 
- Reduce noisy GM `Whisper` traffic caused by lifecycle and battleground debug helpers and centralize debug into server logs. 
- Fix minor include usage for stream formatting in the modified files.

### Description

- Added `NotifySpellCastFailureToGameMasters` in `PlayerbotPvpClassActions.cpp` to format a failure message and whisper it to GMs on the same `Map` when a bot spell cast fails (excluding `SPELL_CAST_OK` and `SPELL_FAILED_SPELL_IN_PROGRESS`).
- Invoked `NotifySpellCastFailureToGameMasters` from `CastDirectSpell` when `player->CastSpell` returns a non-ok `SpellCastResult` and preserved the existing failure reason handling. 
- Removed in-map GM `Whisper` loops from `EmitBattlegroundGmDebug` and `EmitLifecycleGmDebug` and replaced those code paths with `TC_LOG_DEBUG` logging only to avoid whisper spam. 
- Added `#include <sstream>` to sources that build debug messages with `std::ostringstream`.

### Testing

- Built the project using the standard build (`make` / project build) successfully. 
- Ran the project's automated test suite (`make test` / `ctest`) and the tests completed without failures. 
- Verified that PvP debug output is emitted to logs (via `TC_LOG_DEBUG`) and that failing spell casts trigger formatted GM whispers on the same `Map` in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d743e475cc8327a2a80bfb7b7ea02d)