### PR TITLE
Improve battleground pathfinding and Warsong enemy pursuit for playerbots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -385,6 +385,16 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     // collision/pathing entirely.
     if (generatePath && player->InBattleground())
     {
+        bool const canDirectDropToDestination = destination.GetPositionZ() + 8.0f < player->GetPositionZ() &&
+            player->IsWithinLOS(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
+        if (canDirectDropToDestination)
+        {
+            motionMaster->MovePoint(0, destination, false);
+            state.lastDestination = destination;
+            state.lastIssueMs = nowMs;
+            return true;
+        }
+
         PathGenerator path(player);
         path.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
 
@@ -905,6 +915,15 @@ bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
     CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     if (!player->IsWithinLOSInMap(target))
         return TryRecoverLineOfSight(player, target, profile, "move-toward-unit");
+
+    // WSG should not avoid fall damage while pursuing enemies.
+    if (IsWarsongGulch(player) &&
+        target->GetPositionZ() + 6.0f < player->GetPositionZ() &&
+        player->IsWithinLOS(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ()))
+    {
+        player->GetMotionMaster()->MovePoint(0, target->GetPosition(), false);
+        return true;
+    }
 
     if (!player->IsWithinDistInMap(target, desiredDistance))
         player->GetMotionMaster()->MoveFollow(target, desiredDistance, player->GetFollowAngle());

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -37,6 +37,7 @@
 #include "ObjectAccessor.h"
 #include "Item.h"
 #include "ItemTemplate.h"
+#include "PathGenerator.h"
 #include "Player.h"
 #include "Spell.h"
 #include "SpellMgr.h"
@@ -106,95 +107,25 @@ TeamId ResolveBotTeamId(Player const* player)
     return ResolveTeamId(player->GetTeam());
 }
 
-std::vector<Position> const& GetWarsongObjectivePathForTeam(TeamId botTeam)
-{
-    // Reference-style objective routing through the same major WSG lane segments:
-    // own flag room -> tunnel/field spine -> enemy flag room.
-    static std::vector<Position> const allianceToHorde =
-    {
-        // Open through tunnel lane so bots naturally run out of tunnel at match start.
-        Position(1496.823853f, 1458.138062f, 344.574677f, 0.0f), //tunnel entrance
-        Position(1450.383667f, 1459.048950f, 342.465851f, 0.0f), //speed boots
-        Position(1407.761108f, 1460.541626f, 330.990997f, 0.0f), //halfway down tunnel
-        Position(1310.631348f, 1461.185059f, 317.711670f, 0.0f), //halfway to mid
-        Position(1258.810181f, 1463.801758f, 312.229401f, 0.0f) //mid
+Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance);
+bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance);
+bool EngageNearestEnemyPlayer(Player* player, float scanDistance);
+float GetAggressiveCombatScanDistance(Player const* player, float fallbackDistance);
 
-    };
-
-    static std::vector<Position> const hordeToAlliance =
-    {
-        // Open through tunnel lane so bots naturally run out of tunnel at match start.
-        Position(950.949646f, 1458.971802f, 342.466125f, 0.0f), //tunnel entrance
-        Position(1001.682495f, 1459.457397f, 335.441101f, 0.0f), //speed boots
-        Position(1073.515869f, 1459.7177f, 317.142853f, 0.0f), //halfway down tunnel
-        Position(1134.972534f, 1463.462158f, 315.624f, 0.0f), //halfway to mid
-        Position(1204.189331f, 1469.181396f, 307.059204f, 0.0f), //south of big rock
-        Position(1258.810181f, 1463.801758f, 312.229401f, 0.0f) //mid
-    };
-
-    return (botTeam == TEAM_ALLIANCE) ? allianceToHorde : hordeToAlliance;
-}
-
-bool TryGetWarsongObjectiveProgressWaypoint(Player* player, Position const& finalDestination, Position& waypointOut)
+bool TryPursueNearestEnemyInWarsong(Player* player)
 {
     if (!player || !IsWarsongGulch(player))
         return false;
 
-    struct WsgObjectivePathState
-    {
-        uint32 battlegroundInstanceId = 0;
-        uint32 nextIndex = 0;
-    };
-
-    static std::unordered_map<uint64, WsgObjectivePathState> stateByGuid;
-    uint64 const botGuid = player->GetGUID().GetRawValue();
-    WsgObjectivePathState& state = stateByGuid[botGuid];
-
-    Battleground* battleground = player->GetBattleground();
-    if (!battleground)
+    Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max());
+    if (!nearestEnemy)
         return false;
 
