### PR TITLE
Fix playerbot CC gating and flee movement to match reference behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -60,12 +60,18 @@ bool IsCrowdControlledForAction(Player const* player)
         (1u << MECHANIC_HORROR) |
         (1u << MECHANIC_SAPPED);
 
-    return player->HasUnitState(UNIT_STATE_STUNNED) ||
+    MotionMaster const* motionMaster = player->GetMotionMaster();
+    bool const hasControlledMovement = motionMaster &&
+        motionMaster->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE;
+
+    return player->HasUnitState(UNIT_STATE_LOST_CONTROL) ||
+        player->HasUnitState(UNIT_STATE_STUNNED) ||
         player->HasUnitState(UNIT_STATE_CONFUSED) ||
         player->HasUnitState(UNIT_STATE_FLEEING) ||
         player->HasAuraType(SPELL_AURA_MOD_CONFUSE) ||
         player->HasAuraWithMechanic(ccMechanicMask) ||
-        player->IsPolymorphed();
+        player->IsPolymorphed() ||
+        hasControlledMovement;
 }
 
 struct WarlockCurseCooldownKey
@@ -290,7 +296,8 @@ bool CanIssueFollowCommands(Player const* player)
     if (!player || !player->IsAlive())
         return false;
 
-    if (player->HasUnitState(UNIT_STATE_ROOT) ||
+    if (IsCrowdControlledForAction(player) ||
+        player->HasUnitState(UNIT_STATE_ROOT) ||
         player->HasUnitState(UNIT_STATE_STUNNED) ||
         player->HasUnitState(UNIT_STATE_CONFUSED) ||
         player->HasUnitState(UNIT_STATE_FLEEING))
@@ -812,10 +819,16 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                     player->GetFollowAngle());
                 break;
             case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
-                player->GetMotionMaster()->MoveFollow(movementTarget, std::max(1.0f,
-                    context.movementFollowRange > 0.0f ? context.movementFollowRange : PvpCore::GetConfig().closeRange),
-                    player->GetFollowAngle());
+            {
+                Position destination = player->GetPosition();
+                float const fleeDistance = std::max(1.0f,
+                    context.movementFollowRange > 0.0f ? context.movementFollowRange : PvpCore::GetConfig().closeRange);
+                float const angleToTarget = player->GetAngle(movementTarget);
+                destination.RelocateOffset({ std::cos(angleToTarget + static_cast<float>(M_PI)) * fleeDistance,
+                    std::sin(angleToTarget + static_cast<float>(M_PI)) * fleeDistance, 0.0f, 0.0f });
+                player->GetMotionMaster()->MovePoint(0, destination, true);
                 break;
+            }
             case PvpClassSpellContext::MovementDirective::FaceSpellTarget:
                 player->SetFacingToObject(movementTarget);
                 player->SetInFront(movementTarget);
@@ -840,7 +853,9 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
 
         TC_LOG_DEBUG("playerbots.pvp.class",
             "Playerbot PvP movement directive executed: action={} target_guid={} directive={}.",
-            context.actionName ? context.actionName : "none", movementTarget->GetGUID().ToString(), static_cast<uint8>(context.movementDirective));
+            context.actionName ? context.actionName : "none",
+            movementTarget ? movementTarget->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+            static_cast<uint8>(context.movementDirective));
         return true;
     }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -189,12 +189,18 @@ bool IsCrowdControlledForAction(Player const* player)
         (1u << MECHANIC_HORROR) |
         (1u << MECHANIC_SAPPED);
 
-    return player->HasUnitState(UNIT_STATE_STUNNED) ||
+    MotionMaster const* motionMaster = player->GetMotionMaster();
+    bool const hasControlledMovement = motionMaster &&
+        motionMaster->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE;
+
+    return player->HasUnitState(UNIT_STATE_LOST_CONTROL) ||
+        player->HasUnitState(UNIT_STATE_STUNNED) ||
         player->HasUnitState(UNIT_STATE_CONFUSED) ||
         player->HasUnitState(UNIT_STATE_FLEEING) ||
         player->HasAuraType(SPELL_AURA_MOD_CONFUSE) ||
         player->HasAuraWithMechanic(ccMechanicMask) ||
-        player->IsPolymorphed();
+        player->IsPolymorphed() ||
+        hasControlledMovement;
 }
 
 bool TryPursueNearestEnemyInWarsong(Player* player)


### PR DESCRIPTION
### Motivation
- Bots were exhibiting glide/wiggle movement and polymorphed units remained moving inappropriately, indicating movement gating mismatches with the reference module.
- The reference playerbot implementation blocks movement when a motion-control slot is active and when `UNIT_STATE_LOST_CONTROL` is set; the active PvP action paths did not fully mirror that behavior.
- Bring PvP class and lifecycle action movement handling into parity with the reference to stop spurious movement directives while crowd-controlled.

### Description
- Hardened crowd-control detection in `IsCrowdControlledForAction` by checking `UNIT_STATE_LOST_CONTROL` and whether the `MotionMaster`'s `MOTION_SLOT_CONTROLLED` slot is occupied, and applied this in both `PlayerbotPvpClassActions.cpp` and `PlayerbotPvpLifecycleActions.cpp`.
- Prevented movement directives from issuing follow/chase/flee when the stronger CC gate is tripped by making `CanIssueFollowCommands` consult `IsCrowdControlledForAction`.
- Reworked the `FleeTooCloseForSpell` movement directive to compute an explicit point behind the bot relative to the target (using target angle + PI) and call `MovePoint` to back away, replacing the previous `MoveFollow` behavior that could cause oscillation/wiggle.
- Made movement-directive debug logging robust to directives without a movement target by safely handling a null `movementTarget` when composing the log string.

### Testing
- Ran `cmake --build build --target worldserver -j2`; configuration and build started successfully in this environment but the full worldserver build is large and did not complete within the session budget (progress observed, no runtime errors from the changed files surfaced during the run).
- Ran `cmake --build build --target scripts -j2`; the scripts build progressed and compiled many units (warnings observed from system headers), but the full target build is lengthy and remained in progress at handoff.
- Attempted a focused `ninja` object-target invocation for specific object files which failed due to unavailable/unknown ninja target names in this environment (command reported unknown target).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ffb6b848832780fc66c2c8b62d84)