### PR TITLE
Evict virtual-session player when inviting real player to full battleground team

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -28,7 +28,55 @@
 #include "Log.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "WorldSession.h"
 #include "World.h"
+
+namespace
+{
+bool GroupHasRealPlayerInvitee(GroupQueueInfo const* ginfo)
+{
+    if (!ginfo)
+        return false;
+
+    for (auto const& playerEntry : ginfo->Players)
+    {
+        Player* player = ObjectAccessor::FindConnectedPlayer(playerEntry.first);
+        if (!player)
+            continue;
+
+        WorldSession* session = player->GetSession();
+        if (!session || !session->IsVirtualSession())
+            return true;
+    }
+
+    return false;
+}
+
+bool RemoveOneVirtualPlayerFromTeam(Battleground* battleground, uint32 team)
+{
+    if (!battleground)
+        return false;
+
+    for (auto const& [memberGuid, bgPlayer] : battleground->GetPlayers())
+    {
+        if (bgPlayer.Team != team)
+            continue;
+
+        Player* candidate = ObjectAccessor::FindConnectedPlayer(memberGuid);
+        if (!candidate)
+            continue;
+
+        WorldSession* session = candidate->GetSession();
+        if (!session || !session->IsVirtualSession())
+            continue;
+
+        battleground->RemovePlayerAtLeave(memberGuid, true, true);
+        return true;
+    }
+
+    return false;
+}
+}
 
  /*********************************************************/
  /***            BATTLEGROUND QUEUE SYSTEM              ***/
@@ -449,6 +497,14 @@ bool BattlegroundQueue::InviteGroupToBG(GroupQueueInfo* ginfo, Battleground* bg,
     // set side if needed
     if (side)
         ginfo->Team = side;
+
+    // Let bots fully populate battlegrounds, but if a real player is now being invited
+    // and the target team is full, free exactly one slot by dropping a virtual-session actor.
+    if (bg && bg->isBattleground() && GroupHasRealPlayerInvitee(ginfo) && !bg->GetFreeSlotsForTeam(ginfo->Team))
+    {
+        if (!RemoveOneVirtualPlayerFromTeam(bg, ginfo->Team))
+            return false;
+    }
 
     if (!ginfo->IsInvitedToBGInstanceGUID)
     {


### PR DESCRIPTION
### Motivation
- Allow battlegrounds to remain populated by virtual-session actors (bots) while ensuring a real player can take a slot when they are invited to a full team.

### Description
- Added `#include "WorldSession.h"` and two helper functions in an anonymous namespace: `GroupHasRealPlayerInvitee` to detect if a group contains at least one non-virtual-session player, and `RemoveOneVirtualPlayerFromTeam` to evict a single virtual-session player from a battleground team.
- Modified `InviteGroupToBG` to, when inviting a group to a battleground and the target team is full, free exactly one slot by removing a virtual-session actor if the incoming group contains a real player; the function returns failure if a virtual actor could not be removed.
- The removal uses the existing `RemovePlayerAtLeave` call to ensure proper cleanup of the evicted virtual player.

### Testing
- Project was built after the changes and the build completed successfully with the modified files compiled.
- The automated battleground-related test suite and server integration smoke tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab55597608327b115fd78c180002e)