### PR TITLE
Recover stale battleground queue slots, mass-enqueue managed bots, and throttle human-interest rebalances

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -74,12 +74,14 @@ constexpr uint32 PLAYERBOT_BG_OVERSTACK_MIN_DIFF = 2;
 constexpr uint32 PLAYERBOT_BG_OVERSTACK_REQUEUE_COOLDOWN_MS = 30000;
 constexpr uint32 PLAYERBOT_BG_OVERSTACK_INSTANCE_DEPARTURE_SPACING_MS = 8000;
 constexpr uint32 PLAYERBOT_BG_OVERSTACK_INSTANCE_JITTER_WINDOW_MS = 14000;
+constexpr uint32 PLAYERBOT_BG_HUMAN_INTEREST_REBALANCE_THROTTLE_MS = 5000;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
 constexpr uint32 SPELL_DESERTER = 26013;
 std::unordered_map<uint64, uint32> g_BattlegroundOverstackRequeueCooldownUntilMsByGuid;
 std::unordered_map<uint64, uint32> g_BattlegroundOverstackInstanceNextDepartureMsByInstance;
+uint32 g_LastHumanInterestPopulationRebalanceAttemptMs = 0;
 uint64 BuildBattlegroundInstanceKey(Battleground const* battleground);
 
 uint32 ComputeOverstackDepartureJitterMs(Player const* player, Battleground const* battleground)
@@ -942,6 +944,26 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
     if (!bgTemplate)
         return false;
 
+    // Recover stale local queue slot state before evaluating queue eligibility.
+    // Managed bots can occasionally keep orphaned queue ids after lifecycle
+    // transitions, which blocks HasFreeBattlegroundQueueId() and prevents
+    // requeueing after subsequent battlegrounds.
+    for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+    {
+        BattlegroundQueueTypeId const existingQueueTypeId = player->GetBattlegroundQueueTypeId(i);
+        if (existingQueueTypeId == BATTLEGROUND_QUEUE_NONE)
+            continue;
+
+        BattlegroundQueue& existingQueue = sBattlegroundMgr->GetBattlegroundQueue(existingQueueTypeId);
+        GroupQueueInfo ginfo{};
+        if (existingQueue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
+            continue;
+
+        player->RemoveBattlegroundQueueId(existingQueueTypeId);
+        EmitLifecycleDiagnostic(player, "queue-prune-stale-slot",
+            "Removed stale queueTypeId=" + std::to_string(uint32(existingQueueTypeId)));
+    }
+
     // Managed random bots can run on disconnected virtual sessions where RBAC
     // battleground permissions are not always populated like live client sessions.
     // Gate queue eligibility by battleground level + free queue slots instead.
@@ -1641,6 +1663,37 @@ bool HasAnyRealHumanInterestInBattleground(BattlegroundTypeId targetBgType)
     return false;
 }
 
+uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint8 arenaType)
+{
+    std::vector<ObjectGuid> managedBotGuids;
+    {
+        std::shared_lock<std::shared_mutex> lock(*HashMapHolder<Player>::GetLock());
+        for (auto const& [guid, participant] : ObjectAccessor::GetPlayers())
+        {
+            if (!participant || !participant->IsInWorld())
+                continue;
+
+            if (!playerbot::IsManagedRandomBot(participant))
+                continue;
+
+            managedBotGuids.push_back(guid);
+        }
+    }
+
+    uint32 queuedCount = 0;
+    for (ObjectGuid const& guid : managedBotGuids)
+    {
+        Player* managedBot = ObjectAccessor::FindConnectedPlayer(guid);
+        if (!managedBot)
+            continue;
+
+        if (QueuePlayer(managedBot, bgTypeId, arenaType))
+            ++queuedCount;
+    }
+
+    return queuedCount;
+}
+
 void FinalizeVirtualBotTeleportIfPending(Player* player)
 {
     if (!player)
@@ -2250,14 +2303,34 @@ bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
         return false;
 
     constexpr BattlegroundTypeId kManagedBattleground = BATTLEGROUND_SCM;
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    bool const hasHumanInterest = HasAnyRealHumanInterestInBattleground(kManagedBattleground);
 
-    if (!HasAnyRealHumanInterestInBattleground(kManagedBattleground))
+    if (!hasHumanInterest)
     {
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle queue join suppressed due to no real human interest: guid={} bgTypeId={}.",
+            "Playerbot PvP lifecycle queue join proceeding without explicit real human interest: guid={} bgTypeId={}.",
             player->GetGUID().ToString(), uint32(kManagedBattleground));
-        return false;
     }
+
+    // When real human interest exists (especially right after startup), force
+    // an immediate population rebalance so additional managed bots can log in.
+    if (hasHumanInterest &&
+        nowMs >= g_LastHumanInterestPopulationRebalanceAttemptMs + PLAYERBOT_BG_HUMAN_INTEREST_REBALANCE_THROTTLE_MS)
+    {
+        g_LastHumanInterestPopulationRebalanceAttemptMs = nowMs;
+        bool const rebalanceTriggered = RandomBotParticipationManager::TriggerImmediateRebalance();
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle human-interest rebalance: guid={} bgTypeId={} triggered={}.",
+            player->GetGUID().ToString(), uint32(kManagedBattleground), rebalanceTriggered ? 1 : 0);
+    }
+
+    uint32 const massQueued = QueueEligibleManagedBotsForBattleground(kManagedBattleground, 0);
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP lifecycle mass queue attempt: guid={} bgTypeId={} queuedCount={}.",
+        player->GetGUID().ToString(), uint32(kManagedBattleground), massQueued);
+    if (massQueued > 0)
+        return true;
 
     return QueuePlayer(player, kManagedBattleground, 0);
 }


### PR DESCRIPTION
### Motivation
- Prevent managed bots from getting permanently blocked by orphaned local battleground queue ids and improve their ability to requeue.
- Allow managed bots to join queues even when no real human players are currently interested, while enabling an immediate population rebalance when human interest appears.

### Description
- Added cleanup in `QueuePlayer` to prune stale local queue slots by checking `BattlegroundQueue::GetPlayerGroupInfoData` and removing orphaned queue ids, with a lifecycle diagnostic emitted via `EmitLifecycleDiagnostic`.
- Introduced `PLAYERBOT_BG_HUMAN_INTEREST_REBALANCE_THROTTLE_MS` and `g_LastHumanInterestPopulationRebalanceAttemptMs` to throttle immediate rebalance attempts triggered by human interest.
- Added `QueueEligibleManagedBotsForBattleground` to collect and enqueue eligible managed bots en masse, and integrated it into `JoinQueuePrimitive` to attempt mass-queueing before queueing the individual bot.
- Modified `JoinQueuePrimitive` to trigger a throttled immediate rebalance when human interest is observed, to log lifecycle events differently, and to allow queue joins (via mass enqueue) even when no real human interest exists.

### Testing
- Project compiled successfully (`cmake`/`make`).
- Automated unit test suite covering PvP lifecycle and queueing was executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1512ddcd08327a6d78bc44dac386d)