-    TeamId const botTeam = ResolveBotTeamId(player);
-    std::vector<Position> const& path = GetWarsongObjectivePathForTeam(botTeam);
-    if (path.empty())
-        return false;
+    float const combatEngageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
+    if (player->IsWithinDistInMap(nearestEnemy, combatEngageDistance))
+        return EngageNearestEnemyPlayer(player, combatEngageDistance);
 
-    if (state.battlegroundInstanceId != battleground->GetInstanceID())
-    {
-        state.battlegroundInstanceId = battleground->GetInstanceID();
-        state.nextIndex = 0;
-
-        float nearestDist = std::numeric_limits<float>::max();
-        for (uint32 i = 0; i < path.size(); ++i)
-        {
-            float const dist = player->GetDistance(path[i].GetPositionX(), path[i].GetPositionY(), path[i].GetPositionZ());
-            if (dist < nearestDist)
-            {
-                nearestDist = dist;
-                state.nextIndex = i;
-            }
-        }
-    }
-
-    if (state.nextIndex >= path.size())
-        state.nextIndex = static_cast<uint32>(path.size() - 1);
-
-    Position const& currentWp = path[state.nextIndex];
-    if (player->IsWithinDist3d(currentWp.GetPositionX(), currentWp.GetPositionY(), currentWp.GetPositionZ(), 10.0f))
-    {
-        if (state.nextIndex + 1 < path.size())
-            ++state.nextIndex;
-    }
-
-    // Close enough to final objective anchor: move directly to final objective.
-    if (player->IsWithinDist3d(finalDestination.GetPositionX(), finalDestination.GetPositionY(), finalDestination.GetPositionZ(), 35.0f))
-    {
-        waypointOut = finalDestination;
-        return true;
-    }
-
-    waypointOut = path[state.nextIndex];
-    return true;
+    return MoveTowardUnit(player, nearestEnemy, 20.0f);
 }
 
 bool RecoverStaleBattlegroundState(Player* player)
@@ -447,9 +378,41 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
 
-    // Reference parity: issue movement directly to resolved objective/start targets.
-    // Let core pathing own corridor/tunnel traversal instead of script-layer lane steering.
-    motionMaster->MovePoint(0, destination, generatePath);
+    // Battleground long-range movement pathfinder:
+    // build a navmesh path toward the true destination, then issue movement
+    // toward the furthest available point on that segment. This chains
+    // truncated navmesh paths into full-map traversal without disabling
+    // collision/pathing entirely.
+    if (generatePath && player->InBattleground())
+    {
+        PathGenerator path(player);
+        path.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
+
+        Movement::PointsArray const& points = path.GetPath();
+        if (!points.empty())
+        {
+            G3D::Vector3 const& lastPoint = points.back();
+            Position segmentDestination(lastPoint.x, lastPoint.y, lastPoint.z, destination.GetOrientation());
+
+            bool const destinationIsSignificantlyLower = segmentDestination.GetPositionZ() + 8.0f < player->GetPositionZ();
+            bool const canDirectDrop = destinationIsSignificantlyLower &&
+                player->IsWithinLOS(segmentDestination.GetPositionX(), segmentDestination.GetPositionY(), segmentDestination.GetPositionZ());
+
+            if (canDirectDrop)
+                motionMaster->MovePoint(0, segmentDestination, false);
+            else
+                motionMaster->MovePoint(0, segmentDestination, true);
+        }
+        else
+        {
+            motionMaster->MovePoint(0, destination, true);
+        }
+    }
+    else
+    {
+        motionMaster->MovePoint(0, destination, generatePath);
+    }
+
     state.lastDestination = destination;
     state.lastIssueMs = nowMs;
     return true;
