### PR TITLE
Fix PvP lifecycle route step selection compile error

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -313,8 +313,9 @@ bool TryJumpOffWarsongGraveyard(Player* player)
     };
 
     TeamId const teamId = ResolveBotTeamId(player);
-    auto const& steps = (teamId == TEAM_HORDE) ? hordeSteps : allianceSteps;
-    if (state.stepIndex >= steps.size())
+    JumpRouteStep const* steps = (teamId == TEAM_HORDE) ? hordeSteps.data() : allianceSteps.data();
+    size_t const stepCount = (teamId == TEAM_HORDE) ? hordeSteps.size() : allianceSteps.size();
+    if (state.stepIndex >= stepCount)
     {
         state.active = false;
         return false;
@@ -327,7 +328,7 @@ bool TryJumpOffWarsongGraveyard(Player* player)
         ++state.stepIndex;
         state.jumpIssuedForStep = false;
         state.lastStepIssueMs = 0;
-        if (state.stepIndex >= steps.size())
+        if (state.stepIndex >= stepCount)
             state.active = false;
         return true;
     }


### PR DESCRIPTION
### Motivation
- Fix a compile-time type mismatch when selecting between two `std::array<JumpRouteStep, N>` values of different sizes in the PvP lifecycle routing logic which caused an incompatible operand error.

### Description
- In `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` replace the ternary `auto const& steps = (teamId == TEAM_HORDE) ? hordeSteps : allianceSteps;` with an explicit `JumpRouteStep const* steps = ...` and a `size_t const stepCount = ...` using `.data()` and `.size()` and update the bounds checks to use `stepCount`.

### Testing
- No automated build or test run was executed in this environment so compilation and CI were not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d0d21474832790e4c0f0a1895c83)