### PR TITLE
Refactor spirit-guide lookup to use grid creature list and nearest-distance selection

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -58,6 +58,7 @@
 #include <algorithm>
 #include <queue>
 #include <vector>
+#include <list>
 
 namespace
 {
@@ -930,12 +931,38 @@ bool HandleBattlegroundDeathState(Player* player)
         // in that case we still search both faction spirit-guide entries.
         float constexpr spiritGuideSearchRadius = 30.0f;
 
-        Creature* spiritGuide = preferredEntry ? candidate->FindNearestCreature(preferredEntry, spiritGuideSearchRadius, false) : nullptr;
+        auto findGuideByEntry = [candidate, spiritGuideSearchRadius](uint32 entry) -> Creature*
+        {
+            if (!entry)
+                return nullptr;
+
+            std::list<Creature*> guides;
+            candidate->GetCreatureListWithEntryInGrid(guides, entry, spiritGuideSearchRadius);
+
+            Creature* nearestGuide = nullptr;
+            float nearestDistanceSq = std::numeric_limits<float>::max();
+            for (Creature* guide : guides)
+            {
+                if (!guide || !guide->IsSpiritService())
+                    continue;
+
+                float const distanceSq = candidate->GetExactDist2dSq(guide);
+                if (distanceSq < nearestDistanceSq)
+                {
+                    nearestGuide = guide;
+                    nearestDistanceSq = distanceSq;
+                }
+            }
+
+            return nearestGuide;
+        };
+
+        Creature* spiritGuide = findGuideByEntry(preferredEntry);
         if (!spiritGuide)
         {
-            spiritGuide = candidate->FindNearestCreature(BG_CREATURE_ENTRY_A_SPIRITGUIDE, spiritGuideSearchRadius, false);
+            spiritGuide = findGuideByEntry(BG_CREATURE_ENTRY_A_SPIRITGUIDE);
             if (!spiritGuide)
-                spiritGuide = candidate->FindNearestCreature(BG_CREATURE_ENTRY_H_SPIRITGUIDE, spiritGuideSearchRadius, false);
+                spiritGuide = findGuideByEntry(BG_CREATURE_ENTRY_H_SPIRITGUIDE);
         }
 
         return spiritGuide;


### PR DESCRIPTION
### Motivation
- Replace calls to `FindNearestCreature` with a more robust lookup that collects nearby creatures and selects the true nearest spirit-guide. 
- Ensure only valid spirit service NPCs are considered by checking `IsSpiritService()` to avoid false positives. 
- Add missing header for `std::list` usage.

### Description
- Added `#include <list>` to `PlayerbotPvpLifecycleActions.cpp` to support creature list retrieval.
- Replaced inline `FindNearestCreature` calls with a local helper `findGuideByEntry` that calls `GetCreatureListWithEntryInGrid`, filters by `IsSpiritService()`, and chooses the nearest by comparing `GetExactDist2dSq` values.
- Updated the spirit-guide resolution lambda to use the new helper for preferred and faction spirit-guide entries.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d921949be08327bf4ce4a90cb7c690)