### PR TITLE
Playerbot: follow target to correct distance on spell cast range failures

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -654,6 +654,20 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
     {
+        if (!itemTarget && target && CanIssueFollowCommands(player))
+        {
+            if (castResult == SPELL_FAILED_OUT_OF_RANGE)
+            {
+                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+            }
+            else if (castResult == SPELL_FAILED_TOO_CLOSE)
+            {
+                float const desiredRange = minRange > 0.0f ? std::max(1.0f, minRange + 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().closeRange);
+                player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+            }
+        }
+
         NotifySpellCastFailureToGameMasters(player, context, castResult);
         EnumText const reasonText = EnumUtils::ToString(castResult);
         failureReason = reasonText.Title;


### PR DESCRIPTION
### Motivation

- Prevent bots from repeatedly failing instant-cast abilities when they are just out of or too close to range by making them adjust position automatically.
- Mirror client-like behavior for virtual bot sessions by issuing follow movement when applicable so subsequent casts have a better chance of succeeding.

### Description

- When a direct spell cast fails, if there is a valid `target`, no `itemTarget`, and `CanIssueFollowCommands(player)` returns true, issue follow movement to adjust distance instead of immediately stopping on failure.
- Handle `SPELL_FAILED_OUT_OF_RANGE` by moving to `desiredRange = maxRange - 1` (or a fallback configured `spellRange - 1` when `maxRange` is not provided) and `SPELL_FAILED_TOO_CLOSE` by moving to `desiredRange = minRange + 1` (or configured `closeRange` fallback when `minRange` is not provided) using `player->GetMotionMaster()->MoveFollow(...)`.
- Preserve existing failure notification (`NotifySpellCastFailureToGameMasters`) and error reporting when the cast ultimately fails.

### Testing

- Built the server and ran the automated test suite (`make` and `ctest`), and the tests completed successfully.
- Verified that bots now issue follow movement on `SPELL_FAILED_OUT_OF_RANGE` and `SPELL_FAILED_TOO_CLOSE` code paths during automated PvP behavior tests without introducing regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab45089408327a329bbfb4976ae04)