### PR TITLE
Avoid duplicating no-human battleground shutdown; remove helper and forced end logic

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1460,27 +1460,6 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
-bool BattlegroundHasAnyHumanPlayers(Player const* player)
-{
-    if (!player || !player->InBattleground() || !player->GetMap())
-        return false;
-
-    uint32 const battlegroundId = player->GetBattlegroundId();
-    Map::PlayerList const& players = player->GetMap()->GetPlayers();
-    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
-    {
-        Player const* participant = itr->GetSource();
-        if (!participant || participant->GetBattlegroundId() != battlegroundId)
-            continue;
-
-        WorldSession const* participantSession = participant->GetSession();
-        bool const isVirtualBotSession = participantSession && participantSession->IsVirtualSession();
-        if (!isVirtualBotSession && !playerbot::IsManagedRandomBot(participant))
-            return true;
-    }
-
-    return false;
-}
 
 bool ShouldDeferBattlegroundLeaveForTeleportAck(Player const* player)
 {
@@ -2001,17 +1980,10 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
         return false;
 
-    if (!BattlegroundHasAnyHumanPlayers(player))
-    {
-        if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
-            return false;
-
-        battleground->EndBattleground(0);
-        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle forced battleground end due to no human participants: guid={} bgTypeId={} instanceId={}.",
-            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
-        return true;
-    }
+    // Battleground core already owns no-human participant shutdown (with a
+    // non-virtual human grace window and join/leave edge-case handling).
+    // Duplicating that logic here can race invites and eject newly joining
+    // humans before they fully enter the battleground instance.
 
     if (HandleBattlegroundDeathState(player))
         return true;


### PR DESCRIPTION
### Motivation

- Prevent a race between bot lifecycle code and the battleground core when ending a battleground with no human participants by removing duplicate shutdown logic.
- Reduce incorrect early ejection of humans that may be joining during the grace window by deferring to the battleground core implementation.

### Description

- Remove the `BattlegroundHasAnyHumanPlayers` helper function and its use in the in-progress lifecycle handler. 
- Eliminate the early forced `EndBattleground` call that ended battlegrounds when no human players were detected. 
- Add a clarifying comment explaining that the battleground core already implements no-human shutdown with proper grace and edge-case handling. 
- Preserve the existing `ShouldDeferBattlegroundLeaveForTeleportAck` checks and other lifecycle handling around leave/teleport and death state.

### Testing

- Automated build (`make`) completed successfully. 
- No additional automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3e189a288327be4fae5dd9e730eb)