### PR TITLE
Allow GMs to whisper virtual-session playerbots

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -528,14 +528,15 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
             }
 
             Player* receiver = ObjectAccessor::FindConnectedPlayerByName(to);
-            if (!receiver || (lang != LANG_ADDON && !receiver->isAcceptWhispers() && receiver->GetSession()->HasPermission(rbac::RBAC_PERM_CAN_FILTER_WHISPERS) && !receiver->IsInWhisperWhiteList(sender->GetGUID())))
+            bool const gmWhisperingVirtualSession = receiver && sender->IsGameMaster() && receiver->GetSession() && receiver->GetSession()->IsVirtualSession();
+            if (!receiver || (lang != LANG_ADDON && !gmWhisperingVirtualSession && !receiver->isAcceptWhispers() && receiver->GetSession()->HasPermission(rbac::RBAC_PERM_CAN_FILTER_WHISPERS) && !receiver->IsInWhisperWhiteList(sender->GetGUID())))
             {
                 SendPlayerNotFoundNotice(to);
                 return;
             }
 
             // Apply checks only if receiver is not already in whitelist and if receiver is not a GM with ".whisper on"
-            if (!receiver->IsInWhisperWhiteList(sender->GetGUID()) && !receiver->IsGameMasterAcceptingWhispers())
+            if (!gmWhisperingVirtualSession && !receiver->IsInWhisperWhiteList(sender->GetGUID()) && !receiver->IsGameMasterAcceptingWhispers())
             {
                 if (!sender->IsGameMaster() && sender->GetLevel() < sWorld->getIntConfig(CONFIG_CHAT_WHISPER_LEVEL_REQ))
                 {


### PR DESCRIPTION
### Motivation
- GMs must be able to whisper managed playerbots that run on virtual (socketless) sessions, but normal whisper acceptance/filter checks can block those whispers.

### Description
- Added a `gmWhisperingVirtualSession` predicate in `WorldSession::HandleMessagechatOpcode` to detect `sender->IsGameMaster()` -> receiver virtual-session interactions in `src/server/game/Handlers/ChatHandler.cpp`.
- Bypassed the `isAcceptWhispers`/whitelist check for that specific GM→virtual-session path so the whisper is not rejected early.
- Skipped the subsequent level/faction gating when `gmWhisperingVirtualSession` is true so GMs can reach playerbots for status queries.

### Testing
- Ran source inspections and diffs with `git diff -- src/server/game/Handlers/ChatHandler.cpp` and `git status --short`, which completed successfully.
- Printed the modified region with `nl -ba src/server/game/Handlers/ChatHandler.cpp | sed -n '520,560p'` to verify the change location, which completed successfully.
- No full build or runtime test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cd0673dc832799909f6069a31718)