### PR TITLE
Fix missing HasHostileTarget declaration in Playerbot PvP core

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -44,6 +44,7 @@
 namespace
 {
 playerbot::PvpCoreConfig g_PvpCoreConfig;
+bool HasHostileTarget(Player const* player, Unit const* target);
 
 bool IsLifecycleGateEnabled(playerbot::PvpCoreConfig const& config)
 {


### PR DESCRIPTION
### Motivation
- Resolve the compile error `use of undeclared identifier 'HasHostileTarget'` caused by earlier call sites referencing the function before its definition.

### Description
- Add a forward declaration `bool HasHostileTarget(Player const* player, Unit const* target);` in the anonymous namespace at the top of `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` so calls before the out-of-line definition can be resolved.

### Testing
- Ran `cmake --build build --target scripts -- -k 1` to reconfigure and start compilation; the build proceeded and progressed (partial build run) and the prior undeclared-identifier failure no longer surfaced during this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d871b54a088327a04407cf78756977)