### PR TITLE
AI: skip fully invulnerable targets when selecting victims

### DIFF
--- a/azerothcore-wotlk-Playerbot/src/server/game/Entities/Creature/Creature.cpp
+++ b/azerothcore-wotlk-Playerbot/src/server/game/Entities/Creature/Creature.cpp
@@ -2555,6 +2555,10 @@ bool Creature::CanCreatureAttack(Unit const* victim, bool skipDistCheck) const
     if (!IsValidAttackTarget(victim))
         return false;
 
+    // Skip fully invulnerable targets (e.g. Divine Shield / Ice Block) so AI can pick another victim.
+    if (victim->IsImmunedToDamageOrSchool(SPELL_SCHOOL_MASK_ALL))
+        return false;
+
     if (!victim->isInAccessiblePlaceFor(this))
         return false;
 


### PR DESCRIPTION
### Motivation
- Prevent AI-controlled creatures from tunneling on targets that are fully invulnerable (e.g. Divine Shield / Ice Block) so they can switch to other valid opponents.

### Description
- Add a guard in `Creature::CanCreatureAttack` (`azerothcore-wotlk-Playerbot/src/server/game/Entities/Creature/Creature.cpp`) that returns false when `victim->IsImmunedToDamageOrSchool(SPELL_SCHOOL_MASK_ALL)` to treat fully invulnerable units as non-attackable by AI.

### Testing
- No automated tests or full build were executed in this environment; change is a single-line behavior guard with no API/signature changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c2382d708327a95146122ca2d654)