### PR TITLE
Playerbot PvP: skip mounting when hostiles are in engage range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -408,6 +408,16 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
+    // If we are close enough to actively engage a hostile target, force a
+    // dismount so combat spell execution does not stay blocked by mount state.
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
+        player->IsMounted() &&
+        player->IsWithinLOSInMap(target) &&
+        player->IsWithinDistInMap(target, 35.0f))
+    {
+        player->Dismount();
+    }
+
     if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
         {

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -314,6 +314,23 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     if (!player->IsOutdoors())
         return decision;
 
+    // Avoid mounting if a hostile enemy player is already close enough to engage.
+    // This keeps bots on-foot so their combat spell selection can start immediately.
+    if (player->GetMap())
+    {
+        Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+        {
+            Player* candidate = itr->GetSource();
+            if (!HasHostileTarget(player, candidate))
+                continue;
+            if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, 35.0f))
+                continue;
+
+            return decision;
+        }
+    }
+
     if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
         return { "mount", "mount while outside and out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
 


### PR DESCRIPTION
### Motivation
- Prevent playerbots from choosing out-of-combat mount actions when a hostile player is already nearby and visible so they remain on-foot and can start combat spell/ability selection immediately.

### Description
- Added a guard in `SelectOutOfCombatEatDrinkOrMountSpell` (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`) that iterates `player->GetMap()->GetPlayers()` and returns no-mount when `HasHostileTarget(player, candidate)` and the candidate is within line-of-sight and `IsWithinDistInMap(candidate, 35.0f)`.

### Testing
- Ran `cmake --build build --target worldserver -- -j2` to validate compilation; the build progressed and no compile errors were observed in the executed portion, but it was not run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86c35dab88327b8364c209328ddc8)