### PR TITLE
Use resolved spell IDs for PvP casting and correct Warrior intercept spell ID

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -415,13 +415,20 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 {
     failureReason.clear();
 
-    if (!player || !context.spellId || !player->HasSpell(context.spellId))
+    if (!player || !context.spellId)
     {
         failureReason = "missing_spell";
         return false;
     }
 
-    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(context.spellId);
+    uint32 const resolvedSpellId = ResolveKnownSpellInChain(player, context.spellId);
+    if (!resolvedSpellId)
+    {
+        failureReason = "missing_spell";
+        return false;
+    }
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(resolvedSpellId);
     if (!spellInfo)
     {
         failureReason = "spell_info_missing";
@@ -446,7 +453,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (spellInfo->CheckShapeshift(player->GetShapeshiftForm()) == SPELL_FAILED_NOT_SHAPESHIFT)
             player->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
 
-    if (player->GetSpellHistory()->HasCooldown(context.spellId) ||
+    if (player->GetSpellHistory()->HasCooldown(resolvedSpellId) ||
         player->GetSpellHistory()->HasGlobalCooldown(spellInfo) ||
         player->IsNonMeleeSpellCast(false, false, true))
     {
@@ -464,7 +471,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     }();
 
     Item* itemTarget = nullptr;
-    if (context.spellId == 11202 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
+    if (resolvedSpellId == 11202 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
     {
         Item* mainHand = player->GetWeaponForAttack(BASE_ATTACK, true);
         if (mainHand && !mainHand->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
@@ -648,7 +655,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // Cast-time spells like Frostbolt fail while moving. Since playerbots do
     // not have client-side stop-cast behavior, explicitly stop movement before
     // attempting non-instant casts.
-    bool const isFoodOrDrinkSpell = context.spellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT || context.spellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK;
+    bool const isFoodOrDrinkSpell = resolvedSpellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT || resolvedSpellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK;
     if (spellInfo->CalcCastTime() > 0 || isFoodOrDrinkSpell)
     {
         player->StopMoving();
@@ -668,15 +675,15 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         FaceTargetForInstantCast(player, target, spellInfo);
 
     SpellCastResult castResult = SPELL_FAILED_ERROR;
-    if (context.spellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
+    if (resolvedSpellId == 1953 && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Self)
     {
         Position const dest = player->GetFirstCollisionPosition(20.0f, player->GetOrientation());
-        castResult = player->CastSpell(CastSpellTargetArg(dest), context.spellId);
+        castResult = player->CastSpell(CastSpellTargetArg(dest), resolvedSpellId);
     }
     else if (itemTarget)
-        castResult = player->CastSpell(CastSpellTargetArg(itemTarget), context.spellId);
+        castResult = player->CastSpell(CastSpellTargetArg(itemTarget), resolvedSpellId);
     else
-        castResult = player->CastSpell(target, context.spellId, false);
+        castResult = player->CastSpell(target, resolvedSpellId, false);
 
     if (castResult != SPELL_CAST_OK)
     {
@@ -778,7 +785,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         {
             TC_LOG_DEBUG("playerbots.pvp.class",
                 "Playerbot PvP teleport ACK synthesized: guid={} spell={} map={} x={} y={} z={}.",
-                player->GetGUID().ToString(), context.spellId, player->GetMapId(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+                player->GetGUID().ToString(), resolvedSpellId, player->GetMapId(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
             WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
             teleportAck << player->GetPackGUID();
             teleportAck << uint32(0);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2208,7 +2208,7 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
         { "warrior defensive stance", "swap defensive before disarm against melee", 71, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, CountNearbyUnsNaredEnemies(player, 10.0f) >= 2 && IsSpellReady(player, 12323), 56.0f,
         { "warrior piercing howl", "apply area snare when multiple enemies are unsnared in melee range", 12323, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, (IsSpellReady(player, 6552) || IsSpellReady(player, 676) || IsSpellReady(player, 20252) || IsSpellReady(player, 1680) || IsSpellReady(player, 21553)) &&
+    AddDecisionCandidate(candidates, (IsSpellReady(player, 6552) || IsSpellReady(player, 676) || IsSpellReady(player, 20617) || IsSpellReady(player, 1680) || IsSpellReady(player, 21553)) &&
             player->GetPower(POWER_RAGE) < 150 && IsSpellReady(player, 2687), 54.0f,
         { "warrior bloodrage", "generate rage to unlock rotational abilities", 2687, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, inDefensiveStance && (!IsSpellReady(player, 676) || !hasNearbyMeleeThreat) && IsSpellReady(player, 2458), 53.0f,


### PR DESCRIPTION
### Motivation

- Ensure PvP bot casts use the actual known rank from a spell chain so cooldowns, checks and item-target logic operate against the spell the player actually knows. 
- Prevent cast failures and incorrect cooldown lookups caused by using the nominal chain ID instead of the resolved learned spell ID. 
- Avoid bots appearing stuck in shapeshift/movement or misreporting teleport events by keeping instant-cast and teleport handling consistent with the resolved spell. 
- Fix a warrior PvP decision that referenced the wrong spell ID for gap-closing so the correct ability is considered.

### Description

- Resolve the concrete spell to cast with `uint32 resolvedSpellId = ResolveKnownSpellInChain(player, context.spellId)` and validate it before proceeding. 
- Use `resolvedSpellId` (instead of `context.spellId`) to fetch `SpellInfo`, check spell history cooldowns, detect specific spells (poison/imbue/Blink/food-drink), and to actually invoke `player->CastSpell(...)`. 
- Remove the prior `player->HasSpell(context.spellId)` precheck and return a clear `missing_spell` failure when no resolved spell exists. 
- Update teleport ACK logging and Blink/position cast handling to reference `resolvedSpellId`. 
- Adjust warrior PvP selection to use spell ID `20617` for `Intercept` usage in the decision candidates instead of `20252`.

### Testing

- Project built successfully after the changes using the repository build system (`make`/IDE build). 
- Playerbot-related unit/regression tests covering PvP casting and warrior decision logic ran and passed. 
- Manual PvP bot scenarios were exercised via automated integration scripts to ensure casts, cooldown checks and teleport ACK behavior completed without regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db075b76588327b640b89c02372009)