### PR TITLE
End battleground when last non-virtual human leaves; remove legacy playerbot account checks and fix end-timer handling

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -35,7 +35,6 @@
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ReputationMgr.h"
-#include "StringConvert.h"
 #include "Miscellaneous/DepletedMarks.h"
 #include "SpellAuras.h"
 #include "TemporarySummon.h"
@@ -43,56 +42,14 @@
 #include "Util.h"
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
-#include "CharacterCache.h"
 #include "WorldSession.h"
 #include "Item.h"
 #include <algorithm>
-#include <cctype>
 #include <cstdarg>
-#include <sstream>
-#include <unordered_set>
 
 namespace
 {
-std::unordered_set<uint32> BuildConfiguredPlayerbotAccountSet()
-{
-    std::unordered_set<uint32> accountIds;
-    std::string const configured = sConfigMgr->GetStringDefault("Playerbot.RandomPopulation.BotAccountIds", "");
-    if (configured.empty())
-        return accountIds;
-
-    std::stringstream stream(configured);
-    std::string token;
-    while (std::getline(stream, token, ','))
-    {
-        token.erase(std::remove_if(token.begin(), token.end(), [](unsigned char ch) { return std::isspace(ch) != 0; }), token.end());
-        if (token.empty())
-            continue;
-
-        if (Optional<uint32> const accountId = Trinity::StringTo<uint32>(token))
-            accountIds.insert(*accountId);
-    }
-
-    return accountIds;
-}
-
-bool IsConfiguredPlayerbotAccount(Player const* participant)
-{
-    if (!participant)
-        return false;
-
-    static std::unordered_set<uint32> const botAccountIds = BuildConfiguredPlayerbotAccountSet();
-    if (botAccountIds.empty())
-        return false;
-
-    uint32 accountId = 0;
-    if (WorldSession const* session = participant->GetSession())
-        accountId = session->GetAccountId();
-    else
-        accountId = sCharacterCache->GetCharacterAccountIdByGuid(participant->GetGUID());
-
-    return accountId != 0 && botAccountIds.find(accountId) != botAccountIds.end();
-}
+constexpr uint32 NO_NON_VIRTUAL_HUMAN_END_DELAY_MS = 15000;
 
 bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
 {
@@ -102,13 +59,12 @@ bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
     for (auto const& [participantGuid, participantData] : battleground->GetPlayers())
     {
         (void)participantData;
-        Player const* participant = ObjectAccessor::FindPlayer(participantGuid);
+        Player const* participant = ObjectAccessor::FindConnectedPlayer(participantGuid);
         if (!participant)
             continue;
 
         WorldSession const* session = participant->GetSession();
-        bool const isVirtualSession = session && session->IsVirtualSession();
-        if (!isVirtualSession && !IsConfiguredPlayerbotAccount(participant))
+        if (session && !session->IsVirtualSession())
             return true;
     }
 
@@ -160,6 +116,8 @@ Battleground::Battleground()
     m_StartDelayTime    = 0;
     m_IsRated           = false;
     m_BuffChange        = false;
+    m_HasEverHadNonVirtualHumanParticipant = false;
+    m_NoNonVirtualHumanElapsed = 0;
     m_IsRandom          = false;
     m_IsReplay          = false;
     m_ReplayId          = 0;
@@ -269,6 +227,20 @@ void Battleground::Update(uint32 diff)
             }
             break;
         case STATUS_IN_PROGRESS:
+            if (isBattleground() && m_HasEverHadNonVirtualHumanParticipant)
+            {
+                if (HasAnyNonVirtualHumanParticipant(this))
+                    m_NoNonVirtualHumanElapsed = 0;
+                else if ((m_NoNonVirtualHumanElapsed += diff) >= NO_NON_VIRTUAL_HUMAN_END_DELAY_MS)
+                {
+                    TC_LOG_INFO("bg.battleground",
+                        "Battleground::Update ending map={} instance={} because no non-virtual participants remained for {} ms.",
+                        GetMapId(), GetInstanceID(), NO_NON_VIRTUAL_HUMAN_END_DELAY_MS);
+                    EndNow();
+                    return;
+                }
+            }
+
             _ProcessOfflineQueue();
             // after 20 minutes without one team losing, the arena closes with no winner and no rating change
             if (isArena())
@@ -552,8 +524,7 @@ inline void Battleground::_ProcessLeave(uint32 diff)
     // ***           BATTLEGROUND ENDING SYSTEM              ***
     // *********************************************************
     // remove all players from battleground after 2 minutes
-    m_EndTime -= diff;
-    if (m_EndTime <= 0)
+    if (m_EndTime <= diff)
     {
         m_EndTime = 0;
         BattlegroundPlayerMap::iterator itr, next;
@@ -566,6 +537,8 @@ inline void Battleground::_ProcessLeave(uint32 diff)
             // do not change any battleground's private variables
         }
     }
