### PR TITLE
Allow real players to displace virtual-session actors in full battlegrounds

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1331,7 +1331,27 @@ uint32 Battleground::GetFreeSlotsForTeam(uint32 Team) const
 
 bool Battleground::HasFreeSlots() const
 {
-    return GetPlayersSize() < GetMaxPlayers();
+    if (GetPlayersSize() < GetMaxPlayers())
+        return true;
+
+    // Treat virtual-session participants as replaceable occupancy for battlegrounds:
+    // this keeps full bot-populated matches in the free-slot queue so queued real
+    // players can displace one virtual actor on invite.
+    if (!isBattleground())
+        return false;
+
+    for (auto const& playerEntry : m_Players)
+    {
+        Player* player = ObjectAccessor::FindConnectedPlayer(playerEntry.first);
+        if (!player)
+            continue;
+
+        WorldSession* session = player->GetSession();
+        if (session && session->IsVirtualSession())
+            return true;
+    }
+
+    return false;
 }
 
 void Battleground::BuildPvPLogDataPacket(WorldPacket& data)

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -28,7 +28,79 @@
 #include "Log.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "WorldSession.h"
 #include "World.h"
+
+namespace
+{
+bool GroupHasRealPlayerInvitee(GroupQueueInfo const* ginfo)
+{
+    if (!ginfo)
+        return false;
+
+    for (auto const& playerEntry : ginfo->Players)
+    {
+        Player* player = ObjectAccessor::FindConnectedPlayer(playerEntry.first);
+        if (!player)
+            continue;
+
+        WorldSession* session = player->GetSession();
+        if (!session || !session->IsVirtualSession())
+            return true;
+    }
+
+    return false;
+}
+
+bool HasVirtualPlayerOnTeam(Battleground* battleground, uint32 team)
+{
+    if (!battleground)
+        return false;
+
+    for (auto const& [memberGuid, bgPlayer] : battleground->GetPlayers())
+    {
+        if (bgPlayer.Team != team)
+            continue;
+
+        Player* candidate = ObjectAccessor::FindConnectedPlayer(memberGuid);
+        if (!candidate)
+            continue;
+
+        WorldSession* session = candidate->GetSession();
+        if (!session || !session->IsVirtualSession())
+            continue;
+
+        return true;
+    }
+
+    return false;
+}
+
+bool RemoveOneVirtualPlayerFromTeam(Battleground* battleground, uint32 team)
+{
+    if (!battleground)
+        return false;
+
+    for (auto const& [memberGuid, bgPlayer] : battleground->GetPlayers())
+    {
+        if (bgPlayer.Team != team)
+            continue;
+
+        Player* candidate = ObjectAccessor::FindConnectedPlayer(memberGuid);
+        if (!candidate)
+            continue;
+
+        WorldSession* session = candidate->GetSession();
+        if (!session || !session->IsVirtualSession())
+            continue;
+
+        battleground->RemovePlayerAtLeave(memberGuid, true, true);
+        return true;
+    }
+
+    return false;
+}
+}
 
  /*********************************************************/
  /***            BATTLEGROUND QUEUE SYSTEM              ***/
@@ -450,6 +522,14 @@ bool BattlegroundQueue::InviteGroupToBG(GroupQueueInfo* ginfo, Battleground* bg,
     if (side)
         ginfo->Team = side;
 
+    // Let bots fully populate battlegrounds, but if a real player is now being invited
+    // and the target team is full, free exactly one slot by dropping a virtual-session actor.
+    if (bg && bg->isBattleground() && GroupHasRealPlayerInvitee(ginfo) && !bg->GetFreeSlotsForTeam(ginfo->Team))
+    {
+        if (!RemoveOneVirtualPlayerFromTeam(bg, ginfo->Team))
+            return false;
+    }
+
     if (!ginfo->IsInvitedToBGInstanceGUID)
     {
         // not yet invited
@@ -540,12 +620,20 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
 
         if (addToHorde)
         {
-            if(!m_SelectionPools[TEAM_HORDE].AddGroup((*Ali_itr), hordeFree, TEAM_HORDE))
+            uint32 hordeDesired = hordeFree > 0 ? uint32(hordeFree) : 0u;
+            if (!hordeDesired && GroupHasRealPlayerInvitee(*Ali_itr) && HasVirtualPlayerOnTeam(bg, HORDE))
+                hordeDesired = 1;
+
+            if (!m_SelectionPools[TEAM_HORDE].AddGroup((*Ali_itr), hordeDesired, TEAM_HORDE))
                 break;
         }
         else
         {
-            if(!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Ali_itr), aliFree, TEAM_ALLIANCE))
+            uint32 allianceDesired = aliFree > 0 ? uint32(aliFree) : 0u;
+            if (!allianceDesired && GroupHasRealPlayerInvitee(*Ali_itr) && HasVirtualPlayerOnTeam(bg, ALLIANCE))
+                allianceDesired = 1;
+
+            if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Ali_itr), allianceDesired, TEAM_ALLIANCE))
                 break;
         }
         ++Ali_itr;
@@ -565,12 +653,20 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
 
         if (addToHorde)
         {
-            if(!m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeFree, TEAM_HORDE))
+            uint32 hordeDesired = hordeFree > 0 ? uint32(hordeFree) : 0u;
+            if (!hordeDesired && GroupHasRealPlayerInvitee(*Horde_itr) && HasVirtualPlayerOnTeam(bg, HORDE))
+                hordeDesired = 1;
+
+            if (!m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeDesired, TEAM_HORDE))
                 break;
         }
         else
         {
-            if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Horde_itr), aliFree, TEAM_ALLIANCE))
+            uint32 allianceDesired = aliFree > 0 ? uint32(aliFree) : 0u;
+            if (!allianceDesired && GroupHasRealPlayerInvitee(*Horde_itr) && HasVirtualPlayerOnTeam(bg, ALLIANCE))
+                allianceDesired = 1;
+
+            if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Horde_itr), allianceDesired, TEAM_ALLIANCE))
                 break;
         }
         ++Horde_itr;


### PR DESCRIPTION
### Motivation

- Allow real players to join battlegrounds that are otherwise fully populated by virtual-session participants by treating virtual sessions as replaceable occupancy so queued real players can displace a virtual actor on invite.

### Description

- Update `Battleground::HasFreeSlots` to treat a battleground as having a free slot when any connected participant on the target team is a `WorldSession` with `IsVirtualSession()` set, while preserving normal behavior for non-battlegrounds.
- Add helper functions `GroupHasRealPlayerInvitee`, `HasVirtualPlayerOnTeam`, and `RemoveOneVirtualPlayerFromTeam` to `BattlegroundQueue.cpp` and include `WorldSession.h` for virtual-session detection.
- In `InviteGroupToBG` remove exactly one virtual-session player from the target team when inviting a group that contains at least one real player and the team is currently full, to free a slot for the invite.
- In `FillPlayersToBG` compute a `desired` fill value per team (defaulting to 1 when the team is full but the incoming group has a real player and the target team has a virtual player) and pass that into `AddGroup` so selection can displace virtual participants as needed.

### Testing

- Project built successfully after changes using the standard build (`cmake`/`make`) with no compile errors.
- Battleground queue logic unit tests and existing battleground-related regression tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab55597608327b115fd78c180002e)