### PR TITLE
Prioritize enemy pressure in battleground AI and simplify tactical rules

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2453,8 +2453,6 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
     bool const lowMana = player->GetPower(POWER_MANA) > 0 && player->GetPowerPct(POWER_MANA) < 25.0f;
     bool const bgActive = values.battlegroundState == playerbot::BattlegroundState::Active;
     bool const bgWaiting = values.battlegroundState == playerbot::BattlegroundState::WaitingToStart;
-    bool const periodicRefresh = bgActive;
-    bool const often = bgActive;
 
     struct TacticalRule
     {
@@ -2464,17 +2462,12 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
         float priority;
     };
 
-    // Preserve Warsong/Battleground trigger intent as an explicit ordered chain:
-    // highest-priority emergency handling first, then raid/bg pressure, then sustain.
-    std::array<TacticalRule, 9> const rules =
+    // Blind pressure model for battlegrounds: once active, always drive toward
+    // enemy players rather than objective-specific behavior.
+    std::array<TacticalRule, 4> const rules =
     {{
-        { "player has flag", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::PlayerHasFlag, values) && !values.battlegroundTeamHasHumans, "bg move to objective", 90.0f },
-        { "enemy flagcarrier near", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::EnemyFlagCarrierNear, values), "attack enemy flag carrier", 70.0f },
-        { "team flagcarrier near", playerbot::PvpCore::IsTriggerActive(playerbot::PvpTrigger::TeamFlagCarrierNear, values), "bg protect fc", 65.0f },
         { "bg waiting", bgWaiting, "bg move to start", 50.0f },
-        { "bg active", bgActive, "bg move to objective", 50.0f },
-        { "often", often, "bg check objective", 51.0f },
-        { "timer bg", periodicRefresh, "bg reset objective force", 80.0f },
+        { "bg active", bgActive, "bg check objective", 60.0f },
         { "low health", lowHealth, "bg use buff", 45.0f },
         { "low mana", lowMana, "bg use buff", 45.0f }
     }};

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -2186,6 +2186,8 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
 
 bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context)
 {
+    (void)context;
+
     if (!player || !player->InBattleground())
         return false;
 
@@ -2204,8 +2206,8 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
-    if (context.movement != BattlegroundMovementPrimitive::None || context.objective.type != BattlegroundObjectiveType::None)
-        return true;
+    if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max()))
+        return MoveTowardUnit(player, nearestEnemy, 20.0f);
 
     return false;
 }


### PR DESCRIPTION
### Motivation
- Simplify battleground bot behavior to prioritize engaging enemy players instead of objective-specific heuristics.
- Remove periodic/refresh and specialized flagcarrier checks that produced conflicting or brittle behavior.
- Silence an unused-parameter warning and ensure movement falls back to pursuing the nearest enemy when no objective is set.

### Description
- Replace the larger ordered tactical rule set in `SelectBattlegroundTacticalDecision` with a smaller set that drives a "blind pressure" model focused on engaging enemies and handling start/waiting states, and adjust priorities accordingly.
- Remove the `periodicRefresh` and `often` booleans and the flagcarrier/objective-specific rules from the battleground decision chain.
- In `BattlegroundTacticalActions::CheckObjectivePrimitive` add `(void)context` to silence unused-parameter warnings and change the fallback behavior to find the nearest enemy with `FindNearestEnemyBattlegroundPlayer` and call `MoveTowardUnit` when appropriate, instead of relying on `context.movement`/`context.objective` checks.
- Preserve Warsong-specific engage logic.

### Testing
- Project build completed successfully after the changes.
- Ran existing playerbot/unit tests related to PVP/battleground logic; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dacb956cdc832793752464412c27cd)