### PR TITLE
Harden PvP class spell target resolution by GUID

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2483,11 +2483,26 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    Unit const* target = SelectCombatTarget(player);
-    bool const hasValidTarget = target && target->IsAlive() && target->GetGUID() != player->GetGUID();
+    Unit const* selectedTarget = SelectCombatTarget(player);
+    ObjectGuid const selectedTargetGuid = selectedTarget ? selectedTarget->GetGUID() : ObjectGuid::Empty;
+    auto resolveTargetByGuid = [&](ObjectGuid const& guid) -> Unit const*
+    {
+        if (guid.IsEmpty())
+            return nullptr;
+
+        Unit const* resolved = ObjectAccessor::GetUnit(*player, guid);
+        if (!resolved || !resolved->IsAlive() || resolved->GetGUID() == player->GetGUID())
+            return nullptr;
+
+        return resolved;
+    };
+    Unit const* target = resolveTargetByGuid(selectedTargetGuid);
+    bool const hasValidTarget = target != nullptr;
 
     ClassicProfileSelection const profileSelection = DetectClassicClassProfile(player);
-    Unit const* allyTarget = SelectAllyTarget(player);
+    Unit const* selectedAllyTarget = SelectAllyTarget(player);
+    ObjectGuid const selectedAllyGuid = selectedAllyTarget ? selectedAllyTarget->GetGUID() : ObjectGuid::Empty;
+    Unit const* allyTarget = resolveTargetByGuid(selectedAllyGuid);
     if (player->GetClass() == CLASS_HUNTER)
     {
         TC_LOG_DEBUG("playerbots.pvp.classspell",
@@ -2500,14 +2515,20 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     SpellDecision decision;
     {
         DecisionEvaluationScope decisionScope(player, 0);
-        decision = SelectClassOrUtilitySpell(player, hasValidTarget ? target : nullptr, allyTarget, profileSelection);
+        Unit const* decisionTarget = resolveTargetByGuid(selectedTargetGuid);
+        Unit const* decisionAllyTarget = resolveTargetByGuid(selectedAllyGuid);
+        decision = SelectClassOrUtilitySpell(player, decisionTarget, decisionAllyTarget, profileSelection);
     }
 
-    if (decision.spellId && !IsDecisionImmediatelyCastable(player, decision, hasValidTarget ? target : nullptr, allyTarget))
+    Unit const* immediateCastTarget = resolveTargetByGuid(selectedTargetGuid);
+    Unit const* immediateCastAllyTarget = resolveTargetByGuid(selectedAllyGuid);
+    if (decision.spellId && !IsDecisionImmediatelyCastable(player, decision, immediateCastTarget, immediateCastAllyTarget))
     {
         uint32 const initialDecisionSpellId = decision.spellId;
         DecisionEvaluationScope fallbackScope(player, decision.spellId);
-        SpellDecision const fallbackDecision = SelectClassOrUtilitySpell(player, hasValidTarget ? target : nullptr, allyTarget, profileSelection);
+        Unit const* fallbackTarget = resolveTargetByGuid(selectedTargetGuid);
+        Unit const* fallbackAllyTarget = resolveTargetByGuid(selectedAllyGuid);
+        SpellDecision const fallbackDecision = SelectClassOrUtilitySpell(player, fallbackTarget, fallbackAllyTarget, profileSelection);
         if (fallbackDecision.spellId)
         {
             decision = fallbackDecision;


### PR DESCRIPTION
### Motivation
- A crash trace showed dereferences in class-spell selection paths and `Object::GetGuidValue`, suggesting stale `Unit*` pointers were being used across lifecycle processing.
- Reduce pointer lifetime and avoid dereferencing invalidated `Unit*` by resolving targets from stable GUIDs at the moment each decision is evaluated.

### Description
- Store selected enemy and ally GUIDs from `SelectCombatTarget`/`SelectAllyTarget` in local `ObjectGuid` variables and stop reusing earlier `Unit*` pointers in `PvpCore::BuildClassSpellContext`.
- Add a local resolver lambda that calls `ObjectAccessor::GetUnit` and validates the resolved `Unit` is non-null, alive, and not the player before returning it (used as `resolveTargetByGuid`).
- Re-resolve targets via the resolver for initial spell selection (`SelectClassOrUtilitySpell`), the immediate-castability check (`IsDecisionImmediatelyCastable`), and the fallback selection so each stage uses fresh in-world pointers instead of potentially stale `Unit*`.
- Keep behavior/logging intact while ensuring `context.targetGuid`, `targetMode`, and other decision data remain populated from the selected decision.

### Testing
- Ran `git diff --check` to verify no whitespace/format issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9cc60086483278bd9402b6716bc1d)