### PR TITLE
Playerbot: add grace timer before ending battlegrounds when no humans present

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -64,6 +64,8 @@
 namespace
 {
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
+std::unordered_map<uint64, uint32> g_BattlegroundNoHumanSinceMsByInstance;
+constexpr uint32 PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS = 15000;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
@@ -1460,6 +1462,14 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
+uint64 BuildBattlegroundInstanceKey(Battleground const* battleground)
+{
+    if (!battleground)
+        return 0;
+
+    return (uint64(battleground->GetMapId()) << 32) | uint64(battleground->GetInstanceID());
+}
+
 bool BattlegroundHasAnyHumanPlayers(Player const* player)
 {
     if (!player || !player->InBattleground() || !player->GetMap())
@@ -2001,17 +2011,34 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
         return false;
 
+    uint64 const battlegroundInstanceKey = BuildBattlegroundInstanceKey(battleground);
+
     if (!BattlegroundHasAnyHumanPlayers(player))
     {
+        uint32 const nowMs = GameTime::GetGameTimeMS();
+        uint32& noHumanSinceMs = g_BattlegroundNoHumanSinceMsByInstance[battlegroundInstanceKey];
+        if (!noHumanSinceMs)
+        {
+            noHumanSinceMs = nowMs;
+            return false;
+        }
+
+        if (nowMs < noHumanSinceMs + PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS)
+            return false;
+
         if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
             return false;
 
         battleground->EndBattleground(0);
+        player->LeaveBattleground();
+        g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle forced battleground end due to no human participants: guid={} bgTypeId={} instanceId={}.",
             player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
         return true;
     }
+
+    g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
 
     if (HandleBattlegroundDeathState(player))
         return true;


### PR DESCRIPTION
### Motivation
- Prevent managed playerbots from immediately forcing a battleground end and lingering in `/who` when human presence transiently drops. 
- Avoid racing that can instantly kick joining human players due to immediate no-human auto-end behavior.

### Description
- Added a per-instance timer map `g_BattlegroundNoHumanSinceMsByInstance` and a `PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS` (15s) constant to track a grace period before auto-ending a BG. 
- Introduced `BuildBattlegroundInstanceKey` to key timer state by `mapId`+`instanceId` so timing is tracked per battleground instance. 
- Updated `BattlegroundLifecycleActions::HandleInProgressStatusPrimitive` to start the no-human timer when no humans are present, only end the battleground after the grace period, explicitly call `LeaveBattleground()` for the bot after ending, and clear the stored timer entry. 
- Clear the per-instance timer when any human participant is detected again to avoid stale triggers.

### Testing
- Committed the change (`git commit`) and ensured the patch applied cleanly to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.
- Ran a local build start with `cmake --build build --target worldserver -j4` and observed the build configuration and many compilation units begin (no full build log captured to completion).
- Attempted to build a single object via `ninja` but the direct object target name did not match and the targeted invocation failed (target lookup error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3e189a288327be4fae5dd9e730eb)