### PR TITLE
Force-end battlegrounds with no human players and add human-participant check

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1460,6 +1460,28 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
+bool BattlegroundHasAnyHumanPlayers(Player const* player)
+{
+    if (!player || !player->InBattleground() || !player->GetMap())
+        return false;
+
+    uint32 const battlegroundId = player->GetBattlegroundId();
+    Map::PlayerList const& players = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+    {
+        Player const* participant = itr->GetSource();
+        if (!participant || participant->GetBattlegroundId() != battlegroundId)
+            continue;
+
+        WorldSession const* participantSession = participant->GetSession();
+        bool const isVirtualBotSession = participantSession && participantSession->IsVirtualSession();
+        if (!isVirtualBotSession && !playerbot::IsManagedRandomBot(participant))
+            return true;
+    }
+
+    return false;
+}
+
 bool TryReturnDroppedFriendlyFlagWithHumanPriority(Player* player)
 {
     if (!player || !player->InBattleground())
@@ -1960,6 +1982,18 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
 
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
         return false;
+
+    if (!BattlegroundHasAnyHumanPlayers(player))
+    {
+        if (player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear())
+            return false;
+
+        battleground->EndBattleground(0);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle forced battleground end due to no human participants: guid={} bgTypeId={} instanceId={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+        return true;
+    }
 
     if (HandleBattlegroundDeathState(player))
         return true;


### PR DESCRIPTION
### Motivation

- Ensure battlegrounds with only bot participants do not linger indefinitely and allow server to cleanly end such matches.

### Description

- Add `BattlegroundHasAnyHumanPlayers` to detect any non-virtual, non-managed-random human participants in the battleground using `GetSession()` and `IsVirtualSession()` checks. 
- If no human participants are found in `HandleInProgressStatusPrimitive`, call `battleground->EndBattleground(0)` to force the battleground to end and log the action. 
- Preserve existing behavior for flag-return prioritization via `HumanTeammateNearDroppedFlag` and keep movement/respawn guards when ending the battleground.

### Testing

- Project was built successfully (`make`) after the changes. 
- Existing automated unit test suite (`make test`) ran and passed with no regressions related to battleground lifecycle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db046fd4b883279ebf5fff84e6191d)