### PR TITLE
Stabilize PvP class spell logic: safer target resolution and disable weapon imbue automation

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -617,7 +617,7 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
 
 bool HasHostileTarget(Player const* player, Unit const* target)
 {
-    return player && target && target->IsAlive() && target->GetGUID() != player->GetGUID() && player->IsValidAttackTarget(target);
+    return player && target && target != player && target->IsAlive() && player->IsValidAttackTarget(target);
 }
 
 bool HasAnyAura(Unit const* unit, std::initializer_list<uint32> spellIds)
@@ -781,17 +781,6 @@ SpellDecision SelectPreparationBuffSpell(Player const* player)
     }
 
     return decision;
-}
-
-bool HasTemporaryWeaponImbue(Player const* player)
-{
-    if (!player)
-        return false;
-
-    Item* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
-    Item* offHand = player->GetWeaponForAttack(OFF_ATTACK, true);
-    return (mainHand && mainHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT)) ||
-        (offHand && offHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT));
 }
 
 bool IsCasterClass(Unit const* unit)
@@ -2084,15 +2073,8 @@ SpellDecision SelectRogueSpell(Player const* player, Unit const* target)
     Unit const* blindTarget = IsSpellReady(player, 2094) ? SelectRogueBlindTarget(player, target, 15.0f) : nullptr;
 
     std::vector<PrioritizedSpellDecision> candidates;
-    if (!player->IsInCombat() && IsSpellReady(player, 11202))
-    {
-        Item* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
-        Item* offHand = player->GetWeaponForAttack(OFF_ATTACK, true);
-        bool const mainHandMissingPoison = mainHand && !mainHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT);
-        bool const offHandMissingPoison = offHand && !offHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT);
-        AddDecisionCandidate(candidates, mainHandMissingPoison || offHandMissingPoison, 25.0f,
-            { "rogue crippling poison", "apply crippling poison to unpoisoned weapons out of combat", 11202, playerbot::PvpClassSpellContext::TargetMode::Self });
-    }
+    // Disabled: weapon-poison automation from PvP decision loop.
+    // This avoids touching weapon-enchant mutation paths while investigating combat-time crashes.
 
     AddDecisionCandidate(candidates, !player->IsInCombat() && !HasAuraFromSpellChain(player, 1784) && IsSpellReady(player, 1784), 50.0f,
         { "rogue stealth", "enter stealth before engagement", 1784, playerbot::PvpClassSpellContext::TargetMode::Self });
@@ -2128,8 +2110,7 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target)
         return decision;
 
     std::vector<PrioritizedSpellDecision> candidates;
-    AddDecisionCandidate(candidates, !player->IsInCombat() && !HasTemporaryWeaponImbue(player) && IsSpellReady(player, 8232), 35.0f,
-        { "shaman windfury weapon", "maintain weapon imbue out of combat", 8232, playerbot::PvpClassSpellContext::TargetMode::Self });
+    // Disabled: auto-casting Windfury Weapon from PvP loop while investigating weapon-dependent aura crashes.
     AddDecisionCandidate(candidates, !player->IsInCombat() && !HasAuraFromSpellChain(player, 10432) && IsSpellReady(player, 10432), 34.0f,
         { "shaman lightning shield", "maintain shield buff out of combat", 10432, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 10414), 60.0f,
@@ -2467,6 +2448,11 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     if (!inActiveBattleground && !inBattlegroundPreparation && !inActiveDuel)
         return context;
 
+    // Safety guard: class-spell automation is temporarily disabled in active battleground combat
+    // while stabilizing crashes in target-selection/evaluation paths.
+    if (inActiveBattleground)
+        return context;
+
     if (inBattlegroundPreparation)
     {
         SpellDecision const prepDecision = SelectPreparationBuffSpell(player);
@@ -2483,38 +2469,58 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    Unit const* target = SelectCombatTarget(player);
-    bool const hasValidTarget = target && target->IsAlive() && target->GetGUID() != player->GetGUID();
+    Unit const* selectedTarget = SelectCombatTarget(player);
+    ObjectGuid const selectedTargetGuid = selectedTarget ? selectedTarget->GetGUID() : ObjectGuid::Empty;
+    auto resolveTargetByGuid = [&](ObjectGuid const& guid) -> Unit const*
+    {
+        if (guid.IsEmpty() || guid == player->GetGUID())
+            return nullptr;
+
+        Unit const* resolved = ObjectAccessor::GetUnit(*player, guid);
+        if (!resolved || !resolved->IsAlive())
+            return nullptr;
+
+        return resolved;
+    };
+    bool const hasValidTarget = resolveTargetByGuid(selectedTargetGuid) != nullptr;
 
     ClassicProfileSelection const profileSelection = DetectClassicClassProfile(player);
-    Unit const* allyTarget = SelectAllyTarget(player);
+    Unit const* selectedAllyTarget = SelectAllyTarget(player);
+    ObjectGuid const selectedAllyGuid = selectedAllyTarget ? selectedAllyTarget->GetGUID() : ObjectGuid::Empty;
+    bool const hasValidAllyTarget = resolveTargetByGuid(selectedAllyGuid) != nullptr;
     if (player->GetClass() == CLASS_HUNTER)
     {
         TC_LOG_DEBUG("playerbots.pvp.classspell",
             "BuildClassSpellContext snapshot: botGuid={} inBg={} bgActive={} inPrep={} inDuel={} hasValidTarget={} targetGuid={} allyGuid={}.",
             player->GetGUID().ToString(), values.inBattleground ? 1 : 0, IsTriggerActive(PvpTrigger::BgActive, values) ? 1 : 0,
             inBattlegroundPreparation ? 1 : 0, inActiveDuel ? 1 : 0, hasValidTarget ? 1 : 0,
-            hasValidTarget ? target->GetGUID().ToString() : "none", allyTarget ? allyTarget->GetGUID().ToString() : "none");
+            hasValidTarget ? selectedTargetGuid.ToString() : "none", hasValidAllyTarget ? selectedAllyGuid.ToString() : "none");
     }
 
     SpellDecision decision;
     {
         DecisionEvaluationScope decisionScope(player, 0);
-        decision = SelectClassOrUtilitySpell(player, hasValidTarget ? target : nullptr, allyTarget, profileSelection);
+        Unit const* decisionTarget = resolveTargetByGuid(selectedTargetGuid);
+        Unit const* decisionAllyTarget = resolveTargetByGuid(selectedAllyGuid);
+        decision = SelectClassOrUtilitySpell(player, decisionTarget, decisionAllyTarget, profileSelection);
     }
 
-    if (decision.spellId && !IsDecisionImmediatelyCastable(player, decision, hasValidTarget ? target : nullptr, allyTarget))
+    Unit const* immediateCastTarget = resolveTargetByGuid(selectedTargetGuid);
+    Unit const* immediateCastAllyTarget = resolveTargetByGuid(selectedAllyGuid);
+    if (decision.spellId && !IsDecisionImmediatelyCastable(player, decision, immediateCastTarget, immediateCastAllyTarget))
     {
         uint32 const initialDecisionSpellId = decision.spellId;
         DecisionEvaluationScope fallbackScope(player, decision.spellId);
-        SpellDecision const fallbackDecision = SelectClassOrUtilitySpell(player, hasValidTarget ? target : nullptr, allyTarget, profileSelection);
+        Unit const* fallbackTarget = resolveTargetByGuid(selectedTargetGuid);
+        Unit const* fallbackAllyTarget = resolveTargetByGuid(selectedAllyGuid);
+        SpellDecision const fallbackDecision = SelectClassOrUtilitySpell(player, fallbackTarget, fallbackAllyTarget, profileSelection);
         if (fallbackDecision.spellId)
         {
             decision = fallbackDecision;
             TC_LOG_DEBUG("playerbots.pvp.classspell",
                 "Class spell fallback used: botGuid={} initialSpell={} fallbackSpell={} targetGuid={} allyGuid={}.",
                 player->GetGUID().ToString(), initialDecisionSpellId, fallbackDecision.spellId,
-                hasValidTarget ? target->GetGUID().ToString() : "none", allyTarget ? allyTarget->GetGUID().ToString() : "none");
+                hasValidTarget ? selectedTargetGuid.ToString() : "none", hasValidAllyTarget ? selectedAllyGuid.ToString() : "none");
         }
     }
 
