### PR TITLE
Lightwell: skip cast and charge when target already has Renew (27874)

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -640,10 +640,23 @@ class spell_pri_lightwell : public SpellScript
                 return;
         }
 
+        Unit* target = GetHitUnit();
+        if (!target)
+            return;
+
+        if (target->HasAura(lightwellRenew) ||
+            target->HasAura(SPELL_PRIEST_LIGHTWELL_RENEW_R1) ||
+            target->HasAura(SPELL_PRIEST_LIGHTWELL_RENEW_R2) ||
+            target->HasAura(SPELL_PRIEST_LIGHTWELL_RENEW_R3) ||
+            target->HasAura(SPELL_PRIEST_LIGHTWELL_RENEW_R4) ||
+            target->HasAura(SPELL_PRIEST_LIGHTWELL_RENEW_R5) ||
+            target->HasAura(SPELL_PRIEST_LIGHTWELL_RENEW_R6))
+            return;
+
         // proc a spellcast
         if (Aura* chargesAura = caster->GetAura(SPELL_PRIEST_LIGHTWELL_CHARGES))
         {
-            caster->CastSpell(GetHitUnit(), lightwellRenew, caster->ToTempSummon()->GetSummonerGUID());
+            caster->CastSpell(target, lightwellRenew, caster->ToTempSummon()->GetSummonerGUID());
             if (chargesAura->ModCharges(-1))
                 caster->ToTempSummon()->UnSummon();
         }


### PR DESCRIPTION
### Motivation
- Prevent Lightwell from wasting a charge or reapplying Renew when the clicked unit already has any Lightwell Renew aura (including rank 27874).

### Description
- Resolve the clicked unit once via `GetHitUnit()` and return early if the target is null.
- Add a guard that checks `HasAura` for `lightwellRenew` and all `SPELL_PRIEST_LIGHTWELL_RENEW_R*` ranks and returns without casting if any are present.
- Preserve existing behavior to cast the appropriate Renew rank and decrement `SPELL_PRIEST_LIGHTWELL_CHARGES`, unsummoning the Lightwell when charges reach zero.

### Testing
- Ran `git diff --check && git status --short` which completed successfully and the change was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da08683f98832795066e11b8a7f366)