### PR TITLE
Playerbot PvP: stop issuing chase/follow while hard crowd controlled

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -41,6 +41,7 @@
 namespace
 {
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
+bool CanIssueFollowCommands(Player const* player);
 
 struct WarlockCurseCooldownKey
 {
@@ -232,6 +233,22 @@ char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
     }
 }
 
+bool CanIssueFollowCommands(Player const* player)
+{
+    if (!player || !player->IsAlive())
+        return false;
+
+    if (player->HasUnitState(UNIT_STATE_ROOT) ||
+        player->HasUnitState(UNIT_STATE_STUNNED) ||
+        player->HasUnitState(UNIT_STATE_CONFUSED) ||
+        player->HasUnitState(UNIT_STATE_FLEEING))
+    {
+        return false;
+    }
+
+    return true;
+}
+
 Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& context)
 {
     if (!player)
@@ -376,7 +393,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             // While stealthed, keep auto-attack disabled so we do not break
             // stealth early, but keep chase active for Cheap Shot opener so
             // rogues do not idle in place waiting for an exact cast snapshot.
-            if (context.spellId == 1833)
+            if (context.spellId == 1833 && CanIssueFollowCommands(player))
                 player->GetMotionMaster()->MoveChase(target);
 
             player->AttackStop();
@@ -421,9 +438,9 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
         // When we are trying to cast but are still out of range, proactively
         // close the gap instead of idling and repeating failed cast attempts.
-        if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
+        if (CanIssueFollowCommands(player) && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
             player->GetMotionMaster()->MoveFollow(target, std::max(1.0f, maxRange - 1.0f), player->GetFollowAngle());
-        else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
+        else if (CanIssueFollowCommands(player) && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
             player->GetMotionMaster()->MoveFollow(target, std::max(1.0f, maxRange - 1.0f), player->GetFollowAngle());
 
         failureReason = "out_of_range";


### PR DESCRIPTION
### Motivation
- Bots were issuing movement orders while under hard crowd control, making them appear to keep chasing when they should be immobilized; follow/chase orders should be blocked when the bot is rooted, stunned, confused, or fleeing.

### Description
- Add a helper `CanIssueFollowCommands(Player const*)` that returns false if the player is dead or has `UNIT_STATE_ROOT`, `UNIT_STATE_STUNNED`, `UNIT_STATE_CONFUSED`, or `UNIT_STATE_FLEEING`.
- Gate stealth Cheap Shot `MoveChase` and out-of-range recovery `MoveFollow` calls inside `CastDirectSpell` using `CanIssueFollowCommands` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` so movement orders are not issued while hard-CC'd.

### Testing
- Attempted an automated build with `cmake --build build --target scripts -j4`; the scripts build started and compiled many objects but the full scripts target was not completed in this session.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91a5fc2dc8327822bf87301621521)