### PR TITLE
Fix map update iteration race in MapManager::Update

### DIFF
--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -212,19 +212,27 @@ void MapManager::Update(uint32 diff)
     if (!i_timer.Passed())
         return;
 
-    MapMapType::iterator iter = i_maps.begin();
-    for (; iter != i_maps.end(); ++iter)
+    std::vector<Map*> maps;
+    {
+        std::lock_guard<std::mutex> lock(_mapsLock);
+        maps.reserve(i_maps.size());
+        for (auto const& mapPair : i_maps)
+            maps.push_back(mapPair.second);
+    }
+
+    for (Map* map : maps)
     {
         if (m_updater.activated())
-            m_updater.schedule_update(*iter->second, uint32(i_timer.GetCurrent()));
+            m_updater.schedule_update(*map, uint32(i_timer.GetCurrent()));
         else
-            iter->second->Update(uint32(i_timer.GetCurrent()));
+            map->Update(uint32(i_timer.GetCurrent()));
     }
+
     if (m_updater.activated())
         m_updater.wait();
 
-    for (iter = i_maps.begin(); iter != i_maps.end(); ++iter)
-        iter->second->DelayedUpdate(uint32(i_timer.GetCurrent()));
+    for (Map* map : maps)
+        map->DelayedUpdate(uint32(i_timer.GetCurrent()));
 
     i_timer.SetCurrent(0);
 }


### PR DESCRIPTION
### Motivation
- Prevent concurrent-iteration hazards when `i_maps` can be modified while `MapManager::Update` schedules per-map work, which can corrupt iterators and surface as crashes during allocation/MapUpdater scheduling.
- The change snapshots the current set of maps under the maps lock so update work no longer depends on live `unordered_map` iterators.

### Description
- Take a locked snapshot of `i_maps` into a `std::vector<Map*> maps` while holding `_mapsLock` using `maps.reserve(...)` and `maps.push_back(...)`.
- Iterate the snapshot for the main update pass and call `m_updater.schedule_update(*map, uint32(i_timer.GetCurrent()))` or `map->Update(...)` as appropriate.
- Use the same snapshot for the `DelayedUpdate` pass instead of iterating `i_maps` directly to avoid iterator invalidation.
- This removes direct iteration over the `i_maps` container inside `MapManager::Update`.

### Testing
- Compiled the modified translation unit with `ninja -C build src/server/game/CMakeFiles/game.dir/Maps/MapManager.cpp.o -j4`, which succeeded.
- Started a full build with `cmake --build build --target worldserver -j4` to validate the build flow; the full target was initiated but not completed in this environment, and the translation-unit-level compile was used to validate the change.
- No unit tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae97e0148832798de6613ce97b816)