### PR TITLE
Rogue: chase into range for Cheap Shot opener without breaking stealth

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -346,7 +346,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         player->SetSelection(target->GetGUID());
         bool const preserveStealthForOpener = player->HasStealthAura();
         if (preserveStealthForOpener)
+        {
+            // While stealthed, keep auto-attack disabled so we do not break
+            // stealth early, but still chase for Cheap Shot opener range.
+            if (context.spellId == 1833 && !player->IsWithinMeleeRange(target))
+                player->GetMotionMaster()->MoveChase(target);
+
             player->AttackStop();
+        }
         else if (player->GetVictim() != target)
             player->Attack(target, false);
         CommandPetAttackTarget(player, target);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1722,7 +1722,7 @@ SpellDecision SelectRogueSpell(Player const* player, Unit const* target)
 
     if (!player->IsInCombat() && !HasAuraFromSpellChain(player, 1784) && IsSpellReady(player, 1784))
         return { "rogue stealth", "enter stealth before engagement", 1784, playerbot::PvpClassSpellContext::TargetMode::Self };
-    if (IsSpellReady(player, 1833) && player->HasStealthAura())
+    if (player->HasStealthAura() && IsSpellReady(player, 1833))
         return { "rogue cheap shot", "default opener", 1833, playerbot::PvpClassSpellContext::TargetMode::Enemy };
     if (target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 1766))
         return { "rogue kick", "interrupt enemy cast", 1766, playerbot::PvpClassSpellContext::TargetMode::Enemy };


### PR DESCRIPTION
### Motivation
- Ensure stealthed rogues will close distance for `Cheap Shot` (`1833`) without triggering auto-attack and breaking stealth, and slightly optimize the rogue spell selection check order.

### Description
- While preserving stealth for an opener, call `player->GetMotionMaster()->MoveChase(target)` when `context.spellId == 1833` and the bot is not within melee range, and keep `AttackStop()` so auto-attack does not break stealth.
- Reordered the condition in `SelectRogueSpell` to check `player->HasStealthAura()` before `IsSpellReady(player, 1833)`.

### Testing
- Project built successfully and automated unit tests and PvP script smoke tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ca9e42108327835335e86e5b8119)