### PR TITLE
Playerbot: report spell failures to GMs, simplify lifecycle debug emission, and add GM status query

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -21,6 +21,7 @@
 #include "Item.h"
 #include "ObjectAccessor.h"
 #include "Log.h"
+#include "Map.h"
 #include "MotionMaster.h"
 #include "Player.h"
 #include "Pet.h"
@@ -34,6 +35,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <sstream>
 #include <unordered_map>
 
 namespace
@@ -131,6 +133,36 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
         GetTargetModeLabel(context.targetMode), casted ? "yes" : "no", context.reason ? context.reason : "none",
         failureReason.empty() ? "none" : failureReason);
+}
+
+void NotifySpellCastFailureToGameMasters(Player* bot, playerbot::PvpClassSpellContext const& context, SpellCastResult castResult)
+{
+    if (!bot || castResult == SPELL_CAST_OK || castResult == SPELL_FAILED_SPELL_IN_PROGRESS)
+        return;
+
+    Map* map = bot->GetMap();
+    if (!map)
+        return;
+
+    EnumText const resultText = EnumUtils::ToString(castResult);
+    std::ostringstream os;
+    os << "[Playerbot spell-fail] bot=" << bot->GetName()
+       << " guid=" << bot->GetGUID().ToString()
+       << " map=" << bot->GetMapId()
+       << " spell=" << context.spellId
+       << " action=" << (context.actionName ? context.actionName : "none")
+       << " target=" << GetTargetModeLabel(context.targetMode)
+       << " result=" << resultText.Title;
+    std::string const message = os.str();
+
+    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
+    {
+        Player* observer = itr->GetSource();
+        if (!observer || !observer->IsGameMaster())
+            continue;
+
+        bot->Whisper(message, LANG_UNIVERSAL, observer);
+    }
 }
 
 void FinalizeVirtualNearTeleport(Player* player)
@@ -400,6 +432,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
     {
+        NotifySpellCastFailureToGameMasters(player, context, castResult);
         EnumText const reasonText = EnumUtils::ToString(castResult);
         failureReason = reasonText.Title;
         return false;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -370,8 +370,7 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
 
     nextEmitMs = nowMs + throttleMs;
 
-    Map* map = bot->GetMap();
-    if (!map)
+    if (!bot->GetMap())
         return;
 
     std::ostringstream os;
@@ -383,17 +382,6 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
 
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        if (observer->GetBattlegroundId() != bot->GetBattlegroundId())
-            continue;
-
-        bot->Whisper(message, LANG_UNIVERSAL, observer);
-    }
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -86,28 +86,13 @@ void EmitLifecycleGmDebug(Player const* player, std::string const& detail, uint3
 
     nextEmitMs = nowMs + throttleMs;
 
-    Map const* map = player->GetMap();
-    if (!map)
-        return;
-
     std::ostringstream os;
     os << "[PBDBG lifecycle] bot=" << player->GetName()
        << " guid=" << player->GetGUID().ToString()
        << " bgId=" << player->GetBattlegroundId()
        << " detail=" << detail;
     std::string const message = os.str();
-
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        if (observer->GetBattlegroundId() != player->GetBattlegroundId())
-            continue;
-
-        const_cast<Player*>(player)->Whisper(message, LANG_UNIVERSAL, observer);
-    }
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
 }
 
 enum class LifecycleObservationReason : uint8

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -18,16 +18,87 @@
 #include "Log.h"
 #include "Chat.h"
 #include "GameTime.h"
+#include "MotionMaster.h"
 #include "Player.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
 #include "RBAC.h"
 #include "ScriptMgr.h"
 
