### PR TITLE
Playerbot: end battlegrounds when no real humans remain and fix virtual-teleport handling

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -220,15 +220,6 @@ void Battleground::Update(uint32 diff)
     switch (GetStatus())
     {
         case STATUS_WAIT_JOIN:
-            if (isBattleground() && GetPlayersSize() && !HasAnyNonVirtualHumanParticipant(this))
-            {
-                TC_LOG_INFO("bg.battleground",
-                    "Battleground::Update ending map={} instance={} during preparation because no non-virtual participants remain.",
-                    GetMapId(), GetInstanceID());
-                EndNow();
-                return;
-            }
-
             if (GetPlayersSize())
             {
                 _ProcessJoin(diff);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -50,6 +50,7 @@
 #include "CommonHelpers.h"
 
 #include <cstring>
+#include <cstdint>
 #include <cmath>
 #include <chrono>
 #include <limits>
@@ -64,9 +65,13 @@
 namespace
 {
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
+std::unordered_map<uintptr_t, uint32> g_BattlegroundNoHumanSinceMsByPointer;
+constexpr uint32 PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS = 45000;
+constexpr uint32 PLAYERBOT_BG_WAIT_JOIN_NO_HUMAN_END_DELAY_MS = 15000;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
+constexpr uint32 SPELL_DESERTER = 26013;
 
 void ForcePlayerbotDismount(Player* player)
 {
@@ -1460,7 +1465,9 @@ bool HumanTeammateNearDroppedFlag(Player* player, GameObject const* droppedFlag,
     return false;
 }
 
-bool BattlegroundHasAnyHumanPlayers(Player const* player)
+
+
+bool BattlegroundHasAnyRealHumanPlayers(Player const* player)
 {
     if (!player || !player->InBattleground() || !player->GetMap())
         return false;
@@ -1473,13 +1480,63 @@ bool BattlegroundHasAnyHumanPlayers(Player const* player)
         if (!participant || participant->GetBattlegroundId() != battlegroundId)
             continue;
 
-        WorldSession const* participantSession = participant->GetSession();
-        bool const isVirtualBotSession = participantSession && participantSession->IsVirtualSession();
-        if (!isVirtualBotSession && !playerbot::IsManagedRandomBot(participant))
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (!isVirtualSession && !playerbot::IsManagedRandomBot(participant))
             return true;
     }
 
     return false;
+}
+
+void FinalizeVirtualBotTeleportIfPending(Player* player)
+{
+    if (!player)
+        return;
+
+    WorldSession* session = player->GetSession();
+    if (!session || !session->IsVirtualSession())
+        return;
+
+    if (player->IsBeingTeleportedFar())
+        session->HandleMoveWorldportAck();
+
+    if (!player->IsBeingTeleportedNear())
+        return;
+
+    WorldPacket teleportAck(MSG_MOVE_TELEPORT_ACK, 20);
+    teleportAck << player->GetPackGUID();
+    teleportAck << uint32(0);
+    teleportAck << uint32(0);
+    session->HandleMoveTeleportAck(teleportAck);
+
+    if (!player->IsBeingTeleportedNear())
+        return;
+
+    uint32 const oldZone = player->GetZoneId();
+    WorldLocation destination = player->GetTeleportDest();
+    float safeDestinationZ = destination.GetPositionZ();
+    player->UpdateAllowedPositionZ(destination.GetPositionX(), destination.GetPositionY(), safeDestinationZ);
+    destination.Relocate(destination.GetPositionX(), destination.GetPositionY(), safeDestinationZ, destination.GetOrientation());
+    player->SetSemaphoreTeleportNear(false);
+    player->UpdatePosition(destination, true);
+    player->SetFallInformation(0, player->GetPositionZ());
+
+    uint32 newZone = 0;
+    uint32 newArea = 0;
+    player->GetZoneAndAreaId(newZone, newArea);
+    player->UpdateZone(newZone, newArea);
+
+    if (oldZone != newZone)
+    {
+        if (player->pvpInfo.IsHostile)
+            player->CastSpell(player, 2479, true);
+        else if (player->IsPvP() && !player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_IN_PVP))
+            player->UpdatePvP(false, false);
+    }
+
+    player->ResummonPetTemporaryUnSummonedIfAny();
+    player->ProcessDelayedOperations();
 }
 
 bool ShouldDeferBattlegroundLeaveForTeleportAck(Player const* player)
@@ -1490,8 +1547,11 @@ bool ShouldDeferBattlegroundLeaveForTeleportAck(Player const* player)
     if (!player->IsBeingTeleportedFar() && !player->IsBeingTeleportedNear())
         return false;
 
-    // Virtual-session bots can retain stale near/far teleport semaphores inside
+    // Managed bots can retain stale near/far teleport semaphores inside
     // battleground instances; do not deadlock leave/end cleanup on those flags.
+    if (player->InBattleground() && playerbot::IsManagedRandomBot(player))
+        return false;
+
     WorldSession const* session = player->GetSession();
     if (session && session->IsVirtualSession() && player->InBattleground())
         return false;
@@ -1986,12 +2046,45 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (!battleground)
         return false;
 
+    if (battleground->GetStatus() == STATUS_WAIT_JOIN)
+    {
+        uintptr_t const battlegroundPointerKey = reinterpret_cast<uintptr_t>(battleground);
+        if (!BattlegroundHasAnyRealHumanPlayers(player))
+        {
+            uint32 const nowMs = GameTime::GetGameTimeMS();
+            uint32& noHumanSinceMs = g_BattlegroundNoHumanSinceMsByPointer[battlegroundPointerKey];
+            if (!noHumanSinceMs)
+                noHumanSinceMs = nowMs;
+
+            if (nowMs >= noHumanSinceMs + PLAYERBOT_BG_WAIT_JOIN_NO_HUMAN_END_DELAY_MS && !ShouldDeferBattlegroundLeaveForTeleportAck(player))
+            {
+                battleground->EndBattleground(PVP_TEAM_NEUTRAL);
+                g_BattlegroundNoHumanSinceMsByPointer.erase(battlegroundPointerKey);
+                TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                    "Playerbot PvP lifecycle wait-join end due to no real humans: guid={} bgTypeId={} instanceId={}.",
+                    player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+                return true;
+            }
+        }
+        else
+            g_BattlegroundNoHumanSinceMsByPointer.erase(battlegroundPointerKey);
+
+        return false;
+    }
+
     if (battleground->GetStatus() == STATUS_WAIT_LEAVE)
     {
+        g_BattlegroundNoHumanSinceMsByPointer.erase(reinterpret_cast<uintptr_t>(battleground));
+
         if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
             return false;
 
         player->LeaveBattleground();
+        FinalizeVirtualBotTeleportIfPending(player);
+        player->RemoveAurasDueToSpell(SPELL_DESERTER);
+        RemoveMatchingQueues(player, false, false, true);
+        RemoveMatchingQueues(player, true, false, false);
+        player->SetArenaTeamIdInvited(0);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP lifecycle leave after battleground end: guid={} bgTypeId={} instanceId={}.",
             player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
@@ -1999,19 +2092,34 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     }
 
     if (battleground->GetStatus() != STATUS_IN_PROGRESS)
-        return false;
-
-    if (!BattlegroundHasAnyHumanPlayers(player))
     {
-        if (ShouldDeferBattlegroundLeaveForTeleportAck(player))
-            return false;
-
-        battleground->EndBattleground(0);
-        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle forced battleground end due to no human participants: guid={} bgTypeId={} instanceId={}.",
-            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
-        return true;
+        g_BattlegroundNoHumanSinceMsByPointer.erase(reinterpret_cast<uintptr_t>(battleground));
+        return false;
     }
+
+    // Secondary guard for non-virtual managed bot accounts: core battleground
+    // shutdown treats any non-virtual session as human, so these matches can
+    // persist indefinitely after real humans leave.
+    uintptr_t const battlegroundPointerKey = reinterpret_cast<uintptr_t>(battleground);
+    if (!BattlegroundHasAnyRealHumanPlayers(player))
+    {
+        uint32 const nowMs = GameTime::GetGameTimeMS();
+        uint32& noHumanSinceMs = g_BattlegroundNoHumanSinceMsByPointer[battlegroundPointerKey];
+        if (!noHumanSinceMs)
+            noHumanSinceMs = nowMs;
+
+        if (nowMs >= noHumanSinceMs + PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS && !ShouldDeferBattlegroundLeaveForTeleportAck(player))
+        {
+            battleground->EndBattleground(PVP_TEAM_NEUTRAL);
+            g_BattlegroundNoHumanSinceMsByPointer.erase(battlegroundPointerKey);
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP lifecycle end due to no real human participants: guid={} bgTypeId={} instanceId={}.",
+                player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+            return true;
+        }
+    }
+    else
+        g_BattlegroundNoHumanSinceMsByPointer.erase(battlegroundPointerKey);
 
     if (HandleBattlegroundDeathState(player))
         return true;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -280,21 +280,19 @@ bool CanProcessPlayerLifecycle(Player const* player)
 
     if (player->IsBeingTeleported())
     {
-        // Managed random bots can occasionally retain the generic teleport flag
-        // after a battleground transition (especially when start countdowns are
-        // skipped). If near/far teleport semaphores are clear and the bot is
-        // already placed in a battleground map, continue lifecycle processing so
-        // tactical movement does not deadlock at match start.
+        // Managed random bots can occasionally retain a stale generic teleport
+        // flag after battleground transitions. Only block lifecycle when actual
+        // near/far teleport acknowledgements are still pending.
         bool const hasPendingTeleportAck = player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear();
-        if (hasPendingTeleportAck || !player->InBattleground())
+        if (hasPendingTeleportAck)
         {
             ObserveLifecycleReason(LifecycleObservationReason::InvalidPlayerState, guid);
             return false;
         }
 
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot lifecycle pre-check tolerated stale teleport flag: guid={} battlegroundId={}.",
-            guid.ToString(), player->GetBattlegroundId());
+            "Playerbot lifecycle pre-check tolerated stale teleport flag: guid={} battlegroundId={} inBattleground={}",
+            guid.ToString(), player->GetBattlegroundId(), player->InBattleground() ? 1 : 0);
     }
 
     uint64 const playerGuid = guid.GetRawValue();
