### PR TITLE
Use FindConnectedPlayer in battleground resurrection and improve WSG bot engagement

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -308,7 +308,7 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
                 Creature* sh = nullptr;
                 for (GuidVector::const_iterator itr2 = (itr->second).begin(); itr2 != (itr->second).end(); ++itr2)
                 {
-                    Player* player = ObjectAccessor::FindPlayer(*itr2);
+                    Player* player = ObjectAccessor::FindConnectedPlayer(*itr2);
                     if (!player)
                         continue;
 
@@ -333,7 +333,7 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
                     // manually include nearby dead playerbots so they resurrect reliably.
                     for (BattlegroundPlayerMap::const_iterator bgPlayerItr = m_Players.begin(); bgPlayerItr != m_Players.end(); ++bgPlayerItr)
                     {
-                        Player* nearbyPlayer = ObjectAccessor::FindPlayer(bgPlayerItr->first);
+                        Player* nearbyPlayer = ObjectAccessor::FindConnectedPlayer(bgPlayerItr->first);
                         if (!nearbyPlayer || nearbyPlayer->IsAlive() || !nearbyPlayer->IsInWorld() || !nearbyPlayer->IsWithinDistInMap(sh, 15.0f))
                             continue;
 
@@ -362,7 +362,7 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
     {
         for (GuidVector::const_iterator itr = m_ResurrectQueue.begin(); itr != m_ResurrectQueue.end(); ++itr)
         {
-            Player* player = ObjectAccessor::FindPlayer(*itr);
+            Player* player = ObjectAccessor::FindConnectedPlayer(*itr);
             if (!player)
                 continue;
             player->ResurrectPlayer(1.0f);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1525,6 +1525,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
 
     if (player->IsInCombat())
         return EngageNearestEnemyPlayer(player, 100.0f);
+
+    // WSG brawl behavior should aggressively acquire ranged pressure targets
+    // instead of endlessly pathing objective waypoints with no combat target.
+    if (IsWarsongGulch(player) && EngageNearestEnemyPlayer(player, 2000.0f))
+        return true;
+
     if (TryJumpOffWarsongGraveyard(player))
         return true;
 


### PR DESCRIPTION
### Motivation
- Prevent resurrection logic from targeting non-connected or invalid player pointers and ensure virtual/managed playerbots are included reliably during spirit guide waves.
- Make Warsong Gulch (WSG) playerbot behavior more aggressive so bots acquire ranged pressure targets instead of continuously pathing waypoints with no combat target.

### Description
- Replaced `ObjectAccessor::FindPlayer` with `ObjectAccessor::FindConnectedPlayer` in battleground resurrection code paths to only resolve connected player instances during revive queue processing and when adding nearby playerbots to the resurrect list.
- Applied the same `FindConnectedPlayer` change when flushing the `m_ResurrectQueue` before calling `ResurrectPlayer` and related spells.
- Added a WSG-specific early engagement check in `MoveToObjectivePrimitive` that calls `EngageNearestEnemyPlayer` with a large range (`2000.0f`) and returns early when a target is acquired to avoid pointless waypoint movement.

### Testing
- Built the project with `make` and the build completed successfully.
- Ran the automated unit/integration test suite via `ctest` and the tests related to battleground resurrection and playerbot PvP scenarios passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c38e54c08327b21cc8db2384b9f8)