### PR TITLE
Playerbot: leave battleground when all human players are gone

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1460,6 +1460,26 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
+bool BattlegroundHasAnyHumanPlayers(Player const* player)
+{
+    if (!player || !player->InBattleground() || !player->GetMap())
+        return false;
+
+    uint32 const battlegroundId = player->GetBattlegroundId();
+    Map::PlayerList const& players = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+    {
+        Player const* participant = itr->GetSource();
+        if (!participant || participant->GetBattlegroundId() != battlegroundId)
+            continue;
+
+        if (!playerbot::IsManagedRandomBot(participant))
+            return true;
+    }
+
+    return false;
+}
+
 bool TryReturnDroppedFriendlyFlagWithHumanPriority(Player* player)
 {
     if (!player || !player->InBattleground())
@@ -1960,6 +1980,18 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
 
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
         return false;
+
+    if (!BattlegroundHasAnyHumanPlayers(player))
+    {
+        if (player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear())
+            return false;
+
+        player->LeaveBattleground();
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle leave due to no human battleground participants: guid={} bgTypeId={} instanceId={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+        return true;
+    }
 
     if (HandleBattlegroundDeathState(player))
         return true;


### PR DESCRIPTION
### Motivation
- Bots remained stuck in an active battleground instance when the last human player left or AFKed, preventing the battleground from being cleaned up.
- Lifecycle handling should detect bot-only battlegrounds and return bots to their recorded queue point or original map.

### Description
- Added helper `BattlegroundHasAnyHumanPlayers(Player const*)` in `PlayerbotPvpLifecycleActions.cpp` to scan the battleground instance for any non-managed (human) participants.
- Updated `BattlegroundLifecycleActions::HandleInProgressStatusPrimitive` to call `LeaveBattleground()` for managed bots when `BattlegroundHasAnyHumanPlayers` returns false, with existing teleport safety checks preserved.
- Added a debug log message for the new early-leave path to aid diagnostics.

### Testing
- Ran `git diff --check` which reported no issues and succeeded.
- Verified repository status with `git status --short` and committed the change with `git commit` successfully.
- No automated unit/integration tests were available or executed in this rollout; only static/VC checks and the commit were run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db046fd4b883279ebf5fff84e6191d)