### PR TITLE
Treat virtual sessions as bots, delay battleground shutdown when no real humans remain, and tweak lifecycle handling

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -220,15 +220,6 @@ void Battleground::Update(uint32 diff)
     switch (GetStatus())
     {
         case STATUS_WAIT_JOIN:
-            if (isBattleground() && GetPlayersSize() && !HasAnyNonVirtualHumanParticipant(this))
-            {
-                TC_LOG_INFO("bg.battleground",
-                    "Battleground::Update ending map={} instance={} during preparation because no non-virtual participants remain.",
-                    GetMapId(), GetInstanceID());
-                EndNow();
-                return;
-            }
-
             if (GetPlayersSize())
             {
                 _ProcessJoin(diff);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -50,6 +50,7 @@
 #include "CommonHelpers.h"
 
 #include <cstring>
+#include <cstdint>
 #include <cmath>
 #include <chrono>
 #include <limits>
@@ -64,6 +65,8 @@
 namespace
 {
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
+std::unordered_map<uintptr_t, uint32> g_BattlegroundNoHumanSinceMsByPointer;
+constexpr uint32 PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS = 45000;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
@@ -1460,7 +1463,9 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
-bool BattlegroundHasAnyHumanPlayers(Player const* player)
+
+
+bool BattlegroundHasAnyRealHumanPlayers(Player const* player)
 {
     if (!player || !player->InBattleground() || !player->GetMap())
         return false;
@@ -1473,9 +1478,9 @@ bool BattlegroundHasAnyHumanPlayers(Player const* player)
         if (!participant || participant->GetBattlegroundId() != battlegroundId)
             continue;
 
-        WorldSession const* participantSession = participant->GetSession();
-        bool const isVirtualBotSession = participantSession && participantSession->IsVirtualSession();
-        if (!isVirtualBotSession && !playerbot::IsManagedRandomBot(participant))
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (!isVirtualSession && !playerbot::IsManagedRandomBot(participant))
             return true;
     }
 
@@ -1988,6 +1993,8 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
 
     if (battleground->GetStatus() == STATUS_WAIT_LEAVE)
     {
+        g_BattlegroundNoHumanSinceMsByPointer.erase(reinterpret_cast<uintptr_t>(battleground));
+
         if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
             return false;
 
@@ -1999,19 +2006,34 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     }
 
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
-        return false;
-
-    if (!BattlegroundHasAnyHumanPlayers(player))
     {
-        if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
-            return false;
-
-        battleground->EndBattleground(0);
-        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle forced battleground end due to no human participants: guid={} bgTypeId={} instanceId={}.",
-            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
-        return true;
+        g_BattlegroundNoHumanSinceMsByPointer.erase(reinterpret_cast<uintptr_t>(battleground));
+        return false;
     }
+
+    // Secondary guard for non-virtual managed bot accounts: core battleground
+    // shutdown treats any non-virtual session as human, so these matches can
+    // persist indefinitely after real humans leave.
+    uintptr_t const battlegroundPointerKey = reinterpret_cast<uintptr_t>(battleground);
+    if (!BattlegroundHasAnyRealHumanPlayers(player))
+    {
+        uint32 const nowMs = GameTime::GetGameTimeMS();
+        uint32& noHumanSinceMs = g_BattlegroundNoHumanSinceMsByPointer[battlegroundPointerKey];
+        if (!noHumanSinceMs)
+            noHumanSinceMs = nowMs;
+
+        if (nowMs >= noHumanSinceMs + PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS && !ShouldDeferBattlegroundLeaveForTeleportAck(player))
+        {
+            battleground->EndBattleground(PVP_TEAM_NEUTRAL);
+            g_BattlegroundNoHumanSinceMsByPointer.erase(battlegroundPointerKey);
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP lifecycle forced battleground end due to no real human participants: guid={} bgTypeId={} instanceId={}.",
+                player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+            return true;
+        }
+    }
+    else
+        g_BattlegroundNoHumanSinceMsByPointer.erase(battlegroundPointerKey);
 
     if (HandleBattlegroundDeathState(player))
         return true;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -468,20 +468,20 @@ uint32 ResolvePlayerAccountId(Player const* player)
 
 bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> const& botAccounts)
 {
-    if (!player || botAccounts.empty())
+    if (!player)
+        return false;
+
+    if (WorldSession const* session = player->GetSession(); session && session->IsVirtualSession())
+        return true;
+
+    if (botAccounts.empty())
         return false;
 
     uint32 const accountId = ResolvePlayerAccountId(player);
     if (!accountId || botAccounts.find(accountId) == botAccounts.end())
         return false;
 
-    if (WorldSession const* session = player->GetSession())
-    {
-        // BotAccountIds is an explicit allow-list; treat listed accounts as
-        // managed bots even when their virtual session is marked connected.
-        return true;
-    }
-
+    // BotAccountIds remains an explicit allow-list for non-virtual sessions.
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Prevent battlegrounds with only virtual-session or managed-bot participants from being prematurely ended and align Playerbot lifecycle behavior with core battleground semantics.
- Ensure managed random-bot accounts and virtual sessions are distinguished from real human players so matches do not persist indefinitely or end too eagerly.

### Description

- Removed the immediate end condition during `STATUS_WAIT_JOIN` that closed a battleground when no non-virtual human participants remained.  
- Added `g_BattlegroundNoHumanSinceMsByPointer` and `PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS = 45000` to track per-battleground no-human durations and defer shutdown until the grace period elapses.  
- Reworked `BattlegroundHasAnyHumanPlayers` to `BattlegroundHasAnyRealHumanPlayers` to explicitly treat virtual sessions and managed random bots as non-human for shutdown decisions.  
- In `HandleInProgressStatusPrimitive` added logic to set/erase the per-battleground timestamp and to call `EndBattleground(PVP_TEAM_NEUTRAL)` only after the grace period and after checking `ShouldDeferBattlegroundLeaveForTeleportAck`.  
- Adjusted `IsManagedRandomBotImpl` to treat a connected virtual session as a managed bot and simplified account-based managed-bot allow-list handling.  
- Minor includes and cleanup: added `<cstdint>` and small comment/log adjustments.

### Testing

- Built the server sources with the changes and the build completed successfully using the project build system.  
- Ran automated Playerbot PvP lifecycle tests and battleground-related unit checks and observed no failures.  
- Ran integration smoke tests to validate battleground end/leave flows involving virtual sessions and managed bots and confirmed expected behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3e189a288327be4fae5dd9e730eb)