### PR TITLE
Playerbots: apply drink while already eating out of combat

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -300,6 +300,19 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     bool const needsFood = player->GetHealthPct() < 100.0f;
     bool const usesMana = player->GetMaxPower(POWER_MANA) > 0;
     bool const needsDrink = usesMana && player->GetPowerPct(POWER_MANA) < 100.0f;
+    bool const hasEatAura = player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT);
+    bool const hasDrinkAura = player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK);
+
+    // When both health and mana are missing, mirror real player behavior:
+    // apply both food and drink so recovery happens in parallel.
+    if (needsFood && needsDrink)
+    {
+        if (!hasEatAura && IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT))
+            return { "eat", "recover health out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT, playerbot::PvpClassSpellContext::TargetMode::Self };
+
+        if (!hasDrinkAura && IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK))
+            return { "drink", "recover mana out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK, playerbot::PvpClassSpellContext::TargetMode::Self };
+    }
 
     if (needsFood && IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT))
         return { "eat", "recover health out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT, playerbot::PvpClassSpellContext::TargetMode::Self };


### PR DESCRIPTION
### Motivation
- When a bot is missing both health and mana it previously preferred eating and would not apply drink concurrently, causing slower recovery; the change makes bot behavior mirror real players by allowing both recovery effects to be applied.

### Description
- Updated `SelectOutOfCombatEatDrinkOrMountSpell` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` to be aura-aware by adding `hasEatAura` and `hasDrinkAura` checks.
- Added a dual-recovery branch that, when both `needsFood` and `needsDrink` are true, will cast whichever recovery aura (`eat` or `drink`) is still missing so both effects can be active in parallel.
- Preserved existing fallback behavior for single-resource recovery and the subsequent mount/preparation checks.

### Testing
- Ran `git diff --check -- src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and the check completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87ba2da0083279053b4b3d0cc362a)