### PR TITLE
Improve Warsong Gulch pursuit and battleground movement pathing for playerbots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -37,6 +37,7 @@
 #include "ObjectAccessor.h"
 #include "Item.h"
 #include "ItemTemplate.h"
+#include "PathGenerator.h"
 #include "Player.h"
 #include "Spell.h"
 #include "SpellMgr.h"
@@ -106,95 +107,109 @@ TeamId ResolveBotTeamId(Player const* player)
     return ResolveTeamId(player->GetTeam());
 }
 
-std::vector<Position> const& GetWarsongObjectivePathForTeam(TeamId botTeam)
-{
-    // Reference-style objective routing through the same major WSG lane segments:
-    // own flag room -> tunnel/field spine -> enemy flag room.
-    static std::vector<Position> const allianceToHorde =
-    {
-        // Open through tunnel lane so bots naturally run out of tunnel at match start.
-        Position(1496.823853f, 1458.138062f, 344.574677f, 0.0f), //tunnel entrance
-        Position(1450.383667f, 1459.048950f, 342.465851f, 0.0f), //speed boots
-        Position(1407.761108f, 1460.541626f, 330.990997f, 0.0f), //halfway down tunnel
-        Position(1310.631348f, 1461.185059f, 317.711670f, 0.0f), //halfway to mid
-        Position(1258.810181f, 1463.801758f, 312.229401f, 0.0f) //mid
+Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance, uint32* scannedPlayers = nullptr, uint32* attackableEnemies = nullptr);
+bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance);
+bool EngageNearestEnemyPlayer(Player* player, float scanDistance);
+float GetAggressiveCombatScanDistance(Player const* player, float fallbackDistance);
+bool CanIssueBotMovement(Player const* player);
+bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
+void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs);
 
-    };
-
-    static std::vector<Position> const hordeToAlliance =
-    {
-        // Open through tunnel lane so bots naturally run out of tunnel at match start.
-        Position(950.949646f, 1458.971802f, 342.466125f, 0.0f), //tunnel entrance
-        Position(1001.682495f, 1459.457397f, 335.441101f, 0.0f), //speed boots
-        Position(1073.515869f, 1459.7177f, 317.142853f, 0.0f), //halfway down tunnel
-        Position(1134.972534f, 1463.462158f, 315.624f, 0.0f), //halfway to mid
-        Position(1204.189331f, 1469.181396f, 307.059204f, 0.0f), //south of big rock
-        Position(1258.810181f, 1463.801758f, 312.229401f, 0.0f) //mid
-    };
-
-    return (botTeam == TEAM_ALLIANCE) ? allianceToHorde : hordeToAlliance;
-}
-
-bool TryGetWarsongObjectiveProgressWaypoint(Player* player, Position const& finalDestination, Position& waypointOut)
+bool TryPursueNearestEnemyInWarsong(Player* player)
 {
     if (!player || !IsWarsongGulch(player))
         return false;
 
-    struct WsgObjectivePathState
+    static std::unordered_map<uint64, ObjectGuid> chaseTargetByBotGuid;
+    static std::unordered_map<uint64, uint32> chaseTargetSetMsByBotGuid;
+
+    auto const isValidChaseTarget = [player](Player* candidate) -> bool
     {
-        uint32 battlegroundInstanceId = 0;
-        uint32 nextIndex = 0;
+        if (!candidate || candidate == player)
+            return false;
+        if (!candidate->IsAlive() || !candidate->IsInWorld())
+            return false;
+        if (candidate->GetMapId() != player->GetMapId())
+            return false;
+        if (candidate->GetBattlegroundId() != player->GetBattlegroundId())
+            return false;
+        return player->IsValidAttackTarget(candidate);
     };
 
-    static std::unordered_map<uint64, WsgObjectivePathState> stateByGuid;
+    uint32 scannedPlayers = 0;
+    uint32 attackableEnemies = 0;
+    Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), &scannedPlayers, &attackableEnemies);
     uint64 const botGuid = player->GetGUID().GetRawValue();
