### PR TITLE
End battlegrounds with only virtual/bot participants; add configurable bot accounts and teleport-aware leave handling

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -20,6 +20,7 @@
 #include "BattlegroundMgr.h"
 #include "BattlegroundScore.h"
 #include "ChatTextBuilder.h"
+#include "Configuration/Config.h"
 #include "Creature.h"
 #include "CreatureTextMgr.h"
 #include "DatabaseEnv.h"
@@ -34,6 +35,7 @@
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ReputationMgr.h"
+#include "StringConvert.h"
 #include "Miscellaneous/DepletedMarks.h"
 #include "SpellAuras.h"
 #include "TemporarySummon.h"
@@ -44,7 +46,75 @@
 #include "CharacterCache.h"
 #include "WorldSession.h"
 #include "Item.h"
+#include <algorithm>
+#include <cctype>
 #include <cstdarg>
+#include <sstream>
+#include <unordered_set>
+
+namespace
+{
+std::unordered_set<uint32> BuildConfiguredPlayerbotAccountSet()
+{
+    std::unordered_set<uint32> accountIds;
+    std::string const configured = sConfigMgr->GetStringDefault("Playerbot.RandomPopulation.BotAccountIds", "");
+    if (configured.empty())
+        return accountIds;
+
+    std::stringstream stream(configured);
+    std::string token;
+    while (std::getline(stream, token, ','))
+    {
+        token.erase(std::remove_if(token.begin(), token.end(), [](unsigned char ch) { return std::isspace(ch) != 0; }), token.end());
+        if (token.empty())
+            continue;
+
+        if (Optional<uint32> const accountId = Trinity::StringTo<uint32>(token))
+            accountIds.insert(*accountId);
+    }
+
+    return accountIds;
+}
+
+bool IsConfiguredPlayerbotAccount(Player const* participant)
+{
+    if (!participant)
+        return false;
+
+    static std::unordered_set<uint32> const botAccountIds = BuildConfiguredPlayerbotAccountSet();
+    if (botAccountIds.empty())
+        return false;
+
+    uint32 accountId = 0;
+    if (WorldSession const* session = participant->GetSession())
+        accountId = session->GetAccountId();
+    else
+        accountId = sCharacterCache->GetCharacterAccountIdByGuid(participant->GetGUID());
+
+    return accountId != 0 && botAccountIds.find(accountId) != botAccountIds.end();
+}
+
+bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
+{
+    if (!battleground)
+        return false;
+
+    for (auto const& [participantGuid, participantData] : battleground->GetPlayers())
+    {
+        (void)participantData;
+        Player const* participant = ObjectAccessor::FindPlayer(participantGuid);
+        if (!participant)
+            continue;
+
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (!isVirtualSession && !IsConfiguredPlayerbotAccount(participant))
+            return true;
+    }
+
+    return false;
+}
+}
 
 void BattlegroundScore::AppendToPacket(WorldPacket& data)
 {
@@ -946,6 +1016,14 @@ void Battleground::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
         WorldPacket data;
         sBattlegroundMgr->BuildPlayerLeftBattlegroundPacket(&data, guid);
         SendPacketToTeam(team, &data, player, false);
+
+        if (isBattleground() && GetStatus() == STATUS_IN_PROGRESS && !HasAnyNonVirtualHumanParticipant(this))
+        {
+            TC_LOG_DEBUG("bg.battleground",
+                "Battleground::RemovePlayerAtLeave forced end: map={} instance={} no non-virtual participants remain.",
+                GetMapId(), GetInstanceID());
+            EndBattleground(PVP_TEAM_NEUTRAL);
+        }
     }
 
     if (player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1460,6 +1460,45 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
+bool BattlegroundHasAnyHumanPlayers(Player const* player)
+{
+    if (!player || !player->InBattleground() || !player->GetMap())
+        return false;
+
+    uint32 const battlegroundId = player->GetBattlegroundId();
+    Map::PlayerList const& players = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+    {
+        Player const* participant = itr->GetSource();
+        if (!participant || participant->GetBattlegroundId() != battlegroundId)
+            continue;
+
+        WorldSession const* participantSession = participant->GetSession();
+        bool const isVirtualBotSession = participantSession && participantSession->IsVirtualSession();
+        if (!isVirtualBotSession && !playerbot::IsManagedRandomBot(participant))
+            return true;
+    }
+
+    return false;
+}
+
+bool ShouldDeferBattlegroundLeaveForTeleportAck(Player const* player)
+{
+    if (!player)
+        return false;
+
+    if (!player->IsBeingTeleportedFar() && !player->IsBeingTeleportedNear())
+        return false;
+
+    // Virtual-session bots can retain stale near/far teleport semaphores inside
+    // battleground instances; do not deadlock leave/end cleanup on those flags.
+    WorldSession const* session = player->GetSession();
+    if (session && session->IsVirtualSession() && player->InBattleground())
+        return false;
+
+    return true;
+}
+
 bool TryReturnDroppedFriendlyFlagWithHumanPriority(Player* player)
 {
     if (!player || !player->InBattleground())
@@ -1948,7 +1987,7 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
 
     if (battleground->GetStatus() == STATUS_WAIT_LEAVE)
     {
-        if (player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear())
+        if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
             return false;
 
         player->LeaveBattleground();
@@ -1960,6 +1999,18 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
 
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
         return false;
+
+    if (!BattlegroundHasAnyHumanPlayers(player))
+    {
+        if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
+            return false;
+
+        battleground->EndBattleground(0);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle forced battleground end due to no human participants: guid={} bgTypeId={} instanceId={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+        return true;
+    }
 
     if (HandleBattlegroundDeathState(player))
         return true;


### PR DESCRIPTION
### Motivation
- Ensure battleground instances do not remain running when only virtual-session bots or configured bot accounts are present to avoid stale/empty BGs.
- Prevent leave/end deadlocks caused by virtual-session bots retaining teleport semaphores.
- Allow explicit configuration of bot account IDs so bots managed outside the existing `IsManagedRandomBot` check are recognized.

### Description
- Added `BuildConfiguredPlayerbotAccountSet` and `IsConfiguredPlayerbotAccount` to parse `Playerbot.RandomPopulation.BotAccountIds` from config and identify configured bot accounts.
- Implemented `HasAnyNonVirtualHumanParticipant` (internal) and call it from `Battleground::RemovePlayerAtLeave` to force `EndBattleground` when no non-virtual human participants remain, with a debug log.
- Added `BattlegroundHasAnyHumanPlayers` and `ShouldDeferBattlegroundLeaveForTeleportAck` in the playerbot PvP lifecycle to mirror battleground-level checks and to avoid deferring leave for virtual sessions; lifecycle now forces `EndBattleground(0)` if no humans remain while in-progress.
- Updated includes and added STL utilities (`<algorithm>`, `<cctype>`, `<sstream>`, `<unordered_set>`) and headers (`Configuration/Config.h`, `StringConvert.h`) required by the new logic.

### Testing
- Built the project using the standard build (`cmake`/`make`) and confirmed successful compilation.
- Executed the automated test suite including battleground-related unit tests and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db046fd4b883279ebf5fff84e6191d)