### PR TITLE
Auto-end battlegrounds when only virtual/bot players remain and avoid teleport deadlocks

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -46,6 +46,29 @@
 #include "Item.h"
 #include <cstdarg>
 
+namespace
+{
+bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
+{
+    if (!battleground)
+        return false;
+
+    for (auto const& [participantGuid, participantData] : battleground->GetPlayers())
+    {
+        (void)participantData;
+        Player const* participant = ObjectAccessor::FindPlayer(participantGuid);
+        if (!participant)
+            continue;
+
+        WorldSession const* session = participant->GetSession();
+        if (session && !session->IsVirtualSession())
+            return true;
+    }
+
+    return false;
+}
+}
+
 void BattlegroundScore::AppendToPacket(WorldPacket& data)
 {
     data << uint64(PlayerGuid);
@@ -946,6 +969,14 @@ void Battleground::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
         WorldPacket data;
         sBattlegroundMgr->BuildPlayerLeftBattlegroundPacket(&data, guid);
         SendPacketToTeam(team, &data, player, false);
+
+        if (isBattleground() && GetStatus() == STATUS_IN_PROGRESS && !HasAnyNonVirtualHumanParticipant(this))
+        {
+            TC_LOG_DEBUG("bg.battleground",
+                "Battleground::RemovePlayerAtLeave forced end: map={} instance={} no non-virtual participants remain.",
+                GetMapId(), GetInstanceID());
+            EndBattleground(PVP_TEAM_NEUTRAL);
+        }
     }
 
     if (player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1460,6 +1460,45 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
+bool BattlegroundHasAnyHumanPlayers(Player const* player)
+{
+    if (!player || !player->InBattleground() || !player->GetMap())
+        return false;
+
+    uint32 const battlegroundId = player->GetBattlegroundId();
+    Map::PlayerList const& players = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+    {
+        Player const* participant = itr->GetSource();
+        if (!participant || participant->GetBattlegroundId() != battlegroundId)
+            continue;
+
+        WorldSession const* participantSession = participant->GetSession();
+        bool const isVirtualBotSession = participantSession && participantSession->IsVirtualSession();
+        if (!isVirtualBotSession && !playerbot::IsManagedRandomBot(participant))
+            return true;
+    }
+
+    return false;
+}
+
+bool ShouldDeferBattlegroundLeaveForTeleportAck(Player const* player)
+{
+    if (!player)
+        return false;
+
+    if (!player->IsBeingTeleportedFar() && !player->IsBeingTeleportedNear())
+        return false;
+
+    // Virtual-session bots can retain stale near/far teleport semaphores inside
+    // battleground instances; do not deadlock leave/end cleanup on those flags.
+    WorldSession const* session = player->GetSession();
+    if (session && session->IsVirtualSession() && player->InBattleground())
+        return false;
+
+    return true;
+}
+
 bool TryReturnDroppedFriendlyFlagWithHumanPriority(Player* player)
 {
     if (!player || !player->InBattleground())
@@ -1948,7 +1987,7 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
 
     if (battleground->GetStatus() == STATUS_WAIT_LEAVE)
     {
-        if (player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear())
+        if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
             return false;
 
         player->LeaveBattleground();
@@ -1960,6 +1999,18 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
 
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
         return false;
+
+    if (!BattlegroundHasAnyHumanPlayers(player))
+    {
+        if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
+            return false;
+
+        battleground->EndBattleground(0);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle forced battleground end due to no human participants: guid={} bgTypeId={} instanceId={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+        return true;
+    }
 
     if (HandleBattlegroundDeathState(player))
         return true;


### PR DESCRIPTION
### Motivation

- Prevent battleground instances from staying active indefinitely when only virtual (bot) sessions remain. 
- Ensure playerbot lifecycle logic respects ongoing teleport acknowledgements to avoid leaving/end deadlocks caused by virtual sessions. 

### Description

- Added `HasAnyNonVirtualHumanParticipant` in `Battleground.cpp` and use it in `RemovePlayerAtLeave` to force-end a battleground when in-progress and no non-virtual human participants remain. 
- Added helper functions `BattlegroundHasAnyHumanPlayers` and `ShouldDeferBattlegroundLeaveForTeleportAck` to the playerbot PvP lifecycle code to detect human presence and defer leave while a real teleport acknowledgement is pending. 
- Updated `HandleInProgressStatusPrimitive` to defer leaving when an applicable teleport is in progress and to end the battleground when no human players remain, with appropriate debug logging. 

### Testing

- Project build was executed successfully in the automated build environment. 
- Automated unit tests covering battleground lifecycle and playerbot PvP actions were run and passed. 
- CI static checks and logging assertions for the new code paths passed in the automated pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db046fd4b883279ebf5fff84e6191d)