-    WsgObjectivePathState& state = stateByGuid[botGuid];
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    Player* selectedEnemy = nearestEnemy;
+    bool stickyTargetHeld = false;
 
-    Battleground* battleground = player->GetBattleground();
-    if (!battleground)
-        return false;
-
-    TeamId const botTeam = ResolveBotTeamId(player);
-    std::vector<Position> const& path = GetWarsongObjectivePathForTeam(botTeam);
-    if (path.empty())
-        return false;
-
-    if (state.battlegroundInstanceId != battleground->GetInstanceID())
+    std::unordered_map<uint64, ObjectGuid>::const_iterator stickyItr = chaseTargetByBotGuid.find(botGuid);
+    if (stickyItr != chaseTargetByBotGuid.end() && !stickyItr->second.IsEmpty())
     {
-        state.battlegroundInstanceId = battleground->GetInstanceID();
-        state.nextIndex = 0;
-
-        float nearestDist = std::numeric_limits<float>::max();
-        for (uint32 i = 0; i < path.size(); ++i)
+        Player* stickyEnemy = ObjectAccessor::FindConnectedPlayer(stickyItr->second);
+        if (isValidChaseTarget(stickyEnemy))
         {
-            float const dist = player->GetDistance(path[i].GetPositionX(), path[i].GetPositionY(), path[i].GetPositionZ());
-            if (dist < nearestDist)
+            uint32 const setMs = chaseTargetSetMsByBotGuid[botGuid];
+            uint32 const stickyAgeMs = nowMs - setMs;
+            float const stickyDist = player->GetDistance(stickyEnemy);
+            float const nearestDist = nearestEnemy ? player->GetDistance(nearestEnemy) : std::numeric_limits<float>::max();
+            bool const withinStickyWindow = stickyAgeMs < 6000;
+            bool const nearestNotMeaningfullyBetter = nearestDist + 12.0f >= stickyDist;
+
+            if (withinStickyWindow && nearestNotMeaningfullyBetter)
             {
-                nearestDist = dist;
-                state.nextIndex = i;
+                selectedEnemy = stickyEnemy;
+                stickyTargetHeld = true;
             }
         }
     }
 
-    if (state.nextIndex >= path.size())
-        state.nextIndex = static_cast<uint32>(path.size() - 1);
-
-    Position const& currentWp = path[state.nextIndex];
-    if (player->IsWithinDist3d(currentWp.GetPositionX(), currentWp.GetPositionY(), currentWp.GetPositionZ(), 10.0f))
+    if (!selectedEnemy)
     {
-        if (state.nextIndex + 1 < path.size())
-            ++state.nextIndex;
+        chaseTargetByBotGuid.erase(botGuid);
+        chaseTargetSetMsByBotGuid.erase(botGuid);
+        EmitBattlegroundGmDebug(player,
+            "wsg-pursuit=no-enemy scanned=" + std::to_string(scannedPlayers) +
+            " attackable=" + std::to_string(attackableEnemies), 1500);
+        return false;
     }
 
-    // Close enough to final objective anchor: move directly to final objective.
-    if (player->IsWithinDist3d(finalDestination.GetPositionX(), finalDestination.GetPositionY(), finalDestination.GetPositionZ(), 35.0f))
+    if (!stickyTargetHeld || chaseTargetByBotGuid[botGuid] != selectedEnemy->GetGUID())
     {
-        waypointOut = finalDestination;
-        return true;
+        chaseTargetByBotGuid[botGuid] = selectedEnemy->GetGUID();
+        chaseTargetSetMsByBotGuid[botGuid] = nowMs;
     }
 
