### PR TITLE
Refactor spirit guide lookup and improve battleground death resurrection handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -872,6 +872,26 @@ bool HasConflictingBattlegroundLifecycleContext(playerbot::BattlegroundLifecycle
 bool HandleBattlegroundDeathState(Player* player)
 {
     static std::unordered_map<uint64, uint32> queuedSinceMsByGuid;
+    auto resolveSpiritGuide = [](Player* candidate, uint32 preferredEntry) -> Creature*
+    {
+        if (!candidate)
+            return nullptr;
+
+        // Keep spirit-healer lookup local to the graveyard.
+        // Some virtual-session bots can temporarily report a neutral BG team;
+        // in that case we still search both faction spirit-guide entries.
+        float constexpr spiritGuideSearchRadius = 30.0f;
+
+        Creature* spiritGuide = preferredEntry ? candidate->FindNearestCreature(preferredEntry, spiritGuideSearchRadius, false) : nullptr;
+        if (!spiritGuide)
+        {
+            spiritGuide = candidate->FindNearestCreature(BG_CREATURE_ENTRY_A_SPIRITGUIDE, spiritGuideSearchRadius, false);
+            if (!spiritGuide)
+                spiritGuide = candidate->FindNearestCreature(BG_CREATURE_ENTRY_H_SPIRITGUIDE, spiritGuideSearchRadius, false);
+        }
+
+        return spiritGuide;
+    };
 
     if (!player || !player->InBattleground())
         return false;
@@ -911,13 +931,7 @@ bool HandleBattlegroundDeathState(Player* player)
             battleground->RemovePlayerFromResurrectQueue(player->GetGUID());
 
             uint32 const spiritEntry = ResolveBotTeamId(player) == TEAM_ALLIANCE ? BG_CREATURE_ENTRY_A_SPIRITGUIDE : BG_CREATURE_ENTRY_H_SPIRITGUIDE;
-            Creature* spiritGuide = spiritEntry ? player->FindNearestCreature(spiritEntry, 30.0f, false) : nullptr;
-            if (!spiritGuide)
-            {
-                spiritGuide = player->FindNearestCreature(BG_CREATURE_ENTRY_A_SPIRITGUIDE, 30.0f, false);
-                if (!spiritGuide)
-                    spiritGuide = player->FindNearestCreature(BG_CREATURE_ENTRY_H_SPIRITGUIDE, 30.0f, false);
-            }
+            Creature* spiritGuide = resolveSpiritGuide(player, spiritEntry);
 
             if (spiritGuide)
             {
@@ -937,24 +951,14 @@ bool HandleBattlegroundDeathState(Player* player)
     }
 
     uint32 const spiritEntry = ResolveBotTeamId(player) == TEAM_ALLIANCE ? BG_CREATURE_ENTRY_A_SPIRITGUIDE : BG_CREATURE_ENTRY_H_SPIRITGUIDE;
-    if (!spiritEntry)
-        return true;
 
     // Mirror player core BG death handling behavior: once ghosted at a battleground
     // graveyard, register at a nearby spirit guide and wait for the periodic wave rez.
     // Avoid script-driven ghost movement because missed/path-blocked moves can prevent
     // ever getting queued for resurrection.
-    Creature* spiritGuide = player->FindNearestCreature(spiritEntry, 30.0f, false);
+    Creature* spiritGuide = resolveSpiritGuide(player, spiritEntry);
     if (!spiritGuide)
-    {
-        // Rare fallback: if team resolution and nearby search disagree (e.g. after team
-        // swaps or delayed map state), use any nearby spirit guide so bots still rez.
-        spiritGuide = player->FindNearestCreature(BG_CREATURE_ENTRY_A_SPIRITGUIDE, 30.0f, false);
-        if (!spiritGuide)
-            spiritGuide = player->FindNearestCreature(BG_CREATURE_ENTRY_H_SPIRITGUIDE, 30.0f, false);
-        if (!spiritGuide)
-            return true;
-    }
+        return true;
 
     battleground->AddPlayerToResurrectQueue(spiritGuide->GetGUID(), player->GetGUID());
     queuedSinceMsByGuid[player->GetGUID().GetRawValue()] = GameTime::GetGameTimeMS();


### PR DESCRIPTION
### Motivation
- Reduce duplicated spirit-guide lookup logic and make the search robust for virtual-session bots that may report a neutral BG team.
- Ensure bots in battleground graveyards reliably register with a nearby spirit guide for resurrection waves.

### Description
- Introduced a local `resolveSpiritGuide` lambda to encapsulate nearest-creature lookup and to search both faction spirit-guide entries when needed.
- Replaced duplicated `FindNearestCreature` blocks with calls to `resolveSpiritGuide` in the resurrection queue refresh and initial queue registration paths.
- Removed a redundant `spiritEntry` existence check and streamlined the case where no spirit guide is found to return early instead of repeating the fallback search inline.
- Added comments clarifying the intent to keep spirit-healer lookup local to the graveyard and to handle neutral/temporary team reporting.

### Testing
- Performed a full project build which completed successfully with the changes compiled into the server.
- Ran automated server/unit tests related to playerbots and PvP lifecycle which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8347e3f848327931f466eda96ffde)