### PR TITLE
Fix playerbot retargeting after polymorph and reduce decision cadence to 1.5s

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2698,6 +2698,11 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     }
 
     ObjectGuid const selectedTargetGuid = SelectCombatTargetGuid(player);
+    ObjectGuid activeTargetGuid = selectedTargetGuid;
+    if (activeTargetGuid.IsEmpty())
+        if (Unit const* fallbackTarget = SelectClosestEnemyTarget(player, true))
+            activeTargetGuid = fallbackTarget->GetGUID();
+
     auto resolveTargetByGuid = [&](ObjectGuid const& guid) -> Unit const*
     {
         if (guid.IsEmpty() || guid == player->GetGUID())
@@ -2709,8 +2714,8 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
 
         return resolved;
     };
-    bool const hasValidTarget = resolveTargetByGuid(selectedTargetGuid) != nullptr;
-    Unit const* selectedTargetByGuid = resolveTargetByGuid(selectedTargetGuid);
+    bool const hasValidTarget = resolveTargetByGuid(activeTargetGuid) != nullptr;
+    Unit const* selectedTargetByGuid = resolveTargetByGuid(activeTargetGuid);
     bool const hasInvalidSelectedTarget = !selectedTargetGuid.IsEmpty() &&
         (!selectedTargetByGuid || !HasHostileTarget(player, selectedTargetByGuid));
     ObjectGuid const selectedAllyGuid = SelectAllyTargetGuid(player);
@@ -2774,7 +2779,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     while (attempts++ < kMaxDecisionAttempts)
     {
         DecisionEvaluationScope decisionScope(player, suppressedSpellId);
-        Unit const* decisionTarget = resolveTargetByGuid(selectedTargetGuid);
+        Unit const* decisionTarget = resolveTargetByGuid(activeTargetGuid);
         Unit const* decisionAllyTarget = resolveTargetByGuid(selectedAllyGuid);
         SpellDecision const candidate = SelectClassOrUtilitySpell(player, decisionTarget, decisionAllyTarget, profileSelection);
         if (!candidate.spellId)
@@ -2783,7 +2788,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         if (!firstDecision.spellId)
             firstDecision = candidate;
 
-        Unit const* immediateCastTarget = resolveTargetByGuid(selectedTargetGuid);
+        Unit const* immediateCastTarget = resolveTargetByGuid(activeTargetGuid);
         Unit const* immediateCastAllyTarget = resolveTargetByGuid(selectedAllyGuid);
         if (IsDecisionImmediatelyCastable(player, candidate, immediateCastTarget, immediateCastAllyTarget))
         {
@@ -2827,7 +2832,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     context.targetMode = decision.targetMode;
     context.selfCast = context.targetMode == PvpClassSpellContext::TargetMode::Self;
     context.itemEntry = decision.itemEntry;
-    context.targetGuid = hasValidTarget ? selectedTargetGuid : ObjectGuid::Empty;
+    context.targetGuid = hasValidTarget ? activeTargetGuid : ObjectGuid::Empty;
     context.allyTargetGuid = hasValidAllyTarget ? selectedAllyGuid : ObjectGuid::Empty;
     if (!decision.targetGuid.IsEmpty())
         context.targetGuid = decision.targetGuid;
@@ -2869,7 +2874,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
 
     if (!context.spellId && hasValidTarget)
     {
-        Unit const* facingFallbackTarget = resolveTargetByGuid(selectedTargetGuid);
+        Unit const* facingFallbackTarget = resolveTargetByGuid(activeTargetGuid);
         if (facingFallbackTarget && !player->HasInArc(static_cast<float>(M_PI), facingFallbackTarget))
         {
             ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FaceSpellTarget, facingFallbackTarget->GetGUID(), 0.0f,
@@ -2922,7 +2927,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     // too close for spell"). Keep classic spell IDs untouched.
     if (!context.spellId && hasValidTarget && IsPrimaryRangedClassForSpacing(player->GetClass()))
     {
-        Unit const* movementTarget = resolveTargetByGuid(selectedTargetGuid);
+        Unit const* movementTarget = resolveTargetByGuid(activeTargetGuid);
         if (movementTarget)
         {
             float const distance = player->GetDistance(movementTarget);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -105,7 +105,7 @@ bool IsLifecycleGateEnabled()
 using LifecycleCadenceClock = std::chrono::steady_clock;
 using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 
-constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(2000);
+constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(1500);
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;


### PR DESCRIPTION
### Motivation
- Bots could become idle after crowd-control (e.g. polymorph) because the selected combat target was missing/invalid and no nearby fallback was chosen, causing no immediate ranged pressure on other enemies.  
- The lifecycle decision cadence was 2000ms and should be more responsive for tighter PvP reactions.

### Description
- In `PvpCore::BuildClassSpellContext` added an `activeTargetGuid` fallback that uses `SelectClosestEnemyTarget(player, true)` when `SelectCombatTargetGuid(player)` is empty, and updated subsequent decision resolution to use `activeTargetGuid` for spell selection, castability checks, movement/facing directives, and movement fallback.  
- Replaced occurrences of resolving `selectedTargetGuid` with resolving `activeTargetGuid` in decision/evaluation loops so the bot immediately considers a nearby reachable hostile when the explicit selected target is absent.  
- Reduced `RandomBotLifecycleCadenceInterval` from `2000` to `1500` milliseconds in `PlayerbotRandomBotParticipation.cpp` to increase decision-update responsiveness.  
- Changes touch `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`.

### Testing
- Ran an automated build invocation with `cmake --build build --target worldserver -j 2`; CMake configuration succeeded and compilation began, but the full build was not completed within this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac0e8c66c8327a55df2613cfd6e7f)