-    waypointOut = path[state.nextIndex];
-    return true;
+    float const distanceToEnemy = player->GetDistance(selectedEnemy);
+    float const combatEngageDistance = std::clamp(GetAggressiveCombatScanDistance(player, 100.0f), 25.0f, 60.0f);
+    if (distanceToEnemy <= combatEngageDistance)
+    {
+        EmitBattlegroundGmDebug(player,
+            "wsg-pursuit=engage target=" + selectedEnemy->GetName() +
+            " dist=" + std::to_string(int32(distanceToEnemy)) +
+            " scan=" + std::to_string(scannedPlayers) +
+            " attackable=" + std::to_string(attackableEnemies) +
+            " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0), 1200);
+        return EngageNearestEnemyPlayer(player, combatEngageDistance);
+    }
+
+    bool chaseIssued = MoveTowardUnit(player, selectedEnemy, 20.0f);
+    if (!chaseIssued && CanIssueBotMovement(player))
+    {
+        // Last-resort kick in case pursuit helper declines movement while the
+        // bot is otherwise free to move.
+        chaseIssued = IssueMovePointThrottled(player, selectedEnemy->GetPosition(), 30.0f, 2000) || player->isMoving();
+    }
+
+    EmitBattlegroundGmDebug(player,
+        "wsg-pursuit=chase target=" + selectedEnemy->GetName() +
+        " dist=" + std::to_string(int32(distanceToEnemy)) +
+        " scan=" + std::to_string(scannedPlayers) +
+        " attackable=" + std::to_string(attackableEnemies) +
+        " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0) +
+        " issued=" + std::to_string(chaseIssued ? 1 : 0), 1200);
+    return chaseIssued;
 }
 
 bool RecoverStaleBattlegroundState(Player* player)
@@ -222,8 +237,6 @@ bool RecoverStaleBattlegroundState(Player* player)
 
     return true;
 }
