### PR TITLE
playerbot: reduce healer kiting in PvP positioning

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -47,6 +47,7 @@
 #include "WorldSession.h"
 #include "Util.h"
 #include "Containers.h"
+#include "CommonHelpers.h"
 
 #include <cstring>
 #include <cmath>
@@ -1244,6 +1245,18 @@ CombatPositioningProfile GetCombatPositioningProfile(Player const* player)
 {
     if (!player)
         return {};
+
+    if (Trinity::Helpers::Entity::IsPlayerHealer(player))
+    {
+        switch (player->GetClass())
+        {
+            case CLASS_PRIEST: return { 0.0f, 25.0f, 34.0f, true, false, false, "priest-healer" };
+            case CLASS_SHAMAN: return { 0.0f, 20.0f, 30.0f, true, false, true, "shaman-healer" };
+            case CLASS_DRUID: return { 0.0f, 18.0f, 28.0f, true, false, true, "druid-healer" };
+            case CLASS_PALADIN: return { 0.0f, 16.0f, 26.0f, true, false, true, "paladin-healer" };
+            default: break;
+        }
+    }
 
     switch (player->GetClass())
     {


### PR DESCRIPTION
### Motivation
- Healer playerbots were repeatedly creating distance (kiting) instead of standing and casting heals when in range, so combat positioning should prefer holding firing/healing bands for healer specs.

### Description
- Add `#include "CommonHelpers.h"` and update `GetCombatPositioningProfile` to branch on `Trinity::Helpers::Entity::IsPlayerHealer(player)` and return healer-specific profiles for priest/shaman/druid/paladin that set `createDistanceWhenCrowded = false` and use adjusted ideal/heal ranges to bias holding position and casting heals.

### Testing
- Ran `git diff --check` to verify no whitespace or diff errors, which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac0a36ac483278599afdce011c436)