### PR TITLE
Prevent Sweeping Strikes from being removed on stance swap

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1110,6 +1110,19 @@ bool Aura::IsDeathPersistent() const
 
 bool Aura::IsRemovedOnShapeLost(Unit* target) const
 {
+    // Sweeping Strikes should persist through warrior stance swaps.
+    // SpellMgr already sets SPELL_ATTR0_NOT_SHAPESHIFT for these ranks, but
+    // keep an explicit safeguard here in case spell data or load order changes.
+    switch (m_spellInfo->Id)
+    {
+        case 12328: // Sweeping Strikes (Rank 1)
+        case 18765: // Sweeping Strikes (Rank 2)
+        case 35429: // Sweeping Strikes (Rank 3)
+            return false;
+        default:
+            break;
+    }
+
     return GetCasterGUID() == target->GetGUID()
         && m_spellInfo->Stances
         && !m_spellInfo->HasAttribute(SPELL_ATTR2_NOT_NEED_SHAPESHIFT)


### PR DESCRIPTION
### Motivation
- Sweeping Strikes (warrior ranks 12328, 18765, 35429) was being removed when the player changed stances (e.g., Berserker Stance), but the aura should persist across stance swaps.

### Description
- Added an explicit check in `Aura::IsRemovedOnShapeLost` to return `false` for spell IDs `12328`, `18765`, and `35429` so those Sweeping Strikes ranks are not removed on shapeshift/stance loss.
- Added a short explanatory comment and left the existing generic shapeshift-removal logic unchanged for all other spells.
- The change was made in `src/server/game/Spells/Auras/SpellAuras.cpp`.

### Testing
- No automated tests or CI jobs were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94eb46c34832797b2c221612b9b83)