### PR TITLE
Reduce Rehgar's Fury Ghost Wolf cooldown to 15 seconds

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2254,7 +2254,7 @@ void Unit::CompleteGhostWolfCharge(Unit* target)
 
     if (SpellHistory* spellHistory = GetSpellHistory())
     {
-        static constexpr std::chrono::seconds GhostWolfCooldown(18);
+        static constexpr std::chrono::seconds GhostWolfCooldown(15);
         SpellInfo const* ghostWolfInfo = sSpellMgr->GetSpellInfo(SPELL_SHAMAN_GHOST_WOLF);
 
         if (ghostWolfInfo)


### PR DESCRIPTION
### Motivation
- Make the custom Rehgar's Fury Ghost Wolf charge apply a 15-second cooldown instead of the previous 18 seconds so the post-charge cooldown matches the requested behavior.

### Description
- Changed the `GhostWolfCooldown` constant from `18` to `15` seconds in `Unit::CompleteGhostWolfCharge` (`src/server/game/Entities/Unit/Unit.cpp`) which also updates the cooldown value sent in the client cooldown packet.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da073563748327aafa1b966bbb4806)