### PR TITLE
Add .gm bgtele command to force entry into BG/arena instances

### DIFF
--- a/src/server/scripts/Commands/cs_gm.cpp
+++ b/src/server/scripts/Commands/cs_gm.cpp
@@ -37,6 +37,8 @@ EndScriptData */
 #include "World.h"
 #include "WorldSession.h"
 
+#include <array>
+
 using namespace Trinity::ChatCommands;
 
 class gm_commandscript : public CommandScript
@@ -265,17 +267,38 @@ public:
         return true;
     }
 
-    static bool HandleGMBgTeleportCommand(ChatHandler* handler, uint32 battlegroundTypeId, Optional<uint32> arenaTypeArg)
+    static bool HandleGMBgTeleportCommand(ChatHandler* handler, uint32 battlegroundTypeOrMapId, Optional<uint32> arenaTypeArg)
     {
         Player* player = handler->GetPlayer();
         if (!player)
             return false;
 
-        BattlegroundTypeId bgTypeId = BattlegroundTypeId(battlegroundTypeId);
+        BattlegroundTypeId bgTypeId = BattlegroundTypeId(battlegroundTypeOrMapId);
+        if (!sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId))
+        {
+            static constexpr std::array<BattlegroundTypeId, 14> BgTypes =
+            {
+                BATTLEGROUND_AV, BATTLEGROUND_WS, BATTLEGROUND_AB, BATTLEGROUND_NA,
+                BATTLEGROUND_BE, BATTLEGROUND_EY, BATTLEGROUND_RL, BATTLEGROUND_SA,
+                BATTLEGROUND_DS, BATTLEGROUND_RV, BATTLEGROUND_IC, BATTLEGROUND_SCM,
+                BATTLEGROUND_TV, BATTLEGROUND_TTP
+            };
+
+            for (BattlegroundTypeId typeId : BgTypes)
+            {
+                if (Battleground* templateBg = sBattlegroundMgr->GetBattlegroundTemplate(typeId))
+                    if (templateBg->GetMapId() == battlegroundTypeOrMapId)
+                    {
+                        bgTypeId = typeId;
+                        break;
+                    }
+            }
+        }
+
         Battleground* bgTemplate = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
         if (!bgTemplate)
         {
-            handler->PSendSysMessage("Battleground template %u was not found.", battlegroundTypeId);
+            handler->PSendSysMessage("No battleground template found for value %u (expected battleground type id or map id).", battlegroundTypeOrMapId);
             handler->SetSentErrorMessage(true);
             return false;
         }
@@ -319,19 +342,20 @@ public:
         Battleground* battleground = sBattlegroundMgr->CreateNewBattleground(bgTypeId, bracketEntry, arenaType, false);
         if (!battleground)
         {
-            handler->PSendSysMessage("Could not create a battleground instance for type %u.", battlegroundTypeId);
+            handler->PSendSysMessage("Could not create a battleground instance for type %u.", bgTypeId);
             handler->SetSentErrorMessage(true);
             return false;
         }
 
-        battleground->StartBattleground();
+        // Keep this as a simple map test instance without starting a real match countdown.
+        sBattlegroundMgr->AddBattleground(battleground);
 
         player->SetBattlegroundId(battleground->GetInstanceID(), battleground->GetTypeID());
         player->SetBGTeam(player->GetTeam());
 
         sBattlegroundMgr->SendToBattleground(player, battleground->GetInstanceID(), battleground->GetTypeID());
 
-        handler->PSendSysMessage("Teleported to battleground type %u (instance %u, map %u).", battlegroundTypeId, battleground->GetInstanceID(), battleground->GetMapId());
+        handler->PSendSysMessage("Teleported to battleground map %u (bgType %u, instance %u).", battleground->GetMapId(), battleground->GetTypeID(), battleground->GetInstanceID());
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_gm.cpp
+++ b/src/server/scripts/Commands/cs_gm.cpp
@@ -25,6 +25,8 @@ EndScriptData */
 #include "ScriptMgr.h"
 #include "AccountMgr.h"
 #include "Battleground.h"
+#include "BattlegroundMgr.h"
+#include "DBCStores.h"
 #include "Chat.h"
 #include "DatabaseEnv.h"
 #include "Language.h"
@@ -52,6 +54,7 @@ public:
             { "list",       HandleGMListFullCommand,    rbac::RBAC_PERM_COMMAND_GM_LIST,        Console::Yes },
             { "visible",    HandleGMVisibleCommand,     rbac::RBAC_PERM_COMMAND_GM_VISIBLE,     Console::No },
             { "bgstart",    HandleGMBgStartCommand,     rbac::RBAC_PERM_COMMAND_GM,             Console::No },
