### PR TITLE
Conservative indoor mount handling, silence noisy PvP logs, and movement fixes

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -550,16 +550,43 @@ bool IsStrictlyOutdoorsForMount(Player const* player)
     if (!player)
         return false;
 
-    Map const* map = player->GetMap();
-    if (!map)
-        return player->IsOutdoors();
+    // Keep mount checks aligned with reference behavior: require IsOutdoors and
+    // reject cases where the unit is clipping slightly below floor level (which
+    // can misreport outdoor state in battleground tunnels/bases).
+    if (!player->IsOutdoors())
+        return false;
 
-    PositionFullTerrainStatus terrainStatus;
-    map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
-        terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
-    // Mount casts should be conservative: require both outdoor signals to avoid
-    // mounting in indoor edge locations where one check can be stale.
-    return player->IsOutdoors() && terrainStatus.outdoors;
+    float const posZ = player->GetPositionZ();
+    float const groundLevel = player->GetMapWaterOrGroundLevel(player->GetPositionX(), player->GetPositionY(), posZ);
+    if (!player->HasAuraType(SPELL_AURA_WATER_WALK) && posZ < groundLevel)
+        return false;
+
+    return true;
+}
+
+bool ShouldForceIndoorDismount(Player const* player, bool outdoors, uint32 lingerMs = 1500)
+{
+    if (!player)
+        return false;
+
+    static std::unordered_map<uint64, uint32> indoorSinceMsByGuid;
+    uint64 const guid = player->GetGUID().GetRawValue();
+
+    if (outdoors)
+    {
+        indoorSinceMsByGuid.erase(guid);
+        return false;
+    }
+
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    auto itr = indoorSinceMsByGuid.find(guid);
+    if (itr == indoorSinceMsByGuid.end())
+    {
+        indoorSinceMsByGuid.emplace(guid, nowMs);
+        return false;
+    }
+
+    return nowMs >= itr->second + lingerMs;
 }
 
 bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)
@@ -571,7 +598,7 @@ bool HasNearbyAttackableEnemyPlayer(Player const* player, float maxDistance)
     if (!map)
         return false;
 
-    float const checkDistance = std::max(maxDistance, player->GetVisibilityRange());
+    float const checkDistance = std::max(maxDistance, 0.0f);
     for (Map::PlayerList::const_iterator itr = map->GetPlayers().begin(); itr != map->GetPlayers().end(); ++itr)
     {
         Player* candidate = itr->GetSource();
@@ -2678,11 +2705,12 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     // Reference parity guard: never allow mounted state indoors. In addition,
     // while in combat always force mount-state correction immediately.
     bool const outdoors = IsEffectivelyOutdoors(player);
-    if (player->IsMounted() && (!outdoors || player->IsInCombat()))
+    bool const sustainedIndoorMounted = player->IsMounted() && ShouldForceIndoorDismount(player, outdoors);
+    if (player->IsMounted() && (sustainedIndoorMounted || player->IsInCombat()))
     {
         context.movementDirective = PvpClassSpellContext::MovementDirective::CheckMountState;
         context.actionName = "check mount state";
-        context.reason = outdoors ? "mounted in combat" : "mounted indoors";
+        context.reason = player->IsInCombat() ? "mounted in combat" : "mounted indoors";
         context.shouldExecute = true;
         return context;
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -103,6 +103,31 @@ bool IsEffectivelyOutdoors(Player const* player)
     return player->IsOutdoors() || terrainStatus.outdoors;
 }
 
+bool ShouldForceIndoorDismount(Player const* player, bool outdoors, uint32 lingerMs = 1500)
+{
+    if (!player)
+        return false;
+
+    static std::unordered_map<uint64, uint32> indoorSinceMsByGuid;
+    uint64 const guid = player->GetGUID().GetRawValue();
+
+    if (outdoors)
+    {
+        indoorSinceMsByGuid.erase(guid);
+        return false;
+    }
+
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    auto itr = indoorSinceMsByGuid.find(guid);
+    if (itr == indoorSinceMsByGuid.end())
+    {
+        indoorSinceMsByGuid.emplace(guid, nowMs);
+        return false;
+    }
+
+    return nowMs >= itr->second + lingerMs;
+}
+
 bool IsRecoveringByEatingOrDrinking(Player const* player)
 {
     if (!player || !player->IsAlive() || player->IsInCombat())
@@ -493,50 +518,16 @@ std::array<BattlegroundTypeId, 6> BuildRandomBattlegroundOrder()
 
 void EmitLifecycleDiagnostic(Player* player, char const* phase, std::string const& detail)
 {
-    if (!player || !phase)
-        return;
-
-    std::ostringstream oss;
-    oss << "[Playerbot PvP][" << phase << "] bot=" << player->GetName() << " guid=" << player->GetGUID().ToString()
-        << " map=" << player->GetMapId() << " detail=" << detail;
-    std::string const message = oss.str();
-
-    TC_LOG_WARN("playerbots.pvp.lifecycle", "{}", message);
-
-    if (WorldSession* session = player->GetSession())
-        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
+    (void)player;
+    (void)phase;
+    (void)detail;
 }
 
 void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs = 3000)
 {
-    if (!bot || !bot->InBattleground())
-        return;
-
-    if (throttleMs > 0)
-    {
-        static std::unordered_map<uint64, uint32> nextEmitTimeByBotGuid;
-        uint32 const nowMs = GameTime::GetGameTimeMS();
-        uint64 const botGuid = bot->GetGUID().GetRawValue();
-        uint32& nextEmitMs = nextEmitTimeByBotGuid[botGuid];
-        if (nowMs < nextEmitMs)
-            return;
-
-        nextEmitMs = nowMs + throttleMs;
-    }
-
-    if (!bot->GetMap())
-        return;
-
-    std::ostringstream os;
-    os << "[PBDBG movepoint] bot=" << bot->GetName()
-       << " guid=" << bot->GetGUID().ToString()
-       << " bgId=" << bot->GetBattlegroundId()
-       << " detail=" << detail;
-    std::string const message = os.str();
-
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
-    if (WorldSession* session = bot->GetSession())
-        ChatHandler(session).SendGlobalGMSysMessage(message.c_str());
+    (void)bot;
+    (void)detail;
+    (void)throttleMs;
 }
 
 bool CanIssueMovementCommand(Player const* player, uint32 cooldownMs = 500)
@@ -2063,7 +2054,8 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (!player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
         return false;
 
-    if (player->IsMounted() && !IsEffectivelyOutdoors(player))
+    bool const outdoors = IsEffectivelyOutdoors(player);
+    if (player->IsMounted() && ShouldForceIndoorDismount(player, outdoors))
         ForcePlayerbotDismount(player);
 
     switch (player->GetMotionMaster()->GetCurrentMovementGeneratorType())

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -87,6 +87,11 @@ void ClearActiveMovementForControlLoss(Player* player)
 
     player->AttackStop();
     player->SetSelection(ObjectGuid::Empty);
+    // Preserve server-owned confused movement (e.g. polymorph drift). Clearing
+    // active movement while confused pins the unit in place.
+    if (player->HasUnitState(UNIT_STATE_CONFUSED) || player->HasAuraType(SPELL_AURA_MOD_CONFUSE) || player->IsPolymorphed())
+        return;
+
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
 }
@@ -110,25 +115,9 @@ bool g_StartupRevivePending = false;
 
 void EmitLifecycleGmDebug(Player const* player, std::string const& detail, uint32 throttleMs = 5000)
 {
-    if (!player || !player->InBattleground())
-        return;
-
-    static std::unordered_map<uint64, uint32> nextEmitMsByGuid;
-    uint64 const botGuid = player->GetGUID().GetRawValue();
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-    uint32& nextEmitMs = nextEmitMsByGuid[botGuid];
-    if (nowMs < nextEmitMs)
-        return;
-
-    nextEmitMs = nowMs + throttleMs;
-
-    std::ostringstream os;
-    os << "[PBDBG lifecycle] bot=" << player->GetName()
-       << " guid=" << player->GetGUID().ToString()
-       << " bgId=" << player->GetBattlegroundId()
-       << " detail=" << detail;
-    std::string const message = os.str();
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "{}", message);
+    (void)player;
+    (void)detail;
+    (void)throttleMs;
 }
 
 enum class LifecycleObservationReason : uint8