@@ -468,20 +466,20 @@ uint32 ResolvePlayerAccountId(Player const* player)
 
 bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> const& botAccounts)
 {
-    if (!player || botAccounts.empty())
+    if (!player)
+        return false;
+
+    if (WorldSession const* session = player->GetSession(); session && session->IsVirtualSession())
+        return true;
+
+    if (botAccounts.empty())
         return false;
 
     uint32 const accountId = ResolvePlayerAccountId(player);
     if (!accountId || botAccounts.find(accountId) == botAccounts.end())
         return false;
 
-    if (WorldSession const* session = player->GetSession())
-    {
-        // BotAccountIds is an explicit allow-list; treat listed accounts as
-        // managed bots even when their virtual session is marked connected.
-        return true;
-    }
-
+    // BotAccountIds remains an explicit allow-list for non-virtual sessions.
     return true;
 }
 


### PR DESCRIPTION
### Motivation

- Prevent battleground instances from persisting indefinitely when only virtual sessions or managed random bots remain.  
- Avoid lifecycle deadlocks caused by stale near/far teleport semaphores for virtual/managed bots.  
- Make playerbot lifecycle logic treat virtual sessions and managed bot accounts explicitly as non-human participants.

### Description

- Removed the previous early shutdown in `Battleground::Update` for wait-join and implemented playerbot-driven shutdown logic instead.  
- Added `g_BattlegroundNoHumanSinceMsByPointer` and constants `PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS` and `PLAYERBOT_BG_WAIT_JOIN_NO_HUMAN_END_DELAY_MS` to track per-battleground no-human timers and apply delayed shutdowns.  
- Introduced `BattlegroundHasAnyRealHumanPlayers` (replacing prior name) to consider `WorldSession::IsVirtualSession()` and `playerbot::IsManagedRandomBot()` when deciding if a real human is present.  
- Added `FinalizeVirtualBotTeleportIfPending` and updated `ShouldDeferBattlegroundLeaveForTeleportAck` so teleport acknowledgements for virtual/managed bots are finalized safely and to avoid deadlocks.  
- Extended `BattlegroundLifecycleActions::HandleInProgressStatusPrimitive` to: end battlegrounds after a wait-join timeout or in-progress timeout when no real humans remain, finalize pending virtual teleports on leave, remove deserter aura `SPELL_DESERTER`, clear matching queues, and reset invited arena team id.  
- Tolerate stale generic teleport flags for managed random bots in `CanProcessPlayerLifecycle` by only blocking when an actual near/far teleport ack is pending, and improve debug logging.  
- Make `IsManagedRandomBotImpl` treat virtual sessions as managed bots and simplify account-list handling.  
- Minor additions: include `<cstdint>` and small logging updates.

### Testing

- Built the server codebase after changes (`make`/`cmake` build) with no compilation errors.  
- Ran playerbot PvP lifecycle related unit/integration checks and simulated battleground scenarios where real humans joined/left; lifecycle timers triggered expected `EndBattleground` calls and virtual teleport finalization paths as logged.  
- Verified that lifecycle tasks for managed random bots tolerate stale teleport flags and that leave paths remove `SPELL_DESERTER` and clear queues; automated tests and scenario runs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3e189a288327be4fae5dd9e730eb)