### PR TITLE
Playerbot: fully clear mount auras and speed on dismount in PvP

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -69,6 +69,30 @@ std::unordered_map<WarlockCurseCooldownKey, std::chrono::steady_clock::time_poin
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 
+void ForcePlayerbotDismount(Player* player)
+{
+    if (!player)
+        return;
+
+    if (player->IsMounted())
+        player->Dismount();
+
+    // Some server-side mount effects can remain applied when virtual bot
+    // sessions dismount mid-action. Explicitly strip mount-related aura types
+    // and refresh movement rates to prevent residual mounted speed.
+    player->RemoveAurasByType(SPELL_AURA_MOUNTED);
+    player->RemoveAurasByType(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED);
+    player->RemoveAurasByType(SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS);
+    player->RemoveAurasByType(SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK);
+    player->RemoveAurasByType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED);
+    player->RemoveAurasByType(SPELL_AURA_MOD_MOUNTED_FLIGHT_SPEED_ALWAYS);
+    player->RemoveAurasByType(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_NOT_STACKING);
+
+    player->UpdateSpeed(MOVE_RUN);
+    player->UpdateSpeed(MOVE_SWIM);
+    player->UpdateSpeed(MOVE_FLIGHT);
+}
+
 uint32 ResolveKnownSpellInChain(Player const* player, uint32 baseSpellId)
 {
     if (!player || !baseSpellId)
@@ -418,7 +442,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // Most combat/utility spells require an unmounted caster. Dismount before
     // non-mount spell execution so bots do not keep kiting while mounted.
     if (player->IsMounted() && !isMountSpell)
-        player->Dismount();
+        ForcePlayerbotDismount(player);
 
     // Food/drink should immediately break when the bot transitions into active
     // spellcasting (combat or utility), mirroring movement opcode behavior.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -65,6 +65,27 @@ std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 
+void ForcePlayerbotDismount(Player* player)
+{
+    if (!player)
+        return;
+
+    if (player->IsMounted())
+        player->Dismount();
+
+    player->RemoveAurasByType(SPELL_AURA_MOUNTED);
+    player->RemoveAurasByType(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED);
+    player->RemoveAurasByType(SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS);
+    player->RemoveAurasByType(SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK);
+    player->RemoveAurasByType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED);
+    player->RemoveAurasByType(SPELL_AURA_MOD_MOUNTED_FLIGHT_SPEED_ALWAYS);
+    player->RemoveAurasByType(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_NOT_STACKING);
+
+    player->UpdateSpeed(MOVE_RUN);
+    player->UpdateSpeed(MOVE_SWIM);
+    player->UpdateSpeed(MOVE_FLIGHT);
+}
+
 bool IsRecoveringByEatingOrDrinking(Player const* player)
 {
     if (!player || !player->IsAlive() || player->IsInCombat())
@@ -1548,7 +1569,7 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
     // enemy target is acquired. Without this, bots that don't cast right away
     // (or rely on melee/auto attacks) can stay mounted and fail to engage.
     if (player->IsMounted())
-        player->Dismount();
+        ForcePlayerbotDismount(player);
 
     CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     bool const useMeleeAttack = !profile.primarilyRanged || profile.meleeFallbackAcceptable;


### PR DESCRIPTION
### Motivation
- Bots that dismount in PvP could retain server-side mount auras or mounted-speed modifiers and continue moving at elevated speeds after dismounting.
- Ensure bots fully transition out of mounted state when they dismount for casting or when engaging an enemy to avoid residual 200% (or similar) run speeds.

### Description
- Added a helper `ForcePlayerbotDismount(Player*)` that calls `Dismount()`, removes mount-related aura types (e.g. `SPELL_AURA_MOUNTED`, mounted-speed variants) and refreshes movement rates via `UpdateSpeed` for `MOVE_RUN`, `MOVE_SWIM`, and `MOVE_FLIGHT`.
- Replaced direct `Dismount()` calls with `ForcePlayerbotDismount()` in `CastDirectSpell` flow in `PlayerbotPvpClassActions.cpp` to cover non-mount spell execution.
- Replaced direct `Dismount()` calls with `ForcePlayerbotDismount()` in `EngageNearestEnemyPlayer` in `PlayerbotPvpLifecycleActions.cpp` to cover immediate combat engagement.

### Testing
- Ran a scripts build with `ninja -C build scripts`, which configured and began compiling script sources; captured output progressed through many compilation steps and showed only unrelated third-party warnings and no errors related to the modified files.
- Attempted a targeted ninja object build for the two modified translation units, but the direct ninja object target invocation was not available and reported an unknown target (no compilation errors in the normal scripts build output were observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d913e50ff88327a392b8f9e0cb380b)