### PR TITLE
Playerbot PvP: stop unnecessary kiting for ranged bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -804,6 +804,23 @@ bool IsMeleePressureTarget(Unit const* unit)
     }
 }
 
+bool IsActivelyPressuringInMelee(Unit const* attacker, Player const* bot)
+{
+    if (!attacker || !bot || !attacker->IsAlive() || !bot->IsAlive())
+        return false;
+
+    if (!IsMeleePressureTarget(attacker))
+        return false;
+
+    // Only kite if the melee-capable target is actually threatening this bot.
+    // Otherwise, ranged casters (e.g. frost mages) should hold position and
+    // continue turret casting from their current firing band.
+    if (attacker->GetVictim() == bot)
+        return true;
+
+    return attacker->IsWithinMeleeRange(bot) || bot->IsWithinMeleeRange(attacker);
+}
+
 struct CombatPositioningProfile
 {
     float preferredMinRange = 0.0f;
@@ -1165,7 +1182,7 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
             }
         }
 
-        if (profile.createDistanceWhenCrowded && IsMeleePressureTarget(target) && distance < profile.preferredIdealRange)
+        if (profile.createDistanceWhenCrowded && IsActivelyPressuringInMelee(target, player) && distance < profile.preferredIdealRange)
         {
             TC_LOG_DEBUG("playerbots.pvp.lifecycle",
                 "Playerbot PvP distance band: bot={} profile={} decision=create-distance-vs-melee-pressure distance={} min={} ideal={} max={}.",


### PR DESCRIPTION
### Motivation
- Ranged caster bots (e.g. frost mages) were moving out of their firing band whenever an enemy was a melee-capable class, which reduced turret uptime and caused erratic movement. 
- The goal is to keep ranged bots planted and casting (e.g. Frostbolt) unless a melee enemy is actually threatening them.

### Description
- Add `IsActivelyPressuringInMelee(Unit const* attacker, Player const* bot)` which returns true only when the attacker is a melee-capable class and is actively pressuring the bot (either targeting the bot or already within melee range).
- Replace the previous class-only gate in `DriveCombatPositioning` with `IsActivelyPressuringInMelee(...)` so ranged bots only trigger the `create-distance-vs-melee-pressure` kiting behavior when concrete melee pressure exists.
- Preserve existing fallback behavior for targets that are too close (`distance < profile.preferredMinRange`) and keep other distance-band logic unchanged.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it passed.
- Verified the modified file diff with `git diff -- src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to confirm the intended changes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cb5e61e083278f9002b0e37336d9)