-
-bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
 
 bool MoveToClosestBattlegroundGraveyard(Player* player)
 {
@@ -392,14 +405,17 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
     if (!bot || !bot->InBattleground())
         return;
 
-    static std::unordered_map<uint64, uint32> nextEmitTimeByBotGuid;
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-    uint64 const botGuid = bot->GetGUID().GetRawValue();
-    uint32& nextEmitMs = nextEmitTimeByBotGuid[botGuid];
-    if (nowMs < nextEmitMs)
-        return;
+    if (throttleMs > 0)
+    {
+        static std::unordered_map<uint64, uint32> nextEmitTimeByBotGuid;
+        uint32 const nowMs = GameTime::GetGameTimeMS();
+        uint64 const botGuid = bot->GetGUID().GetRawValue();
+        uint32& nextEmitMs = nextEmitTimeByBotGuid[botGuid];
+        if (nowMs < nextEmitMs)
+            return;
 
-    nextEmitMs = nowMs + throttleMs;
+        nextEmitMs = nowMs + throttleMs;
+    }
 
     if (!bot->GetMap())
         return;
@@ -412,13 +428,17 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
     std::string const message = os.str();
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
-
+    if (WorldSession* session = bot->GetSession())
+        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
 }
 
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)
 {
     if (!player)
         return false;
+
+    if (IsWarsongGulch(player))
+        minReissueMs = std::max<uint32>(minReissueMs, 2000);
 
     struct MoveOrderState
     {
@@ -427,15 +447,43 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     };
 
     static std::unordered_map<uint64, MoveOrderState> stateByGuid;
+    static std::unordered_map<uint64, uint8> stationaryReissueCountByGuid;
+    uint64 const botGuid = player->GetGUID().GetRawValue();
     MoveOrderState& state = stateByGuid[player->GetGUID().GetRawValue()];
+    uint8& stationaryReissueCount = stationaryReissueCountByGuid[botGuid];
     uint32 const nowMs = GameTime::GetGameTimeMS();
 
     bool const destinationChanged = state.lastIssueMs == 0 ||
         state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
-    if (!destinationChanged && !canReissueByTime)
+    bool const botCurrentlyMoving = player->isMoving();
+    bool const hardThrottleActive = IsWarsongGulch(player) && !canReissueByTime;
+    bool const forcedStationaryReissue = !destinationChanged && !canReissueByTime && !botCurrentlyMoving;
+    if (forcedStationaryReissue)
+        stationaryReissueCount = std::min<uint8>(uint8(stationaryReissueCount + 1), 20);
+    else
+        stationaryReissueCount = 0;
+
+    if (hardThrottleActive && botCurrentlyMoving)
+        return false;
+
+    if (!destinationChanged && !canReissueByTime && botCurrentlyMoving)
     {
         return false;
+    }
+
+    uint32 bgStatus = 0;
+    if (Battleground* bg = player->GetBattleground())
+        bgStatus = uint32(bg->GetStatus());
+
+    if (forcedStationaryReissue)
+    {
+        EmitBattlegroundGmDebug(player,
+            "movepoint=forced-reissue reason=stationary-with-throttle lastIssueMs=" + std::to_string(state.lastIssueMs) +
+            " nowMs=" + std::to_string(nowMs) +
+            " motionType=" + std::to_string(uint32(player->GetMotionMaster()->GetCurrentMovementGeneratorType())) +
+            " bgStatus=" + std::to_string(bgStatus) +
+            " reissueCount=" + std::to_string(stationaryReissueCount), 1000);
     }
 
     MotionMaster* motionMaster = player->GetMotionMaster();
@@ -444,13 +492,162 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     {
         motionMaster->Clear();
     }
+    else if (!botCurrentlyMoving && player->InBattleground() &&
+        currentMovement != IDLE_MOTION_TYPE &&
+        currentMovement != CHASE_MOTION_TYPE &&
+        currentMovement != POINT_MOTION_TYPE)
+    {
+        // Some stale movement generators can block new MovePoint while actor is
+        // stationary. Clear them before reissuing battleground movement.
+        EmitBattlegroundGmDebug(player,
+            "movepoint=clear-stale-generator motionType=" + std::to_string(uint32(currentMovement)), 1000);
+        motionMaster->Clear();
+    }
 
     bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
 
-    // Reference parity: issue movement directly to resolved objective/start targets.
-    // Let core pathing own corridor/tunnel traversal instead of script-layer lane steering.
-    motionMaster->MovePoint(0, destination, generatePath);
-    state.lastDestination = destination;
+    // Battleground long-range movement pathfinder:
+    // build a navmesh path toward the true destination, then issue movement
+    // toward the furthest available point on that segment. This chains
+    // truncated navmesh paths into full-map traversal without disabling
+    // collision/pathing entirely.
+    Position issuedDestination = destination;
+    if (generatePath && player->InBattleground())
+    {
+        PathGenerator path(player);
+        // Explicitly cap each navmesh solve to a medium segment so very long
+        // cross-map targets still yield incremental path points immediately.
+        path.SetPathLengthLimit(90.0f);
+        bool const pathOk = path.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), true);
+        PathType pathType = path.GetPathType();
+        Movement::PointsArray points = path.GetPath();
+        G3D::Vector3 actualEnd = path.GetActualEndPosition();
+
+        if ((pathType & PATHFIND_SHORTCUT) != 0)
+        {
+            PathGenerator retryPath(player);
+            retryPath.SetPathLengthLimit(90.0f);
+            bool const retryOk = retryPath.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), false);
+            PathType const retryType = retryPath.GetPathType();
+            if (retryOk && (retryType & PATHFIND_SHORTCUT) == 0 && retryPath.GetPath().size() > 1)
+            {
+                points = retryPath.GetPath();
+                pathType = retryType;
+                actualEnd = retryPath.GetActualEndPosition();
+                EmitBattlegroundGmDebug(player,
+                    "movepoint=retry-no-shortcut pathType=" + std::to_string(uint32(pathType)), 0);
+            }
+        }
+
+        if (points.size() > 1)
+        {
+            G3D::Vector3 const& lastPoint = points.back();
+            Position segmentDestination(lastPoint.x, lastPoint.y, lastPoint.z, destination.GetOrientation());
+            float const segmentDistance = player->GetDistance(segmentDestination);
+            bool const suspiciousLongSegment = (pathType & PATHFIND_SHORTCUT) != 0 && segmentDistance > 160.0f;
+            if (suspiciousLongSegment)
+            {
+                float const dx = segmentDestination.GetPositionX() - player->GetPositionX();
+                float const dy = segmentDestination.GetPositionY() - player->GetPositionY();
+                float const dz = segmentDestination.GetPositionZ() - player->GetPositionZ();
+                float const planarLength = std::sqrt(dx * dx + dy * dy);
+                if (planarLength > 0.001f)
+                {
+                    float const cappedStepDistance = 90.0f;
+                    float const cappedRatio = std::min(cappedStepDistance / planarLength, 1.0f);
+                    Position cappedSegmentDestination(
+                        player->GetPositionX() + dx * cappedRatio,
+                        player->GetPositionY() + dy * cappedRatio,
+                        player->GetPositionZ() + dz * cappedRatio,
+                        destination.GetOrientation());
+                    motionMaster->MovePoint(0, cappedSegmentDestination, true);
+                    issuedDestination = cappedSegmentDestination;
+                    EmitBattlegroundGmDebug(player,
+                        "movepoint=segmented-capped pathType=" + std::to_string(uint32(pathType)) +
+                        " segDist=" + std::to_string(int32(segmentDistance)) +
+                        " cappedDist=" + std::to_string(int32(player->GetDistance(cappedSegmentDestination))), 0);
+                    state.lastDestination = issuedDestination;
+                    state.lastIssueMs = nowMs;
+                    return true;
+                }
+            }
+
+            motionMaster->MovePoint(0, segmentDestination, true);
+            issuedDestination = segmentDestination;
+
+            EmitBattlegroundGmDebug(player,
+                "movepoint=segmented pathType=" + std::to_string(uint32(pathType)) +
+                " points=" + std::to_string(points.size()) +
+                " segDist=" + std::to_string(int32(segmentDistance)), 0);
+        }
+        else
+        {
+            float const destinationDistance = player->GetDistance(destination);
+            Position actualEndDestination(actualEnd.x, actualEnd.y, actualEnd.z, destination.GetOrientation());
+            float const actualEndDistance = player->GetDistance(actualEndDestination);
+            if (actualEndDistance > 3.0f && actualEndDistance + 5.0f < destinationDistance)
+            {
+                motionMaster->MovePoint(0, actualEndDestination, true);
+                issuedDestination = actualEndDestination;
+                EmitBattlegroundGmDebug(player,
+                    "movepoint=fallback-actual-end pathOk=" + std::to_string(pathOk ? 1 : 0) +
+                    " pathType=" + std::to_string(uint32(pathType)) +
+                    " points=" + std::to_string(points.size()) +
+                    " actualEndDist=" + std::to_string(int32(actualEndDistance)) +
+                    " destDist=" + std::to_string(int32(destinationDistance)), 0);
+
+                state.lastDestination = actualEndDestination;
+                state.lastIssueMs = nowMs;
+                return true;
+            }
+
+            if (destinationDistance > 120.0f)
+            {
+                float const dx = destination.GetPositionX() - player->GetPositionX();
+                float const dy = destination.GetPositionY() - player->GetPositionY();
+                float const dz = destination.GetPositionZ() - player->GetPositionZ();
+                float const planarLength = std::sqrt(dx * dx + dy * dy);
+                if (planarLength > 0.001f)
+                {
+                    float const stepDistance = 70.0f;
+                    float const stepRatio = std::min(stepDistance / planarLength, 1.0f);
+                    Position intermediateDestination(
+                        player->GetPositionX() + dx * stepRatio,
+                        player->GetPositionY() + dy * stepRatio,
+                        player->GetPositionZ() + dz * stepRatio,
+                        destination.GetOrientation());
+
+                    motionMaster->MovePoint(0, intermediateDestination, true);
+                    issuedDestination = intermediateDestination;
+                    EmitBattlegroundGmDebug(player,
+                        "movepoint=fallback-intermediate pathOk=" + std::to_string(pathOk ? 1 : 0) +
+                        " pathType=" + std::to_string(uint32(pathType)) +
+                        " points=" + std::to_string(points.size()) +
+                        " stepDist=" + std::to_string(int32(player->GetDistance(intermediateDestination))) +
+                        " destDist=" + std::to_string(int32(destinationDistance)), 0);
+
+                    state.lastDestination = intermediateDestination;
+                    state.lastIssueMs = nowMs;
+                    return true;
+                }
+            }
+
+            motionMaster->MovePoint(0, destination, true);
+            issuedDestination = destination;
+            EmitBattlegroundGmDebug(player,
+                "movepoint=fallback-direct pathOk=" + std::to_string(pathOk ? 1 : 0) +
+                " pathType=" + std::to_string(uint32(pathType)) +
+                " points=" + std::to_string(points.size()) +
+                " destDist=" + std::to_string(int32(destinationDistance)), 0);
+        }
+    }
+    else
+    {
+        motionMaster->MovePoint(0, destination, generatePath);
+        issuedDestination = destination;
+    }
+
+    state.lastDestination = issuedDestination;
     state.lastIssueMs = nowMs;
     return true;
 }
