### PR TITLE
Playerbot: avoid premature BG shutdown and add timed end for matches without real humans

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -220,15 +220,6 @@ void Battleground::Update(uint32 diff)
     switch (GetStatus())
     {
         case STATUS_WAIT_JOIN:
-            if (isBattleground() && GetPlayersSize() && !HasAnyNonVirtualHumanParticipant(this))
-            {
-                TC_LOG_INFO("bg.battleground",
-                    "Battleground::Update ending map={} instance={} during preparation because no non-virtual participants remain.",
-                    GetMapId(), GetInstanceID());
-                EndNow();
-                return;
-            }
-
             if (GetPlayersSize())
             {
                 _ProcessJoin(diff);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -50,6 +50,7 @@
 #include "CommonHelpers.h"
 
 #include <cstring>
+#include <cstdint>
 #include <cmath>
 #include <chrono>
 #include <limits>
@@ -64,6 +65,8 @@
 namespace
 {
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
+std::unordered_map<uintptr_t, uint32> g_BattlegroundNoHumanSinceMsByPointer;
+constexpr uint32 PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS = 45000;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
@@ -1460,7 +1463,9 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
-bool BattlegroundHasAnyHumanPlayers(Player const* player)
+
+
+bool BattlegroundHasAnyRealHumanPlayers(Player const* player)
 {
     if (!player || !player->InBattleground() || !player->GetMap())
         return false;
@@ -1473,9 +1478,9 @@ bool BattlegroundHasAnyHumanPlayers(Player const* player)
         if (!participant || participant->GetBattlegroundId() != battlegroundId)
             continue;
 
-        WorldSession const* participantSession = participant->GetSession();
-        bool const isVirtualBotSession = participantSession && participantSession->IsVirtualSession();
-        if (!isVirtualBotSession && !playerbot::IsManagedRandomBot(participant))
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (!isVirtualSession && !playerbot::IsManagedRandomBot(participant))
             return true;
     }
 
@@ -1490,8 +1495,11 @@ bool ShouldDeferBattlegroundLeaveForTeleportAck(Player const* player)
     if (!player->IsBeingTeleportedFar() && !player->IsBeingTeleportedNear())
         return false;
 
-    // Virtual-session bots can retain stale near/far teleport semaphores inside
+    // Managed bots can retain stale near/far teleport semaphores inside
     // battleground instances; do not deadlock leave/end cleanup on those flags.
+    if (player->InBattleground() && playerbot::IsManagedRandomBot(player))
+        return false;
+
     WorldSession const* session = player->GetSession();
     if (session && session->IsVirtualSession() && player->InBattleground())
         return false;
@@ -1988,6 +1996,8 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
 
     if (battleground->GetStatus() == STATUS_WAIT_LEAVE)
     {
+        g_BattlegroundNoHumanSinceMsByPointer.erase(reinterpret_cast<uintptr_t>(battleground));
+
         if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
             return false;
 
@@ -1999,19 +2009,34 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     }
 
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
-        return false;
-
-    if (!BattlegroundHasAnyHumanPlayers(player))
     {
-        if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
-            return false;
-
-        battleground->EndBattleground(0);
-        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle forced battleground end due to no human participants: guid={} bgTypeId={} instanceId={}.",
-            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
-        return true;
+        g_BattlegroundNoHumanSinceMsByPointer.erase(reinterpret_cast<uintptr_t>(battleground));
+        return false;
     }
+
+    // Secondary guard for non-virtual managed bot accounts: core battleground
+    // shutdown treats any non-virtual session as human, so these matches can
+    // persist indefinitely after real humans leave.
+    uintptr_t const battlegroundPointerKey = reinterpret_cast<uintptr_t>(battleground);
+    if (!BattlegroundHasAnyRealHumanPlayers(player))
+    {
+        uint32 const nowMs = GameTime::GetGameTimeMS();
+        uint32& noHumanSinceMs = g_BattlegroundNoHumanSinceMsByPointer[battlegroundPointerKey];
+        if (!noHumanSinceMs)
+            noHumanSinceMs = nowMs;
+
+        if (nowMs >= noHumanSinceMs + PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS && !ShouldDeferBattlegroundLeaveForTeleportAck(player))
+        {
+            battleground->EndBattleground(PVP_TEAM_NEUTRAL);
+            g_BattlegroundNoHumanSinceMsByPointer.erase(battlegroundPointerKey);
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP lifecycle forced battleground end due to no real human participants: guid={} bgTypeId={} instanceId={}.",
+                player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+            return true;
+        }
+    }
+    else
+        g_BattlegroundNoHumanSinceMsByPointer.erase(battlegroundPointerKey);
 
     if (HandleBattlegroundDeathState(player))
         return true;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -468,20 +468,20 @@ uint32 ResolvePlayerAccountId(Player const* player)
 
 bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> const& botAccounts)
 {
-    if (!player || botAccounts.empty())
+    if (!player)
+        return false;
+
+    if (WorldSession const* session = player->GetSession(); session && session->IsVirtualSession())
+        return true;
+
+    if (botAccounts.empty())
         return false;
 
     uint32 const accountId = ResolvePlayerAccountId(player);
     if (!accountId || botAccounts.find(accountId) == botAccounts.end())
         return false;
 
-    if (WorldSession const* session = player->GetSession())
-    {
-        // BotAccountIds is an explicit allow-list; treat listed accounts as
-        // managed bots even when their virtual session is marked connected.
-        return true;
-    }
-
+    // BotAccountIds remains an explicit allow-list for non-virtual sessions.
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Prevent battlegrounds from being closed prematurely when only managed/virtual bot accounts remain and ensure playerbot logic closes such matches gracefully after a short timeout.
- Make playerbot-managed-bot detection and teleport-defer logic more accurate by distinguishing real human sessions from virtual/managed bot sessions.

### Description

- Removed the early `EndNow()` path from `Battleground::Update` that closed battlegrounds during `STATUS_WAIT_JOIN` when only non-virtual participants were absent. 
- Added `g_BattlegroundNoHumanSinceMsByPointer` and `PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS` to track when a battleground loses all real human players and introduced a delayed forced end using `EndBattleground(PVP_TEAM_NEUTRAL)` after the timeout inside `HandleInProgressStatusPrimitive`.
- Renamed and tightened human detection to `BattlegroundHasAnyRealHumanPlayers` and now consider `WorldSession::IsVirtualSession()` and `playerbot::IsManagedRandomBot()` appropriately when deciding if a participant is a real human.
- Updated `ShouldDeferBattlegroundLeaveForTeleportAck` to skip deferral for managed random bots in battlegrounds and adjusted `IsManagedRandomBotImpl` to treat virtual sessions as managed bots while preserving the account allow-list behavior for non-virtual sessions.
- Clean up per-battleground tracking entries in the no-human map when a battleground reaches `STATUS_WAIT_LEAVE` or regains a human participant.

### Testing

- Project build was executed (`make`) after changes and compilation succeeded. 
- Playerbot PvP lifecycle code paths were exercised in automated tests and local PvP scenarios, and the new delayed end behavior for battlegrounds without real humans completed as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3e189a288327be4fae5dd9e730eb)