### PR TITLE
Playerbot: Refactor Warsong Gulch graveyard post-resurrect routing and jump logic

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -255,8 +255,9 @@ bool TryJumpOffWarsongGraveyard(Player* player)
         uint32 battlegroundInstanceId = 0;
         bool wasAlive = true;
         bool active = false;
-        uint8 phase = 0; // 0 = move to tip, 1 = run forward burst, 2 = move to mid
-        uint32 forwardBurstEndMs = 0;
+        uint8 stepIndex = 0;
+        uint32 lastStepIssueMs = 0;
+        bool jumpIssuedForStep = false;
     };
 
     static std::unordered_map<uint64, PostResurrectRouteState> stateByGuid;
@@ -278,74 +279,81 @@ bool TryJumpOffWarsongGraveyard(Player* player)
     if (justResurrected)
     {
         state.active = true;
-        state.phase = 0;
-        state.forwardBurstEndMs = 0;
+        state.stepIndex = 0;
+        state.lastStepIssueMs = 0;
+        state.jumpIssuedForStep = false;
     }
 
     if (!state.active)
         return false;
 
-    static Position const hordeGraveyardTip(1066.0946404f, 1380.843994f, 340.612305f, 0.0f);
-    static Position const allianceGraveyardTip(1406.597412f, 1553.099121f, 343.533295f, 0.0f);
-    static Position const midPoint(1258.810181f, 1463.801758f, 312.229401f, 0.0f);
-    // Per-side anchors that point off the graveyard ledge into the field.
-    static Position const hordeForwardAnchor(978.20f, 1427.10f, 335.20f, 0.0f);
-    static Position const allianceForwardAnchor(1498.60f, 1484.30f, 340.20f, 0.0f);
+    struct JumpRouteStep
+    {
+        Position destination;
+        bool useJump = false;
+    };
+
+    // Reference-style WSG graveyard jump-down routing:
+    // Horde actions: move(1029)->move(1045)->move(1057)->jump(1075)->move(1096)->move(1134)
+    static std::array<JumpRouteStep, 6> const hordeSteps = {
+        JumpRouteStep{ Position(1029.242f, 1387.024f, 340.866f, 0.0f), false },
+        JumpRouteStep{ Position(1045.764f, 1389.831f, 340.825f, 0.0f), false },
+        JumpRouteStep{ Position(1057.076f, 1393.081f, 339.505f, 0.0f), false },
+        JumpRouteStep{ Position(1075.233f, 1398.645f, 323.669f, 0.0f), true  },
+        JumpRouteStep{ Position(1096.590f, 1395.070f, 317.016f, 0.0f), false },
+        JumpRouteStep{ Position(1134.380f, 1370.130f, 312.741f, 0.0f), false }
+    };
+
+    // Alliance actions: move(1407)->jump(1385)->move(1370)->move(1339)
+    static std::array<JumpRouteStep, 4> const allianceSteps = {
+        JumpRouteStep{ Position(1407.234f, 1551.658f, 343.432f, 0.0f), false },
+        JumpRouteStep{ Position(1385.325f, 1544.592f, 322.047f, 0.0f), true  },
+        JumpRouteStep{ Position(1370.710f, 1543.550f, 321.585f, 0.0f), false },
+        JumpRouteStep{ Position(1339.410f, 1533.420f, 313.336f, 0.0f), false }
+    };
 
     TeamId const teamId = ResolveBotTeamId(player);
-    Position const& graveyardTip = (teamId == TEAM_HORDE) ? hordeGraveyardTip : allianceGraveyardTip;
-    Position const& forwardAnchor = (teamId == TEAM_HORDE) ? hordeForwardAnchor : allianceForwardAnchor;
-
-    if (state.phase == 0)
+    auto const& steps = (teamId == TEAM_HORDE) ? hordeSteps : allianceSteps;
+    if (state.stepIndex >= steps.size())
     {
-        if (!player->IsWithinDist3d(graveyardTip.GetPositionX(), graveyardTip.GetPositionY(), graveyardTip.GetPositionZ(), 2.5f))
-        {
-            IssueMovePointThrottled(player, graveyardTip, 1.0f, 300);
-            return true;
-        }
-
-        state.phase = 1;
+        state.active = false;
+        return false;
     }
 
