### PR TITLE
Improve PvP target selection and ranged spacing for playerbots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2699,6 +2699,9 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     ObjectGuid const selectedTargetGuid = SelectCombatTargetGuid(player);
     ObjectGuid activeTargetGuid = selectedTargetGuid;
     if (activeTargetGuid.IsEmpty())
+        if (Unit const* combatVictim = player->GetVictim(); HasHostileTarget(player, combatVictim))
+            activeTargetGuid = combatVictim->GetGUID();
+    if (activeTargetGuid.IsEmpty())
         if (Unit const* fallbackTarget = SelectClosestEnemyTarget(player, true))
             activeTargetGuid = fallbackTarget->GetGUID();
 
@@ -2912,6 +2915,21 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, spacingTarget->GetGUID(),
                     std::max(1.0f, GetConfiguredCloseRange()), "flee", "selected spell minimum range violation", 84.0f);
+                context.spellId = 0;
+                context.itemEntry = 0;
+                context.targetMode = PvpClassSpellContext::TargetMode::None;
+                context.targetGuid = ObjectGuid::Empty;
+                context.selfCast = false;
+            }
+            else if (context.targetMode == PvpClassSpellContext::TargetMode::Enemy &&
+                distance > (GetConfiguredSpellRange() + kRangedSpacingEnterOutOfRangeBuffer))
+            {
+                // Some classic spell entries report atypical range metadata,
+                // which can leave ranged bots idling at ~35-40y while still
+                // selecting enemy casts. Keep a config-based engage floor so
+                // they always step in to practical casting distance.
+                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
+                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy outside configured cast distance", 82.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;


### PR DESCRIPTION
### Motivation
- Ensure playerbots have a reliable active target when `SelectCombatTargetGuid` returns empty by falling back to the current combat victim.
- Prevent ranged bots from idling at impractical distances due to incorrect or atypical classic spell range metadata by enforcing a configurable engage floor.
- Provide movement directives that match trigger-like behavior so bots consistently move to useful casting distance while preserving classic spell IDs.

### Description
- If no `selectedTargetGuid` is chosen, set `activeTargetGuid` from `player->GetVictim()` when `HasHostileTarget` is true so bots will engage their current combat victim.
- Add a spacing check in the spell-range branch that, when `context.targetMode == PvpClassSpellContext::TargetMode::Enemy` and the distance exceeds `GetConfiguredSpellRange() + kRangedSpacingEnterOutOfRangeBuffer`, issues a `ReachSpellRange` movement directive and clears the planned cast (resetting `spellId`, `itemEntry`, `targetMode`, `targetGuid`, and `selfCast`).
- Leave existing classic spell range behavior intact and keep the separate movement-directive logic that applies when no castable spell is selected.

### Testing
- Performed a full project build (`cmake`/`make`) which completed successfully.
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e158a1b224832782dae4e8b5762f01)