### PR TITLE
Remove duplicate HasAnyNonVirtualHumanParticipant in Battleground.cpp

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -116,29 +116,6 @@ bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
 }
 }
 
-namespace
-{
-bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
-{
-    if (!battleground)
-        return false;
-
-    for (auto const& [participantGuid, participantData] : battleground->GetPlayers())
-    {
-        (void)participantData;
-        Player const* participant = ObjectAccessor::FindPlayer(participantGuid);
-        if (!participant)
-            continue;
-
-        WorldSession const* session = participant->GetSession();
-        if (session && !session->IsVirtualSession())
-            return true;
-    }
-
-    return false;
-}
-}
-
 void BattlegroundScore::AppendToPacket(WorldPacket& data)
 {
     data << uint64(PlayerGuid);


### PR DESCRIPTION
### Motivation
- Fix a compile-time redefinition error by removing the duplicated helper and preserve the intended logic that excludes virtual sessions and configured playerbot accounts when detecting human participants.

### Description
- Deleted the second anonymous-namespace `HasAnyNonVirtualHumanParticipant(Battleground const*)` block in `src/server/game/Battlegrounds/Battleground.cpp`, keeping the primary implementation that checks for virtual sessions and configured bot accounts.

### Testing
- Ran a symbol search with `rg -n "HasAnyNonVirtualHumanParticipant(" src/server/game/Battlegrounds/Battleground.cpp` and inspected the file diff to confirm only the duplicate block was removed, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2e60122c8327b126ea7fbfa70f19)