@@ -936,8 +1133,30 @@ Player* FindFlagCarrierForDirective(Player* player, playerbot::FlagCarrierDirect
 
 bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
 {
-    if (!player || !player->IsAlive() || !target || !target->IsAlive() || player->GetMapId() != target->GetMapId() || !CanIssueBotMovement(player))
+    if (!player || !target)
         return false;
+    if (!player->IsAlive() || !target->IsAlive() || player->GetMapId() != target->GetMapId() || !CanIssueBotMovement(player))
+    {
+        EmitBattlegroundGmDebug(player,
+            "move-toward-unit=blocked botAlive=" + std::to_string(player->IsAlive() ? 1 : 0) +
+            " targetAlive=" + std::to_string(target->IsAlive() ? 1 : 0) +
+            " sameMap=" + std::to_string(player->GetMapId() == target->GetMapId() ? 1 : 0) +
+            " canMove=" + std::to_string(CanIssueBotMovement(player) ? 1 : 0) +
+            " motionType=" + std::to_string(uint32(player->GetMotionMaster()->GetCurrentMovementGeneratorType())), 1200);
+        return false;
+    }
+
+    float const distanceToTarget = player->GetDistance(target);
+    if (IsWarsongGulch(player) && distanceToTarget > desiredDistance)
+    {
+        Position destination = target->GetPosition();
+        bool const moved = IssueMovePointThrottled(player, destination, 30.0f, 2000);
+        EmitBattlegroundGmDebug(player,
+            "move-toward-unit mode=segmented target=" + target->GetName() +
+            " dist=" + std::to_string(int32(distanceToTarget)) +
+            " issued=" + std::to_string(moved ? 1 : 0), 1200);
+        return moved || player->isMoving();
+    }
 
     CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     if (!player->IsWithinLOSInMap(target))
@@ -1047,7 +1266,7 @@ bool TryReturnDroppedFriendlyFlagWithHumanPriority(Player* player)
     return true;
 }
 
-Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance)
+Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance, uint32* scannedPlayers, uint32* attackableEnemies)
 {
     if (!player || !player->InBattleground() || !player->GetMap())
         return nullptr;
@@ -1057,6 +1276,10 @@ Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance)
         return nullptr;
 
     TeamId const playerBgTeam = ResolveBotTeamId(player);
