### PR TITLE
Fix playerbots idling when spell target is out of range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -387,6 +387,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     float const maxRange = spellInfo->GetMaxRange(false);
     if (!itemTarget && maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
     {
+        // When we are trying to cast but are still out of range, proactively
+        // close the gap instead of idling and repeating failed cast attempts.
+        if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
+            player->GetMotionMaster()->MoveFollow(target, std::max(1.0f, maxRange - 1.0f), player->GetFollowAngle());
+        else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
+            player->GetMotionMaster()->MoveFollow(target, std::max(1.0f, maxRange - 1.0f), player->GetFollowAngle());
+
         failureReason = "out_of_range";
         return false;
     }


### PR DESCRIPTION
### Motivation
- Playerbot PvP direct-cast flow would fail with `out_of_range` while the bot remained idle instead of closing distance, causing missed casts at max range.

### Description
- When a direct-target spell is out of range, issue a `MoveFollow` toward the `target` so the bot begins closing the gap before the next cast attempt.
- Apply the movement behavior for both `TargetMode::Enemy` and `TargetMode::Ally` in `CastDirectSpell`.
- Change is implemented in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` inside the range check before returning `out_of_range`.

### Testing
- Ran `git diff --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d830ef519483279d11e4fd9f8c3054)