### PR TITLE
Improve playerbot melee pursuit and GM whisper diagnostics

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -291,6 +291,30 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
 }
 
+void IssueMeleeApproachMovement(Player* player, Unit* target)
+{
+    if (!player || !target)
+        return;
+
+    if (RequiresStrictHumanPathing(player))
+    {
+        // Keep melee bots close to contact range instead of orbiting around a
+        // larger follow radius (which can look like "running away" after
+        // melee openers and while continuously reissuing approach directives).
+        IssueStrictHumanFollow(player, target, 1.5f);
+        return;
+    }
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    if (player->IsValidAttackTarget(target))
+        motionMaster->MoveChase(target);
+    else
+        motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
+}
+
 bool IsCrowdControlledForAction(Player const* player)
 {
     if (!player)
@@ -1214,9 +1238,7 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         {
             case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
             {
-                float const desiredRange = std::max(1.0f,
-                    context.movementFollowRange > 0.0f ? context.movementFollowRange : (PvpCore::GetConfig().meleeRange - 1.0f));
-                IssueRangedApproachMovement(player, movementTarget, desiredRange);
+                IssueMeleeApproachMovement(player, movementTarget);
             }
                 break;
             case PvpClassSpellContext::MovementDirective::ReachSpellRange:

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -19,6 +19,7 @@
 #include "Chat.h"
 #include "GameTime.h"
 #include "MotionMaster.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
@@ -65,6 +66,34 @@ char const* ToString(playerbot::InvitationResponseType response)
     }
 }
 
+char const* ToString(playerbot::PvpClassSpellContext::MovementDirective directive)
+{
+    switch (directive)
+    {
+        case playerbot::PvpClassSpellContext::MovementDirective::ReachMeleeRange: return "reach_melee";
+        case playerbot::PvpClassSpellContext::MovementDirective::ReachSpellRange: return "reach_spell";
+        case playerbot::PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell: return "flee";
+        case playerbot::PvpClassSpellContext::MovementDirective::FaceSpellTarget: return "face_target";
+        case playerbot::PvpClassSpellContext::MovementDirective::DropInvalidTarget: return "drop_target";
+        case playerbot::PvpClassSpellContext::MovementDirective::CheckMountState: return "check_mount";
+        case playerbot::PvpClassSpellContext::MovementDirective::ResetCombatState: return "reset_combat";
+        case playerbot::PvpClassSpellContext::MovementDirective::None:
+        default: return "none";
+    }
+}
+
+char const* ToString(playerbot::PvpClassSpellContext::TargetMode mode)
+{
+    switch (mode)
+    {
+        case playerbot::PvpClassSpellContext::TargetMode::Enemy: return "enemy";
+        case playerbot::PvpClassSpellContext::TargetMode::Ally: return "ally";
+        case playerbot::PvpClassSpellContext::TargetMode::Self: return "self";
+        case playerbot::PvpClassSpellContext::TargetMode::None:
+        default: return "none";
+    }
+}
+
 std::string BuildManagedBotStatusLine(Player* bot)
 {
     if (!bot)
@@ -85,16 +114,35 @@ std::string BuildManagedBotStatusLine(Player* bot)
            << " class_action=" << (classContext.actionName ? classContext.actionName : "none")
            << " spell=" << classContext.spellId
            << " reason=" << (classContext.reason ? classContext.reason : "none")
+           << " target_mode=" << ToString(classContext.targetMode)
+           << " target_guid=" << classContext.targetGuid.ToString()
+           << " move_directive=" << ToString(classContext.movementDirective)
+           << " move_target=" << classContext.movementTargetGuid.ToString()
+           << " move_range=" << classContext.movementFollowRange
            << " lifecycle_q=" << ToString(lifecycleContext.queueOperation)
            << " lifecycle_invite=" << ToString(lifecycleContext.invitationResponse)
            << " hooks(bg=" << (hooks.battlegroundParticipationHook ? "on" : "off")
            << ",arena=" << (hooks.arenaParticipationHook ? "on" : "off") << ")"
-           << " motion=" << uint32(bot->GetMotionMaster()->GetCurrentMovementGeneratorType());
+           << " motion=" << uint32(bot->GetMotionMaster()->GetCurrentMovementGeneratorType())
+           << " pos=(" << bot->GetMapId() << ":" << bot->GetPositionX() << "," << bot->GetPositionY() << "," << bot->GetPositionZ() << ")"
+           << " o=" << bot->GetOrientation();
 
     if (Unit* victim = bot->GetVictim())
-        status << " victim=" << victim->GetName();
+        status << " victim=" << victim->GetName() << " victim_dist=" << bot->GetDistance(victim);
     else
         status << " victim=none";
+
+    if (Unit* selected = ObjectAccessor::GetUnit(*bot, bot->GetSelection()))
+    {
+        constexpr float kHalfCircleArc = 3.14159265358979323846f;
+        status << " selected=" << selected->GetName()
+               << " selected_dist=" << bot->GetDistance(selected)
+               << " in_front=" << (bot->HasInArc(kHalfCircleArc, selected) ? "yes" : "no");
+    }
+    else
+    {
+        status << " selected=none";
+    }
 
     return status.str();
 }
@@ -177,9 +225,12 @@ public:
         challenger->SendDuelCountdown(3000);
     }
 
-    void OnChat(Player* sender, uint32 /*type*/, uint32 lang, std::string& /*msg*/, Player* receiver) override
+    void OnChat(Player* sender, uint32 type, uint32 lang, std::string& /*msg*/, Player* receiver) override
     {
         if (!sender || !receiver)
+            return;
+
+        if (type != CHAT_MSG_WHISPER)
             return;
 
         if (lang == LANG_ADDON)


### PR DESCRIPTION
### Motivation

- Prevent melee playerbots (warriors/rogues) from oscillating/orbiting or appearing to run away after openers by tightening melee approach behavior. 
- Provide richer diagnostics when a GM whispers a managed playerbot so GMs can inspect the bot's current decision, movement directive and position for debugging.

### Description

- Added a dedicated melee approach routine `IssueMeleeApproachMovement` and use it for `ReachMeleeRange` directives in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`, which uses `MoveChase` for hostile targets and a tight 1.5y follow fallback for non-hostile follow and strict-pathing mode.
- Extended the GM diagnostic payload in `BuildManagedBotStatusLine` in `src/server/scripts/Playerbot/playerbot_loader.cpp` to include `target_mode`, `target_guid`, `move_directive`, `move_target`, `move_range`, motion generator, full `pos`/orientation, victim distance, selected target distance and facing status, and added helper `ToString` overloads for the new fields.
- Scoped the automatic diagnostic response to actual whispers only by checking `type == CHAT_MSG_WHISPER` in the playerbot chat hook so only GM whispers trigger the diagnostic reply.

### Testing

- Ran `git diff --check` to validate whitespace and trivial issues, which reported no problems.
- Started a full build with `cmake --build build -j2 --target game`; the build progressed and compiled many translation units without reporting immediate errors before the run was stopped due to environment constraints.
- Performed local source inspections and compilation-syntax checks on changed units (early compilation output showed no immediate syntax errors for the modified files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15b3ce2108327834c5e3c273249b8)