### PR TITLE
Fix player chase fleeing flag when movement is blocked

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -114,11 +114,16 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
     if (owner->HasUnitState(UNIT_STATE_NOT_MOVE) || owner->IsMovementPreventedByCasting() || HasLostTarget(owner, target))
     {
         owner->StopMoving();
+        if (owner->GetTypeId() == TYPEID_PLAYER)
+            owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
         _lastTargetPosition.reset();
         if (Creature* cOwner = owner->ToCreature())
             cOwner->SetCannotReachTarget(false);
         return true;
     }
+
+    if (owner->GetTypeId() == TYPEID_PLAYER)
+        owner->SetUnitFlag(UNIT_FLAG_FLEEING);
 
     bool const mutualChase = IsMutualChase(owner, target);
     float const hitboxSum = owner->GetCombatReach() + target->GetCombatReach();


### PR DESCRIPTION
### Motivation
- Prevent player units under server-controlled chase from behaving like they are feared when chase is paused by movement-blocking states (stun/root/casting/target loss).

### Description
- In `ChaseMovementGenerator::Update` clear `UNIT_FLAG_FLEEING` for `TYPEID_PLAYER` when movement is paused due to `UNIT_STATE_NOT_MOVE`, casting prevention, or lost target in `src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp`.
- Re-assert `UNIT_FLAG_FLEEING` for `TYPEID_PLAYER` when chase updates resume so normal server-controlled fleeing/chase behavior is preserved.

### Testing
- Built the updated translation unit with `cmake --build build --target src/server/game/CMakeFiles/game.dir/Movement/MovementGenerators/ChaseMovementGenerator.cpp.o -j2`, which completed successfully.
- Started a full `worldserver` build with `cmake --build build --target worldserver -j2`, which progressed through many targets without immediate compile errors in the touched area (full build is long-running in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a576e5e08327a23bf1d7eb74d093)