### PR TITLE
Prioritize visible enemy engagement over objective waypoint routing

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1572,6 +1572,13 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (TryJumpOffWarsongGraveyard(player))
         return true;
 
+    // Prioritize combat over objective waypoint routing:
+    // if an enemy is currently detectable within the bot's vision envelope,
+    // switch to engagement immediately and defer waypoint movement.
+    float const visionScanDistance = std::max(5.0f, player->GetVisibilityRange());
+    if (EngageNearestEnemyPlayer(player, visionScanDistance))
+        return true;
+
     if (context.objective.type == BattlegroundObjectiveType::None &&
         context.movement == BattlegroundMovementPrimitive::None &&
         context.flagCarrierDirective == FlagCarrierDirective::None)


### PR DESCRIPTION
### Motivation
- Ensure playerbots prefer engaging detectable enemies over immediately running waypoint/objective routing so combat takes precedence when a target is within their vision range.

### Description
- Added a pre-objective engagement gate in `BattlegroundTacticalActions::MoveToObjectivePrimitive` (file `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`) that computes `visionScanDistance = max(5.0f, player->GetVisibilityRange())` and calls `EngageNearestEnemyPlayer(player, visionScanDistance)`, deferring waypoint movement when engagement occurs.

### Testing
- Started a build with `cmake --build build --target worldserver -j2` which progressed but was intentionally interrupted before completion; an attempted targeted `ninja` compile of the TU failed due to an unknown target, so the change was not fully validated via a completed worldserver build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cba16bc08327a9732163bbfd48f5)