### PR TITLE
Hardcode battleground spirit waves to resurrect all dead playerbots

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -326,27 +326,24 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
                     m_ResurrectQueue.push_back(*itr2);
                 }
 
-                if (sh)
+                // Hard override for managed playerbot avatars (virtual sessions):
+                // when a spirit guide resurrection wave happens, include every dead
+                // playerbot in this battleground, regardless of graveyard location.
+                for (BattlegroundPlayerMap::const_iterator bgPlayerItr = m_Players.begin(); bgPlayerItr != m_Players.end(); ++bgPlayerItr)
                 {
-                    // Managed playerbot avatars (virtual sessions) can occasionally miss the
-                    // regular resurrect queue registration. During each spirit guide wave,
-                    // manually include nearby dead playerbots so they resurrect reliably.
-                    for (BattlegroundPlayerMap::const_iterator bgPlayerItr = m_Players.begin(); bgPlayerItr != m_Players.end(); ++bgPlayerItr)
-                    {
-                        Player* nearbyPlayer = ObjectAccessor::FindConnectedPlayer(bgPlayerItr->first);
-                        if (!nearbyPlayer || nearbyPlayer->IsAlive() || !nearbyPlayer->IsInWorld() || !nearbyPlayer->IsWithinDistInMap(sh, 15.0f))
-                            continue;
+                    Player* botPlayer = ObjectAccessor::FindConnectedPlayer(bgPlayerItr->first);
+                    if (!botPlayer || botPlayer->IsAlive() || !botPlayer->IsInWorld())
+                        continue;
 
-                        WorldSession* session = nearbyPlayer->GetSession();
-                        if (!session || !session->IsVirtualSession())
-                            continue;
+                    WorldSession* session = botPlayer->GetSession();
+                    if (!session || !session->IsVirtualSession())
+                        continue;
 
-                        if (std::find(m_ResurrectQueue.begin(), m_ResurrectQueue.end(), nearbyPlayer->GetGUID()) != m_ResurrectQueue.end())
-                            continue;
+                    if (std::find(m_ResurrectQueue.begin(), m_ResurrectQueue.end(), botPlayer->GetGUID()) != m_ResurrectQueue.end())
+                        continue;
 
-                        nearbyPlayer->CastSpell(nearbyPlayer, SPELL_RESURRECTION_VISUAL, true);
-                        m_ResurrectQueue.push_back(nearbyPlayer->GetGUID());
-                    }
+                    botPlayer->CastSpell(botPlayer, SPELL_RESURRECTION_VISUAL, true);
+                    m_ResurrectQueue.push_back(botPlayer->GetGUID());
                 }
                 (itr->second).clear();
             }


### PR DESCRIPTION
### Motivation
- Ensure managed playerbot avatars (virtual sessions) reliably resurrect during spirit guide waves by removing the previous proximity restriction and force-including them in the wave.

### Description
- Replaced the proximity-gated inclusion logic in `src/server/game/Battlegrounds/Battleground.cpp` with a battleground-wide scan over `m_Players` to find dead playerbots.
- Only players with a virtual session are considered and existing queue membership is checked to avoid duplicates, and each selected bot receives `SPELL_RESURRECTION_VISUAL` and is pushed to `m_ResurrectQueue`.
- Removed the `IsWithinDistInMap(sh, 15.0f)` check and the nested loop that limited resurrect registration to bots near the spirit guide.
- Change is localized to the `_ProcessResurrect` handling in the `Battleground` implementation.

### Testing
- Ran `git diff --check` to validate patch formatting and found no issues (passed). 
- Inspected commit output via `git show --stat` to confirm the intended file change was recorded (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d3a65e08832783dd5cb5d762a000)