### PR TITLE
Playerbot: allow mounting outdoors, remove GM spell-fail whispers, and restore polymorph wandering

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -35,7 +35,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <sstream>
 #include <unordered_map>
 
 namespace
@@ -72,7 +71,10 @@ bool IsStrictlyOutdoorsForMount(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    return player->IsOutdoors() && terrainStatus.outdoors;
+    // Mount checks should tolerate occasional outdoor-flag desync at ramps,
+    // bridges, and battleground geometry seams. Accept either outdoors signal
+    // so valid outdoor positions do not get stuck in a permanent no-mount loop.
+    return player->IsOutdoors() || terrainStatus.outdoors;
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -249,36 +251,6 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
         failureReason.empty() ? "none" : failureReason);
 }
 
-void NotifySpellCastFailureToGameMasters(Player* bot, playerbot::PvpClassSpellContext const& context, SpellCastResult castResult)
-{
-    if (!bot || castResult == SPELL_CAST_OK || castResult == SPELL_FAILED_SPELL_IN_PROGRESS)
-        return;
-
-    Map* map = bot->GetMap();
-    if (!map)
-        return;
-
-    EnumText const resultText = EnumUtils::ToString(castResult);
-    std::ostringstream os;
-    os << "[Playerbot spell-fail] bot=" << bot->GetName()
-       << " guid=" << bot->GetGUID().ToString()
-       << " map=" << bot->GetMapId()
-       << " spell=" << context.spellId
-       << " action=" << (context.actionName ? context.actionName : "none")
-       << " target=" << GetTargetModeLabel(context.targetMode)
-       << " result=" << resultText.Title;
-    std::string const message = os.str();
-
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        bot->Whisper(message, LANG_UNIVERSAL, observer);
-    }
-}
-
 void FinalizeVirtualNearTeleport(Player* player)
 {
     if (!player || !player->IsBeingTeleportedNear())
@@ -347,7 +319,11 @@ void ClearActiveMovementForControlLoss(Player* player)
     // Confused/polymorphed units need the server-driven wander movement to
     // remain intact. Clearing active movement each tick pins them in place.
     if (player->HasUnitState(UNIT_STATE_CONFUSED) || player->HasAuraType(SPELL_AURA_MOD_CONFUSE) || player->IsPolymorphed())
+    {
+        if (MotionMaster* motionMaster = player->GetMotionMaster())
+            motionMaster->MoveConfused();
         return;
+    }
 
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
@@ -654,7 +630,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
     {
-        NotifySpellCastFailureToGameMasters(player, context, castResult);
         EnumText const reasonText = EnumUtils::ToString(castResult);
         failureReason = reasonText.Title;
         return false;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -557,9 +557,9 @@ bool IsStrictlyOutdoorsForMount(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    // Mount casts should be conservative: require both outdoor signals to avoid
-    // mounting in indoor edge locations where one check can be stale.
-    return player->IsOutdoors() && terrainStatus.outdoors;
+    // Outdoor flags can briefly disagree around map seams/ramps. Accept either
+    // signal here so outdoor bots do not get permanently blocked from mounting.
+    return player->IsOutdoors() || terrainStatus.outdoors;
 }
 
 bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1145,7 +1145,11 @@ void ClearActiveMovementForControlLoss(Player* player)
     // Preserve server-side confused wander (e.g. polymorph/sheep). Clearing
     // the active movement slot repeatedly can freeze the expected drifting.
     if (player->HasUnitState(UNIT_STATE_CONFUSED) || player->HasAuraType(SPELL_AURA_MOD_CONFUSE) || player->IsPolymorphed())
+    {
+        if (MotionMaster* motionMaster = player->GetMotionMaster())
+            motionMaster->MoveConfused();
         return;
+    }
 
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);


### PR DESCRIPTION
### Motivation
- Fix playerbot regressions where bots never mounted due to overly strict outdoors gating, remove noisy diagnostic GM server whispers for spell failures, and restore expected wandering for polymorphed/confused targets that were freezing in place.

### Description
- Relaxed the mount outdoors check in `IsStrictlyOutdoorsForMount` (changed requiring both signals to accepting either) in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` so bots can mount at valid outdoor positions despite occasional terrain-flag desync.
- Removed the GM diagnostic whisper broadcast by deleting `NotifySpellCastFailureToGameMasters` and its invocation in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`, and removed the now-unused `#include <sstream>`.
- Restored server-driven confused/polymorph wandering by calling `MotionMaster::MoveConfused()` when a bot is `UNIT_STATE_CONFUSED`/`SPELL_AURA_MOD_CONFUSE`/`IsPolymorphed()` instead of clearing the active motion slot in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.

### Testing
- Ran `git diff --check` to validate the patch formatting and local diffs, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da937c7ca08327b9d33f22f139dd39)