### PR TITLE
Playerbot: detect battleground preparation via preparation auras

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2072,7 +2072,8 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         return context;
 
     bool const inActiveBattleground = values.inBattleground && IsTriggerActive(PvpTrigger::BgActive, values);
-    bool const inBattlegroundPreparation = player->InBattleground() && player->HasUnitFlag(UNIT_FLAG_PREPARATION);
+    bool const inBattlegroundPreparation = player->InBattleground() &&
+        (player->HasAura(SPELL_PREPARATION) || player->HasAura(SPELL_ARENA_PREPARATION) || player->HasUnitFlag(UNIT_FLAG_PREPARATION));
     bool const inActiveDuel = player->duel && player->duel->State == DUEL_STATE_IN_PROGRESS;
     if (!inActiveBattleground && !inBattlegroundPreparation && !inActiveDuel)
         return context;


### PR DESCRIPTION
### Motivation
- Playerbots were often not casting preparation buffs during battleground prep because `UNIT_FLAG_PREPARATION` is not always present; prep logic should trigger when the preparation aura(s) are active.

### Description
- Change `PvpCore::BuildClassSpellContext` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` so `inBattlegroundPreparation` is true when `player->HasAura(SPELL_PREPARATION)` or `player->HasAura(SPELL_ARENA_PREPARATION)` or `player->HasUnitFlag(UNIT_FLAG_PREPARATION)`.

### Testing
- Ran `cmake --build build --target game -j 2`; the build started and progressed through many compilation units with no compile errors shown in the captured output, but the full build did not finish within the session time window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cae4749c8327b8adcdb3d91b3a3d)