### PR TITLE
Playerbot PvP: block movement while crowd-controlled and clear Waiting to Resurrect aura

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -65,6 +65,7 @@ namespace
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
+constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
 
 void ForcePlayerbotDismount(Player* player)
 {
@@ -107,6 +108,15 @@ void ClearEatDrinkAurasForMovement(Player* player)
         player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT);
     if (player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK))
         player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK);
+}
+
+void ClearStaleWaitingForResurrectAura(Player* player)
+{
+    if (!player || !player->IsAlive())
+        return;
+
+    if (player->HasAura(SPELL_WAITING_FOR_RESURRECT))
+        player->RemoveAurasDueToSpell(SPELL_WAITING_FOR_RESURRECT);
 }
 
 
@@ -1092,6 +1102,9 @@ bool CanIssueBotMovement(Player const* player)
     if (!player || !player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
         return false;
 
+    if (IsCrowdControlledForAction(player))
+        return false;
+
     if (player->HasUnitState(UNIT_STATE_ROOT) ||
         player->HasUnitState(UNIT_STATE_STUNNED) ||
         player->HasUnitState(UNIT_STATE_CONFUSED) ||
@@ -1848,6 +1861,8 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (HandleBattlegroundDeathState(player))
         return true;
 
+    ClearStaleWaitingForResurrectAura(player);
+
     if (player->HasAura(SPELL_PREPARATION) || player->HasAura(SPELL_ARENA_PREPARATION) || player->HasUnitFlag(UNIT_FLAG_PREPARATION))
     {
         player->RemoveAurasDueToSpell(SPELL_PREPARATION);
@@ -1867,6 +1882,8 @@ bool BattlegroundTacticalActions::Execute(Player* player, BattlegroundTacticalCo
 
     if (!player->IsAlive())
         return false;
+
+    ClearStaleWaitingForResurrectAura(player);
 
     if (IsRecoveringByEatingOrDrinking(player))
     {


### PR DESCRIPTION
### Motivation
- Prevent playerbots that are polymorphed/confused/etc. from continuing to receive or execute movement orders, and ensure the client/server "Waiting to Resurrect" aura (2584) does not remain on bots after they are revived.

### Description
- Added a constant `SPELL_WAITING_FOR_RESURRECT` (`2584`) and a helper `ClearStaleWaitingForResurrectAura(Player*)` to remove the stale rez aura when the bot is alive in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.
- Blocked tactical movement by checking `IsCrowdControlledForAction(player)` in `CanIssueBotMovement` so bots under crowd control (including polymorph) will not issue movement orders.
- Invoked `ClearStaleWaitingForResurrectAura` from `BattlegroundLifecycleActions::HandleInProgressStatusPrimitive` and `BattlegroundTacticalActions::Execute` so the stale rez aura is cleaned up promptly when a bot is alive after resurrection.

### Testing
- Ran `git diff --check` to verify there are no whitespace/diff errors and the change passes that check (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92de516048327ba59ef7abdc67041)