### PR TITLE
Playerbot PvP: tighten mount/outdoor checks, preserve confused movement, and silence lifecycle debug logging

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -550,16 +550,18 @@ bool IsStrictlyOutdoorsForMount(Player const* player)
     if (!player)
         return false;
 
-    Map const* map = player->GetMap();
-    if (!map)
-        return player->IsOutdoors();
+    // Keep mount checks aligned with reference behavior: require IsOutdoors and
+    // reject cases where the unit is clipping slightly below floor level (which
+    // can misreport outdoor state in battleground tunnels/bases).
+    if (!player->IsOutdoors())
+        return false;
 
-    PositionFullTerrainStatus terrainStatus;
-    map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
-        terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    // Mount casts should be conservative: require both outdoor signals to avoid
-    // mounting in indoor edge locations where one check can be stale.
-    return player->IsOutdoors() && terrainStatus.outdoors;
+    float const posZ = player->GetPositionZ();
+    float const groundLevel = player->GetMapWaterOrGroundLevel(player->GetPositionX(), player->GetPositionY(), posZ);
+    if (!player->HasAuraType(SPELL_AURA_WATER_WALK) && posZ < groundLevel)
+        return false;
+
+    return true;
 }
 
 bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)
@@ -571,7 +573,7 @@ bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)
     if (!map)
         return false;
 
-    float const checkDistance = std::max(maxDistance, player->GetVisibilityRange());
+    float const checkDistance = std::max(maxDistance, 0.0f);
     for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
     {
         Player* candidate = itr->GetSource();

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -493,50 +493,16 @@ std::array<BattlegroundTypeId, 6> BuildRandomBattlegroundOrder()
 
 void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string const& detail)
 {
-    if (!player || !phase)
-        return;
-
-    std::ostringstream oss;
-    oss << "[Playerbot PvP][" << phase << "] bot=" << player->GetName() << " guid=" << player->GetGUID().ToString()
-        << " map=" << player->GetMapId() << " detail=" << detail;
-    std::string const message = oss.str();
-
-    TC_LOG_WARN("playerbots.pvp.lifecycle", "{}", message);
-
-    if (WorldSession* session = player->GetSession())
-        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
+    (void)player;
+    (void)phase;
+    (void)detail;
 }
 
 void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs = 3000)
 {
-    if (!bot || !bot->InBattleground())
-        return;
-
-    if (throttleMs > 0)
-    {
-        static std::unordered_map<uint64, uint32> nextEmitTimeByBotGuid;
-        uint32 const nowMs = GameTime::GetGameTimeMS();
-        uint64 const botGuid = bot->GetGUID().GetRawValue();
-        uint32& nextEmitMs = nextEmitTimeByBotGuid[botGuid];
-        if (nowMs < nextEmitMs)
-            return;
-
-        nextEmitMs = nowMs + throttleMs;
-    }
-
-    if (!bot->GetMap())
-        return;
-
-    std::ostringstream os;
-    os << "[PBDBG movepoint] bot=" << bot->GetName()
-       << " guid=" << bot->GetGUID().ToString()
-       << " bgId=" << bot->GetBattlegroundId()
-       << " detail=" << detail;
-    std::string const message = os.str();
-
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
-    if (WorldSession* session = bot->GetSession())
-        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
+    (void)bot;
+    (void)detail;
+    (void)throttleMs;
 }
 
 bool CanIssueMovementCommand(Player const* player, uint32 cooldownMs = 500)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -87,6 +87,11 @@ void ClearActiveMovementForControlLoss(Player* player)
 
     player->AttackStop();
     player->SetSelection(ObjectGuid::Empty);
+    // Preserve server-owned confused movement (e.g. polymorph drift). Clearing
+    // active movement while confused pins the unit in place.
+    if (player->HasUnitState(UNIT_STATE_CONFUSED) || player->HasAuraType(SPELL_AURA_MOD_CONFUSE) || player->IsPolymorphed())
+        return;
+
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
 }
@@ -110,25 +115,9 @@ bool g_StartupRevivePending = false;
 
 void EmitLifecycleGmDebug(Player const* player, std::string const& detail, uint32 throttleMs = 5000)
 {
-    if (!player || !player->InBattleground())
-        return;
-
-    static std::unordered_map<uint64, uint32> nextEmitMsByGuid;
-    uint64 const botGuid = player->GetGUID().GetRawValue();
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-    uint32& nextEmitMs = nextEmitMsByGuid[botGuid];
-    if (nowMs < nextEmitMs)
-        return;
-
-    nextEmitMs = nowMs + throttleMs;
-
-    std::ostringstream os;
-    os << "[PBDBG lifecycle] bot=" << player->GetName()
-       << " guid=" << player->GetGUID().ToString()
-       << " bgId=" << player->GetBattlegroundId()
-       << " detail=" << detail;
-    std::string const message = os.str();
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
+    (void)player;
+    (void)detail;
+    (void)throttleMs;
 }
 
 enum class LifecycleObservationReason : uint8
@@ -247,13 +236,15 @@ void ObserveLifecycleReason(LifecycleObservationReason reason, ObjectGuid const&
             break;
     }
 
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "Playerbot PvP lifecycle observation: reason={} guid={} count={}.",
-        reasonLabel, guid.ToString(), total);
+    (void)reasonLabel;
+    (void)guid;
+    (void)total;
 }
 
 void LogLifecycleBranchSummary(ObjectGuid const& guid, char const* branchLabel)
 {
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "Playerbot PvP lifecycle branch: guid={} branch={}.", guid.ToString(), branchLabel);
+    (void)guid;
+    (void)branchLabel;
 }
 
 bool CanProcessPlayerLifecycle(Player const* player)


### PR DESCRIPTION
### Motivation
- Reduce incorrect mount attempts by avoiding edge-case outdoor detections and rejecting mounts when the unit is clipping below ground level.
- Avoid clearing server-driven confused/polymorphed movement which can pin units in place when control is lost.
- Remove noisy runtime debug/GM messages and throttled logs from lifecycle and battleground helpers to reduce log spam.

### Description
- Update `IsStrictlyOutdoorsForMount` to require `IsOutdoors()` and verify the unit's `Z` against `GetMapWaterOrGroundLevel`, rejecting mount attempts when `posZ < groundLevel` unless `SPELL_AURA_WATER_WALK` is present.
- Change `HasNearbyAttackableEnemyPlayer` to use `std::max(maxDistance, 0.0f)` for the distance check, removing reliance on `GetVisibilityRange()`.
- Prevent `ClearActiveMovementForControlLoss` from clearing server-owned confused movement by early-returning when the player is `UNIT_STATE_CONFUSED`, has `SPELL_AURA_MOD_CONFUSE`, or is polymorphed.
- Silence multiple diagnostic and debug helpers (`EmitLifecycleDiagnostic`, `EmitBattlegroundGmDebug`, `EmitLifecycleGmDebug`, `ObserveLifecycleReason`, and `LogLifecycleBranchSummary`) by replacing their bodies with no-op parameter casts to stop emitting chat and log messages.

### Testing
- Built the server with the changes applied; the build completed successfully.
- Ran the repository's automated unit tests (including PvP/playerbot related tests); all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9b61965c8327bc921b81eb4652d9)