### PR TITLE
Playerbot PvP: unify nearby-enemy boundary to prevent OOC mount/eat/drink

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -340,6 +340,25 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     if (IsHardControlled(player))
         return decision;
 
+    // Keep a single nearby-enemy boundary for "switch to combat posture".
+    // Inside this range we should avoid out-of-combat utility behaviors
+    // (eat/drink/mount), so movement + combat targeting can take over cleanly.
+    constexpr float kNearbyHostileCombatBoundary = 60.0f;
+    if (player->GetMap())
+    {
+        Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+        {
+            Player* candidate = itr->GetSource();
+            if (!HasHostileTarget(player, candidate))
+                continue;
+            if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, kNearbyHostileCombatBoundary))
+                continue;
+
+            return decision;
+        }
+    }
+
     bool const needsFood = player->GetHealthPct() < 100.0f;
     bool const usesMana = player->GetMaxPower(POWER_MANA) > 0;
     bool const needsDrink = usesMana && player->GetPowerPct(POWER_MANA) < 100.0f;
@@ -380,23 +399,6 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
 
     if (!player->IsOutdoors())
         return decision;
-
-    // Avoid mounting if a hostile enemy player is already close enough to engage.
-    // This keeps bots on-foot so their combat spell selection can start immediately.
-    if (player->GetMap())
-    {
-        Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
-        for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
-        {
-            Player* candidate = itr->GetSource();
-            if (!HasHostileTarget(player, candidate))
-                continue;
-            if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, 35.0f))
-                continue;
-
-            return decision;
-        }
-    }
 
     if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
         if (SpellInfo const* defaultMountInfo = sSpellMgr->GetSpellInfo(SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))


### PR DESCRIPTION
### Motivation
- Playerbots were oscillating between mounting/eating/drinking and engaging nearby opponents because mount gating and combat engagement used different proximity checks.

### Description
- Added an early guard in `SelectOutOfCombatEatDrinkOrMountSpell` that scans nearby players in LOS and returns early if a hostile is within `kNearbyHostileCombatBoundary = 60.0f`, preventing out-of-combat utilities when enemies are close (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`).
- Removed the previous redundant mount-only proximity check (the older `35.0f` case) by consolidating the logic into the single boundary so all OOC utility choices are uniformly gated.
- The change keeps bots on-foot and ready to transition to combat posture when a hostile is nearby.

### Testing
- Ran `git diff --check` to validate the patch formatting and spacing, which succeeded.
- Verified the modified file diff and committed the change (`git show --stat`), with no automated test failures reported by the performed checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9201c5d5c832792c1c2889ff96e22)