### PR TITLE
Playerbot PvP: notify GMs on spell failures and reduce in-world GM whisper noise

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -21,6 +21,7 @@
 #include "Item.h"
 #include "ObjectAccessor.h"
 #include "Log.h"
+#include "Map.h"
 #include "MotionMaster.h"
 #include "Player.h"
 #include "Pet.h"
@@ -34,6 +35,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <sstream>
 #include <unordered_map>
 
 namespace
@@ -131,6 +133,36 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
         GetTargetModeLabel(context.targetMode), casted ? "yes" : "no", context.reason ? context.reason : "none",
         failureReason.empty() ? "none" : failureReason);
+}
+
+void NotifySpellCastFailureToGameMasters(Player* bot, playerbot::PvpClassSpellContext const& context, SpellCastResult castResult)
+{
+    if (!bot || castResult == SPELL_CAST_OK || castResult == SPELL_FAILED_SPELL_IN_PROGRESS)
+        return;
+
+    Map* map = bot->GetMap();
+    if (!map)
+        return;
+
+    EnumText const resultText = EnumUtils::ToString(castResult);
+    std::ostringstream os;
+    os << "[Playerbot spell-fail] bot=" << bot->GetName()
+       << " guid=" << bot->GetGUID().ToString()
+       << " map=" << bot->GetMapId()
+       << " spell=" << context.spellId
+       << " action=" << (context.actionName ? context.actionName : "none")
+       << " target=" << GetTargetModeLabel(context.targetMode)
+       << " result=" << resultText.Title;
+    std::string const message = os.str();
+
+    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
+    {
+        Player* observer = itr->GetSource();
+        if (!observer || !observer->IsGameMaster())
+            continue;
+
+        bot->Whisper(message, LANG_UNIVERSAL, observer);
+    }
 }
 
 void FinalizeVirtualNearTeleport(Player* player)
@@ -400,6 +432,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
     {
+        NotifySpellCastFailureToGameMasters(player, context, castResult);
         EnumText const reasonText = EnumUtils::ToString(castResult);
         failureReason = reasonText.Title;
         return false;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -370,8 +370,7 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
 
     nextEmitMs = nowMs + throttleMs;
 
-    Map* map = bot->GetMap();
-    if (!map)
+    if (!bot->GetMap())
         return;
 
     std::ostringstream os;
@@ -383,17 +382,6 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
 
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        if (observer->GetBattlegroundId() != bot->GetBattlegroundId())
-            continue;
-
-        bot->Whisper(message, LANG_UNIVERSAL, observer);
-    }
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -86,28 +86,13 @@ void EmitLifecycleGmDebug(Player const* player, std::string const& detail, uint3
 
     nextEmitMs = nowMs + throttleMs;
 
-    Map const* map = player->GetMap();
-    if (!map)
-        return;
-
     std::ostringstream os;
     os << "[PBDBG lifecycle] bot=" << player->GetName()
        << " guid=" << player->GetGUID().ToString()
        << " bgId=" << player->GetBattlegroundId()
        << " detail=" << detail;
     std::string const message = os.str();
-
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        if (observer->GetBattlegroundId() != player->GetBattlegroundId())
-            continue;
-
-        const_cast<Player*>(player)->Whisper(message, LANG_UNIVERSAL, observer);
-    }
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
 }
 
 enum class LifecycleObservationReason : uint8


### PR DESCRIPTION
### Motivation

- Surface failed bot spell casts to online GMs so admins can observe problematic casts and debug PvP bot behavior. 
- Reduce noisy in-world whisper broadcasts for lifecycle/debug diagnostics and prefer server logging to avoid spamming GMs. 

### Description

- Add `NotifySpellCastFailureToGameMasters` which builds a failure message and whispers it to any online Game Masters on the bot's `Map`, and call it from `CastDirectSpell` when a cast fails. 
- Add required includes (`Map`, `sstream`) to support the new notification function and message composition. 
- Replace per-player GM whisper loops in `EmitBattlegroundGmDebug` and `EmitLifecycleGmDebug` with `TC_LOG_DEBUG` logging, removing iteration over `Map::GetPlayers()` and related map null-checks. 
- Minor refactor and cleanup around debug emission throttling and message construction for PvP lifecycle and random-bot participation codepaths. 

### Testing

- Performed a full project build to validate compilation after the changes and the build completed successfully. 
- Ran PvP-related smoke checks exercising spell cast failure paths and lifecycle debug emission and observed the new log lines and GM whispers for spell failures as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d743e475cc8327a2a80bfb7b7ea02d)