@@ -1586,6 +1549,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (TryJumpOffWarsongGraveyard(player))
         return true;
 
+    if (TryPursueNearestEnemyInWarsong(player))
+        return true;
+
     // Evaluate combat/WSG post-res logic before this guard so stale movement
     // flags do not suppress target pursuit immediately after graveyard rez.
     if (player->isMoving())
@@ -1621,13 +1587,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
             Position destination;
             if (TryGetObjectivePosition(battleground, player, destination))
             {
-                Position issuedDestination = destination;
-                if (IsWarsongGulch(player))
-                    TryGetWarsongObjectiveProgressWaypoint(player, destination, issuedDestination);
-
-                bool const withinObjectiveRange = player->IsWithinDist3d(issuedDestination.GetPositionX(), issuedDestination.GetPositionY(), issuedDestination.GetPositionZ(), 12.0f);
+                bool const withinObjectiveRange = player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f);
                 if (!withinObjectiveRange)
-                    IssueMovePointThrottled(player, issuedDestination);
+                    IssueMovePointThrottled(player, destination);
                 else
                     EmitBattlegroundGmDebug(player, "objective-skip reason=already-near-objective range=12");
                 return true;
@@ -1645,12 +1607,12 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (!player || !player->InBattleground())
         return false;
 
-    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : GetAggressiveCombatScanDistance(player, 100.0f);
+    float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
     if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
     if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
+        return TryPursueNearestEnemyInWarsong(player) || MoveToClosestBattlegroundGraveyard(player);
 
     return context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None;
 }


### PR DESCRIPTION
### Motivation
- Replace brittle, hardcoded Warsong Gulch waypoint routing with direct enemy pursuit to make bot behavior more responsive during flag engagements.
- Improve long-range battleground movement by leveraging the server navmesh pathfinder to avoid issuing unreachable endpoints and reduce stuck/truncated movement.
- Unify and simplify combat engagement scanning so bots pick appropriate engagement distances and pursue nearby enemies more reliably.

### Description
- Added `#include "PathGenerator.h"` and integrated navmesh path generation into `IssueMovePointThrottled` to calculate a path to the destination and issue movement toward the furthest available path point instead of always issuing the final destination directly.
- Replaced the WSG lane waypoint system (`GetWarsongObjectivePathForTeam` / `TryGetWarsongObjectiveProgressWaypoint`) with a new `TryPursueNearestEnemyInWarsong` flow that finds the nearest enemy player and attempts to move toward or engage them using helper stubs like `FindNearestEnemyBattlegroundPlayer`, `MoveTowardUnit`, `EngageNearestEnemyPlayer`, and `GetAggressiveCombatScanDistance`.
- Updated `MoveToObjectivePrimitive` to remove the WSG-specific waypoint override and to call `TryPursueNearestEnemyInWarsong` early, and updated `CheckObjectivePrimitive` to use the new pursuit logic and remove the prior 2000.0f WSG engagement exception.
- Implemented direct-drop heuristics when the path endpoint is significantly below the bot and within line-of-sight, and preserved fallback behavior to use core pathing when no navmesh points are available.

### Testing
- Compiled the server with the modified `PlayerbotPvpLifecycleActions.cpp` and related headers to ensure no build regressions (`build` completed successfully).
- Ran existing automated unit/integration tests for battleground movement and playerbot PvP behaviour and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d5d343188327bd3a45a5aa53e3bb)