### PR TITLE
Fix post-res battleground bots skipping combat pursuit

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1553,9 +1553,6 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
         return false;
 
-    if (player->isMoving())
-        return false;
-
     switch (player->GetMotionMaster()->GetCurrentMovementGeneratorType())
     {
         case IDLE_MOTION_TYPE:
@@ -1571,6 +1568,11 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         return EngageNearestEnemyPlayer(player, GetAggressiveCombatScanDistance(player, 100.0f));
     if (TryJumpOffWarsongGraveyard(player))
         return true;
+
+    // Evaluate combat/WSG post-res logic before this guard so stale movement
+    // flags do not suppress target pursuit immediately after graveyard rez.
+    if (player->isMoving())
+        return false;
 
     if (context.objective.type == BattlegroundObjectiveType::None &&
         context.movement == BattlegroundMovementPrimitive::None &&


### PR DESCRIPTION
### Motivation
- Bots could remain standing at the graveyard after resurrection because a movement short-circuit (`player->isMoving()`) ran before combat engagement and Warsong post-res routing logic, preventing immediate target pursuit.

### Description
- Reordered logic in `BattlegroundTacticalActions::MoveToObjectivePrimitive` so `EngageNearestEnemyPlayer` and `TryJumpOffWarsongGraveyard` run before the `player->isMoving()` early-return. 
- Added an inline comment explaining the ordering to avoid stale movement flags suppressing immediate pursuit. 
- Change is confined to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.

### Testing
- Ran `cmake --build build --target worldserver -j2`, which configured and compiled many targets (build progressed substantially but was intentionally stopped due to environment time constraints). (partial)
- Attempted `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o`, which failed because that ninja target is not exposed by the generator (no object-level target available). (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cc3482908327959c5ce5be10db71)