### PR TITLE
PvP: allow stealth-rogue chase override and restrict Rogue Cheap Shot to melee range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2258,7 +2258,7 @@ SpellDecision SelectRogueSpell(Player const* player, Unit const* target)
 
     AddDecisionCandidate(candidates, !player->IsInCombat() && !HasAuraFromSpellChain(player, 1784) && IsSpellReady(player, 1784), 50.0f,
         { "rogue stealth", "enter stealth before engagement", 1784, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, player->HasStealthAura() && IsSpellReady(player, 1833), 49.0f,
+    AddDecisionCandidate(candidates, player->HasStealthAura() && player->IsWithinMeleeRange(target) && IsSpellReady(player, 1833), 49.0f,
         { "rogue cheap shot", "default opener", 1833, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 1766), 48.0f,
         { "rogue kick", "interrupt enemy cast", 1766, playerbot::PvpClassSpellContext::TargetMode::Enemy });

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1723,12 +1723,13 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
     if (distance > profile.preferredMaxPressureRange || !player->IsWithinMeleeRange(target))
     {
-        if (!CanIssueMovementCommand(player, 500))
+        bool const forceStealthRogueChase = player->GetClass() == CLASS_ROGUE && player->HasStealthAura();
+        if (!forceStealthRogueChase && !CanIssueMovementCommand(player, 500))
             return true;
         player->GetMotionMaster()->MoveChase(target);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP distance band: bot={} profile={} decision=melee-close distance={} max={}.",
-            player->GetGUID().ToString(), profile.label, distance, profile.preferredMaxPressureRange);
+            "Playerbot PvP distance band: bot={} profile={} decision=melee-close distance={} max={} forceStealthRogueChase={}.",
+            player->GetGUID().ToString(), profile.label, distance, profile.preferredMaxPressureRange, forceStealthRogueChase ? 1 : 0);
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent stealth rogues from being prevented from chasing targets when movement commands are being throttled, and avoid attempting `Cheap Shot` out of melee range.

### Description
- In `DriveCombatPositioning` added a `forceStealthRogueChase` override that bypasses the `CanIssueMovementCommand` throttle for rogues with a stealth aura so stealth bots may `MoveChase` even when movement commands are limited.
- Updated the debug log in `DriveCombatPositioning` to include the `forceStealthRogueChase` flag for easier diagnosis.
- In `SelectRogueSpell` added a melee-range check to the `rogue cheap shot` candidate so `Cheap Shot` is only considered when `player->IsWithinMeleeRange(target)`.

### Testing
- Performed a full server build which completed successfully.
- Exercised PvP playerbot behavior scenarios involving stealth rogues and melee-openers and verified no regressions in PvP decision logic via existing PvP unit tests, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db07cdc1fc83279fb8a9f7f9ebbe94)