-    if (state.phase == 1)
+    JumpRouteStep const& step = steps[state.stepIndex];
+    float const arrivalRadius = 4.0f;
+    if (player->IsWithinDist3d(step.destination.GetPositionX(), step.destination.GetPositionY(), step.destination.GetPositionZ(), arrivalRadius))
     {
-        uint32 const nowMs = GameTime::GetGameTimeMS();
-        if (!state.forwardBurstEndMs)
-            state.forwardBurstEndMs = nowMs + 1000;
-
-        // Push straight off the graveyard ledge first, then route to mid.
-        float const dx = forwardAnchor.GetPositionX() - graveyardTip.GetPositionX();
-        float const dy = forwardAnchor.GetPositionY() - graveyardTip.GetPositionY();
-        float const len = std::sqrt(dx * dx + dy * dy);
-        if (len <= 0.001f)
-        {
-            state.phase = 2;
-            return true;
-        }
-
-        float const forwardDistance = player->GetSpeed(MOVE_RUN) * 1.0f;
-        Position forwardPoint(
-            graveyardTip.GetPositionX() + (dx / len) * forwardDistance,
-            graveyardTip.GetPositionY() + (dy / len) * forwardDistance,
-            graveyardTip.GetPositionZ(),
-            player->GetAbsoluteAngle(forwardAnchor.GetPositionX(), forwardAnchor.GetPositionY()));
-
-        IssueMovePointThrottled(player, forwardPoint, 0.5f, 100);
-
-        if (nowMs >= state.forwardBurstEndMs)
-            state.phase = 2;
-        return true;
-    }
-
-    if (state.phase == 2)
-    {
-        IssueMovePointThrottled(player, midPoint, 1.0f, 300);
-
-        if (player->IsWithinDist3d(midPoint.GetPositionX(), midPoint.GetPositionY(), midPoint.GetPositionZ(), 6.0f))
+        ++state.stepIndex;
+        state.jumpIssuedForStep = false;
+        state.lastStepIssueMs = 0;
+        if (state.stepIndex >= steps.size())
             state.active = false;
         return true;
     }
 
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    if (step.useJump)
+    {
+        // Re-issue the jump periodically until we land near the destination.
+        if (!state.jumpIssuedForStep || nowMs >= state.lastStepIssueMs + 900)
+        {
+            float const speed = player->GetSpeed(MOVE_RUN);
+            MotionMaster* motionMaster = player->GetMotionMaster();
+            if (motionMaster)
+            {
+                motionMaster->Clear();
+                motionMaster->MoveJump(step.destination.GetPositionX(), step.destination.GetPositionY(),
+                    step.destination.GetPositionZ(), speed, speed, 1.0f);
+            }
+
+            state.jumpIssuedForStep = true;
+            state.lastStepIssueMs = nowMs;
+        }
+        return true;
+    }
+
+    IssueMovePointThrottled(player, step.destination, 1.0f, 300);
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- Simplify and make the post-resurrect route for Warsong Gulch (WSG) more deterministic and robust by replacing ad-hoc phases with explicit route steps.
- Improve jump issuing so jumps are re-issued reliably until the bot lands near the intended destination.

### Description
- Replaced `PostResurrectRouteState` fields `phase` and `forwardBurstEndMs` with `stepIndex`, `lastStepIssueMs`, and `jumpIssuedForStep` to track discrete route steps.
- Introduced `JumpRouteStep` and explicit step arrays for Horde and Alliance WSG routes with hardcoded `Position` waypoints and a `useJump` flag. 
- Replaced phase-based movement logic with step iteration that advances `stepIndex` on waypoint arrival and disables the route when complete.
- Implemented jump behavior by calling `motionMaster->MoveJump(...)` and re-issuing the jump periodically (every 900ms) until the bot reaches the step destination, and used `IssueMovePointThrottled` for regular move steps.

### Testing
- Built the project using `make` (Debug/Release) to verify compilation succeeded with the changes.
- Ran the automated test suite via `make test` / `ctest` and observed no regressions in the tested components.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cc9bf4008327a520ff08a2e1ecd5)