### PR TITLE
Fix Hand of Freedom apply crash when caster is missing

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -2434,13 +2434,11 @@ class spell_pal_hand_of_freedom : public AuraScript
     {
         Unit* caster = GetCaster();
         Unit* target = GetTarget();
-        if (caster->HasAura(SPELL_PALADIN_IMP_HAND_OF_FREEDOM))
-        {
-            if (caster->GetGUID() != target->GetGUID())
-            {
-                caster->CastSpell(caster, SPELL_PALADIN_LESSER_HAND_OF_FREEDOM);
-            }
-        }
+        if (!caster || !target)
+            return;
+
+        if (caster->HasAura(SPELL_PALADIN_IMP_HAND_OF_FREEDOM) && caster->GetGUID() != target->GetGUID())
+            caster->CastSpell(caster, SPELL_PALADIN_LESSER_HAND_OF_FREEDOM);
     }
 
     void Register() override


### PR DESCRIPTION
### Motivation
- Prevent a null-dereference crash occurring during aura application (e.g. login-time aura restoration) when the original caster is unavailable by guarding the `HandleApply` path.

### Description
- Add null checks for `GetCaster()` and `GetTarget()` and simplify the condition in `spell_pal_hand_of_freedom::HandleApply` so the spell cast only occurs when both units are valid and different (`src/server/scripts/Spells/spell_paladin.cpp`).

### Testing
- Ran `cmake --build build --target game -- -j2`, which started a full build and compiled deep into the tree (build initiated successfully but did not finish within the interactive run window), and no compilation errors were reported for the modified translation unit during the observed build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e165d2709483278acb7c5c772f0709)