### PR TITLE
PVP: Always chase for Cheap Shot opener and pick known mount for out-of-combat mounting

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -348,8 +348,9 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (preserveStealthForOpener)
         {
             // While stealthed, keep auto-attack disabled so we do not break
-            // stealth early, but still chase for Cheap Shot opener range.
-            if (context.spellId == 1833 && !player->IsWithinMeleeRange(target))
+            // stealth early, but keep chase active for Cheap Shot opener so
+            // rogues do not idle in place waiting for an exact cast snapshot.
+            if (context.spellId == 1833)
                 player->GetMotionMaster()->MoveChase(target);
 
             player->AttackStop();

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -131,6 +131,32 @@ bool CanAttemptOutOfCombatSpell(Player const* player, uint32 spellId)
     return !player->GetSpellHistory()->HasCooldown(spellInfo->Id);
 }
 
+uint32 SelectKnownMountSpell(Player const* player)
+{
+    if (!player)
+        return 0;
+
+    for (PlayerSpellMap::value_type const& knownSpellPair : player->GetSpellMap())
+    {
+        uint32 const spellId = knownSpellPair.first;
+        PlayerSpell const& knownSpell = knownSpellPair.second;
+        if (!knownSpell.active || knownSpell.disabled)
+            continue;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+        if (!spellInfo || spellInfo->IsPassive())
+            continue;
+        if (!spellInfo->HasAura(SPELL_AURA_MOUNTED) && spellInfo->Mechanic != MECHANIC_MOUNT)
+            continue;
+        if (!CanAttemptOutOfCombatSpell(player, spellId))
+            continue;
+
+        return spellId;
+    }
+
+    return 0;
+}
+
 bool TryHandleOutOfCombatRecoveryAndMount(Player* player, bool allowMount)
 {
     if (!player || !player->IsAlive() || player->IsInCombat() || player->IsMounted())
@@ -155,15 +181,22 @@ bool TryHandleOutOfCombatRecoveryAndMount(Player* player, bool allowMount)
             didCastRecovery = true;
         }
 
-        return didCastRecovery;
+        if (didCastRecovery)
+            return true;
     }
 
     if (!allowMount || !player->IsOutdoors())
         return false;
 
+    uint32 mountSpellId = 0;
     if (CanAttemptOutOfCombatSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
+        mountSpellId = SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT;
+    else
+        mountSpellId = SelectKnownMountSpell(player);
+
+    if (mountSpellId)
     {
-        player->CastSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, false);
+        player->CastSpell(player, mountSpellId, false);
         return true;
     }
 


### PR DESCRIPTION
### Motivation

- Ensure rogues in virtual sessions actively chase for the Cheap Shot opener instead of idling while stealthed. 
- Allow bots to mount using a known mount spell when the configured out-of-combat mount constant is not available.

### Description

- Removed the melee-range check for the Cheap Shot spell ID `1833` so the bot always issues a chase via `GetMotionMaster()->MoveChase(target)` while stealthed to avoid standing idle during an opener. 
- Clarified related comment to explain why chasing is preserved for the Cheap Shot opener. 
- Added `SelectKnownMountSpell(Player const*)` to pick a usable mount-style spell from the bot's known spells that is off cooldown. 
- Updated `TryHandleOutOfCombatRecoveryAndMount` to prefer the configured `SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT` and fall back to `SelectKnownMountSpell`, and to only return early if recovery spells were actually cast. 

### Testing

- Built the server code (`make`) with the changes without build errors. 
- Ran the project's automated unit test suite (`make test`) and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83a25eec88327916378ee61461b84)