### PR TITLE
Refine outdoor detection, mount gating and movement during crowd-control for PvP playerbots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -43,6 +43,7 @@ namespace
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
 bool CanIssueFollowCommands(Player const* player);
 bool IsEffectivelyOutdoors(Player const* player);
+bool IsStrictlyOutdoorsForMount(Player const* player);
 
 bool IsEffectivelyOutdoors(Player const* player)
 {
@@ -56,7 +57,22 @@ bool IsEffectivelyOutdoors(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    return terrainStatus.outdoors;
+    return player->IsOutdoors() || terrainStatus.outdoors;
+}
+
+bool IsStrictlyOutdoorsForMount(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Map const* map = player->GetMap();
+    if (!map)
+        return player->IsOutdoors();
+
+    PositionFullTerrainStatus terrainStatus;
+    map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
+        terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
+    return player->IsOutdoors() && terrainStatus.outdoors;
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -328,6 +344,11 @@ void ClearActiveMovementForControlLoss(Player* player)
 
     player->AttackStop();
     player->SetSelection(ObjectGuid::Empty);
+    // Confused/polymorphed units need the server-driven wander movement to
+    // remain intact. Clearing active movement each tick pins them in place.
+    if (player->HasUnitState(UNIT_STATE_CONFUSED) || player->HasAuraType(SPELL_AURA_MOD_CONFUSE) || player->IsPolymorphed())
+        return;
+
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
 }
@@ -568,7 +589,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "controlled_cannot_mount";
         return false;
     }
-    if (isMountSpell && !IsEffectivelyOutdoors(player))
+    if (isMountSpell && !IsStrictlyOutdoorsForMount(player))
     {
         // Enforce indoor mount denial server-side for virtual bot casters.
         // Mount selection already prefers outdoors, but execution must also

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -145,6 +145,8 @@ playerbot::PvpCoreConfig g_PvpCoreConfig;
 bool CanAttemptMount(Player const* player, SpellInfo const* mountSpellInfo);
 bool IsHardControlled(Player const* player);
 bool IsEffectivelyOutdoors(Player const* player);
+bool IsStrictlyOutdoorsForMount(Player const* player);
+bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance);
 
 float GetConfiguredSpellRange() { return g_PvpCoreConfig.spellRange; }
 float GetConfiguredHealRange() { return g_PvpCoreConfig.healRange; }
@@ -538,7 +540,51 @@ bool IsEffectivelyOutdoors(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    return terrainStatus.outdoors;
+    // Travel-state checks should tolerate brief map flag flickers around
+    // battleground ramps/fences, so treat either signal as outdoors.
+    return player->IsOutdoors() || terrainStatus.outdoors;
+}
+
+bool IsStrictlyOutdoorsForMount(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Map const* map = player->GetMap();
+    if (!map)
+        return player->IsOutdoors();
+
+    PositionFullTerrainStatus terrainStatus;
+    map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
+        terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
+    // Mount casts should be conservative: require both outdoor signals to avoid
+    // mounting in indoor edge locations where one check can be stale.
+    return player->IsOutdoors() && terrainStatus.outdoors;
+}
+
+bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)
+{
+    if (!player || !player->IsInWorld())
+        return false;
+
+    Map const* map = player->GetMap();
+    if (!map)
+        return false;
+
+    float const checkDistance = std::max(maxDistance, player->GetVisibilityRange());
+    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!candidate || candidate == player || !candidate->IsAlive())
+            continue;
+        if (!player->IsWithinDistInMap(candidate, checkDistance))
+            continue;
+        if (!player->IsValidAttackTarget(candidate))
+            continue;
+        return true;
+    }
+
+    return false;
 }
 
 bool CanAttemptMount(Player const* player, SpellInfo const* mountSpellInfo)
@@ -679,7 +725,12 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     if (inBattlegroundPreparation)
         return decision;
 
-    if (!IsEffectivelyOutdoors(player))
+    if (!IsStrictlyOutdoorsForMount(player))
+        return decision;
+
+    // Keep pressure logic responsive: don't choose an out-of-combat mount
+    // action while hostile players are already within practical engage range.
+    if (HasNearbyAttackableEnemyPlayer(player, 45.0f))
         return decision;
 
     if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -88,6 +88,21 @@ void ForcePlayerbotDismount(Player* player)
     player->UpdateSpeed(MOVE_FLIGHT);
 }
 
+bool IsEffectivelyOutdoors(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Map const* map = player->GetMap();
+    if (!map)
+        return player->IsOutdoors();
+
+    PositionFullTerrainStatus terrainStatus;
+    map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
+        terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
+    return player->IsOutdoors() || terrainStatus.outdoors;
+}
+
 bool IsRecoveringByEatingOrDrinking(Player const* player)
 {
     if (!player || !player->IsAlive() || player->IsInCombat())
@@ -1127,6 +1142,11 @@ void ClearActiveMovementForControlLoss(Player* player)
 
     player->AttackStop();
     player->SetSelection(ObjectGuid::Empty);
+    // Preserve server-side confused wander (e.g. polymorph/sheep). Clearing
+    // the active movement slot repeatedly can freeze the expected drifting.
+    if (player->HasUnitState(UNIT_STATE_CONFUSED) || player->HasAuraType(SPELL_AURA_MOD_CONFUSE) || player->IsPolymorphed())
+        return;
+
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
 }
@@ -2043,7 +2063,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
         return false;
 
-    if (player->IsMounted() && !player->IsOutdoors())
+    if (player->IsMounted() && !IsEffectivelyOutdoors(player))
         ForcePlayerbotDismount(player);
 
     switch (player->GetMotionMaster()->GetCurrentMovementGeneratorType())


### PR DESCRIPTION
### Motivation
- Prevent bots from mounting in ambiguous edge cases where one outdoors check may be stale and avoid out-of-combat mounting when enemies are already nearby. 
- Avoid repeatedly clearing server-driven confused/polymorphed wander movement which can pin CC'd units in place. 
- Make travel/state outdoors checks tolerant for movement logic while keeping mount casts conservative.

### Description
- Broadened `IsEffectivelyOutdoors` to treat either the player flag or terrain query as outdoors (`player->IsOutdoors() || terrainStatus.outdoors`) for travel/movement decisions. 
- Added `IsStrictlyOutdoorsForMount` which requires both the player flag and terrain query to be true and used it to gate mount casts. 
- Added `HasNearbyAttackableEnemyPlayer` and used it to avoid choosing out-of-combat mount actions when hostile players are within practical engagement range. 
- Updated mount casting logic to use the strict outdoors check and preserved early-denial for mounts while hard-controlled. 
- Modified `ClearActiveMovementForControlLoss` in lifecycle and class/action modules to skip clearing the active motion slot when the player is confused or polymorphed to preserve server-driven wander. 
- Changed battleground objective movement to use the updated `IsEffectivelyOutdoors` when deciding to dismount.

### Testing
- Performed a full project build which completed without compile errors. 
- Ran playerbot PvP unit and integration tests covering mount selection, out-of-combat mount behavior, and battleground movement/navigation, and they passed. 
- Verified crowd-control movement behavior in automated scenarios to ensure confused/polymorphed bots retained expected server wander behavior during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da878a4f848327a2207252fa06ff2d)