### PR TITLE
Avoid eat/drink/mount blocking combat: clear recovery auras and dismount when engaging enemies

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -390,6 +390,11 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     float const maxRange = spellInfo->GetMaxRange(false);
     if (!itemTarget && maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
     {
+        if (player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT))
+            player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT);
+        if (player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK))
+            player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK);
+
         // When we are trying to cast but are still out of range, proactively
         // close the gap instead of idling and repeating failed cast attempts.
         if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
@@ -406,6 +411,16 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     {
         failureReason = "too_close";
         return false;
+    }
+
+    // If we are close enough to actively engage a hostile target, force a
+    // dismount so combat spell execution does not stay blocked by mount state.
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
+        player->IsMounted() &&
+        player->IsWithinLOSInMap(target) &&
+        player->IsWithinDistInMap(target, 35.0f))
+    {
+        player->Dismount();
     }
 
     if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -314,6 +314,23 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     if (!player->IsOutdoors())
         return decision;
 
+    // Avoid mounting if a hostile enemy player is already close enough to engage.
+    // This keeps bots on-foot so their combat spell selection can start immediately.
+    if (player->GetMap())
+    {
+        Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+        {
+            Player* candidate = itr->GetSource();
+            if (!HasHostileTarget(player, candidate))
+                continue;
+            if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, 35.0f))
+                continue;
+
+            return decision;
+        }
+    }
+
     if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
         return { "mount", "mount while outside and out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -76,6 +76,17 @@ bool IsRecoveringByEatingOrDrinking(Player const* player)
     return needsFood || needsDrink;
 }
 
+void ClearEatDrinkAurasForMovement(Player* player)
+{
+    if (!player)
+        return;
+
+    if (player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT))
+        player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT);
+    if (player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK))
+        player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK);
+}
+
 
 bool IsWarsongGulch(Player const* player)
 {
@@ -450,6 +461,8 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 {
     if (!player)
         return false;
+
+    ClearEatDrinkAurasForMovement(player);
 
     if (IsWarsongGulch(player))
         minReissueMs = std::max<uint32>(minReissueMs, 2000);
@@ -1202,12 +1215,16 @@ bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
         target->GetPositionZ() + 6.0f < player->GetPositionZ() &&
         player->IsWithinLOS(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ()))
     {
+        ClearEatDrinkAurasForMovement(player);
         player->GetMotionMaster()->MovePoint(0, target->GetPosition(), false);
         return true;
     }
 
     if (!player->IsWithinDistInMap(target, desiredDistance))
+    {
+        ClearEatDrinkAurasForMovement(player);
         player->GetMotionMaster()->MoveFollow(target, desiredDistance, player->GetFollowAngle());
+    }
 
     return true;
 }


### PR DESCRIPTION
### Motivation

- Prevent out-of-combat `eat`/`drink` recovery and mounting from blocking or delaying combat spell execution and movement when hostile players are already nearby.

### Description

- Added `ClearEatDrinkAurasForMovement` helper to remove `SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT` and `SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK` from a bot when movement is about to be issued.
- Call `ClearEatDrinkAurasForMovement` from `IssueMovePointThrottled`, `MoveTowardUnit`, and when initiating follow movement in `CastDirectSpell` so eating/drinking no longer blocks moving or following targets.
- In `CastDirectSpell`, proactively remove eat/drink auras when an attempted cast is out of range and then issue a follow to close the gap, and force `Dismount()` when the bot is mounted and an enemy is within 35.0f to ensure combat spell execution is not blocked by mount state.
- In `SelectOutOfCombatEatDrinkOrMountSpell`, avoid selecting a mount spell if a hostile player is within line-of-sight and 35.0f, keeping the bot on-foot so combat spells can start immediately.
- Added nearby-hostile checks using `HasHostileTarget` and small range/LOS threshold (35.0f) to determine when to suppress mounting.

### Testing

- Project built successfully using the standard build (`cmake`/`make`) workflow without compile errors.
- Automated test suite executed with `ctest` and completed with no failures related to the modified PvP playerbot behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86c35dab88327b8364c209328ddc8)