### PR TITLE
Playerbot: avoid issuing follow/mount actions while control-locked and refine mount selection

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -41,6 +41,7 @@
 namespace
 {
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
+bool CanIssueFollowCommands(Player const* player);
 
 struct WarlockCurseCooldownKey
 {
@@ -232,6 +233,22 @@ char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
     }
 }
 
+bool CanIssueFollowCommands(Player const* player)
+{
+    if (!player || !player->IsAlive())
+        return false;
+
+    if (player->HasUnitState(UNIT_STATE_ROOT) ||
+        player->HasUnitState(UNIT_STATE_STUNNED) ||
+        player->HasUnitState(UNIT_STATE_CONFUSED) ||
+        player->HasUnitState(UNIT_STATE_FLEEING))
+    {
+        return false;
+    }
+
+    return true;
+}
+
 Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& context)
 {
     if (!player)
@@ -376,7 +393,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             // While stealthed, keep auto-attack disabled so we do not break
             // stealth early, but keep chase active for Cheap Shot opener so
             // rogues do not idle in place waiting for an exact cast snapshot.
-            if (context.spellId == 1833)
+            if (context.spellId == 1833 && CanIssueFollowCommands(player))
                 player->GetMotionMaster()->MoveChase(target);
 
             player->AttackStop();
@@ -421,9 +438,9 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
         // When we are trying to cast but are still out of range, proactively
         // close the gap instead of idling and repeating failed cast attempts.
-        if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
+        if (CanIssueFollowCommands(player) && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
             player->GetMotionMaster()->MoveFollow(target, std::max(1.0f, maxRange - 1.0f), player->GetFollowAngle());
-        else if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
+        else if (CanIssueFollowCommands(player) && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
             player->GetMotionMaster()->MoveFollow(target, std::max(1.0f, maxRange - 1.0f), player->GetFollowAngle());
 
         failureReason = "out_of_range";
@@ -438,6 +455,16 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     }
 
     bool const isMountSpell = spellInfo->HasAura(SPELL_AURA_MOUNTED) || spellInfo->Mechanic == MECHANIC_MOUNT;
+
+    if (isMountSpell &&
+        (player->HasUnitState(UNIT_STATE_STUNNED) ||
+         player->HasUnitState(UNIT_STATE_CONFUSED) ||
+         player->HasUnitState(UNIT_STATE_FLEEING) ||
+         player->HasUnitState(UNIT_STATE_ROOT)))
+    {
+        failureReason = "controlled_cannot_mount";
+        return false;
+    }
 
     // Most combat/utility spells require an unmounted caster. Dismount before
     // non-mount spell execution so bots do not keep kiting while mounted.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -28,6 +28,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "ObjectAccessor.h"
+#include "ObjectMgr.h"
 #include "Player.h"
 #include "Pet.h"
 #include "Spell.h"
@@ -45,6 +46,8 @@ namespace
 {
 playerbot::PvpCoreConfig g_PvpCoreConfig;
 bool HasHostileTarget(Player const* player, Unit const* target);
+bool CanAttemptMount(Player const* player, SpellInfo const* mountSpellInfo);
+bool IsHardControlled(Player const* player);
 
 bool IsLifecycleGateEnabled(playerbot::PvpCoreConfig const& config)
 {
@@ -265,6 +268,39 @@ bool IsSpellReady(Player const* player, uint32 spellId)
     return !player->GetSpellHistory()->HasCooldown(resolvedSpellId);
 }
 
+bool CanAttemptMount(Player const* player, SpellInfo const* mountSpellInfo)
+{
+    if (!player || !mountSpellInfo)
+        return false;
+
+    uint32 zoneId = 0;
+    uint32 areaId = 0;
+    player->GetZoneAndAreaId(zoneId, areaId);
+    if (mountSpellInfo->CheckLocation(player->GetMapId(), zoneId, areaId, player, false) != SPELL_CAST_OK)
+        return false;
+
+    Map const* map = player->GetMap();
+    if (!map)
+        return false;
+
+    bool allowMount = !map->IsDungeon() || map->IsBattlegroundOrArena();
+    if (InstanceTemplate const* instanceTemplate = sObjectMgr->GetInstanceTemplate(player->GetMapId()))
+        allowMount = instanceTemplate->AllowMount;
+
+    return allowMount || mountSpellInfo->AreaGroupId;
+}
+
+bool IsHardControlled(Player const* player)
+{
+    if (!player)
+        return false;
+
+    return player->HasUnitState(UNIT_STATE_STUNNED) ||
+        player->HasUnitState(UNIT_STATE_CONFUSED) ||
+        player->HasUnitState(UNIT_STATE_FLEEING) ||
+        player->HasUnitState(UNIT_STATE_ROOT);
+}
+
 uint32 SelectReadyKnownMountSpell(Player const* player)
 {
     if (!player)
@@ -284,6 +320,8 @@ uint32 SelectReadyKnownMountSpell(Player const* player)
             continue;
         if (!IsSpellReady(player, spellId))
             continue;
+        if (!CanAttemptMount(player, spellInfo))
+            continue;
 
         return spellId;
     }
@@ -295,6 +333,11 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
 {
     SpellDecision decision;
     if (!player || !player->IsAlive() || player->IsInCombat() || player->IsMounted())
+        return decision;
+
+    // Do not attempt recovery/mount actions while hard controlled. This avoids
+    // mount selections during fear/polymorph/stun/root states.
+    if (IsHardControlled(player))
         return decision;
 
     bool const needsFood = player->GetHealthPct() < 100.0f;
@@ -356,7 +399,9 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     }
 
     if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
-        return { "mount", "mount while outside and out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
+        if (SpellInfo const* defaultMountInfo = sSpellMgr->GetSpellInfo(SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
+            if (CanAttemptMount(player, defaultMountInfo))
+                return { "mount", "mount while outside and out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
 
     if (uint32 const knownMountSpellId = SelectReadyKnownMountSpell(player))
         return { "mount", "mount while outside and out of combat", knownMountSpellId, playerbot::PvpClassSpellContext::TargetMode::Self };


### PR DESCRIPTION
### Motivation
- Prevent bots from attempting follow/chase/mount actions while under control effects (stun/fear/root/confuse) which can cause invalid movement behavior or failed casts.
- Ensure mount selection only occurs where mounting is allowed by map/instance or the mount spell itself to avoid illegal mount attempts.
- Make out-of-combat recovery behavior (eat/drink/mount) more robust when bots are hard-controlled.

### Description
- Added `CanIssueFollowCommands(Player const*)` and used it to guard chase/follow calls in `CastDirectSpell` so bots do not issue follow/move commands while control-locked.
- Added mount-related helpers `CanAttemptMount(Player const*, SpellInfo const*)` and `IsHardControlled(Player const*)` and included `ObjectMgr.h` for instance template queries.
- Prevented selection of mount spells unless `CanAttemptMount` returns true, and skip recovery/mount selection entirely while `IsHardControlled` is true (`SelectOutOfCombatEatDrinkOrMountSpell` and `SelectReadyKnownMountSpell`).
- Added a mount-failure branch in `CastDirectSpell` that returns `controlled_cannot_mount` when attempting to cast a mount while under control effects.

### Testing
- Built the project after changes; the build completed successfully.
- Ran available unit/CI tests for server/playerbot modules; tests completed and passed.
- Performed basic runtime validation of PvP bot behavior in a local development environment to confirm that follow/mount attempts are suppressed while control-locked and that mounts are only chosen in allowed areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91a5fc2dc8327822bf87301621521)