### PR TITLE
Playerbots: move to recover line-of-sight before casting and handle LOS cast failures

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -766,13 +766,22 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
+    float const maxRange = spellInfo->GetMaxRange(false);
     if (!itemTarget && !player->IsWithinLOSInMap(target))
     {
+        if (CanIssueFollowCommands(player))
+        {
+            float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+            if (RequiresStrictHumanPathing(player))
+                IssueStrictHumanFollow(player, target, desiredRange);
+            else
+                player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+        }
+
         failureReason = "no_los";
         return false;
     }
 
-    float const maxRange = spellInfo->GetMaxRange(false);
     if (!itemTarget && maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
     {
         if (player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT))
@@ -923,6 +932,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             else if (castResult == SPELL_FAILED_TOO_CLOSE)
             {
                 float const desiredRange = minRange > 0.0f ? std::max(1.0f, minRange + 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().closeRange);
+                if (RequiresStrictHumanPathing(player))
+                    IssueStrictHumanFollow(player, target, desiredRange);
+                else
+                    player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+            }
+            else if (castResult == SPELL_FAILED_LINE_OF_SIGHT)
+            {
+                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
                 if (RequiresStrictHumanPathing(player))
                     IssueStrictHumanFollow(player, target, desiredRange);
                 else


### PR DESCRIPTION
### Motivation
- Playerbot PvP direct-cast code returned `no_los` without attempting to reposition, causing bots to repeatedly fail when a target was temporarily out of line of sight.
- The goal is for bots to proactively recover LOS (similar to existing out-of-range/too-close behavior) so casts have a better chance to succeed.

### Description
- When a non-item target is out of LOS, the bot now issues follow movement toward an appropriate spell range using `MoveFollow` or `IssueStrictHumanFollow` before returning `no_los` (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`).
- Added handling of `SPELL_FAILED_LINE_OF_SIGHT` after a failed `CastSpell` so the bot repositions toward the target just like it does for `SPELL_FAILED_OUT_OF_RANGE` and `SPELL_FAILED_TOO_CLOSE`.
- Reused existing pathing policy by selecting `IssueStrictHumanFollow` when `RequiresStrictHumanPathing` returns true, and `MotionMaster::MoveFollow` otherwise.

### Testing
- Ran repository searches with `rg` to verify references to LOS and cast-failure handling, which completed successfully.
- Started a local build with `cmake --build build --target worldserver -j4`, which compiled many translation units and produced warnings but showed no compilation errors for the modified file; the full build completion was not captured in the session.
- Verified the modified file diff and compiled translation unit lines to ensure the new branches are reachable and syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e131fd67788327a74dd387946dd545)