### PR TITLE
Improve PvP movement and CC handling; add movement throttling and ranged spacing tweaks

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -60,12 +60,15 @@ bool IsCrowdControlledForAction(Player const* player)
         (1u << MECHANIC_HORROR) |
         (1u << MECHANIC_SAPPED);
 
-    return player->HasUnitState(UNIT_STATE_STUNNED) ||
+    bool const hasLostControlState = player->HasUnitState(UNIT_STATE_LOST_CONTROL);
+    bool const hasHardCcState = player->HasUnitState(UNIT_STATE_STUNNED) ||
         player->HasUnitState(UNIT_STATE_CONFUSED) ||
-        player->HasUnitState(UNIT_STATE_FLEEING) ||
-        player->HasAuraType(SPELL_AURA_MOD_CONFUSE) ||
+        player->HasUnitState(UNIT_STATE_FLEEING);
+    bool const hasCcAura = player->HasAuraType(SPELL_AURA_MOD_CONFUSE) ||
         player->HasAuraWithMechanic(ccMechanicMask) ||
         player->IsPolymorphed();
+
+    return hasLostControlState || hasHardCcState || hasCcAura;
 }
 
 struct WarlockCurseCooldownKey
@@ -290,7 +293,8 @@ bool CanIssueFollowCommands(Player const* player)
     if (!player || !player->IsAlive())
         return false;
 
-    if (player->HasUnitState(UNIT_STATE_ROOT) ||
+    if (IsCrowdControlledForAction(player) ||
+        player->HasUnitState(UNIT_STATE_ROOT) ||
         player->HasUnitState(UNIT_STATE_STUNNED) ||
         player->HasUnitState(UNIT_STATE_CONFUSED) ||
         player->HasUnitState(UNIT_STATE_FLEEING))
@@ -299,6 +303,22 @@ bool CanIssueFollowCommands(Player const* player)
     }
 
     return true;
+}
+
+void ClearActiveMovementForControlLoss(Player* player)
+{
+    if (!player)
+        return;
+
+    player->StopMoving();
+    if (MotionMaster* motionMaster = player->GetMotionMaster())
+        motionMaster->Clear(MOTION_SLOT_ACTIVE);
+
+    if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
+    {
+        player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+        player->SendMovementFlagUpdate();
+    }
 }
 
 Unit* ResolveTarget(Player* player, playerbot::PvpClassSpellContext const& context)
@@ -797,7 +817,11 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
             return false;
 
         if (directiveNeedsTarget && !CanIssueFollowCommands(player))
+        {
+            if (IsCrowdControlledForAction(player))
+                ClearActiveMovementForControlLoss(player);
             return false;
+        }
 
         switch (context.movementDirective)
         {
@@ -812,10 +836,16 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                     player->GetFollowAngle());
                 break;
             case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
-                player->GetMotionMaster()->MoveFollow(movementTarget, std::max(1.0f,
-                    context.movementFollowRange > 0.0f ? context.movementFollowRange : PvpCore::GetConfig().closeRange),
-                    player->GetFollowAngle());
+            {
+                Position destination = player->GetPosition();
+                float const fleeDistance = std::max(1.0f,
+                    context.movementFollowRange > 0.0f ? context.movementFollowRange : PvpCore::GetConfig().closeRange);
+                float const angleToTarget = player->GetAbsoluteAngle(movementTarget->GetPosition());
+                destination.RelocateOffset({ std::cos(angleToTarget + static_cast<float>(M_PI)) * fleeDistance,
+                    std::sin(angleToTarget + static_cast<float>(M_PI)) * fleeDistance, 0.0f, 0.0f });
+                player->GetMotionMaster()->MovePoint(0, destination, true);
                 break;
+            }
             case PvpClassSpellContext::MovementDirective::FaceSpellTarget:
                 player->SetFacingToObject(movementTarget);
                 player->SetInFront(movementTarget);
@@ -840,7 +870,9 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
 
         TC_LOG_DEBUG("playerbots.pvp.class",
             "Playerbot PvP movement directive executed: action={} target_guid={} directive={}.",
-            context.actionName ? context.actionName : "none", movementTarget->GetGUID().ToString(), static_cast<uint8>(context.movementDirective));
+            context.actionName ? context.actionName : "none",
+            movementTarget ? movementTarget->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+            static_cast<uint8>(context.movementDirective));
         return true;
     }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -52,6 +52,8 @@ bool HasHostileTarget(Player const* player, Unit const* target);
 SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player);
 
 constexpr float kReferenceHunterSwitchDistance = 8.0f;
+constexpr float kRangedSpacingEnterOutOfRangeBuffer = 2.0f;
+constexpr float kRangedSpacingEnterTooCloseBuffer = 1.0f;
 std::unordered_map<ObjectGuid, bool> g_HunterRangedModeByBot;
 std::mutex g_HunterRangedModeByBotLock;
 std::unordered_map<ObjectGuid, uint8> g_CombatNoTargetTicksByBot;
@@ -2606,13 +2608,13 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         ResetCombatNoTargetTicks(player);
     }
 
