### PR TITLE
Improve Warsong Gulch post-resurrect routing and spirit-guide lookup in playerbot PvP lifecycle

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -58,6 +58,7 @@
 #include <algorithm>
 #include <queue>
 #include <vector>
+#include <list>
 
 namespace
 {
@@ -306,7 +307,7 @@ bool MoveToClosestBattlegroundGraveyard(Player* player)
 
 bool TryJumpOffWarsongGraveyard(Player* player)
 {
-    if (!player || !player->IsAlive() || !IsWarsongGulch(player) || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
+    if (!player || !IsWarsongGulch(player))
         return false;
 
     struct PostResurrectRouteState
@@ -332,8 +333,15 @@ bool TryJumpOffWarsongGraveyard(Player* player)
         state.wasAlive = player->IsAlive();
     }
 
-    bool const justResurrected = !state.wasAlive && player->IsAlive();
-    state.wasAlive = player->IsAlive();
+    if (!player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
+    {
+        state.wasAlive = false;
+        state.active = false;
+        return false;
+    }
+
+    bool const justResurrected = !state.wasAlive;
+    state.wasAlive = true;
     if (justResurrected)
     {
         state.active = true;
@@ -930,12 +938,38 @@ bool HandleBattlegroundDeathState(Player* player)
         // in that case we still search both faction spirit-guide entries.
         float constexpr spiritGuideSearchRadius = 30.0f;
 
-        Creature* spiritGuide = preferredEntry ? candidate->FindNearestCreature(preferredEntry, spiritGuideSearchRadius, false) : nullptr;
+        auto findGuideByEntry = [candidate, spiritGuideSearchRadius](uint32 entry) -> Creature*
+        {
+            if (!entry)
+                return nullptr;
+
+            std::list<Creature*> guides;
+            candidate->GetCreatureListWithEntryInGrid(guides, entry, spiritGuideSearchRadius);
+
+            Creature* nearestGuide = nullptr;
+            float nearestDistanceSq = std::numeric_limits<float>::max();
+            for (Creature* guide : guides)
+            {
+                if (!guide || !guide->IsSpiritService())
+                    continue;
+
+                float const distanceSq = candidate->GetExactDist2dSq(guide);
+                if (distanceSq < nearestDistanceSq)
+                {
+                    nearestGuide = guide;
+                    nearestDistanceSq = distanceSq;
+                }
+            }
+
+            return nearestGuide;
+        };
+
+        Creature* spiritGuide = findGuideByEntry(preferredEntry);
         if (!spiritGuide)
         {
-            spiritGuide = candidate->FindNearestCreature(BG_CREATURE_ENTRY_A_SPIRITGUIDE, spiritGuideSearchRadius, false);
+            spiritGuide = findGuideByEntry(BG_CREATURE_ENTRY_A_SPIRITGUIDE);
             if (!spiritGuide)
-                spiritGuide = candidate->FindNearestCreature(BG_CREATURE_ENTRY_H_SPIRITGUIDE, spiritGuideSearchRadius, false);
+                spiritGuide = findGuideByEntry(BG_CREATURE_ENTRY_H_SPIRITGUIDE);
         }
 
         return spiritGuide;


### PR DESCRIPTION
### Motivation
- Ensure playerbot post-resurrect routing on the Warsong Gulch graveyard reliably triggers after a resurrection and does not retain stale active state when the player is dead or a ghost.
- Improve reliability of locating the spirit-guide NPC by explicitly gathering nearby creatures and selecting the nearest spirit-service instance.
- Fix a missing header dependency required for the new container usage.

### Description
- Adjusted `TryJumpOffWarsongGraveyard` to reset `PostResurrectRouteState` when the player is dead or a ghost, compute `justResurrected` from the stored `wasAlive` flag, and only activate the route when appropriate.
- Replaced `FindNearestCreature` calls with a new `findGuideByEntry` lambda that uses `GetCreatureListWithEntryInGrid` and selects the nearest creature implementing `IsSpiritService()` using a 2D distance check.
- Added `#include <list>` for the container used when gathering nearby creatures and cleaned up state initialization for the resurrection route mapping.

### Testing
- Built the project using `cmake --build .` and the build completed successfully.
- Executed the test suite with `ctest` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d921949be08327bf4ce4a90cb7c690)