### PR TITLE
Fix SCM battleground buff respawn timer override

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -275,3 +275,8 @@ void BattlegroundSCM::EndBattleground(uint32 winner)
     UpdateTeamScoreWorldStates();
     Battleground::EndBattleground(winner);
 }
+
+uint32 BattlegroundSCM::GetBuffRespawnTime(uint32 /*type*/) const
+{
+    return BG_SCM_BUFF_RESPAWN_TIME;
+}

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
@@ -105,6 +105,7 @@ public:
     void FillInitialWorldStates(WorldPackets::WorldState::InitWorldStates& packet) override;
     bool HandlePlayerUnderMap(Player* player) override;
     void EndBattleground(uint32 winner) override;
+    uint32 GetBuffRespawnTime(uint32 type) const override;
 
 private:
     WorldSafeLocsEntry const* GetRandomTeamGraveyard(TeamId teamId) const;


### PR DESCRIPTION
### Motivation
- SCM buff pickups were falling back to the global battleground default respawn interval (`BUFF_RESPAWN_TIME = 180`) because the SCM battleground did not override `GetBuffRespawnTime`, even though `BG_SCM_BUFF_RESPAWN_TIME = 60` is defined for SCM.

### Description
- Added a `GetBuffRespawnTime(uint32)` override to `BattlegroundSCM` in `src/server/game/Battlegrounds/Zones/BattlegroundSCM.h` and implemented it in `BattlegroundSCM.cpp` to return `BG_SCM_BUFF_RESPAWN_TIME`.
- This ensures `Battleground::HandleTriggerBuff` uses the intended 60-second respawn for SCM buff gameobjects.

### Testing
- Built the SCM translation unit with `ninja -C build src/server/game/CMakeFiles/game.dir/Battlegrounds/Zones/BattlegroundSCM.cpp.o`, which completed successfully.
- A full `cmake --build build --target game -- -j2` invocation was started in the environment but not completed due to runtime constraints; the targeted SCM object compilation confirms the change compiles in the game module build graph.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1505fbe3883279f9c07bb48a6a13f)