### PR TITLE
Playerbot: toggle Hunter Auto Shot strictly by range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1525,11 +1525,26 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
     else if (!alreadyAttackingTarget || !meleeAutoAttackActive)
         player->Attack(target, useMeleeAttack);
 
-    if (player->GetClass() == CLASS_HUNTER && profile.primarilyRanged && !player->IsWithinMeleeRange(target) && player->IsWithinLOSInMap(target))
+    if (player->GetClass() == CLASS_HUNTER && profile.primarilyRanged && player->HasSpell(75))
     {
         Spell const* autoRepeatSpell = player->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
         bool const autoShotActive = autoRepeatSpell && autoRepeatSpell->GetSpellInfo()->Id == 75;
-        if (!autoShotActive && player->HasSpell(75))
+
+        bool inAutoShotRange = false;
+        if (SpellInfo const* autoShotInfo = sSpellMgr->GetSpellInfo(75))
+        {
+            float const minAutoShotRange = autoShotInfo->GetMinRange(false);
+            float const maxAutoShotRange = autoShotInfo->GetMaxRange(false);
+            float const distance = player->GetDistance(target);
+            inAutoShotRange = player->IsWithinLOSInMap(target) && distance > minAutoShotRange && distance <= maxAutoShotRange;
+        }
+
+        if (!inAutoShotRange)
+        {
+            if (autoShotActive)
+                player->InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+        }
+        else if (!autoShotActive)
             player->CastSpell(target, 75, false);
     }
 


### PR DESCRIPTION
### Motivation
- Hunters controlled by playerbots repeatedly toggled their ranged auto-attack because Auto Shot was not being gated to the spell's true firing band, so behavior needs to be deterministic: Auto Shot ON when in valid auto-shot range+LOS and OFF when out of range.

### Description
- Updated `EngageNearestEnemyPlayer` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to gate Auto Shot by checking `SpellInfo` for spell `75` and evaluating `GetMinRange`/`GetMaxRange` plus `IsWithinLOSInMap` before toggling auto-repeat.
- Added a `player->HasSpell(75)` guard and logic to `player->CastSpell(target, 75, false)` when the target is in range and `player->InterruptSpell(CURRENT_AUTOREPEAT_SPELL)` when the target is out of range and Auto Shot is active.
- This replaces the prior looser condition and makes enabling/disabling Auto Shot deterministic and tied to the actual Auto Shot spell parameters.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch errors and it succeeded.
- Started an incremental build of the `worldserver` target with `cmake --build build --target worldserver -j2`, which progressed through compilation steps, but the build run was terminated manually before full completion. No unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83153c3308327a2f3958d16d34fdb)