@@ -2539,8 +2545,8 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     context.targetMode = decision.targetMode;
     context.selfCast = context.targetMode == PvpClassSpellContext::TargetMode::Self;
     context.itemEntry = decision.itemEntry;
-    context.targetGuid = hasValidTarget ? target->GetGUID() : ObjectGuid::Empty;
-    context.allyTargetGuid = allyTarget ? allyTarget->GetGUID() : ObjectGuid::Empty;
+    context.targetGuid = hasValidTarget ? selectedTargetGuid : ObjectGuid::Empty;
+    context.allyTargetGuid = hasValidAllyTarget ? selectedAllyGuid : ObjectGuid::Empty;
     if (!decision.targetGuid.IsEmpty())
         context.targetGuid = decision.targetGuid;
     if (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
@@ -2597,7 +2603,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     TC_LOG_DEBUG("playerbots.pvp.class",
         "Playerbot PvP class context: class={} profile={} fallback={} unsupported={} has_enemy_target={} enemy_target_guid={} ally_target_guid={} target_mode={} spell={} action={} reason={}.",
         GetClassLabel(player->GetClass()), profileSelection.profileLabel, profileSelection.usedFallback,
-        profileSelection.unsupportedClass, hasValidTarget, hasValidTarget ? target->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+        profileSelection.unsupportedClass, hasValidTarget, hasValidTarget ? selectedTargetGuid.ToString() : ObjectGuid::Empty.ToString(),
         context.allyTargetGuid.ToString(), targetModeLabel, context.spellId, context.actionName ? context.actionName : "none",
         context.reason ? context.reason : "none");
     return context;


### PR DESCRIPTION
### Motivation
- Prevent crashes and undefined behavior caused by stale or invalid target pointers and weapon-enchantment mutation in PvP decision paths. 
- Temporarily avoid automatic weapon poison/windfury casting and class-spell automation in active battlegrounds while investigating combat-time crashes. 

### Description
- Fix pointer/GUID check in `HasHostileTarget` to compare the `target` pointer against `player` before calling other accessors. 
- Remove/disable the `HasTemporaryWeaponImbue` usage and comment out automatic rogue poison and shaman Windfury automation from the PvP decision loop. 
- Replace direct `SelectCombatTarget`/`SelectAllyTarget` pointer use with captured GUIDs and a `resolveTargetByGuid` helper that uses `ObjectAccessor::GetUnit` and validates liveliness and non-self targets. 
- Thread the resolver through `BuildClassSpellContext` so target resolution, immediate-cast checks, fallback decision selection, and debug logging consistently use validated targets. 
- Add a safety early-return to temporarily disable class-spell automation when `inActiveBattleground` is true. 

### Testing
- Project builds successfully after the changes (`compile` succeeded). 
- Existing automated PvP/Playerbot test suite and integration checks were executed and completed without failures (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9cc60086483278bd9402b6716bc1d)