+            { "bgtele",     HandleGMBgTeleportCommand,  rbac::RBAC_PERM_COMMAND_GM,             Console::No },
             { "on",         HandleGMOnCommand,          rbac::RBAC_PERM_COMMAND_GM,             Console::No },
             { "off",        HandleGMOffCommand,         rbac::RBAC_PERM_COMMAND_GM,             Console::No },
         };
@@ -259,6 +262,76 @@ public:
         }
 
         handler->SendSysMessage("Skipped the battleground or arena start countdown.");
+        return true;
+    }
+
+    static bool HandleGMBgTeleportCommand(ChatHandler* handler, uint32 battlegroundTypeId, Optional<uint32> arenaTypeArg)
+    {
+        Player* player = handler->GetPlayer();
+        if (!player)
+            return false;
+
+        BattlegroundTypeId bgTypeId = BattlegroundTypeId(battlegroundTypeId);
+        Battleground* bgTemplate = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
+        if (!bgTemplate)
+        {
+            handler->PSendSysMessage("Battleground template %u was not found.", battlegroundTypeId);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        uint8 arenaType = bgTemplate->isArena() ? ARENA_TYPE_2v2 : 0;
+        if (arenaTypeArg)
+            arenaType = uint8(*arenaTypeArg);
+
+        if (bgTemplate->isArena())
+        {
+            if (arenaType < ARENA_TYPE_2v2 || arenaType > ARENA_TYPE_5v5)
+            {
+                handler->SendSysMessage("Arena type must be between 2 and 5 for arena maps.");
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+        }
+        else if (arenaType != 0)
+        {
+            handler->SendSysMessage("Arena type can only be set when teleporting to an arena map.");
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        PvPDifficultyEntry const* bracketEntry = GetBattlegroundBracketByLevel(bgTemplate->GetMapId(), player->GetLevel());
+        if (!bracketEntry)
+        {
+            handler->PSendSysMessage("Could not find a PvP bracket for map %u at level %u.", bgTemplate->GetMapId(), player->GetLevel());
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (player->InBattleground())
+            player->LeaveBattleground(false);
+        else
+            player->SetBattlegroundEntryPoint();
+
+        if (player->IsInFlight())
+            player->FinishTaxiFlight();
+
+        Battleground* battleground = sBattlegroundMgr->CreateNewBattleground(bgTypeId, bracketEntry, arenaType, false);
+        if (!battleground)
+        {
+            handler->PSendSysMessage("Could not create a battleground instance for type %u.", battlegroundTypeId);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        battleground->StartBattleground();
+
+        player->SetBattlegroundId(battleground->GetInstanceID(), battleground->GetTypeID());
+        player->SetBGTeam(player->GetTeam());
+
+        sBattlegroundMgr->SendToBattleground(player, battleground->GetInstanceID(), battleground->GetTypeID());
+
+        handler->PSendSysMessage("Teleported to battleground type %u (instance %u, map %u).", battlegroundTypeId, battleground->GetInstanceID(), battleground->GetMapId());
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Provide a GM command to force-teleport a GM into a battleground or arena instance for testing maps that otherwise block direct teleports. 
- Support testing workflows (e.g. Tol'viron) by creating a proper BG/arena context instead of circumventing battleground bookkeeping.

### Description
- Added a new `gm bgtele` subcommand entry and implemented `HandleGMBgTeleportCommand` in `cs_gm.cpp` to accept a battleground type id and an optional arena size. 
- The handler resolves the battleground template, validates arena size for arena maps, finds a PvP bracket for the player's level, and creates a fresh BG/arena instance via `BattlegroundMgr::CreateNewBattleground`. 
- The code preserves BG bookkeeping by saving the entry point, leaving any current BG cleanly, setting the player's battleground id/team, starting the battleground, and teleporting the player using `BattlegroundMgr::SendToBattleground`. 
- Added necessary includes (`BattlegroundMgr.h`, `DBCStores.h`) and clear error messages for invalid input or missing templates/brackets.

### Testing
- Ran configuration with `cmake -S . -B build -G Ninja`, which completed successfully. 
- Built the `scripts` target with `cmake --build build --target scripts -j2`; `cs_gm.cpp` compiled and its object was produced, but the overall `scripts` build stopped due to an unrelated pre-existing compile error in `src/server/scripts/Custom/custom_gurubashi_arena.cpp`. 
- Verified `build/src/server/scripts/CMakeFiles/scripts.dir/Commands/cs_gm.cpp.o` exists, confirming the new command code compiles in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13424cbdc8327983fbed64936312c)