+    if (scannedPlayers)
+        *scannedPlayers = 0;
+    if (attackableEnemies)
+        *attackableEnemies = 0;
 
     float nearestDistance = std::numeric_limits<float>::max();
     Player* nearestEnemy = nullptr;
@@ -1067,6 +1290,8 @@ Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance)
         Player* candidate = itr->GetSource();
         if (!candidate || candidate == player || !candidate->IsAlive())
             continue;
+        if (scannedPlayers)
+            ++(*scannedPlayers);
         if (candidate->GetBattlegroundId() != player->GetBattlegroundId())
             continue;
         TeamId const candidateBgTeam = ResolveBotTeamId(candidate);
@@ -1074,6 +1299,8 @@ Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance)
             continue;
         if (!player->IsValidAttackTarget(candidate))
             continue;
+        if (attackableEnemies)
+            ++(*attackableEnemies);
 
         float const distance = player->GetDistance(candidate);
         if (distance > maxDistance || distance >= nearestDistance)
@@ -1578,12 +1805,29 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         case FOLLOW_MOTION_TYPE:
             break;
         default:
+        {
+            // If the bot is effectively stationary while stuck in a non-tactical
+            // movement generator, clear it so objective/pursuit movement can
+            // issue a fresh MovePoint.
+            if (!player->isMoving())
+            {
+                EmitBattlegroundGmDebug(player,
+                    "move-to-objective=clear-stale-motion motionType=" +
+                    std::to_string(uint32(player->GetMotionMaster()->GetCurrentMovementGeneratorType())), 1200);
+                player->GetMotionMaster()->Clear();
+                break;
+            }
+
             return true;
+        }
     }
 
     if (player->IsInCombat())
         return EngageNearestEnemyPlayer(player, GetAggressiveCombatScanDistance(player, 100.0f));
     if (TryJumpOffWarsongGraveyard(player))
