### PR TITLE
Fix battleground shutdown when only bots remain

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -269,6 +269,15 @@ void Battleground::Update(uint32 diff)
             }
             break;
         case STATUS_IN_PROGRESS:
+            if (isBattleground() && !HasAnyNonVirtualHumanParticipant(this))
+            {
+                TC_LOG_INFO("bg.battleground",
+                    "Battleground::Update ending map={} instance={} because no non-virtual participants remain.",
+                    GetMapId(), GetInstanceID());
+                EndNow();
+                return;
+            }
+
             _ProcessOfflineQueue();
             // after 20 minutes without one team losing, the arena closes with no winner and no rating change
             if (isArena())


### PR DESCRIPTION
### Motivation
- Playerbot-controlled (virtual) sessions were keeping battleground instances alive after all real human players left, causing lingering matches (for example WSG) to remain visible via `/who`.
- The intent is to end a battleground immediately when no non-virtual human participants remain so the usual leave/cleanup path runs and bots are removed.

### Description
- Add a guard at the start of the `STATUS_IN_PROGRESS` branch in `Battleground::Update` (file `src/server/game/Battlegrounds/Battleground.cpp`) that checks `isBattleground()` and `!HasAnyNonVirtualHumanParticipant(this)` and calls `EndNow()` when true.
- Reuse the existing `HasAnyNonVirtualHumanParticipant` helper so configured bot accounts and virtual sessions are excluded consistently, and log the forced shutdown with `TC_LOG_INFO`.
- This triggers the existing leave-processing (`STATUS_WAIT_LEAVE`) on the next update tick so remaining bots are removed via the normal battleground cleanup.

### Testing
- Ran `git diff --check` to ensure no whitespace/diff issues, which succeeded.
- Verified working tree status with `git status --short`, which reported the intended file modification.
- Committed the change with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db30c1a3088327bec030124de0ad67)