### PR TITLE
Fix outdoor/mount detection, remove GM whisper spam, and tolerate confused motion in movement logic

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -35,7 +35,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <sstream>
 #include <unordered_map>
 
 namespace
@@ -72,7 +71,10 @@ bool IsStrictlyOutdoorsForMount(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    return player->IsOutdoors() && terrainStatus.outdoors;
+    // Mount checks should tolerate occasional outdoor-flag desync at ramps,
+    // bridges, and battleground geometry seams. Accept either outdoors signal
+    // so valid outdoor positions do not get stuck in a permanent no-mount loop.
+    return player->IsOutdoors() || terrainStatus.outdoors;
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -224,59 +226,11 @@ void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& c
     if (!player || !player->duel)
         return;
 
-    Player* opponent = player->duel->Opponent;
-    if (opponent)
-    {
-        std::string message = "Decision: ";
-        message += context.actionName ? context.actionName : "none";
-        message += " | spell=" + std::to_string(context.spellId);
-        message += " | target=";
-        message += GetTargetModeLabel(context.targetMode);
-        message += " | success=";
-        message += casted ? "yes" : "no";
-        message += " | reason=";
-        message += context.reason ? context.reason : "none";
-        message += " | fail_reason=";
-        message += failureReason.empty() ? "none" : failureReason;
-
-        player->Whisper(message, LANG_UNIVERSAL, opponent);
-    }
-
     TC_LOG_DEBUG("playerbots.pvp.class",
         "[PvP duel] {} decision={} spell={} target={} success={} reason={} fail_reason={}",
         player->GetName(), context.actionName ? context.actionName : "none", context.spellId,
         GetTargetModeLabel(context.targetMode), casted ? "yes" : "no", context.reason ? context.reason : "none",
         failureReason.empty() ? "none" : failureReason);
-}
-
-void NotifySpellCastFailureToGameMasters(Player* bot, playerbot::PvpClassSpellContext const& context, SpellCastResult castResult)
-{
-    if (!bot || castResult == SPELL_CAST_OK || castResult == SPELL_FAILED_SPELL_IN_PROGRESS)
-        return;
-
-    Map* map = bot->GetMap();
-    if (!map)
-        return;
-
-    EnumText const resultText = EnumUtils::ToString(castResult);
-    std::ostringstream os;
-    os << "[Playerbot spell-fail] bot=" << bot->GetName()
-       << " guid=" << bot->GetGUID().ToString()
-       << " map=" << bot->GetMapId()
-       << " spell=" << context.spellId
-       << " action=" << (context.actionName ? context.actionName : "none")
-       << " target=" << GetTargetModeLabel(context.targetMode)
-       << " result=" << resultText.Title;
-    std::string const message = os.str();
-
-    for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
-    {
-        Player* observer = itr->GetSource();
-        if (!observer || !observer->IsGameMaster())
-            continue;
-
-        bot->Whisper(message, LANG_UNIVERSAL, observer);
-    }
 }
 
 void FinalizeVirtualNearTeleport(Player* player)
@@ -654,7 +608,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
     {
-        NotifySpellCastFailureToGameMasters(player, context, castResult);
         EnumText const reasonText = EnumUtils::ToString(castResult);
         failureReason = reasonText.Title;
         return false;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -557,9 +557,9 @@ bool IsStrictlyOutdoorsForMount(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    // Mount casts should be conservative: require both outdoor signals to avoid
-    // mounting in indoor edge locations where one check can be stale.
-    return player->IsOutdoors() && terrainStatus.outdoors;
+    // Outdoor flags can briefly disagree around map seams/ramps. Accept either
+    // signal here so outdoor bots do not get permanently blocked from mounting.
+    return player->IsOutdoors() || terrainStatus.outdoors;
 }
 
 bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)
@@ -732,11 +732,6 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     // action while hostile players are already within practical engage range.
     if (HasNearbyAttackableEnemyPlayer(player, 45.0f))
         return decision;
-
-    if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
-        if (SpellInfo const* defaultMountInfo = sSpellMgr->GetSpellInfo(SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
-            if (CanAttemptMount(player, defaultMountInfo))
-                return { "mount", "mount while outside and out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
 
     if (uint32 const knownMountSpellId = SelectReadyKnownMountSpell(player))
         return { "mount", "mount while outside and out of combat", knownMountSpellId, playerbot::PvpClassSpellContext::TargetMode::Self };

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -502,9 +502,6 @@ void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string cons
     std::string const message = oss.str();
 
     TC_LOG_WARN("playerbots.pvp.lifecycle", "{}", message);
-
-    if (WorldSession* session = player->GetSession())
-        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
 }
 
 void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs = 3000)
@@ -535,8 +532,6 @@ void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 thro
     std::string const message = os.str();
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
-    if (WorldSession* session = bot->GetSession())
-        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
 }
 
 bool CanIssueMovementCommand(Player const* player, uint32 cooldownMs = 500)
@@ -633,7 +628,8 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     else if (!botCurrentlyMoving && player->InBattleground() &&
         currentMovement != IDLE_MOTION_TYPE &&
         currentMovement != CHASE_MOTION_TYPE &&
-        currentMovement != POINT_MOTION_TYPE)
+        currentMovement != POINT_MOTION_TYPE &&
+        currentMovement != CONFUSED_MOTION_TYPE)
     {
         // Some stale movement generators can block new MovePoint while actor is
         // stationary. Clear them before reissuing battleground movement.
@@ -2072,6 +2068,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         case CHASE_MOTION_TYPE:
         case POINT_MOTION_TYPE:
         case FOLLOW_MOTION_TYPE:
+        case CONFUSED_MOTION_TYPE:
             break;
         default:
         {


### PR DESCRIPTION
### Motivation
- Avoid bots getting stuck unable to mount due to brief outdoors-flag desyncs on ramps/bridges/battleground seams by relaxing the outdoors check for mounting. 
- Reduce noisy/unsafe GM and player-facing whisper messages for PvP decisions and spell failures by removing automatic GM/duel whispers and relying on structured logs. 
- Prevent unnecessary clearing of valid movement when the bot is in a `CONFUSED_MOTION_TYPE` state so battleground movement remains responsive.

### Description
- Changed `IsStrictlyOutdoorsForMount` to accept either `player->IsOutdoors()` or `terrainStatus.outdoors` (logical OR) in both `PlayerbotPvpClassActions.cpp` and `PlayerbotPvpCore.cpp` with updated comments explaining the reason. 
- Removed the duel opponent whisper in `NotifyDuelDecision` and retained a structured `TC_LOG_DEBUG` entry instead. 
- Removed the `NotifySpellCastFailureToGameMasters` helper and calls to it so spell-cast failures are no longer broadcast to GMs via chat. 
- Removed GM system message sends from `EmitLifecycleDiagnostic` and `EmitBattlegroundGmDebug`, leaving only logged diagnostics. 
- Dropped the fallback automatic use of `SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT` inside `SelectOutOfCombatEatDrinkOrMountSpell` and now prefer selecting a known mount spell via `SelectReadyKnownMountSpell`. 
- Added `CONFUSED_MOTION_TYPE` to the set of motion types treated as non-blocking in movement checks and pathing logic inside `PlayerbotPvpLifecycleActions.cpp`. 
- Removed an unused `#include <sstream>` where message construction and chat sends were removed.

### Testing
- Performed a full project build (server compilation) to verify no compile errors after the refactor and all build targets succeeded. 
- Ran automated unit tests and playerbot PvP integration tests (bot movement/mounting scenarios and spell-cast flows), and the test suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da937c7ca08327b9d33f22f139dd39)