+    else
+        m_EndTime -= diff;
 }
 
 Player* Battleground::_GetPlayer(ObjectGuid guid, bool offlineRemove, char const* context) const
@@ -946,6 +919,7 @@ void Battleground::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
     RemovePlayerFromResurrectQueue(guid);
 
     Player* player = ObjectAccessor::FindPlayer(guid);
+    bool const removedNonVirtualHuman = player && player->GetSession() && !player->GetSession()->IsVirtualSession();
 
     if (player)
     {
@@ -1017,7 +991,9 @@ void Battleground::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
         sBattlegroundMgr->BuildPlayerLeftBattlegroundPacket(&data, guid);
         SendPacketToTeam(team, &data, player, false);
 
-        if (isBattleground() && GetStatus() == STATUS_IN_PROGRESS && !HasAnyNonVirtualHumanParticipant(this))
+        if (isBattleground() && removedNonVirtualHuman && m_HasEverHadNonVirtualHumanParticipant &&
+            (GetStatus() == STATUS_IN_PROGRESS || GetStatus() == STATUS_WAIT_JOIN) &&
+            !HasAnyNonVirtualHumanParticipant(this))
         {
             TC_LOG_DEBUG("bg.battleground",
                 "Battleground::RemovePlayerAtLeave forced end: map={} instance={} no non-virtual participants remain.",
@@ -1062,6 +1038,8 @@ void Battleground::Reset()
     m_InvitedAlliance = 0;
     m_InvitedHorde = 0;
     m_InBGFreeSlotQueue = false;
+    m_HasEverHadNonVirtualHumanParticipant = false;
+    m_NoNonVirtualHumanElapsed = 0;
 
     m_Players.clear();
 
@@ -1208,6 +1186,12 @@ void Battleground::AddPlayer(Player* player)
 
     if (!isInBattleground)
         UpdatePlayersCountByTeam(team, false);                  // +1 player
+
+    if (WorldSession const* session = player->GetSession(); session && !session->IsVirtualSession())
+    {
+        m_HasEverHadNonVirtualHumanParticipant = true;
+        m_NoNonVirtualHumanElapsed = 0;
+    }
 
     WorldPacket data;
     sBattlegroundMgr->BuildPlayerJoinedBattlegroundPacket(&data, player);

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -592,6 +592,8 @@ class TC_GAME_API Battleground
         int32  m_StartDelayTime;
         bool   m_IsRated;                                   // is this battle rated?
         bool   m_PrematureCountDown;
+        bool   m_HasEverHadNonVirtualHumanParticipant;
+        uint32 m_NoNonVirtualHumanElapsed;
         bool   m_IsReplay;
         uint32 m_ReplayId;
         uint32 m_FightId;


### PR DESCRIPTION
### Motivation
- Ensure battlegrounds end automatically shortly after the last real (non-virtual) human player disconnects or leaves, avoiding stuck instances driven only by virtual sessions or bots. 
- Remove legacy account-based playerbot detection code that parsed configured bot account IDs and relied on character cache lookups. 
- Fix end-timer decrement logic to avoid negative counts and keep bg-end behavior consistent. 

### Description
- Added detection for connected (non-virtual) players by using `ObjectAccessor::FindConnectedPlayer` in `HasAnyNonVirtualHumanParticipant` and introduced a 15s delay constant `NO_NON_VIRTUAL_HUMAN_END_DELAY_MS`. 
- Tracked whether a battleground ever had a non-virtual human via `m_HasEverHadNonVirtualHumanParticipant` and an elapsed timer `m_NoNonVirtualHumanElapsed` on the battleground object, and call `EndNow()` when the elapsed time exceeds the threshold. 
- Set `m_HasEverHadNonVirtualHumanParticipant` and reset the elapsed timer in `AddPlayer` for non-virtual sessions, and clear both in `Reset`. 
- Use a local `removedNonVirtualHuman` flag in `RemovePlayerAtLeave` to trigger a forced end when the last non-virtual human departs during an active match. 
- Removed legacy helper functions and includes related to configured playerbot account parsing and character cache lookups. 
- Fixed `m_EndTime` decrement in `_ProcessLeave` to avoid negative underflow by checking `if (m_EndTime <= diff)` and otherwise subtracting `diff`. 
- Added concise logging when the battleground is ended due to absence of non-virtual participants. 

### Testing
- Project compiled successfully after the changes. 
- Ran automated server/unit test suite (`make` + test runner) and observed no regressions in the test run. 
- Performed an automated integration smoke test that simulates joining/leaving with virtual and non-virtual sessions and verified the battleground ends after the configured ~15s delay when only virtual sessions remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db30c1a3088327bec030124de0ad67)