### PR TITLE
Fix playerbot selected target accessor compile error

### DIFF
--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -19,7 +19,6 @@
 #include "Chat.h"
 #include "GameTime.h"
 #include "MotionMaster.h"
-#include "ObjectAccessor.h"
 #include "Player.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
@@ -132,7 +131,7 @@ std::string BuildManagedBotStatusLine(Player* bot)
     else
         status << " victim=none";
 
-    if (Unit* selected = ObjectAccessor::GetUnit(*bot, bot->GetSelection()))
+    if (Unit* selected = bot->GetSelectedUnit())
     {
         constexpr float kHalfCircleArc = 3.14159265358979323846f;
         status << " selected=" << selected->GetName()


### PR DESCRIPTION
### Motivation
- The playerbot status code used `Player::GetSelection()` and `ObjectAccessor::GetUnit(...)`, which no longer matched the `Player` API and caused a compile error when building the project.

### Description
- Replace the `ObjectAccessor::GetUnit(*bot, bot->GetSelection())` call with `bot->GetSelectedUnit()` and remove the now-unused `ObjectAccessor.h` include in `src/server/scripts/Playerbot/playerbot_loader.cpp`.

### Testing
- Ran `git diff --check` and `git status --short` to validate the patch formatting and staged changes, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e160bfa61c8327b47e12285f29110f)