-    // Reference parity: allow mounted travel in active battlegrounds when
-    // out of combat; only force mount-state correction while in combat.
-    if (player->IsMounted() && player->IsInCombat())
+    // Reference parity guard: never allow mounted state indoors. In addition,
+    // while in combat always force mount-state correction immediately.
+    if (player->IsMounted() && (!player->IsOutdoors() || player->IsInCombat()))
     {
         context.movementDirective = PvpClassSpellContext::MovementDirective::CheckMountState;
         context.actionName = "check mount state";
-        context.reason = "mounted in combat";
+        context.reason = player->IsOutdoors() ? "mounted in combat" : "mounted indoors";
         context.shouldExecute = true;
         return context;
     }
@@ -2765,7 +2767,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             float const distance = player->GetDistance(spacingTarget);
             float const maxRange = spellInfo->GetMaxRange(false);
             float const minRange = spellInfo->GetMinRange(false);
-            if (maxRange > 0.0f && distance > maxRange)
+            if (maxRange > 0.0f && distance > (maxRange + kRangedSpacingEnterOutOfRangeBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
                     std::max(1.0f, maxRange - 1.0f), "reach spell", "selected spell out of range", 84.0f);
@@ -2775,7 +2777,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
                 context.targetGuid = ObjectGuid::Empty;
                 context.selfCast = false;
             }
-            else if (minRange > 0.0f && distance < minRange)
+            else if (minRange > 0.0f && distance < std::max(0.0f, minRange - kRangedSpacingEnterTooCloseBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, spacingTarget->GetGUID(),
                     std::max(1.0f, GetConfiguredCloseRange()), "flee", "selected spell minimum range violation", 84.0f);
@@ -2797,12 +2799,12 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         if (movementTarget)
         {
             float const distance = player->GetDistance(movementTarget);
-            if (distance > GetConfiguredSpellRange())
+            if (distance > (GetConfiguredSpellRange() + kRangedSpacingEnterOutOfRangeBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, movementTarget->GetGUID(),
                     std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy out of spell range", 70.0f);
             }
-            else if (distance < GetConfiguredMeleeRange())
+            else if (distance < std::max(0.0f, GetConfiguredMeleeRange() - kRangedSpacingEnterTooCloseBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, movementTarget->GetGUID(),
                     std::max(1.0f, GetConfiguredCloseRange()), "flee", "enemy too close for spell", 71.0f);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -168,7 +168,7 @@ Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance, ui
 bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance);
 bool EngageNearestEnemyPlayer(Player* player, float scanDistance);
 float GetAggressiveCombatScanDistance(Player const* player, float fallbackDistance);
-bool CanIssueBotMovement(Player const* player);
+bool CanIssueBotMovement(Player* player);
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold, uint32 minReissueMs);
 void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs);
 
@@ -189,12 +189,15 @@ bool IsCrowdControlledForAction(Player const* player)
         (1u << MECHANIC_HORROR) |
         (1u << MECHANIC_SAPPED);
 
-    return player->HasUnitState(UNIT_STATE_STUNNED) ||
+    bool const hasLostControlState = player->HasUnitState(UNIT_STATE_LOST_CONTROL);
+    bool const hasHardCcState = player->HasUnitState(UNIT_STATE_STUNNED) ||
         player->HasUnitState(UNIT_STATE_CONFUSED) ||
-        player->HasUnitState(UNIT_STATE_FLEEING) ||
-        player->HasAuraType(SPELL_AURA_MOD_CONFUSE) ||
+        player->HasUnitState(UNIT_STATE_FLEEING);
+    bool const hasCcAura = player->HasAuraType(SPELL_AURA_MOD_CONFUSE) ||
         player->HasAuraWithMechanic(ccMechanicMask) ||
         player->IsPolymorphed();
+
+    return hasLostControlState || hasHardCcState || hasCcAura;
 }
 
 bool TryPursueNearestEnemyInWarsong(Player* player)
@@ -521,12 +524,32 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
         ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
 }
 
-bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)
+bool CanIssueMovementCommand(Player const* player, uint32 cooldownMs = 500)
 {
     if (!player)
         return false;
 
+    static std::unordered_map<uint64, uint32> nextAllowedMoveCommandMsByGuid;
+    uint64 const botGuid = player->GetGUID().GetRawValue();
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint32& nextAllowedMs = nextAllowedMoveCommandMsByGuid[botGuid];
+    if (nowMs < nextAllowedMs)
+        return false;
+
+    nextAllowedMs = nowMs + cooldownMs;
+    return true;
+}
+
+bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000)
+{
+    if (!player)
+        return false;
+    if (!CanIssueMovementCommand(player, 500))
+        return false;
+
     ClearEatDrinkAurasForMovement(player);
+
+    minReissueMs = std::max<uint32>(minReissueMs, 2000);
 
     if (IsWarsongGulch(player))
         minReissueMs = std::max<uint32>(minReissueMs, 2000);
@@ -1097,13 +1120,32 @@ bool IsTacticalAction(char const* actionName, char const* expected)
     return actionName && expected && std::strcmp(actionName, expected) == 0;
 }
 
