### PR TITLE
Fix WSG mount suppression, polymorph wander freeze, and remove playerbot diagnostic broadcasts

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -557,9 +557,10 @@ bool IsStrictlyOutdoorsForMount(Player const* player)
     PositionFullTerrainStatus terrainStatus;
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    // Mount casts should be conservative: require both outdoor signals to avoid
-    // mounting in indoor edge locations where one check can be stale.
-    return player->IsOutdoors() && terrainStatus.outdoors;
+    // Prefer permissive outdoor detection in battleground flow. Requiring both
+    // signals can incorrectly block valid WSG field mounts when one source
+    // briefly desynchronizes near terrain seams.
+    return player->IsOutdoors() || terrainStatus.outdoors;
 }
 
 bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)
@@ -571,7 +572,7 @@ bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)
     if (!map)
         return false;
 
-    float const checkDistance = std::max(maxDistance, player->GetVisibilityRange());
+    float const checkDistance = std::max(maxDistance, 0.0f);
     for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
     {
         Player* candidate = itr->GetSource();
@@ -730,7 +731,7 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
 
     // Keep pressure logic responsive: don't choose an out-of-combat mount
     // action while hostile players are already within practical engage range.
-    if (HasNearbyAttackableEnemyPlayer(player, 45.0f))
+    if (!player->InBattleground() && HasNearbyAttackableEnemyPlayer(player, 45.0f))
         return decision;
 
     if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -493,50 +493,16 @@ std::array<BattlegroundTypeId, 6> BuildRandomBattlegroundOrder()
 
 void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string const& detail)
 {
-    if (!player || !phase)
-        return;
-
-    std::ostringstream oss;
-    oss << "[Playerbot PvP][" << phase << "] bot=" << player->GetName() << " guid=" << player->GetGUID().ToString()
-        << " map=" << player->GetMapId() << " detail=" << detail;
-    std::string const message = oss.str();
-
-    TC_LOG_WARN("playerbots.pvp.lifecycle", "{}", message);
-
-    if (WorldSession* session = player->GetSession())
-        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
+    (void)player;
+    (void)phase;
+    (void)detail;
 }
 
 void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs = 3000)
 {
-    if (!bot || !bot->InBattleground())
-        return;
-
-    if (throttleMs > 0)
-    {
-        static std::unordered_map<uint64, uint32> nextEmitTimeByBotGuid;
-        uint32 const nowMs = GameTime::GetGameTimeMS();
-        uint64 const botGuid = bot->GetGUID().GetRawValue();
-        uint32& nextEmitMs = nextEmitTimeByBotGuid[botGuid];
-        if (nowMs < nextEmitMs)
-            return;
-
-        nextEmitMs = nowMs + throttleMs;
-    }
-
-    if (!bot->GetMap())
-        return;
-
-    std::ostringstream os;
-    os << "[PBDBG movepoint] bot=" << bot->GetName()
-       << " guid=" << bot->GetGUID().ToString()
-       << " bgId=" << bot->GetBattlegroundId()
-       << " detail=" << detail;
-    std::string const message = os.str();
-
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
-    if (WorldSession* session = bot->GetSession())
-        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
+    (void)bot;
+    (void)detail;
+    (void)throttleMs;
 }
 
 bool CanIssueMovementCommand(Player const* player, uint32 cooldownMs = 500)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -87,6 +87,11 @@ void ClearActiveMovementForControlLoss(Player* player)
 
     player->AttackStop();
     player->SetSelection(ObjectGuid::Empty);
+    // Preserve server-owned confused movement (e.g. polymorph drift). Clearing
+    // active movement while confused pins the unit in place.
+    if (player->HasUnitState(UNIT_STATE_CONFUSED) || player->HasAuraType(SPELL_AURA_MOD_CONFUSE) || player->IsPolymorphed())
+        return;
+
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
 }
@@ -110,25 +115,9 @@ bool g_StartupRevivePending = false;
 
 void EmitLifecycleGmDebug(Player const* player, std::string const& detail, uint32 throttleMs = 5000)
 {
-    if (!player || !player->InBattleground())
-        return;
-
-    static std::unordered_map<uint64, uint32> nextEmitMsByGuid;
-    uint64 const botGuid = player->GetGUID().GetRawValue();
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-    uint32& nextEmitMs = nextEmitMsByGuid[botGuid];
-    if (nowMs < nextEmitMs)
-        return;
-
-    nextEmitMs = nowMs + throttleMs;
-
-    std::ostringstream os;
-    os << "[PBDBG lifecycle] bot=" << player->GetName()
-       << " guid=" << player->GetGUID().ToString()
-       << " bgId=" << player->GetBattlegroundId()
-       << " detail=" << detail;
-    std::string const message = os.str();
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
+    (void)player;
+    (void)detail;
+    (void)throttleMs;
 }
 
 enum class LifecycleObservationReason : uint8
@@ -247,13 +236,15 @@ void ObserveLifecycleReason(LifecycleObservationReason reason, ObjectGuid const&
             break;
     }
 
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "Playerbot PvP lifecycle observation: reason={} guid={} count={}.",
-        reasonLabel, guid.ToString(), total);
+    (void)reasonLabel;
+    (void)guid;
+    (void)total;
 }
 
 void LogLifecycleBranchSummary(ObjectGuid const& guid, char const* branchLabel)
 {
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "Playerbot PvP lifecycle branch: guid={} branch={}.", guid.ToString(), branchLabel);
+    (void)guid;
+    (void)branchLabel;
 }
 
 bool CanProcessPlayerLifecycle(Player const* player)


### PR DESCRIPTION
### Motivation
- Resolve three playerbot PvP problems observed in battlegrounds: bots failing to mount (WSG), diagnostic server/GMs spam from lifecycle code, and polymorphed/confused targets becoming immobile instead of drifting.

### Description
- Relaxed the outdoor mount gate in `SelectOutOfCombatEatDrinkOrMountSpell` by changing `IsStrictlyOutdoorsForMount` to accept either `IsOutdoors()` OR the terrain `outdoors` flag to avoid false negatives near BG geometry seams (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`).
- Corrected the nearby-hostile detection radius by stopping use of the player's visibility range in `HasNearbyAttackableEnemyPlayer` and preserved the intended `maxDistance`, and skipped the nearby-hostile mount suppression when `player->InBattleground()` so bots may mount during normal BG travel flow (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`).
- Preserved server-driven confused/polymorph wander by making `ClearActiveMovementForControlLoss` return early when the unit is `UNIT_STATE_CONFUSED`, has `SPELL_AURA_MOD_CONFUSE`, or `IsPolymorphed()` to avoid clearing the server motion slot and pinning the unit (`src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`).
- Removed/disabled lifecycle diagnostic broadcast and GM debug plumbing by turning `EmitLifecycleDiagnostic`, `EmitBattlegroundGmDebug`, and `EmitLifecycleGmDebug` into no-ops and silencing lifecycle observation logging paths to stop server-side GM/global message broadcasts and debug spam (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`).

### Testing
- Ran `git diff --check` to validate the patch; the check completed with no reported whitespace/diff errors.
- Verified repository status with `git status --short` to confirm only the intended source files were modified and staged; the check succeeded.
- Performed targeted code inspections of the adjusted mount, movement-clear, and diagnostic emitter code paths to confirm the changes align with the reference behavior; inspection completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9b61965c8327bc921b81eb4652d9)