### PR TITLE
Fix stale playerbot BG queue slots before SCM requeue

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -942,6 +942,26 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     if (!bgTemplate)
         return false;
 
+    // Recover stale local queue slot state before evaluating queue eligibility.
+    // Managed bots can occasionally keep orphaned queue ids after lifecycle
+    // transitions, which blocks HasFreeBattlegroundQueueId() and prevents
+    // requeueing after subsequent battlegrounds.
+    for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+    {
+        BattlegroundQueueTypeId const existingQueueTypeId = player->GetBattlegroundQueueTypeId(i);
+        if (existingQueueTypeId == BATTLEGROUND_QUEUE_NONE)
+            continue;
+
+        BattlegroundQueue& existingQueue = sBattlegroundMgr->GetBattlegroundQueue(existingQueueTypeId);
+        GroupQueueInfo ginfo{};
+        if (existingQueue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
+            continue;
+
+        player->RemoveBattlegroundQueueId(existingQueueTypeId);
+        EmitLifecycleDiagnostic(player, "queue-prune-stale-slot",
+            "Removed stale queueTypeId=" + std::to_string(uint32(existingQueueTypeId)));
+    }
+
     // Managed random bots can run on disconnected virtual sessions where RBAC
     // battleground permissions are not always populated like live client sessions.
     // Gate queue eligibility by battleground level + free queue slots instead.


### PR DESCRIPTION
### Motivation
- Some managed playerbots could retain orphaned local battleground queue ids after lifecycle transitions, which prevents `HasFreeBattlegroundQueueId()` from reporting a free slot and causes only a subset of bots to rejoin SCM on requeue. 
- The change aims to ensure bots can requeue reliably by removing stale local queue slots that no longer exist in the global `BattlegroundQueue`.

### Description
- Add a stale-slot pruning pass in `QueuePlayer` (file `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`) that runs before queue eligibility checks. 
- Verify membership using `BattlegroundQueue::GetPlayerGroupInfoData` and only remove local slots when no group info exists for that queue id. 
- Remove stale ids with `player->RemoveBattlegroundQueueId(...)` and emit a lifecycle diagnostic `queue-prune-stale-slot` for observability. 
- Preserve valid queue entries so active queues are not affected.

### Testing
- Verified the code change with `git diff` and inspected the updated file content (`nl`/`sed`) to confirm the insertion point and logic, with all checks succeeding. 
- Committed the change using `git add` and `git commit` and created PR metadata via the internal `make_pr` helper, all of which completed successfully. 
- No automated runtime/unit tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1512ddcd08327a6d78bc44dac386d)