### PR TITLE
Fix playerbots stuck in ended battlegrounds/arenas

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3101,7 +3101,10 @@ InvitationResponseType PvpCore::SelectBattlegroundInvitationResponseSkeleton(Pvp
 
 bool PvpCore::ShouldHandleBattlegroundInProgressStatusSkeleton(PvpValues const& values)
 {
-    return values.battlegroundState == BattlegroundState::Active;
+    // Keep lifecycle handling active for bots that are still flagged in a battleground,
+    // including STATUS_WAIT_LEAVE so they can execute LeaveBattleground() and return
+    // to their recorded queue entry point.
+    return values.inBattleground;
 }
 
 QueueOperationType PvpCore::SelectArenaQueueOperationSkeleton(PvpValues const& values)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1887,11 +1887,24 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (!player->InBattleground())
         return false;
 
-    if (Battleground* battleground = player->GetBattleground())
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground)
+        return false;
+
+    if (battleground->GetStatus() == STATUS_WAIT_LEAVE)
     {
-        if (battleground->GetStatus() != STATUS_IN_PROGRESS)
+        if (player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear())
             return false;
+
+        player->LeaveBattleground();
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle leave after battleground end: guid={} bgTypeId={} instanceId={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+        return true;
     }
+
+    if (battleground->GetStatus() != STATUS_IN_PROGRESS)
+        return false;
 
     if (HandleBattlegroundDeathState(player))
         return true;


### PR DESCRIPTION
### Motivation
- Managed playerbots could remain stuck inside battleground/arena instances after a match ended because lifecycle handling only ran while the BG was `Active` (`STATUS_IN_PROGRESS`).
- We need bots to execute post-match leave behavior (return to their recorded queue entry point) when the battleground transitions to the end-of-match state (`STATUS_WAIT_LEAVE`).

### Description
- Update `PvpCore::ShouldHandleBattlegroundInProgressStatusSkeleton` to keep lifecycle handling active while the bot is still flagged in a battleground by returning `values.inBattleground` instead of checking for `BattlegroundState::Active`.
- Update `BattlegroundLifecycleActions::HandleInProgressStatusPrimitive` to fetch `Battleground*` early, detect `STATUS_WAIT_LEAVE`, skip if the player is mid-teleport, call `player->LeaveBattleground()` for post-match exit, and emit a debug log entry for verification.
- Reordered the status checks so normal in-progress handling still applies when appropriate and death/respawn handling remains unchanged.

### Testing
- Ran a static check using `git diff --check` against the modified files and it reported no issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daaea7f5848327b37c168ce9baeb50)