### PR TITLE
Playerbot PvP: reissue MoveFollow when cast fails due to range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -654,6 +654,20 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
     {
+        if (!itemTarget && target && CanIssueFollowCommands(player))
+        {
+            if (castResult == SPELL_FAILED_OUT_OF_RANGE)
+            {
+                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, PvpCore::GetConfig().spellRange - 1.0f);
+                player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+            }
+            else if (castResult == SPELL_FAILED_TOO_CLOSE)
+            {
+                float const desiredRange = minRange > 0.0f ? std::max(1.0f, minRange + 1.0f) : std::max(1.0f, PvpCore::GetConfig().closeRange);
+                player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+            }
+        }
+
         NotifySpellCastFailureToGameMasters(player, context, castResult);
         EnumText const reasonText = EnumUtils::ToString(castResult);
         failureReason = reasonText.Title;


### PR DESCRIPTION
### Motivation
- Prevent ranged playerbots (e.g. mages casting `Frostbolt`) from idling after a server-side cast failure by making them reposition automatically when the failure indicates they are out of or too close for spell range.

### Description
- In `CastDirectSpell` (file `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`) added logic in the post-cast-failure branch to check `SPELL_FAILED_OUT_OF_RANGE` and `SPELL_FAILED_TOO_CLOSE` and reissue `player->GetMotionMaster()->MoveFollow(...)` toward a computed `desiredRange` when `CanIssueFollowCommands(player)` is true.

### Testing
- Ran the automated build command `cmake --build build --target worldserver -j2`, which started configure/build and advanced through compilation; the build was exercised but not waited to full completion in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab45089408327a329bbfb4976ae04)