### PR TITLE
Ensure stealthed rogue playerbots continue closing (MoveChase) during openers

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -529,9 +529,9 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (preserveStealthForOpener)
         {
             // While stealthed, keep auto-attack disabled so we do not break
-            // stealth early, but keep chase active for Cheap Shot opener so
-            // rogues do not idle in place waiting for an exact cast snapshot.
-            if (context.spellId == 1833 && CanIssueFollowCommands(player))
+            // stealth early, but keep chase active so rogues continue
+            // closing distance instead of idling in place during openers.
+            if (CanIssueFollowCommands(player))
                 player->GetMotionMaster()->MoveChase(target);
 
             player->AttackStop();


### PR DESCRIPTION
### Motivation
- Prevent stealthed rogue playerbots from stalling in place during stealth openers by ensuring they continue to close distance to their target while preserving stealth.

### Description
- Remove the `Cheap Shot`-only gate and make stealthed bots issue `player->GetMotionMaster()->MoveChase(target)` whenever `player->HasStealthAura()` and `CanIssueFollowCommands(player)` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`, while keeping the existing `player->AttackStop()` behavior to avoid breaking stealth.

### Testing
- Ran `git diff --check` and `git status --short` to validate the working tree and affected file; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daca00e5948327be42f51259946371)