### PR TITLE
playerbots: restore warrior gap-closers and add low-mana fallback / melee-fallback behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -165,6 +165,26 @@ bool IsClassSpellGateEnabled(playerbot::PvpCoreConfig const& config)
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpClassSpellsEnabled;
 }
 
+bool IsLowOrOutOfManaForFallback(Player const* player)
+{
+    if (!player || player->GetPowerType() != POWER_MANA)
+        return false;
+
+    return player->GetPowerPct(POWER_MANA) <= 10.0f || player->GetPower(POWER_MANA) < 250;
+}
+
+bool HasWandEquipped(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Item const* ranged = player->GetWeaponForAttack(RANGED_ATTACK, true);
+    if (!ranged || !ranged->GetTemplate())
+        return false;
+
+    return ranged->GetTemplate()->SubClass == ITEM_SUBCLASS_WEAPON_WAND;
+}
+
 bool IsFlagCarrierNear(Player const* player, ObjectGuid const& carrierGuid, float maxDistance)
 {
     if (!player || carrierGuid.IsEmpty())
@@ -2029,6 +2049,8 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
         { "priest shadow word pain", "fallback pressure on non-breakable crowd-controlled or open targets", 27605, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, controlledTarget && !HasAuraFromSpellChain(controlledTarget, 27605), 18.0f,
         { "priest shadow word pain", "fallback pressure on non-breakable crowd-controlled targets", 27605, playerbot::PvpClassSpellContext::TargetMode::Enemy, controlledTarget ? controlledTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates, hasHostileTarget && target && IsLowOrOutOfManaForFallback(player) && HasWandEquipped(player) && IsSpellReady(player, 5019), 18.5f,
+        { "priest shoot wand", "fallback to wand pressure while low on mana", 5019, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, IsSpellReady(player, 10917) && player->HealthBelowPct(85), 17.0f,
         { "priest flash heal", "fallback self-healing while under pressure", 10917, playerbot::PvpClassSpellContext::TargetMode::Self });
 
@@ -2120,6 +2142,8 @@ SpellDecision SelectPaladinSpell(Player const* player, Unit const* target)
         { "paladin flash of light", "heal injured allies efficiently", 19943, flashHealTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, flashHealTarget ? flashHealTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, holyLightTarget, 47.0f,
         { "paladin holy light", "large heal for heavily injured ally", 635, holyLightTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, holyLightTarget ? holyLightTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates, executeTarget && IsSpellReady(player, 20271), 46.0f,
+        { "paladin judgement", "default offensive pressure when healing is not required", 20271, playerbot::PvpClassSpellContext::TargetMode::Enemy, executeTarget ? executeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !player->HasAura(19746) && IsSpellReady(player, 19746), 20.0f,
         { "paladin concentration aura", "maintain concentration aura", 19746, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, !player->IsInCombat() && !player->HasAura(25898) && IsSpellReady(player, 25898), 19.0f,
@@ -2174,6 +2198,8 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
         { "warlock death coil", "peel melee or finish low enemy target", 17926, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, player->GetPower(POWER_MANA) < 400 && IsSpellReady(player, 11689), 32.0f,
         { "warlock life tap", "convert health to mana for sustained casting", 11689, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, IsLowOrOutOfManaForFallback(player) && HasWandEquipped(player) && IsSpellReady(player, 5019), 31.5f,
+        { "warlock shoot wand", "fallback to wand pressure while low on mana", 5019, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, player->HasAura(17941) && IsSpellReady(player, 25307), 20.0f,
         { "warlock shadow bolt", "consume nightfall proc for instant pressure", 25307, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, IsSpellReady(player, 25307), 19.0f,
@@ -2346,7 +2372,12 @@ SpellDecision SelectClassicClassSpell(Player const* player, Unit const* target, 
     case CLASS_HUNTER:
         return SelectHunterSpell(player, target, inMelee);
     case CLASS_MAGE:
-        return SelectMageSpell(player, target, inMelee);
+    {
+        SpellDecision mageDecision = SelectMageSpell(player, target, inMelee);
+        if (!mageDecision.spellId && HasHostileTarget(player, target) && IsLowOrOutOfManaForFallback(player) && HasWandEquipped(player) && IsSpellReady(player, 5019))
+            return { "mage shoot wand", "fallback to wand pressure while low on mana", 5019, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+        return mageDecision;
+    }
     case CLASS_PRIEST:
         return SelectPriestSpell(player, target, allyTarget, profileSelection);
     case CLASS_PALADIN:
@@ -2865,7 +2896,8 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     if (context.spellId && context.targetMode == PvpClassSpellContext::TargetMode::Enemy && IsPrimaryMeleeClassForSpacing(player->GetClass()))
     {
         Unit const* meleeTarget = resolveTargetByGuid(context.targetGuid);
-        if (meleeTarget && !player->IsWithinMeleeRange(meleeTarget))
+        bool const isGapCloser = context.spellId == 11578 || context.spellId == 20617;
+        if (meleeTarget && !player->IsWithinMeleeRange(meleeTarget) && !isGapCloser)
         {
             ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, meleeTarget->GetGUID(),
                 std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "enemy out of melee", 85.0f);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1378,6 +1378,17 @@ bool IsActivelyPressuringInMelee(Unit const* attacker, Player const* bot)
     return attacker->IsWithinMeleeRange(bot) || bot->IsWithinMeleeRange(attacker);
 }
 
+bool ShouldForceMeleeFallbackOnLowMana(Player const* player)
+{
+    if (!player || player->GetPowerType() != POWER_MANA)
+        return false;
+
+    if (player->GetClass() != CLASS_SHAMAN && player->GetClass() != CLASS_PALADIN)
+        return false;
+
+    return player->GetPowerPct(POWER_MANA) <= 10.0f || player->GetPower(POWER_MANA) < 250;
+}
+
 struct CombatPositioningProfile
 {
     float preferredMinRange = 0.0f;
@@ -1996,6 +2007,14 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
     if (profile.primarilyRanged)
     {
+        if (ShouldForceMeleeFallbackOnLowMana(player))
+        {
+            if (!CanIssueMovementCommand(player, 500))
+                return true;
+
+            return MoveTowardUnit(player, target, std::max(1.0f, playerbot::PvpCore::GetConfig().meleeRange - 1.0f));
+        }
+
         if (player->GetClass() == CLASS_HUNTER)
         {
             uint32 const nowMs = GameTime::GetGameTimeMS();


### PR DESCRIPTION
### Motivation
- Fix warrior bots that were not using `Charge`/`Intercept` when available by preventing those gap-closer spells from being pruned by melee-spacing logic.
- Make healers and casters continue to act when out of primary healing/casting work or low on mana by providing offensive fallbacks and wand usage.
- Ensure hybrid casters (shaman/paladin) close to melee and rely on auto-attacks when low on mana instead of idling.

### Description
- Added low-mana and wand helpers `IsLowOrOutOfManaForFallback` and `HasWandEquipped` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and used them to add wand-fallback decisions (spell `5019`) for `Mage`, `Priest`, and `Warlock` when low on mana.
- Restored warrior gap-closer behaviour by exempting `Charge (11578)` and `Intercept (20617)` from the melee-range spacing pruning so those gap-closers can be executed even when out of melee range, implemented in the class-spell context selection (`PlayerbotPvpCore.cpp`).
- Added offensive fallback for paladin healers by adding a `Judgement (20271)` decision so paladin healers use an offensive action when healing is not required (`PlayerbotPvpCore.cpp`).
- Added `ShouldForceMeleeFallbackOnLowMana` and a combat-positioning override in `DriveCombatPositioning` (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`) so low-mana `Shaman`/`Paladin` close the gap and rely on melee/auto-attacks instead of standing idle.
- Small safety/spacing change: when building cast context, gap-closer spells are detected and skipped from being converted into movement directives so they can be cast as intended (`PlayerbotPvpCore.cpp`).
- Files changed: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.

### Testing
- Started a script-target build with `cmake --build build --target scripts -j4` to validate compile of modified scripts; the build was launched successfully but the full target is large and did not complete within this run.
- No automated unit test suites were run in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e163d2f1248327a1cf125f742a491d)