### PR TITLE
Playerbot PvP: retarget when enemy is immune

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -565,7 +565,16 @@ bool IsTargetInvalidByImmunity(Player const* player, Unit const* target)
     if (!player || !target)
         return true;
 
+    if (Player const* targetPlayer = target->ToPlayer())
+    {
+        if (targetPlayer->isTotalImmune())
+            return true;
+    }
+
     if (target->HasAura(642)) // Divine Shield
+        return true;
+
+    if (target->HasAura(11958)) // Ice Block
         return true;
 
     if (IsPhysicalDamageClass(player->GetClass()) && HasAnyAura(target, { 1022, 5599, 10278 })) // Blessing of Protection ranks


### PR DESCRIPTION
### Motivation
- Prevent playerbots from tunneling on targets that are temporarily or fully immune (Divine Shield, Ice Block, total immunity, Blessing of Protection) so they retarget to a vulnerable opponent.

### Description
- Update `IsTargetInvalidByImmunity` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` to treat a player with `isTotalImmune()` as an invalid attack target and to explicitly consider aura `11958` (Ice Block) invalid in addition to the existing Divine Shield (`642`) and Blessing of Protection checks.

### Testing
- Verified the change by inspecting the modified file with `git diff` and reviewing the updated function body to confirm the new checks were present and correctly ordered; inspection succeeded.
- No build or automated test suite (`ctest` / full server build) was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c37bf82c83278f7ebf295884683b)