### PR TITLE
Track real human participants and end empty battlegrounds; remove legacy bot-account checks

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -35,7 +35,6 @@
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ReputationMgr.h"
-#include "StringConvert.h"
 #include "Miscellaneous/DepletedMarks.h"
 #include "SpellAuras.h"
 #include "TemporarySummon.h"
@@ -43,57 +42,13 @@
 #include "Util.h"
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
-#include "CharacterCache.h"
 #include "WorldSession.h"
 #include "Item.h"
 #include <algorithm>
-#include <cctype>
 #include <cstdarg>
-#include <sstream>
-#include <unordered_set>
 
 namespace
 {
-std::unordered_set<uint32> BuildConfiguredPlayerbotAccountSet()
-{
-    std::unordered_set<uint32> accountIds;
-    std::string const configured = sConfigMgr->GetStringDefault("Playerbot.RandomPopulation.BotAccountIds", "");
-    if (configured.empty())
-        return accountIds;
-
-    std::stringstream stream(configured);
-    std::string token;
-    while (std::getline(stream, token, ','))
-    {
-        token.erase(std::remove_if(token.begin(), token.end(), [](unsigned char ch) { return std::isspace(ch) != 0; }), token.end());
-        if (token.empty())
-            continue;
-
-        if (Optional<uint32> const accountId = Trinity::StringTo<uint32>(token))
-            accountIds.insert(*accountId);
-    }
-
-    return accountIds;
-}
-
-bool IsConfiguredPlayerbotAccount(Player const* participant)
-{
-    if (!participant)
-        return false;
-
-    static std::unordered_set<uint32> const botAccountIds = BuildConfiguredPlayerbotAccountSet();
-    if (botAccountIds.empty())
-        return false;
-
-    uint32 accountId = 0;
-    if (WorldSession const* session = participant->GetSession())
-        accountId = session->GetAccountId();
-    else
-        accountId = sCharacterCache->GetCharacterAccountIdByGuid(participant->GetGUID());
-
-    return accountId != 0 && botAccountIds.find(accountId) != botAccountIds.end();
-}
-
 bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
 {
     if (!battleground)
@@ -107,8 +62,7 @@ bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
             continue;
 
         WorldSession const* session = participant->GetSession();
-        bool const isVirtualSession = session && session->IsVirtualSession();
-        if (!isVirtualSession && !IsConfiguredPlayerbotAccount(participant))
+        if (session && !session->IsVirtualSession())
             return true;
     }
 
@@ -160,6 +114,7 @@ Battleground::Battleground()
     m_StartDelayTime    = 0;
     m_IsRated           = false;
     m_BuffChange        = false;
+    m_HasEverHadNonVirtualHumanParticipant = false;
     m_IsRandom          = false;
     m_IsReplay          = false;
     m_ReplayId          = 0;
@@ -269,6 +224,15 @@ void Battleground::Update(uint32 diff)
             }
             break;
         case STATUS_IN_PROGRESS:
+            if (isBattleground() && m_HasEverHadNonVirtualHumanParticipant && !HasAnyNonVirtualHumanParticipant(this))
+            {
+                TC_LOG_INFO("bg.battleground",
+                    "Battleground::Update ending map={} instance={} because no non-virtual participants remain.",
+                    GetMapId(), GetInstanceID());
+                EndNow();
+                return;
+            }
+
             _ProcessOfflineQueue();
             // after 20 minutes without one team losing, the arena closes with no winner and no rating change
             if (isArena())
@@ -552,8 +516,7 @@ inline void Battleground::_ProcessLeave(uint32 diff)
     // ***           BATTLEGROUND ENDING SYSTEM              ***
     // *********************************************************
     // remove all players from battleground after 2 minutes
-    m_EndTime -= diff;
-    if (m_EndTime <= 0)
+    if (m_EndTime <= diff)
     {
         m_EndTime = 0;
         BattlegroundPlayerMap::iterator itr, next;
@@ -566,6 +529,8 @@ inline void Battleground::_ProcessLeave(uint32 diff)
             // do not change any battleground's private variables
         }
     }
