### PR TITLE
Playerbot: add battleground/arena preparation buff phase

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -326,6 +326,108 @@ bool HasAuraFromSpellChain(Unit const* unit, uint32 baseSpellId)
     return false;
 }
 
+ObjectGuid SelectFriendlyWithoutAuraFromSpellChain(Player const* player, uint32 baseSpellId, float maxDistance, bool includeSelf)
+{
+    if (!player || !player->GetMap() || !baseSpellId)
+        return ObjectGuid::Empty;
+
+    auto isEligible = [&](Player* candidate)
+    {
+        if (!candidate || !candidate->IsAlive())
+            return false;
+        if (candidate != player && !player->IsValidAssistTarget(candidate))
+            return false;
+        if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, maxDistance))
+            return false;
+        if (HasAuraFromSpellChain(candidate, baseSpellId))
+            return false;
+
+        return true;
+    };
+
+    if (includeSelf &&
+        player->IsAlive() &&
+        player->IsWithinLOSInMap(player) &&
+        player->IsWithinDistInMap(player, maxDistance) &&
+        !HasAuraFromSpellChain(player, baseSpellId))
+    {
+        return player->GetGUID();
+    }
+
+    Player* bestTarget = nullptr;
+    float bestDistance = std::numeric_limits<float>::max();
+    Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!isEligible(candidate))
+            continue;
+
+        float const distance = player->GetDistance(candidate);
+        if (distance < bestDistance)
+        {
+            bestDistance = distance;
+            bestTarget = candidate;
+        }
+    }
+
+    return bestTarget ? bestTarget->GetGUID() : ObjectGuid::Empty;
+}
+
+SpellDecision SelectPreparationBuffSpell(Player const* player)
+{
+    SpellDecision decision;
+    if (!player || player->IsInCombat())
+        return decision;
+
+    switch (player->GetClass())
+    {
+        case CLASS_PRIEST:
+        {
+            if (IsSpellReady(player, 10938))
+            {
+                if (ObjectGuid targetGuid = SelectFriendlyWithoutAuraFromSpellChain(player, 10938, 45.0f, true); !targetGuid.IsEmpty())
+                    return { "priest power word fortitude prep", "buff nearby team before gates open", 10938, playerbot::PvpClassSpellContext::TargetMode::Ally, targetGuid };
+            }
+
+            if (IsSpellReady(player, 10958))
+            {
+                if (ObjectGuid targetGuid = SelectFriendlyWithoutAuraFromSpellChain(player, 10958, 45.0f, true); !targetGuid.IsEmpty())
+                    return { "priest shadow protection prep", "buff nearby team before gates open", 10958, playerbot::PvpClassSpellContext::TargetMode::Ally, targetGuid };
+            }
+
+            break;
+        }
+        case CLASS_MAGE:
+        {
+            if (IsSpellReady(player, 10157))
+            {
+                if (ObjectGuid targetGuid = SelectFriendlyWithoutAuraFromSpellChain(player, 10157, 45.0f, true); !targetGuid.IsEmpty())
+                    return { "arcane intellect prep", "buff nearby team before gates open", 10157, playerbot::PvpClassSpellContext::TargetMode::Ally, targetGuid };
+            }
+
+            if (!HasAuraFromSpellChain(player, 10220) && IsSpellReady(player, 10220))
+                return { "frost armor prep", "maintain armor before gates open", 10220, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
+
+            break;
+        }
+        case CLASS_PALADIN:
+        {
+            if (IsSpellReady(player, 25898))
+            {
+                if (ObjectGuid targetGuid = SelectFriendlyWithoutAuraFromSpellChain(player, 25898, 45.0f, true); !targetGuid.IsEmpty())
+                    return { "paladin greater blessing of kings prep", "buff nearby team before gates open", 25898, playerbot::PvpClassSpellContext::TargetMode::Ally, targetGuid };
+            }
+
+            break;
+        }
+        default:
+            break;
+    }
+
+    return decision;
+}
+
 bool HasTemporaryWeaponImbue(Player const* player)
 {
     if (!player)
@@ -1961,9 +2063,26 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         return context;
 
     bool const inActiveBattleground = values.inBattleground && IsTriggerActive(PvpTrigger::BgActive, values);
+    bool const inBattlegroundPreparation = player->InBattleground() && player->HasUnitFlag(UNIT_FLAG_PREPARATION);
     bool const inActiveDuel = player->duel && player->duel->State == DUEL_STATE_IN_PROGRESS;
-    if (!inActiveBattleground && !inActiveDuel)
+    if (!inActiveBattleground && !inBattlegroundPreparation && !inActiveDuel)
         return context;
+
+    if (inBattlegroundPreparation)
+    {
+        SpellDecision const prepDecision = SelectPreparationBuffSpell(player);
+        if (prepDecision.spellId)
+        {
+            context.actionName = prepDecision.actionName;
+            context.reason = prepDecision.reason;
+            context.spellId = prepDecision.spellId;
+            context.targetMode = prepDecision.targetMode;
+            context.targetGuid = prepDecision.targetGuid;
+            context.selfCast = context.targetMode == PvpClassSpellContext::TargetMode::Self;
+            context.shouldExecute = true;
+            return context;
+        }
+    }
 
     Unit const* target = SelectCombatTarget(player);
     bool const hasValidTarget = target && target->IsAlive() && target->GetGUID() != player->GetGUID();


### PR DESCRIPTION
### Motivation
- Allow managed playerbots to perform pre-match support (cast group buffs / self-buffs) while behind battleground/arena gates, since class-spell logic previously only executed during active BG combat or duels.

### Description
- Add helper `SelectFriendlyWithoutAuraFromSpellChain` to pick the nearest eligible friendly in LOS/range missing a spell-chain aura and return its `ObjectGuid`.
- Add `SelectPreparationBuffSpell` which selects prep-phase buff spells for classes (priest: `10938` Power Word: Fortitude, `10958` Shadow Protection; mage: `10157` Arcane Intellect and `10220` Frost Armor self-maintenance; paladin: `25898` Greater Blessing of Kings) when out of combat and ready.
- Wire prep-phase logic into `PvpCore::BuildClassSpellContext` to run when a player is in a battleground and has `UNIT_FLAG_PREPARATION`, setting the returned `PvpClassSpellContext` fields so the existing `PvpClassActions::Execute` path can cast the buffs.
- Keep existing combat/active-BG/duel behavior unchanged by only executing prep logic during the preparation window and outside of combat.

### Testing
- Ran `cmake --build build --target worldserver -j2` which started a full build; the compile progressed normally through many targets (no immediate compile errors observed during the interactive window) but did not complete within the session time allotment. 
- Verified repository changes with `git status --short` and `git show --stat --oneline HEAD` and committed the change successfully.
- No automated unit tests were present or run for this change in the session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c4a788c08327b615d11aee1e6c94)