-bool CanIssueBotMovement(Player const* player)
+void ClearActiveMovementForControlLoss(Player* player)
+{
+    if (!player)
+        return;
+
+    player->StopMoving();
+    if (MotionMaster* motionMaster = player->GetMotionMaster())
+        motionMaster->Clear(MOTION_SLOT_ACTIVE);
+
+    if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
+    {
+        player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+        player->SendMovementFlagUpdate();
+    }
+}
+
+bool CanIssueBotMovement(Player* player)
 {
     if (!player || !player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
         return false;
 
     if (IsCrowdControlledForAction(player))
+    {
+        ClearActiveMovementForControlLoss(player);
         return false;
+    }
 
     if (player->HasUnitState(UNIT_STATE_ROOT) ||
         player->HasUnitState(UNIT_STATE_STUNNED) ||
@@ -1199,6 +1241,8 @@ bool MoveAwayFromUnit(Player* player, Unit* target, float desiredDistance)
 {
     if (!player || !target || !CanIssueBotMovement(player))
         return false;
+    if (!CanIssueMovementCommand(player, 500))
+        return false;
 
     float const angleAway = target->GetAbsoluteAngle(player);
     float const currentDistance = player->GetDistance(target);
@@ -1214,6 +1258,8 @@ bool MoveAwayFromUnit(Player* player, Unit* target, float desiredDistance)
 bool TryRecoverLineOfSight(Player* player, Unit* target, CombatPositioningProfile const& profile, char const* reason)
 {
     if (!player || !target || !target->IsAlive() || !CanIssueBotMovement(player))
+        return false;
+    if (!CanIssueMovementCommand(player, 500))
         return false;
 
     if (player->IsWithinLOSInMap(target))
@@ -1313,6 +1359,8 @@ bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
         target->GetPositionZ() + 6.0f < player->GetPositionZ() &&
         player->IsWithinLOS(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ()))
     {
+        if (!CanIssueMovementCommand(player, 500))
+            return false;
         ClearEatDrinkAurasForMovement(player);
         player->GetMotionMaster()->MovePoint(0, target->GetPosition(), false);
         return true;
@@ -1320,6 +1368,8 @@ bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
 
     if (!player->IsWithinDistInMap(target, desiredDistance))
     {
+        if (!CanIssueMovementCommand(player, 500))
+            return false;
         ClearEatDrinkAurasForMovement(player);
         player->GetMotionMaster()->MoveFollow(target, desiredDistance, player->GetFollowAngle());
     }
@@ -1588,6 +1638,8 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
         if (distance > profile.preferredMaxPressureRange)
         {
+            if (!CanIssueMovementCommand(player, 500))
+                return true;
             player->GetMotionMaster()->MoveFollow(target, profile.preferredIdealRange, player->GetFollowAngle());
             TC_LOG_DEBUG("playerbots.pvp.lifecycle",
                 "Playerbot PvP distance band: bot={} profile={} decision=close-distance distance={} min={} ideal={} max={}.",
@@ -1615,6 +1667,8 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
     if (distance > profile.preferredMaxPressureRange || !player->IsWithinMeleeRange(target))
     {
+        if (!CanIssueMovementCommand(player, 500))
+            return true;
         player->GetMotionMaster()->MoveChase(target);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP distance band: bot={} profile={} decision=melee-close distance={} max={}.",


### PR DESCRIPTION
### Motivation
- Improve bot behavior when losing control so movement is reliably stopped and follow/movement commands are suppressed during CC. 
- Reduce movement spam by throttling move command issuance and enforce sane reissue timing in battlegrounds. 
- Make ranged spacing logic more robust and compute flee destinations explicitly for close-range avoidance.

### Description
- Enhance `IsCrowdControlledForAction` to include `UNIT_STATE_LOST_CONTROL` and refactor the state/aura checks into `hasLostControlState`, `hasHardCcState`, and `hasCcAura` branches. 
- Add `ClearActiveMovementForControlLoss` to stop movement, clear the active `MotionMaster` slot and update virtual session movement flags, and call it where movement should be canceled on CC (follow/movement checks and bot movement gating). 
- Introduce movement throttling via `CanIssueMovementCommand` and integrate it into `IssueMovePointThrottled`, `MoveAwayFromUnit`, `TryRecoverLineOfSight`, `MoveTowardUnit`, and `DriveCombatPositioning` to rate-limit move orders. 
- Add ranged spacing constants `kRangedSpacingEnterOutOfRangeBuffer` and `kRangedSpacingEnterTooCloseBuffer` and use them to adjust out-of-range / too-close checks; change `FleeTooCloseForSpell` handling to compute an explicit opposite-point `MovePoint` destination instead of `MoveFollow`. 
- Miscellaneous: never allow mounted state indoors (immediately correct in combat or indoors), ensure `minReissueMs` floor of 2000 in move throttling, and fix debug logging to handle null movement targets.

### Testing
- Project build (compile) was run and completed successfully with the changes; no compile errors. 
- Existing automated test suite / CI checks were executed and completed with no failures. 
- Static analysis / format checks run as part of CI passed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ffb6b848832780fc66c2c8b62d84)