+        return true;
+
+    if (TryPursueNearestEnemyInWarsong(player))
         return true;
 
     // Evaluate combat/WSG post-res logic before this guard so stale movement
@@ -1621,13 +1865,9 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
             Position destination;
             if (TryGetObjectivePosition(battleground, player, destination))
             {
-                Position issuedDestination = destination;
-                if (IsWarsongGulch(player))
-                    TryGetWarsongObjectiveProgressWaypoint(player, destination, issuedDestination);
-
-                bool const withinObjectiveRange = player->IsWithinDist3d(issuedDestination.GetPositionX(), issuedDestination.GetPositionY(), issuedDestination.GetPositionZ(), 12.0f);
+                bool const withinObjectiveRange = player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f);
                 if (!withinObjectiveRange)
-                    IssueMovePointThrottled(player, issuedDestination);
+                    IssueMovePointThrottled(player, destination);
                 else
                     EmitBattlegroundGmDebug(player, "objective-skip reason=already-near-objective range=12");
                 return true;
@@ -1645,12 +1885,16 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (!player || !player->InBattleground())
         return false;
 
-    float const engageDistance = IsWarsongGulch(player) ? 2000.0f : GetAggressiveCombatScanDistance(player, 100.0f);
+    if (IsWarsongGulch(player))
+    {
+        if (EngageNearestEnemyPlayer(player, 60.0f))
+            return true;
+        return TryPursueNearestEnemyInWarsong(player) || MoveToClosestBattlegroundGraveyard(player);
+    }
+
+    float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
     if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
-
-    if (IsWarsongGulch(player))
-        return MoveToClosestBattlegroundGraveyard(player);
 
     return context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None;
 }


### PR DESCRIPTION
### Motivation
- Reduce stuck or suboptimal movement for playerbots in battlegrounds, especially Warsong Gulch, and make bots more aggressive about pursuing enemy players (flag carriers) while avoiding noisy or unsafe pathing commands. 

### Description
- Add `PathGenerator`-backed segmented pathing and step-capping inside `IssueMovePointThrottled` to produce incremental navmesh waypoints, retry logic to avoid `PATHFIND_SHORTCUT` pitfalls, and fallback intermediate steps for very long targets. 
- Implement Warsong Gulch pursuit behavior via `TryPursueNearestEnemyInWarsong`, including sticky-target selection, scanning counters, and integration into `MoveToObjectivePrimitive` and `CheckObjectivePrimitive`. 
- Enhance movement and pursuit helpers by adding `MoveTowardUnit` improvements, `FindNearestEnemyBattlegroundPlayer` counters for debugging, and new throttled debug emission via `EmitBattlegroundGmDebug`. 

### Testing
- Built the server code with the project's normal build (`make`) and the build completed successfully. 
- Executed the repository's automated test suite (`ctest`) and observed no regressions or failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d5d343188327bd3a45a5aa53e3bb)