### PR TITLE
Playerbot: tighten mount outdoors checks and smooth dismount edges

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -43,6 +43,7 @@ namespace
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
 bool CanIssueFollowCommands(Player const* player);
 bool IsEffectivelyOutdoors(Player const* player);
+bool IsStrictlyOutdoorsForMount(Player const* player);
 
 bool IsEffectivelyOutdoors(Player const* player)
 {
@@ -56,7 +57,22 @@ bool IsEffectivelyOutdoors(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    return terrainStatus.outdoors;
+    return player->IsOutdoors() || terrainStatus.outdoors;
+}
+
+bool IsStrictlyOutdoorsForMount(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Map const* map = player->GetMap();
+    if (!map)
+        return player->IsOutdoors();
+
+    PositionFullTerrainStatus terrainStatus;
+    map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
+        terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
+    return player->IsOutdoors() && terrainStatus.outdoors;
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -568,7 +584,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "controlled_cannot_mount";
         return false;
     }
-    if (isMountSpell && !IsEffectivelyOutdoors(player))
+    if (isMountSpell && !IsStrictlyOutdoorsForMount(player))
     {
         // Enforce indoor mount denial server-side for virtual bot casters.
         // Mount selection already prefers outdoors, but execution must also

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -145,6 +145,7 @@ playerbot::PvpCoreConfig g_PvpCoreConfig;
 bool CanAttemptMount(Player const* player, SpellInfo const* mountSpellInfo);
 bool IsHardControlled(Player const* player);
 bool IsEffectivelyOutdoors(Player const* player);
+bool IsStrictlyOutdoorsForMount(Player const* player);
 
 float GetConfiguredSpellRange() { return g_PvpCoreConfig.spellRange; }
 float GetConfiguredHealRange() { return g_PvpCoreConfig.healRange; }
@@ -538,7 +539,26 @@ bool IsEffectivelyOutdoors(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    return terrainStatus.outdoors;
+    // Travel-state checks should tolerate brief map flag flickers around
+    // battleground ramps/fences, so treat either signal as outdoors.
+    return player->IsOutdoors() || terrainStatus.outdoors;
+}
+
+bool IsStrictlyOutdoorsForMount(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Map const* map = player->GetMap();
+    if (!map)
+        return player->IsOutdoors();
+
+    PositionFullTerrainStatus terrainStatus;
+    map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
+        terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
+    // Mount casts should be conservative: require both outdoor signals to avoid
+    // mounting in indoor edge locations where one check can be stale.
+    return player->IsOutdoors() && terrainStatus.outdoors;
 }
 
 bool CanAttemptMount(Player const* player, SpellInfo const* mountSpellInfo)
@@ -679,7 +699,7 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     if (inBattlegroundPreparation)
         return decision;
 
-    if (!IsEffectivelyOutdoors(player))
+    if (!IsStrictlyOutdoorsForMount(player))
         return decision;
 
     if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -88,6 +88,21 @@ void ForcePlayerbotDismount(Player* player)
     player->UpdateSpeed(MOVE_FLIGHT);
 }
 
+bool IsEffectivelyOutdoors(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Map const* map = player->GetMap();
+    if (!map)
+        return player->IsOutdoors();
+
+    PositionFullTerrainStatus terrainStatus;
+    map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
+        terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
+    return player->IsOutdoors() || terrainStatus.outdoors;
+}
+
 bool IsRecoveringByEatingOrDrinking(Player const* player)
 {
     if (!player || !player->IsAlive() || player->IsInCombat())
@@ -2043,7 +2058,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
         return false;
 
-    if (player->IsMounted() && !player->IsOutdoors())
+    if (player->IsMounted() && !IsEffectivelyOutdoors(player))
         ForcePlayerbotDismount(player);
 
     switch (player->GetMotionMaster()->GetCurrentMovementGeneratorType())


### PR DESCRIPTION
### Motivation
- Bots were mounting while effectively indoor at battleground ramp/fence edges and were randomly dismounting when crossing those transitions; this change aims to prevent indoor mount attempts while avoiding spurious dismounts on map-flag flickers.

### Description
- Introduced `IsStrictlyOutdoorsForMount` which requires both `Player::IsOutdoors()` and the terrain `outdoors` flag to be true for mount eligibility. 
- Made `IsEffectivelyOutdoors` tolerant (returns `player->IsOutdoors() || terrainStatus.outdoors`) for movement/dismount gating so short-lived map flag flickers don't force dismounts. 
- Switched out-of-combat mount selection to use `IsStrictlyOutdoorsForMount` to avoid choosing mounts in indoor-edge locations. 
- Enforced the strict outdoors gate at mount cast-time in class spell execution and used the tolerant check in battleground lifecycle movement to reduce ramp/fence flicker dismounts. 
- Modified files: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`, `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`, and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.

### Testing
- Ran `git diff --check` and it completed cleanly. 
- Started a build with `cmake --build build --target worldserver -j 2`, which began compiling and progressed successfully in this environment but did not finish within the interactive window. 
- Changes were staged and committed with message `Playerbot: tighten mount outdoors checks and smooth dismount edges`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da878a4f848327a2207252fa06ff2d)