@@ -247,13 +236,15 @@ void ObserveLifecycleReason(LifecycleObservationReason reason, ObjectGuid const&
             break;
     }
 
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "Playerbot PvP lifecycle observation: reason={} guid={} count={}.",
-        reasonLabel, guid.ToString(), total);
+    (void)reasonLabel;
+    (void)guid;
+    (void)total;
 }
 
 void LogLifecycleBranchSummary(ObjectGuid const& guid, char const* branchLabel)
 {
-    TC_LOG_DEBUG("playerbots.pvp.lifecycle", "Playerbot PvP lifecycle branch: guid={} branch={}.", guid.ToString(), branchLabel);
+    (void)guid;
+    (void)branchLabel;
 }
 
 bool CanProcessPlayerLifecycle(Player const* player)


### PR DESCRIPTION
### Motivation
- Reduce incorrect mount/dismount behavior caused by transient terrain flags and prevent bots from mounting indoors or remaining mounted while briefly clipping below ground level.
- Eliminate noisy runtime debug/GM message emission from PvP lifecycle paths to reduce log/GM spam.
- Avoid clearing server-controlled confused movement and tighten proximity checks for nearby attackable players.

### Description
- Add `ShouldForceIndoorDismount` to track when a player has been continuously indoors and only force dismount after a configurable linger period (default 1500ms). 
- Replace previous `IsStrictlyOutdoorsForMount` logic with a conservative check that requires `player->IsOutdoors()` and rejects positions below ground level unless water-walk is active, using `GetMapWaterOrGroundLevel`.
- Use `ShouldForceIndoorDismount` in `PvpCore::BuildClassSpellContext` and `BattlegroundTacticalActions::MoveToObjectivePrimitive` to trigger mount-state correction only for sustained indoor conditions (or immediate correction while in combat).
- Change `HasNearbyAttackableEnemyPlayer` to compute `checkDistance` with `std::max(maxDistance, 0.0f)` instead of using the player visibility range.
- Prevent clearing active movement while a player is `UNIT_STATE_CONFUSED`, has `SPELL_AURA_MOD_CONFUSE`, or is polymorphed to preserve server-driven confused movement drift.
- Silence several lifecycle and battleground debug/GM output functions (`EmitLifecycleDiagnostic`, `EmitBattlegroundGmDebug`, `EmitLifecycleGmDebug`, `ObserveLifecycleReason`, `LogLifecycleBranchSummary`) by turning them into no-ops to remove log and GM chat spam.
- Minor message/variable cleanup for mount reason text and a few comments.

### Testing
- Built the server code successfully using the project build system (`cmake`/`cmake --build .`) with no compile errors.
- Executed the repository's automated test suite for playerbot/PvP components and related unit tests, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9b61965c8327bc921b81eb4652d9)