### PR TITLE
Track non-virtual human participants and end empty battlegrounds; remove configured bot-account logic

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -35,7 +35,6 @@
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ReputationMgr.h"
-#include "StringConvert.h"
 #include "Miscellaneous/DepletedMarks.h"
 #include "SpellAuras.h"
 #include "TemporarySummon.h"
@@ -43,57 +42,13 @@
 #include "Util.h"
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
-#include "CharacterCache.h"
 #include "WorldSession.h"
 #include "Item.h"
 #include <algorithm>
-#include <cctype>
 #include <cstdarg>
-#include <sstream>
-#include <unordered_set>
 
 namespace
 {
-std::unordered_set<uint32> BuildConfiguredPlayerbotAccountSet()
-{
-    std::unordered_set<uint32> accountIds;
-    std::string const configured = sConfigMgr->GetStringDefault("Playerbot.RandomPopulation.BotAccountIds", "");
-    if (configured.empty())
-        return accountIds;
-
-    std::stringstream stream(configured);
-    std::string token;
-    while (std::getline(stream, token, ','))
-    {
-        token.erase(std::remove_if(token.begin(), token.end(), [](unsigned char ch) { return std::isspace(ch) != 0; }), token.end());
-        if (token.empty())
-            continue;
-
-        if (Optional<uint32> const accountId = Trinity::StringTo<uint32>(token))
-            accountIds.insert(*accountId);
-    }
-
-    return accountIds;
-}
-
-bool IsConfiguredPlayerbotAccount(Player const* participant)
-{
-    if (!participant)
-        return false;
-
-    static std::unordered_set<uint32> const botAccountIds = BuildConfiguredPlayerbotAccountSet();
-    if (botAccountIds.empty())
-        return false;
-
-    uint32 accountId = 0;
-    if (WorldSession const* session = participant->GetSession())
-        accountId = session->GetAccountId();
-    else
-        accountId = sCharacterCache->GetCharacterAccountIdByGuid(participant->GetGUID());
-
-    return accountId != 0 && botAccountIds.find(accountId) != botAccountIds.end();
-}
-
 bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
 {
     if (!battleground)
@@ -102,13 +57,12 @@ bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
     for (auto const& [participantGuid, participantData] : battleground->GetPlayers())
     {
         (void)participantData;
-        Player const* participant = ObjectAccessor::FindPlayer(participantGuid);
+        Player const* participant = ObjectAccessor::FindConnectedPlayer(participantGuid);
         if (!participant)
             continue;
 
         WorldSession const* session = participant->GetSession();
-        bool const isVirtualSession = session && session->IsVirtualSession();
-        if (!isVirtualSession && !IsConfiguredPlayerbotAccount(participant))
+        if (session && !session->IsVirtualSession())
             return true;
     }
 
@@ -160,6 +114,7 @@ Battleground::Battleground()
     m_StartDelayTime    = 0;
     m_IsRated           = false;
     m_BuffChange        = false;
+    m_HasEverHadNonVirtualHumanParticipant = false;
     m_IsRandom          = false;
     m_IsReplay          = false;
     m_ReplayId          = 0;
@@ -269,6 +224,15 @@ void Battleground::Update(uint32 diff)
             }
             break;
         case STATUS_IN_PROGRESS:
+            if (isBattleground() && m_HasEverHadNonVirtualHumanParticipant && !HasAnyNonVirtualHumanParticipant(this))
+            {
+                TC_LOG_INFO("bg.battleground",
+                    "Battleground::Update ending map={} instance={} because no non-virtual participants remain.",
+                    GetMapId(), GetInstanceID());
+                EndNow();
+                return;
+            }
+
             _ProcessOfflineQueue();
             // after 20 minutes without one team losing, the arena closes with no winner and no rating change
             if (isArena())
@@ -552,8 +516,7 @@ inline void Battleground::_ProcessLeave(uint32 diff)
     // ***           BATTLEGROUND ENDING SYSTEM              ***
     // *********************************************************
     // remove all players from battleground after 2 minutes
-    m_EndTime -= diff;
-    if (m_EndTime <= 0)
+    if (m_EndTime <= diff)
     {
         m_EndTime = 0;
         BattlegroundPlayerMap::iterator itr, next;
@@ -566,6 +529,8 @@ inline void Battleground::_ProcessLeave(uint32 diff)
             // do not change any battleground's private variables
         }
     }
