### PR TITLE
Playerbot: block scripted movement while feared/confused

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1033,8 +1033,13 @@ bool CanIssueBotMovement(Player const* player)
     if (!player || !player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
         return false;
 
-    if (player->HasUnitState(UNIT_STATE_ROOT) || player->HasUnitState(UNIT_STATE_STUNNED))
+    if (player->HasUnitState(UNIT_STATE_ROOT) ||
+        player->HasUnitState(UNIT_STATE_STUNNED) ||
+        player->HasUnitState(UNIT_STATE_CONFUSED) ||
+        player->HasUnitState(UNIT_STATE_FLEEING))
+    {
         return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
### Motivation
- Prevent PvP playerbots from issuing scripted movement while under fear-like control so they no longer ignore crowd-control states and keep moving when they should be incapacitated.

### Description
- Update `CanIssueBotMovement` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to also treat `UNIT_STATE_CONFUSED` and `UNIT_STATE_FLEEING` as movement-blocking states so lifecycle movement actions are gated consistently with other CC checks.

### Testing
- Verified the change by inspecting `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` (e.g. `nl -ba src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp | sed -n '1024,1052p'`) to confirm `CanIssueBotMovement` now returns false for `UNIT_STATE_CONFUSED` and `UNIT_STATE_FLEEING`; no automated build or unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d921caa3c08327935208796a12290a)