### PR TITLE
Playerbot: stagger battleground overstack exits to rebalance teams

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -106,6 +106,12 @@ bool ShouldManagedBotLeaveForOverstack(Player* player, Battleground* battlegroun
     if (!allianceCount || !hordeCount)
         return false;
 
+    // Never rebalance on a one-player gap. A departure on 9v8 would immediately
+    // flip (or re-flip) stack pressure and cause oscillation between teams.
+    uint32 const absoluteTeamDiff = (allianceCount > hordeCount) ? (allianceCount - hordeCount) : (hordeCount - allianceCount);
+    if (absoluteTeamDiff <= 1)
+        return false;
+
     uint32 const botTeamCount = assignedTeam == ALLIANCE ? allianceCount : hordeCount;
     uint32 const otherTeamCount = assignedTeam == ALLIANCE ? hordeCount : allianceCount;
     if (botTeamCount <= otherTeamCount)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -70,10 +70,75 @@ std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
 std::unordered_map<uint64, uint32> g_BattlegroundNoHumanSinceMsByInstance;
 constexpr uint32 PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS = 45000;
 constexpr uint32 PLAYERBOT_BG_WAIT_JOIN_NO_HUMAN_END_DELAY_MS = 15000;
+constexpr uint32 PLAYERBOT_BG_OVERSTACK_MIN_DIFF = 2;
+constexpr uint32 PLAYERBOT_BG_OVERSTACK_REQUEUE_COOLDOWN_MS = 30000;
+constexpr uint32 PLAYERBOT_BG_OVERSTACK_INSTANCE_DEPARTURE_SPACING_MS = 8000;
+constexpr uint32 PLAYERBOT_BG_OVERSTACK_INSTANCE_JITTER_WINDOW_MS = 14000;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
 constexpr uint32 SPELL_DESERTER = 26013;
+std::unordered_map<uint64, uint32> g_BattlegroundOverstackRequeueCooldownUntilMsByGuid;
+std::unordered_map<uint64, uint32> g_BattlegroundOverstackInstanceNextDepartureMsByInstance;
+uint64 BuildBattlegroundInstanceKey(Battleground const* battleground);
+
+uint32 ComputeOverstackDepartureJitterMs(Player const* player, Battleground const* battleground)
+{
+    if (!player || !battleground)
+        return 0;
+
+    uint64 const mix = (player->GetGUID().GetRawValue() * 11400714819323198485ull) ^
+        (static_cast<uint64>(battleground->GetInstanceID()) * 7046029254386353131ull);
+    return static_cast<uint32>(mix % PLAYERBOT_BG_OVERSTACK_INSTANCE_JITTER_WINDOW_MS);
+}
+
+bool ShouldManagedBotLeaveForOverstack(Player* player, Battleground* battleground)
+{
+    if (!player || !battleground || !playerbot::IsManagedRandomBot(player))
+        return false;
+
+    uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
+    if (assignedTeam != ALLIANCE && assignedTeam != HORDE)
+        return false;
+
+    uint32 const allianceCount = battleground->GetPlayersCountByTeam(ALLIANCE);
+    uint32 const hordeCount = battleground->GetPlayersCountByTeam(HORDE);
+    if (!allianceCount || !hordeCount)
+        return false;
+
+    uint32 const botTeamCount = assignedTeam == ALLIANCE ? allianceCount : hordeCount;
+    uint32 const otherTeamCount = assignedTeam == ALLIANCE ? hordeCount : allianceCount;
+    if (botTeamCount <= otherTeamCount)
+        return false;
+
+    uint32 const teamDiff = botTeamCount - otherTeamCount;
+    if (teamDiff < PLAYERBOT_BG_OVERSTACK_MIN_DIFF)
+        return false;
+
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint64 const botGuidRaw = player->GetGUID().GetRawValue();
+    uint32 const cooldownUntilMs = g_BattlegroundOverstackRequeueCooldownUntilMsByGuid[botGuidRaw];
+    if (cooldownUntilMs && nowMs < cooldownUntilMs)
+        return false;
+
+    uint64 const instanceKey = BuildBattlegroundInstanceKey(battleground);
+    uint32 const nextDepartureEarliestMs = g_BattlegroundOverstackInstanceNextDepartureMsByInstance[instanceKey];
+    if (nextDepartureEarliestMs && nowMs < nextDepartureEarliestMs)
+        return false;
+
+    uint32 const jitterMs = ComputeOverstackDepartureJitterMs(player, battleground);
+    if (nowMs % PLAYERBOT_BG_OVERSTACK_INSTANCE_JITTER_WINDOW_MS < jitterMs)
+        return false;
+
+    g_BattlegroundOverstackRequeueCooldownUntilMsByGuid[botGuidRaw] = nowMs + PLAYERBOT_BG_OVERSTACK_REQUEUE_COOLDOWN_MS;
+    g_BattlegroundOverstackInstanceNextDepartureMsByInstance[instanceKey] = nowMs + PLAYERBOT_BG_OVERSTACK_INSTANCE_DEPARTURE_SPACING_MS;
+
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP overstack rebalance trigger: guid={} bgTypeId={} instanceId={} assignedTeam={} teamCount={} otherTeamCount={} diff={}.",
+        player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID(), assignedTeam, botTeamCount,
+        otherTeamCount, teamDiff);
+    return true;
+}
 
 void ForcePlayerbotDismount(Player* player)
 {
@@ -2307,6 +2372,14 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     }
     else
         g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
+
+    if (ShouldManagedBotLeaveForOverstack(player, battleground))
+    {
+        player->LeaveBattleground();
+        FinalizeVirtualBotTeleportIfPending(player);
+        player->RemoveAurasDueToSpell(SPELL_DESERTER);
+        return true;
+    }
 
     if (HandleBattlegroundDeathState(player))
         return true;


### PR DESCRIPTION
### Motivation
- Prevent managed playerbots from permanently overstacking a battleground team by having them evaluate live team sizes and leave/requeue when their assigned team is larger by a threshold. 
- Avoid thrashing where many bots leave simultaneously by staggering departures with cooldowns and jitter so the other team does not become repeatedly overstacked.

### Description
- Added overstack rebalance configuration constants and runtime maps: `PLAYERBOT_BG_OVERSTACK_*` and `g_BattlegroundOverstack*` for cooldowns and per-instance spacing in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.
- Implemented a deterministic jitter computation `ComputeOverstackDepartureJitterMs()` and the core decision function `ShouldManagedBotLeaveForOverstack()` which checks assigned team counts, minimum diff, per-bot cooldown, per-instance spacing, and jitter gate before permitting a managed bot to leave.
- Wired the overstack check into the in-progress battleground lifecycle path so managed bots will `LeaveBattleground()` (and call `FinalizeVirtualBotTeleportIfPending()` / clear deserter aura) when selected to depart.
- Localized change to the active playerbot lifecycle implementation only (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`) and did not modify any `playerbot reference/` files.

### Testing
- Attempted targeted build with `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o` which failed because that specific object target name is not present in the generated Ninja graph. (expected in this environment.)
- Launched a full scripts build with `ninja -C build scripts` which started successfully and compiled many script targets but did not complete within the interactive runtime window (no deterministic compile failure observed before the run was interrupted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e131b290f48327871b04a3839b57ea)