+    else
+        m_EndTime -= diff;
 }
 
 Player* Battleground::_GetPlayer(ObjectGuid guid, bool offlineRemove, char const* context) const
@@ -1017,7 +982,9 @@ void Battleground::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
         sBattlegroundMgr->BuildPlayerLeftBattlegroundPacket(&data, guid);
         SendPacketToTeam(team, &data, player, false);
 
-        if (isBattleground() && GetStatus() == STATUS_IN_PROGRESS && !HasAnyNonVirtualHumanParticipant(this))
+        if (isBattleground() && m_HasEverHadNonVirtualHumanParticipant &&
+            (GetStatus() == STATUS_IN_PROGRESS || GetStatus() == STATUS_WAIT_JOIN) &&
+            !HasAnyNonVirtualHumanParticipant(this))
         {
             TC_LOG_DEBUG("bg.battleground",
                 "Battleground::RemovePlayerAtLeave forced end: map={} instance={} no non-virtual participants remain.",
@@ -1062,6 +1029,7 @@ void Battleground::Reset()
     m_InvitedAlliance = 0;
     m_InvitedHorde = 0;
     m_InBGFreeSlotQueue = false;
+    m_HasEverHadNonVirtualHumanParticipant = false;
 
     m_Players.clear();
 
@@ -1208,6 +1176,9 @@ void Battleground::AddPlayer(Player* player)
 
     if (!isInBattleground)
         UpdatePlayersCountByTeam(team, false);                  // +1 player
+
+    if (WorldSession const* session = player->GetSession(); session && !session->IsVirtualSession())
+        m_HasEverHadNonVirtualHumanParticipant = true;
 
     WorldPacket data;
     sBattlegroundMgr->BuildPlayerJoinedBattlegroundPacket(&data, player);

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -592,6 +592,7 @@ class TC_GAME_API Battleground
         int32  m_StartDelayTime;
         bool   m_IsRated;                                   // is this battle rated?
         bool   m_PrematureCountDown;
+        bool   m_HasEverHadNonVirtualHumanParticipant;
         bool   m_IsReplay;
         uint32 m_ReplayId;
         uint32 m_FightId;


### PR DESCRIPTION
### Motivation
- Ensure battleground instances that once had real (non-virtual) human participants terminate when no such participants remain, and simplify the detection logic by removing legacy configured bot-account handling.

### Description
- Add `m_HasEverHadNonVirtualHumanParticipant` to `Battleground` and initialize/reset it in constructors and `Reset()` to track whether any non-virtual human player has ever been present.
- Replace `ObjectAccessor::FindPlayer` with `ObjectAccessor::FindConnectedPlayer` in `HasAnyNonVirtualHumanParticipant()` and remove the configured bot-account parsing helpers and related includes, simplifying session checks to treat only virtual sessions as non-human.
- Set `m_HasEverHadNonVirtualHumanParticipant` in `AddPlayer()` when a joining player has a real (non-virtual) `WorldSession` and use this flag in `Update()` and `RemovePlayerAtLeave()` to force-end battlegrounds when appropriate; add informative logging when forced end occurs.
- Fix `Battleground::_ProcessLeave()` timer handling to avoid underflow by only subtracting `diff` when `m_EndTime` is greater than `diff`.

### Testing
- Built the project with `make` and the compilation succeeded without errors.
- Executed battleground lifecycle unit/integration checks related to join/leave and end conditions and they passed, confirming BGs now end when no non-virtual human participants remain.
- No regressions were observed in the battleground end/leave automated tests after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db30c1a3088327bec030124de0ad67)