### PR TITLE
playerbot: move eat/drink and mount into per-class spell trees

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -125,6 +125,10 @@ struct SpellDecision
     uint32 itemEntry = 0;
 };
 
+constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 22734;
+constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 29073;
+constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT = 22328;
+
 struct TacticalDecision
 {
     char const* triggerName = nullptr;
@@ -258,6 +262,60 @@ bool IsSpellReady(Player const* player, uint32 spellId)
         return false;
 
     return !player->GetSpellHistory()->HasCooldown(resolvedSpellId);
+}
+
+uint32 SelectReadyKnownMountSpell(Player const* player)
+{
+    if (!player)
+        return 0;
+
+    for (PlayerSpellMap::value_type const& knownSpellPair : player->GetSpellMap())
+    {
+        uint32 const spellId = knownSpellPair.first;
+        PlayerSpell const& knownSpell = knownSpellPair.second;
+        if (!knownSpell.active || knownSpell.disabled)
+            continue;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+        if (!spellInfo || spellInfo->IsPassive())
+            continue;
+        if (!spellInfo->HasAura(SPELL_AURA_MOUNTED) && spellInfo->Mechanic != MECHANIC_MOUNT)
+            continue;
+        if (!IsSpellReady(player, spellId))
+            continue;
+
+        return spellId;
+    }
+
+    return 0;
+}
+
+SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
+{
+    SpellDecision decision;
+    if (!player || !player->IsAlive() || player->IsInCombat() || player->IsMounted())
+        return decision;
+
+    bool const needsFood = player->GetHealthPct() < 100.0f;
+    bool const usesMana = player->GetMaxPower(POWER_MANA) > 0;
+    bool const needsDrink = usesMana && player->GetPowerPct(POWER_MANA) < 100.0f;
+
+    if (needsFood && IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT))
+        return { "eat", "recover health out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT, playerbot::PvpClassSpellContext::TargetMode::Self };
+
+    if (needsDrink && IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK))
+        return { "drink", "recover mana out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK, playerbot::PvpClassSpellContext::TargetMode::Self };
+
+    if (!player->IsOutdoors())
+        return decision;
+
+    if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
+        return { "mount", "mount while outside and out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
+
+    if (uint32 const knownMountSpellId = SelectReadyKnownMountSpell(player))
+        return { "mount", "mount while outside and out of combat", knownMountSpellId, playerbot::PvpClassSpellContext::TargetMode::Self };
+
+    return decision;
 }
 
 bool HasHostileTarget(Player const* player, Unit const* target)
@@ -1341,6 +1399,9 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
     if (!player)
         return decision;
 
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
+
     Unit const* activeTarget = SelectCombatTarget(player);
     if (!HasHostileTarget(player, activeTarget))
         return decision;
@@ -1409,6 +1470,9 @@ SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inM
     if (!player)
         return decision;
 
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
+
     bool const hasHostileTarget = HasHostileTarget(player, target);
     bool const closePressure = hasHostileTarget && player->IsWithinDistInMap(target, 8.0f);
     float const manaPct = player->GetPowerPct(POWER_MANA);
@@ -1460,6 +1524,9 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
     SpellDecision decision;
     if (!player)
         return decision;
+
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
 
     if (profileSelection.profile == ClassicClassProfile::PrimaryClassic)
     {
@@ -1521,6 +1588,9 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target)
     if (!player)
         return decision;
 
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
+
     if (IsSpellReady(player, 29166))
         if (Unit const* lowManaAlly = SelectFriendlyLowManaTarget(player, 40.0f, 10.0f))
             if (!lowManaAlly->HasAura(29166))
@@ -1569,6 +1639,9 @@ SpellDecision SelectPaladinSpell(Player const* player, Unit const* target)
     if (!player)
         return decision;
 
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
+
     if (player->HealthBelowPct(20) && IsSpellReady(player, 1020))
         return { "paladin divine shield", "emergency immunity under lethal pressure", 1020, playerbot::PvpClassSpellContext::TargetMode::Self };
     if (!player->HasAura(19746) && IsSpellReady(player, 19746))
@@ -1609,6 +1682,12 @@ SpellDecision SelectPaladinSpell(Player const* player, Unit const* target)
 SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
 {
     SpellDecision decision;
+    if (!player)
+        return decision;
+
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
+
     if (!HasHostileTarget(player, target))
         return decision;
 
@@ -1654,6 +1733,12 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
 SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, ClassicProfileSelection const& profileSelection)
 {
     SpellDecision decision;
+    if (!player)
+        return decision;
+
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
+
     if (!HasHostileTarget(player, target))
         return decision;
 
@@ -1707,6 +1792,12 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
 SpellDecision SelectRogueSpell(Player const* player, Unit const* target)
 {
     SpellDecision decision;
+    if (!player)
+        return decision;
+
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
+
     if (!HasHostileTarget(player, target))
         return decision;
 
@@ -1748,6 +1839,12 @@ SpellDecision SelectRogueSpell(Player const* player, Unit const* target)
 SpellDecision SelectShamanSpell(Player const* player, Unit const* target)
 {
     SpellDecision decision;
+    if (!player)
+        return decision;
+
+    if (SpellDecision const utilityDecision = SelectOutOfCombatEatDrinkOrMountSpell(player); utilityDecision.spellId)
+        return utilityDecision;
+
     if (!HasHostileTarget(player, target))
         return decision;
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -63,9 +63,6 @@ namespace
 {
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
 
-constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_A = 22734;
-constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_B = 29073;
-constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT = 22328;
 
 bool IsWarsongGulch(Player const* player)
 {
@@ -118,90 +115,6 @@ float GetAggressiveCombatScanDistance(Player const* player, float fallbackDistan
 bool CanIssueBotMovement(Player const* player);
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
 void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs);
-
-bool CanAttemptOutOfCombatSpell(Player const* player, uint32 spellId)
-{
-    if (!player || !spellId || !player->HasSpell(spellId))
-        return false;
-
-    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
-    if (!spellInfo)
-        return false;
-
-    return !player->GetSpellHistory()->HasCooldown(spellInfo->Id);
-}
-
-uint32 SelectKnownMountSpell(Player const* player)
-{
-    if (!player)
-        return 0;
-
-    for (PlayerSpellMap::value_type const& knownSpellPair : player->GetSpellMap())
-    {
-        uint32 const spellId = knownSpellPair.first;
-        PlayerSpell const& knownSpell = knownSpellPair.second;
-        if (!knownSpell.active || knownSpell.disabled)
-            continue;
-
-        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
-        if (!spellInfo || spellInfo->IsPassive())
-            continue;
-        if (!spellInfo->HasAura(SPELL_AURA_MOUNTED) && spellInfo->Mechanic != MECHANIC_MOUNT)
-            continue;
-        if (!CanAttemptOutOfCombatSpell(player, spellId))
-            continue;
-
-        return spellId;
-    }
-
-    return 0;
-}
-
-bool TryHandleOutOfCombatRecoveryAndMount(Player* player, bool allowMount)
-{
-    if (!player || !player->IsAlive() || player->IsInCombat() || player->IsMounted())
-        return false;
-
-    bool const needsHealthRecovery = player->GetHealthPct() < 100.0f;
-    bool const usesMana = player->GetMaxPower(POWER_MANA) > 0;
-    bool const needsManaRecovery = usesMana && player->GetPowerPct(POWER_MANA) < 100.0f;
-
-    if (needsHealthRecovery || needsManaRecovery)
-    {
-        bool didCastRecovery = false;
-        if (CanAttemptOutOfCombatSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_A))
-        {
-            player->CastSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_A, false);
-            didCastRecovery = true;
-        }
-
-        if (CanAttemptOutOfCombatSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_B))
-        {
-            player->CastSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_RECOVERY_B, false);
-            didCastRecovery = true;
-        }
-
-        if (didCastRecovery)
-            return true;
-    }
-
-    if (!allowMount || !player->IsOutdoors())
-        return false;
-
-    uint32 mountSpellId = 0;
-    if (CanAttemptOutOfCombatSpell(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
-        mountSpellId = SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT;
-    else
-        mountSpellId = SelectKnownMountSpell(player);
-
-    if (mountSpellId)
-    {
-        player->CastSpell(player, mountSpellId, false);
-        return true;
-    }
-
-    return false;
-}
 
 bool TryPursueNearestEnemyInWarsong(Player* player)
 {
@@ -2018,9 +1931,6 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (!player || !player->InBattleground())
         return false;
 
-    if (TryHandleOutOfCombatRecoveryAndMount(player, false))
-        return true;
-
     if (IsWarsongGulch(player))
     {
         if (EngageNearestEnemyPlayer(player, 60.0f))
@@ -2029,7 +1939,7 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
         if (TryPursueNearestEnemyInWarsong(player) || MoveToClosestBattlegroundGraveyard(player))
             return true;
 
-        return TryHandleOutOfCombatRecoveryAndMount(player, true);
+        return false;
     }
 
     float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
@@ -2039,7 +1949,7 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None)
         return true;
 
-    return TryHandleOutOfCombatRecoveryAndMount(player, true);
+    return false;
 }
 
 bool BattlegroundTacticalActions::ResetObjectiveForcePrimitive(Player* player)
@@ -2055,7 +1965,7 @@ bool BattlegroundTacticalActions::UseBuffPrimitive(Player* player)
     if (!player || !player->InBattleground())
         return false;
 
-    return TryHandleOutOfCombatRecoveryAndMount(player, false);
+    return false;
 }
 
 bool BattlegroundTacticalActions::AttackEnemyFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context)


### PR DESCRIPTION
### Motivation
- Centralize out-of-combat recovery and mount logic so each class evaluates eat/drink/mount decisions inside its own spell decision tree rather than from lifecycle tactical code. 
- Replace the generic "recovery" lifecycle behavior with explicit `eat`/`drink` semantics and ensure mounts only happen when the player is outdoors. 

### Description
- Added `SelectOutOfCombatEatDrinkOrMountSpell` and `SelectReadyKnownMountSpell` helpers to `PlayerbotPvpCore.cpp` and new constants `SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT`, `SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK`, and `SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT`. 
- Wired the new helper into each class spell selector (`SelectHunterSpell`, `SelectMageSpell`, `SelectPriestSpell`, `SelectDruidSpell`, `SelectPaladinSpell`, `SelectWarlockSpell`, `SelectWarriorSpell`, `SelectRogueSpell`, `SelectShamanSpell`) so eat/drink/mount is evaluated up front in the class decision flow. 
- Removed the lifecycle-scoped recovery/mount functions from `PlayerbotPvpLifecycleActions.cpp` and stopped invoking `TryHandleOutOfCombatRecoveryAndMount` from battleground tactical primitives so lifecycle no longer performs these actions. 
- Mounting is gated by `player->IsOutdoors()` and falls back to a ready known mount spell when the fixed mount spell is unavailable. 

### Testing
- Ran a configure/build invocation with `cmake --build build -j2 --target worldserver`, which started configuration and build generation successfully but the full worldserver target was not completed in this session due to runtime limits. (partial success)
- Verified build graph and targets with `ninja -C build -n | head -n 80`, which produced expected build plan output. (success)
- Searched the modified code with `rg` to confirm `TryHandleOutOfCombatRecoveryAndMount` and lifecycle-mounted recovery references were removed and the new helpers are present; the search results matched the intended changes. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d841fb20b08327ac8f4070422d17cf)