### PR TITLE
Playerbot PvP: throttle paladin Hand of Sacrifice casts

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -366,6 +366,29 @@ struct WarlockCurseCooldownKeyHash
 };
 
 std::unordered_map<WarlockCurseCooldownKey, std::chrono::steady_clock::time_point, WarlockCurseCooldownKeyHash> g_WarlockCurseTargetCooldowns;
+
+struct CasterSpellCooldownKey
+{
+    ObjectGuid casterGuid;
+    uint32 spellId = 0;
+
+    bool operator==(CasterSpellCooldownKey const& other) const
+    {
+        return casterGuid == other.casterGuid && spellId == other.spellId;
+    }
+};
+
+struct CasterSpellCooldownKeyHash
+{
+    std::size_t operator()(CasterSpellCooldownKey const& key) const
+    {
+        std::size_t const casterHash = std::hash<uint64>{}(key.casterGuid.GetRawValue());
+        std::size_t const spellHash = std::hash<uint32>{}(key.spellId);
+        return casterHash ^ (spellHash << 1);
+    }
+};
+
+std::unordered_map<CasterSpellCooldownKey, std::chrono::steady_clock::time_point, CasterSpellCooldownKeyHash> g_CasterSpellCooldowns;
 struct LastDirectiveState
 {
     playerbot::PvpClassSpellContext::MovementDirective directive = playerbot::PvpClassSpellContext::MovementDirective::None;
@@ -1070,6 +1093,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if ((context.spellId == 11719 || context.spellId == 11713) && target)
         playerbot::PvpClassActions::RegisterWarlockCurseTargetCooldown(player, target, context.spellId, std::chrono::seconds(12));
+    if (context.spellId == 6940)
+        playerbot::PvpClassActions::RegisterCasterSpellCooldown(player, context.spellId, std::chrono::seconds(10));
 
     return true;
 }
@@ -1130,6 +1155,33 @@ void PvpClassActions::RegisterWarlockCurseTargetCooldown(Player const* player, U
         return;
 
     g_WarlockCurseTargetCooldowns[{ player->GetGUID(), target->GetGUID(), spellId }] = GameTime::Now() + cooldown;
+}
+
+bool PvpClassActions::IsCasterSpellCooldownActive(Player const* player, uint32 spellId)
+{
+    if (!player || !spellId)
+        return false;
+
+    CasterSpellCooldownKey const key{ player->GetGUID(), spellId };
+    auto const itr = g_CasterSpellCooldowns.find(key);
+    if (itr == g_CasterSpellCooldowns.end())
+        return false;
+
+    if (GameTime::Now() >= itr->second)
+    {
+        g_CasterSpellCooldowns.erase(itr);
+        return false;
+    }
+
+    return true;
+}
+
+void PvpClassActions::RegisterCasterSpellCooldown(Player const* player, uint32 spellId, std::chrono::seconds cooldown)
+{
+    if (!player || !spellId || cooldown <= std::chrono::seconds::zero())
+        return;
+
+    g_CasterSpellCooldowns[{ player->GetGUID(), spellId }] = GameTime::Now() + cooldown;
 }
 
 bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& context)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
@@ -33,6 +33,8 @@ public:
     static bool Execute(Player* player, PvpClassSpellContext const& context);
     static bool IsWarlockCurseTargetCooldownActive(Player const* player, Unit const* target, uint32 spellId);
     static void RegisterWarlockCurseTargetCooldown(Player const* player, Unit const* target, uint32 spellId, std::chrono::seconds cooldown);
+    static bool IsCasterSpellCooldownActive(Player const* player, uint32 spellId);
+    static void RegisterCasterSpellCooldown(Player const* player, uint32 spellId, std::chrono::seconds cooldown);
 };
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2100,7 +2100,13 @@ SpellDecision SelectPaladinSpell(Player const* player, Unit const* target)
         { "paladin cleanse", "prioritize cleansing allies", 4987, cleanseTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, cleanseTarget ? cleanseTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, freedomTarget, 54.0f,
         { "paladin hand of freedom", "free snared or rooted ally", 1044, freedomTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, freedomTarget ? freedomTarget->GetGUID() : ObjectGuid::Empty });
-    AddDecisionCandidate(candidates, sacrificeTarget && sacrificeTarget != player && !sacrificeTarget->HasAura(6940), 53.0f,
+    AddDecisionCandidate(candidates,
+        sacrificeTarget && sacrificeTarget != player &&
+        !player->HasAura(6940) &&
+        !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, 6940) &&
+        !HasAuraFromSpellChain(sacrificeTarget, 6940) &&
+        !HasAuraFromSpellChain(sacrificeTarget, 1022) &&
+        !HasAuraFromSpellChain(sacrificeTarget, 1044), 53.0f,
         { "paladin hand of sacrifice", "keep hand of sacrifice cycling on allies", 6940, playerbot::PvpClassSpellContext::TargetMode::Ally, sacrificeTarget ? sacrificeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, CountNearbyEnemies(player, 8.0f) >= 2 && IsSpellReady(player, 26573), 52.0f,
         { "paladin consecration", "aoe pressure under close melee collapse", 26573, playerbot::PvpClassSpellContext::TargetMode::Self });


### PR DESCRIPTION
### Motivation
- Prevent paladin playerbot from repeatedly casting Hand of Sacrifice and avoid applying conflicting Hand spells on the same ally.

### Description
- Introduced a per-caster/per-spell tactical cooldown registry with `IsCasterSpellCooldownActive` and `RegisterCasterSpellCooldown` in `playerbot::PvpClassActions` (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h` and `.cpp`).
- Register a 10-second tactical cooldown after a successful Hand of Sacrifice cast in `CastDirectSpell` so the caster will not immediately reissue the same hand spell (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`).
- Updated paladin PvP spell selection to only consider `Hand of Sacrifice (6940)` when the caster is not already affected by it, the caster-side tactical cooldown for 6940 is not active, and the target does not already have Hand of Sacrifice or other hand spells (Hand of Protection / Hand of Freedom) (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`).

### Testing
- Ran `git diff --check`, which returned no issues.
- Started a `cmake --build build --target scripts -j2` build to validate compilation, but the full build is long-running and was stopped before completion, so compilation was not fully verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e157fba3d083279a16479e7d275ff3)