### PR TITLE
Use connected player lookup for battleground resurrection and make WSG bots engage nearby enemies

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -308,7 +308,7 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
                 Creature* sh = nullptr;
                 for (GuidVector::const_iterator itr2 = (itr->second).begin(); itr2 != (itr->second).end(); ++itr2)
                 {
-                    Player* player = ObjectAccessor::FindPlayer(*itr2);
+                    Player* player = ObjectAccessor::FindConnectedPlayer(*itr2);
                     if (!player)
                         continue;
 
@@ -330,11 +330,11 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
                 {
                     // Managed playerbot avatars (virtual sessions) can occasionally miss the
                     // regular resurrect queue registration. During each spirit guide wave,
-                    // manually include nearby dead playerbots so they resurrect reliably.
+                    // include all dead virtual bots in the battleground for this wave.
                     for (BattlegroundPlayerMap::const_iterator bgPlayerItr = m_Players.begin(); bgPlayerItr != m_Players.end(); ++bgPlayerItr)
                     {
-                        Player* nearbyPlayer = ObjectAccessor::FindPlayer(bgPlayerItr->first);
-                        if (!nearbyPlayer || nearbyPlayer->IsAlive() || !nearbyPlayer->IsInWorld() || !nearbyPlayer->IsWithinDistInMap(sh, 15.0f))
+                        Player* nearbyPlayer = ObjectAccessor::FindConnectedPlayer(bgPlayerItr->first);
+                        if (!nearbyPlayer || nearbyPlayer->IsAlive() || !nearbyPlayer->IsInWorld())
                             continue;
 
                         WorldSession* session = nearbyPlayer->GetSession();
@@ -362,7 +362,7 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
     {
         for (GuidVector::const_iterator itr = m_ResurrectQueue.begin(); itr != m_ResurrectQueue.end(); ++itr)
         {
-            Player* player = ObjectAccessor::FindPlayer(*itr);
+            Player* player = ObjectAccessor::FindConnectedPlayer(*itr);
             if (!player)
                 continue;
             player->ResurrectPlayer(1.0f);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1525,6 +1525,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
 
     if (player->IsInCombat())
         return EngageNearestEnemyPlayer(player, 100.0f);
+
+    // WSG brawl behavior should aggressively acquire ranged pressure targets
+    // instead of endlessly pathing objective waypoints with no combat target.
+    if (IsWarsongGulch(player) && EngageNearestEnemyPlayer(player, 2000.0f))
+        return true;
+
     if (TryJumpOffWarsongGraveyard(player))
         return true;
 


### PR DESCRIPTION
### Motivation
- Ensure virtual/managed bot sessions and disconnected-but-present players are reliably resurrected during battleground spirit-guide waves. 
- Avoid using stale/non-connected player references when processing revive/resurrect queues to reduce missed resurrections and null lookups. 
- Make Warsong Gulch (WSG) playerbots prioritize immediate combat targets instead of endlessly following objective waypoints when under ranged pressure.

### Description
- Replaced `ObjectAccessor::FindPlayer` with `ObjectAccessor::FindConnectedPlayer` when iterating revive and resurrect queues to only act on connected players. 
- Broadened the spirit-guide inclusion logic to include all dead virtual bot players in the battleground for each resurrection wave by removing a proximity check and using connected-player lookup. 
- Added an early-path behavior in `MoveToObjectivePrimitive` so that in WSG bots call `EngageNearestEnemyPlayer(player, 2000.0f)` and will engage if a target is found, preventing unnecessary waypoint movement.

### Testing
- Built the project to ensure the changes compile successfully, and the server binary starts without regressions. (build succeeded) 
- Ran automated unit/integration tests covering battleground resurrection and playerbot PvP lifecycle paths, and the affected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c38e54c08327b21cc8db2384b9f8)