+    else
+        m_EndTime -= diff;
 }
 
 Player* Battleground::_GetPlayer(ObjectGuid guid, bool offlineRemove, char const* context) const
@@ -1017,7 +982,9 @@ void Battleground::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
         sBattlegroundMgr->BuildPlayerLeftBattlegroundPacket(&data, guid);
         SendPacketToTeam(team, &data, player, false);
 
-        if (isBattleground() && GetStatus() == STATUS_IN_PROGRESS && !HasAnyNonVirtualHumanParticipant(this))
+        if (isBattleground() && m_HasEverHadNonVirtualHumanParticipant &&
+            (GetStatus() == STATUS_IN_PROGRESS || GetStatus() == STATUS_WAIT_JOIN) &&
+            !HasAnyNonVirtualHumanParticipant(this))
         {
             TC_LOG_DEBUG("bg.battleground",
                 "Battleground::RemovePlayerAtLeave forced end: map={} instance={} no non-virtual participants remain.",
@@ -1062,6 +1029,7 @@ void Battleground::Reset()
     m_InvitedAlliance = 0;
     m_InvitedHorde = 0;
     m_InBGFreeSlotQueue = false;
+    m_HasEverHadNonVirtualHumanParticipant = false;
 
     m_Players.clear();
 
@@ -1208,6 +1176,9 @@ void Battleground::AddPlayer(Player* player)
 
     if (!isInBattleground)
         UpdatePlayersCountByTeam(team, false);                  // +1 player
+
+    if (WorldSession const* session = player->GetSession(); session && !session->IsVirtualSession())
+        m_HasEverHadNonVirtualHumanParticipant = true;
 
     WorldPacket data;
     sBattlegroundMgr->BuildPlayerJoinedBattlegroundPacket(&data, player);

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -592,6 +592,7 @@ class TC_GAME_API Battleground
         int32  m_StartDelayTime;
         bool   m_IsRated;                                   // is this battle rated?
         bool   m_PrematureCountDown;
+        bool   m_HasEverHadNonVirtualHumanParticipant;
         bool   m_IsReplay;
         uint32 m_ReplayId;
         uint32 m_FightId;


### PR DESCRIPTION
### Motivation

- Remove legacy logic that treated configured bot-account IDs as special and simplify detection of human participants to rely on session virtuality. 
- Ensure battleground instances that once had a real (non-virtual) human player are ended automatically if no non-virtual human participants remain. 

### Description

- Deleted the `BuildConfiguredPlayerbotAccountSet` / `IsConfiguredPlayerbotAccount` logic and related includes, simplifying participant checks to only consider `WorldSession::IsVirtualSession()`. 
- Added a new member `m_HasEverHadNonVirtualHumanParticipant` to `Battleground` initialized to `false`, set to `true` in `Battleground::AddPlayer` when a joining player's session is non-virtual, and reset in `Reset`. 
- Updated `HasAnyNonVirtualHumanParticipant` to only check `session && !session->IsVirtualSession()`. 
- When in-progress battlegrounds have previously seen a real human (`m_HasEverHadNonVirtualHumanParticipant == true`) but currently have none, call `EndNow()` from `Update()` and log an info message. 
- Adjusted `RemovePlayerAtLeave` to use the new flag and to trigger `EndBattleground(PVP_TEAM_NEUTRAL)` when appropriate, with a debug log. 
- Fixed `Battleground::_ProcessLeave` time-decrement to avoid underflow by checking `if (m_EndTime <= diff)` before subtracting. 

### Testing

- Built the server with the changes and verified there are no compilation errors. 
- Ran battleground-related unit/smoke checks and observed success for battleground lifecycle behaviors (join, leave, reset) in automated tests. 
- Observed logs from automated runs indicating the new `EndNow()` and `EndBattleground()` code paths are exercised when expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db30c1a3088327bec030124de0ad67)