### PR TITLE
Fix stale grouped queue state when removing party members

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -547,6 +547,44 @@ bool Group::RemoveMember(ObjectGuid guid, RemoveMethod const& method /*= GROUP_R
     Player* player = ObjectAccessor::FindConnectedPlayer(guid);
     if (player)
     {
+        // If group composition changes while this player is queued with other group members,
+        // remove this player from those battleground/arena queues to avoid stale queue groups.
+        if (!isBGGroup() && !isBFGroup())
+        {
+            for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+            {
+                BattlegroundQueueTypeId bgQueueTypeId = player->GetBattlegroundQueueTypeId(i);
+                if (!bgQueueTypeId)
+                    continue;
+
+                BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
+                GroupQueueInfo ginfo;
+                if (!bgQueue.GetPlayerGroupInfoData(guid, &ginfo))
+                    continue;
+
+                // Keep solo queues intact; only remove entries that still represent a grouped queue.
+                if (ginfo.Players.size() <= 1)
+                    continue;
+
+                uint32 queueSlot = player->GetBattlegroundQueueIndex(bgQueueTypeId);
+                player->RemoveBattlegroundQueueId(bgQueueTypeId);
+                bgQueue.RemovePlayer(guid, true);
+
+                if (Battleground* bg = sBattlegroundMgr->GetBattlegroundTemplate(ginfo.BgTypeId))
+                {
+                    WorldPacket data;
+                    sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_NONE, 0, 0, 0, 0);
+                    player->SendDirectMessage(&data);
+
+                    if (!ginfo.ArenaType)
+                    {
+                        if (PvPDifficultyEntry const* bracketEntry = GetBattlegroundBracketByLevel(bg->GetMapId(), player->GetLevel()))
+                            sBattlegroundMgr->ScheduleQueueUpdate(ginfo.ArenaMatchmakerRating, ginfo.ArenaType, bgQueueTypeId, ginfo.BgTypeId, bracketEntry->GetBracketId());
+                    }
+                }
+            }
+        }
+
         for (GroupReference* itr = GetFirstMember(); itr != nullptr; itr = itr->next())
         {
             if (Player* groupMember = itr->GetSource())


### PR DESCRIPTION
### Motivation
- Removing a player from a regular party could leave them listed in a grouped battleground/arena queue, producing stale group queue entries that break matchmaking when groups are modified (e.g. AFK member replaced/kicked). 
- The intent is to keep queue state consistent when party composition changes while members remain queued.

### Description
- Added queue-cleanup logic in `Group::RemoveMember` to iterate the player's battleground queue slots and remove the player from any grouped `GroupQueueInfo` that still contains multiple players. 
- The change preserves solo queue entries by skipping removals when `ginfo.Players.size() <= 1`. 
- After removal the code clears the player's queue slot (`RemoveBattlegroundQueueId` / `RemovePlayer`) and sends a `STATUS_NONE` battleground status packet to the player, and it triggers a non-arena `ScheduleQueueUpdate` when appropriate. 
- All edits are contained in `src/server/game/Groups/Group.cpp` within the `RemoveMember` function.

### Testing
- Compiled the modified translation unit successfully with `ninja -C build src/server/game/CMakeFiles/game.dir/Groups/Group.cpp.o` and observed no compilation errors. 
- The change was committed after a successful object build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daadc11fe483279da8c5b5925492c2)