### PR TITLE
Playerbot: Cast out-of-combat recovery spells and mount when recovered

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -63,6 +63,10 @@ namespace
 {
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
 
+constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_A = 22734;
+constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_B = 29073;
+constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT = 22328;
+
 bool IsWarsongGulch(Player const* player)
 {
     if (!player)
@@ -114,6 +118,57 @@ float GetAggressiveCombatScanDistance(Player const* player, float fallbackDistan
 bool CanIssueBotMovement(Player const* player);
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
 void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs);
+
+bool CanAttemptOutOfCombatSpell(Player const* player, uint32 spellId)
+{
+    if (!player || !spellId || !player->HasSpell(spellId))
+        return false;
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!spellInfo)
+        return false;
+
+    return !player->GetSpellHistory()->HasCooldown(spellInfo->Id);
+}
+
+bool TryHandleOutOfCombatRecoveryAndMount(Player* player, bool allowMount)
+{
+    if (!player || !player->IsAlive() || player->IsInCombat() || player->IsMounted())
+        return false;
+
+    bool const needsHealthRecovery = player->GetHealthPct() < 100.0f;
+    bool const usesMana = player->GetMaxPower(POWER_MANA) > 0;
+    bool const needsManaRecovery = usesMana && player->GetPowerPct(POWER_MANA) < 100.0f;
+
+    if (needsHealthRecovery || needsManaRecovery)
+    {
+        bool didCastRecovery = false;
+        if (CanAttemptOutOfCombatSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_A))
+        {
+            player->CastSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_A, false);
+            didCastRecovery = true;
+        }
+
+        if (CanAttemptOutOfCombatSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_B))
+        {
+            player->CastSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_B, false);
+            didCastRecovery = true;
+        }
+
+        return didCastRecovery;
+    }
+
+    if (!allowMount || !player->IsOutdoors())
+        return false;
+
+    if (CanAttemptOutOfCombatSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
+    {
+        player->CastSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, false);
+        return true;
+    }
+
+    return false;
+}
 
 bool TryPursueNearestEnemyInWarsong(Player* player)
 {
@@ -1926,18 +1981,28 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (!player || !player->InBattleground())
         return false;
 
+    if (TryHandleOutOfCombatRecoveryAndMount(player, false))
+        return true;
+
     if (IsWarsongGulch(player))
     {
         if (EngageNearestEnemyPlayer(player, 60.0f))
             return true;
-        return TryPursueNearestEnemyInWarsong(player) || MoveToClosestBattlegroundGraveyard(player);
+
+        if (TryPursueNearestEnemyInWarsong(player) || MoveToClosestBattlegroundGraveyard(player))
+            return true;
+
+        return TryHandleOutOfCombatRecoveryAndMount(player, true);
     }
 
     float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
     if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
-    return context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None;
+    if (context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None)
+        return true;
+
+    return TryHandleOutOfCombatRecoveryAndMount(player, true);
 }
 
 bool BattlegroundTacticalActions::ResetObjectiveForcePrimitive(Player* player)
@@ -1953,7 +2018,7 @@ bool BattlegroundTacticalActions::UseBuffPrimitive(Player* player)
     if (!player || !player->InBattleground())
         return false;
 
-    return true;
+    return TryHandleOutOfCombatRecoveryAndMount(player, false);
 }
 
 bool BattlegroundTacticalActions::AttackEnemyFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context)


### PR DESCRIPTION
### Motivation
- Implement out-of-combat recovery and automatic mounting behavior for managed playerbots so they self-heal/recover and mount when appropriate.
- Target behavior: when out of combat and missing health or (for mana users) missing mana the bot should cast spells `22734` and `29073`, and when fully recovered and outdoors cast mount `22328`.

### Description
- Added constants for the three spell IDs and implemented `CanAttemptOutOfCombatSpell` to gate casts by known spell and spell-history cooldown checks.
- Implemented `TryHandleOutOfCombatRecoveryAndMount` which attempts both recovery spells in the same tick when HP or mana is not full, and optionally attempts the mount when fully recovered, outdoors, alive, unmounted, and out of combat.
- Integrated the helper into battleground tactical flows by calling it from `CheckObjectivePrimitive` and `UseBuffPrimitive` so the behavior runs during normal tactical evaluation.
- All casts are invoked via `player->CastSpell(...)` and are defensively guarded to avoid invalid or spammy attempts (existence check, cooldown check, mount/outdoors checks).

### Testing
- Ran `cmake --build build --target game -j2` (configuration and compile started), which began a full build but did not complete within the session so no full verification was possible.
- Ran `cmake --build build --target scripts -j2` (script build started), which also did not complete within the session window so scripts-only verification is incomplete.
- Ran `ninja -C build ...` for a single object target and it failed due to an unknown/invalid target (no unit test failures reported for changed code during these attempts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d833e34d008327addc3f0d8a724150)