+#include <sstream>
+
 using namespace Trinity::ChatCommands;
 
 namespace
 {
+char const* ToString(playerbot::BattlegroundState state)
+{
+    switch (state)
+    {
+        case playerbot::BattlegroundState::Queueing: return "queueing";
+        case playerbot::BattlegroundState::WaitingToStart: return "waiting";
+        case playerbot::BattlegroundState::Active: return "active";
+        case playerbot::BattlegroundState::None:
+        default: return "none";
+    }
+}
+
+char const* ToString(playerbot::QueueOperationType op)
+{
+    switch (op)
+    {
+        case playerbot::QueueOperationType::Join: return "join";
+        case playerbot::QueueOperationType::Leave: return "leave";
+        case playerbot::QueueOperationType::None:
+        default: return "none";
+    }
+}
+
+char const* ToString(playerbot::InvitationResponseType response)
+{
+    switch (response)
+    {
+        case playerbot::InvitationResponseType::Accept: return "accept";
+        case playerbot::InvitationResponseType::Decline: return "decline";
+        case playerbot::InvitationResponseType::None:
+        default: return "none";
+    }
+}
+
+std::string BuildManagedBotStatusLine(Player* bot)
+{
+    if (!bot)
+        return "Playerbot status unavailable.";
+
+    playerbot::PvpValues const values = playerbot::PvpCore::CollectValues(bot);
+    playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(bot, values);
+    playerbot::BattlegroundLifecycleContext const lifecycleContext = playerbot::PvpCore::BuildBattlegroundLifecycleContext(bot, values);
+    playerbot::RandomBotParticipationHooks const hooks = playerbot::PvpCore::BuildRandomBotParticipationHooks(bot, values);
+
+    std::ostringstream status;
+    status << "PB status: "
+           << "combat=" << (bot->IsInCombat() ? "yes" : "no")
+           << " alive=" << (bot->IsAlive() ? "yes" : "no")
+           << " moving=" << (bot->isMoving() ? "yes" : "no")
+           << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
+           << " bg_state=" << ToString(values.battlegroundState)
+           << " class_action=" << (classContext.actionName ? classContext.actionName : "none")
+           << " spell=" << classContext.spellId
+           << " reason=" << (classContext.reason ? classContext.reason : "none")
+           << " lifecycle_q=" << ToString(lifecycleContext.queueOperation)
+           << " lifecycle_invite=" << ToString(lifecycleContext.invitationResponse)
+           << " hooks(bg=" << (hooks.battlegroundParticipationHook ? "on" : "off")
+           << ",arena=" << (hooks.arenaParticipationHook ? "on" : "off") << ")"
+           << " motion=" << uint32(bot->GetMotionMaster()->GetCurrentMovementGeneratorType());
+
+    if (Unit* victim = bot->GetVictim())
+        status << " victim=" << victim->GetName();
+    else
+        status << " victim=none";
+
+    return status.str();
+}
+
 class PlayerbotBootstrapWorldScript final : public WorldScript
 {
 public:
@@ -104,6 +175,23 @@ public:
 
         target->SendDuelCountdown(3000);
         challenger->SendDuelCountdown(3000);
+    }
+
+    void OnChat(Player* sender, uint32 /*type*/, uint32 lang, std::string& /*msg*/, Player* receiver) override
+    {
+        if (!sender || !receiver)
+            return;
+
+        if (lang == LANG_ADDON)
+            return;
+
+        if (!sender->IsGameMaster())
+            return;
+
+        if (!playerbot::IsManagedRandomBot(receiver))
+            return;
+
+        receiver->Whisper(BuildManagedBotStatusLine(receiver), LANG_UNIVERSAL, sender);
     }
 };
 


### PR DESCRIPTION
### Motivation
- Improve visibility when managed playerbots fail to cast spells so GMs can observe and triage issues in real-time.
- Reduce chat spam to in-map players from lifecycle/battleground debug helpers and centralize debug output to logs.
- Provide a quick GM-accessible status report for managed bots to inspect runtime state on demand.

### Description
- Added `NotifySpellCastFailureToGameMasters` to whisper detailed spell-failure information to any GMs on the same map and call it when `CastDirectSpell` fails for non-trivial failure codes.
- Removed in-map GM whisper loops from `EmitBattlegroundGmDebug` and `EmitLifecycleGmDebug`, replacing them with `TC_LOG_DEBUG` entries to avoid broadcasting debug messages to players.
- Added helper string conversion functions and `BuildManagedBotStatusLine` to assemble a compact runtime status string for a managed bot, and wired an `OnChat` handler in `PlayerbotBootstrapWorldScript` that replies to GM chat by whispering the status to the GM.
- Included required header additions (`Map`, `MotionMaster`, `<sstream>`) and small related wiring changes in the playerbot bootstrap loader.

### Testing
- No new automated tests were added for these changes.
- Project compilation and the existing automated test/CI steps were executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d743e475cc8327a2a80bfb7b7ea02d)