### PR TITLE
End battleground when no non-virtual human participants remain

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -262,6 +262,15 @@ void Battleground::Update(uint32 diff)
     switch (GetStatus())
     {
         case STATUS_WAIT_JOIN:
+            if (isBattleground() && GetPlayersSize() && !HasAnyNonVirtualHumanParticipant(this))
+            {
+                TC_LOG_INFO("bg.battleground",
+                    "Battleground::Update ending map={} instance={} during preparation because no non-virtual participants remain.",
+                    GetMapId(), GetInstanceID());
+                EndNow();
+                return;
+            }
+
             if (GetPlayersSize())
             {
                 _ProcessJoin(diff);
@@ -269,6 +278,15 @@ void Battleground::Update(uint32 diff)
             }
             break;
         case STATUS_IN_PROGRESS:
+            if (isBattleground() && !HasAnyNonVirtualHumanParticipant(this))
+            {
+                TC_LOG_INFO("bg.battleground",
+                    "Battleground::Update ending map={} instance={} because no non-virtual participants remain.",
+                    GetMapId(), GetInstanceID());
+                EndNow();
+                return;
+            }
+
             _ProcessOfflineQueue();
             // after 20 minutes without one team losing, the arena closes with no winner and no rating change
             if (isArena())


### PR DESCRIPTION
### Motivation
- Prevent battleground instances from lingering when only virtual/bot participants remain, freeing resources and avoiding stuck matches.
- Ensure battlegrounds are terminated both during preparation and in-progress phases if there are no real human participants left.

### Description
- Added early-exit checks in `Battleground::Update` for `STATUS_WAIT_JOIN` and `STATUS_IN_PROGRESS` that call `HasAnyNonVirtualHumanParticipant(this)` and invoke `EndNow()` when no non-virtual participants remain and the map is a battleground.
- Added informational logging via `TC_LOG_INFO` indicating the map and instance being ended for clarity when the new path is taken.
- Preserved existing processing paths for join, offline queue, resurrection, premature finish, and leave states when human participants exist.

### Testing
- Project was rebuilt to ensure the change compiles successfully. 
- Existing automated battleground/unit tests and integration tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db30c1a3088327bec030124de0ad67)