### PR TITLE
Dismount playerbots when acquiring an enemy target

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1527,6 +1527,12 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
         return false;
     }
 
+    // Ensure mounted bots immediately transition into combat posture once an
+    // enemy target is acquired. Without this, bots that don't cast right away
+    // (or rely on melee/auto attacks) can stay mounted and fail to engage.
+    if (player->IsMounted())
+        player->Dismount();
+
     CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     bool const useMeleeAttack = !profile.primarilyRanged || profile.meleeFallbackAcceptable;
     bool const isStealthedRogue = player->GetClass() == CLASS_ROGUE && player->HasStealthAura();


### PR DESCRIPTION
### Motivation
- Playerbots could remain mounted after acquiring a hostile target and thus fail to reliably engage via melee/auto-attack or non-instant casts, so they need to transition immediately into combat posture.

### Description
- Inserted an immediate dismount check in `EngageNearestEnemyPlayer` inside `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` so bots dismount as soon as an enemy target is acquired, before attack/positioning logic runs.
- Added an inline comment that documents why the dismount is necessary for non-immediate-cast and melee engagement paths.

### Testing
- Ran `cmake --build build --target worldserver -j2` to validate compilation flow; the build started and progressed through many compile units but a full worldserver build did not complete within the session window.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d878d665a48327bc0f6a1f9f54b6f3)