### PR TITLE
Introduce IssueRangedApproachMovement and centralize ranged approach logic

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -269,6 +269,28 @@ bool IssueStrictHumanFollow(Player* player, Unit* target, float desiredDistance)
     return IssueStrictHumanMove(player, BuildFollowDestination(player, target, desiredDistance));
 }
 
+void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDistance)
+{
+    if (!player || !target)
+        return;
+
+    float const safeDistance = std::max(1.0f, desiredDistance);
+    if (RequiresStrictHumanPathing(player))
+    {
+        IssueStrictHumanFollow(player, target, safeDistance);
+        return;
+    }
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    if (player->IsValidAttackTarget(target))
+        motionMaster->MoveChase(target, safeDistance);
+    else
+        motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+}
+
 bool IsCrowdControlledForAction(Player const* player)
 {
     if (!player)
@@ -766,13 +788,19 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
+    float const maxRange = spellInfo->GetMaxRange(false);
     if (!itemTarget && !player->IsWithinLOSInMap(target))
     {
+        if (CanIssueFollowCommands(player))
+        {
+            float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+            IssueRangedApproachMovement(player, target, desiredRange);
+        }
+
         failureReason = "no_los";
         return false;
     }
 
-    float const maxRange = spellInfo->GetMaxRange(false);
     if (!itemTarget && maxRange > 0.0f && !player->IsWithinDistInMap(target, maxRange))
     {
         if (player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT))
@@ -785,10 +813,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (CanIssueFollowCommands(player) && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
         {
             float const desiredRange = std::max(1.0f, maxRange - 1.0f);
-            if (RequiresStrictHumanPathing(player))
-                IssueStrictHumanFollow(player, target, desiredRange);
-            else
-                player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+            IssueRangedApproachMovement(player, target, desiredRange);
         }
         else if (CanIssueFollowCommands(player) && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
         {
@@ -915,10 +940,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             if (castResult == SPELL_FAILED_OUT_OF_RANGE)
             {
                 float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
-                if (RequiresStrictHumanPathing(player))
-                    IssueStrictHumanFollow(player, target, desiredRange);
-                else
-                    player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+                IssueRangedApproachMovement(player, target, desiredRange);
             }
             else if (castResult == SPELL_FAILED_TOO_CLOSE)
             {
@@ -927,6 +949,11 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                     IssueStrictHumanFollow(player, target, desiredRange);
                 else
                     player->GetMotionMaster()->MoveFollow(target, desiredRange, player->GetFollowAngle());
+            }
+            else if (castResult == SPELL_FAILED_LINE_OF_SIGHT)
+            {
+                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                IssueRangedApproachMovement(player, target, desiredRange);
             }
         }
 
@@ -1137,20 +1164,14 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
             {
                 float const desiredRange = std::max(1.0f,
                     context.movementFollowRange > 0.0f ? context.movementFollowRange : (PvpCore::GetConfig().meleeRange - 1.0f));
-                if (RequiresStrictHumanPathing(player))
-                    IssueStrictHumanFollow(player, movementTarget, desiredRange);
-                else
-                    player->GetMotionMaster()->MoveFollow(movementTarget, desiredRange, player->GetFollowAngle());
+                IssueRangedApproachMovement(player, movementTarget, desiredRange);
             }
                 break;
             case PvpClassSpellContext::MovementDirective::ReachSpellRange:
             {
                 float const desiredRange = std::max(1.0f,
                     context.movementFollowRange > 0.0f ? context.movementFollowRange : (PvpCore::GetConfig().spellRange - 1.0f));
-                if (RequiresStrictHumanPathing(player))
-                    IssueStrictHumanFollow(player, movementTarget, desiredRange);
-                else
-                    player->GetMotionMaster()->MoveFollow(movementTarget, desiredRange, player->GetFollowAngle());
+                IssueRangedApproachMovement(player, movementTarget, desiredRange);
             }
                 break;
             case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:


### PR DESCRIPTION
### Motivation

- Reduce duplicated follow/approach logic and ensure ranged approach uses appropriate motion methods (chase vs follow) and respects strict-human pathing behavior.
- Improve behavior when casting without line-of-sight or out-of-range by proactively moving into position instead of repeatedly failing.

### Description

- Add `IssueRangedApproachMovement(Player*, Unit*, float)` to encapsulate ranged approach behavior and to choose `MoveChase` for valid attack targets or `MoveFollow` otherwise, while delegating to `IssueStrictHumanFollow` when strict-human pathing is required.
- Move `maxRange` retrieval earlier in `CastDirectSpell` and use `IssueRangedApproachMovement` for LOS and out-of-range handling instead of duplicating `MoveFollow`/`IssueStrictHumanFollow` branches.
- Use `IssueRangedApproachMovement` when handling cast failures including `SPELL_FAILED_OUT_OF_RANGE` and newly `SPELL_FAILED_LINE_OF_SIGHT` to attempt to resolve positioning before failing.
- Replace several movement directive branches (`ReachMeleeRange` and `ReachSpellRange`) to call `IssueRangedApproachMovement` for consistent approach behavior.

### Testing

- Built the project with the normal build system (`make`/project build) and the build completed successfully.  
- Ran unit tests and PvP-related tests and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e131fd67788327a74dd387946dd545)