### PR TITLE
Make Overpower ignore armor when attacker has aura 81413

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1711,6 +1711,22 @@ void Unit::HandleEmoteCommand(Emote emoteId)
                 armor = std::floor(AddPct(armor, -aurEff->GetAmount()));
         }
 
+        // Custom: if a warrior has aura 81413, Overpower bypasses all armor.
+        if (spellInfo && attacker->GetTypeId() == TYPEID_PLAYER && attacker->HasAura(81413))
+        {
+            switch (spellInfo->Id)
+            {
+                case 7384:   // Overpower (Rank 1)
+                case 7887:   // Overpower (Rank 2)
+                case 11584:  // Overpower (Rank 3)
+                case 11585:  // Overpower (Rank 4)
+                    armor = 0.0f;
+                    break;
+                default:
+                    break;
+            }
+        }
+
         // Apply Player CR_ARMOR_PENETRATION rating and buffs from stances\specializations etc.
         if (attacker->GetTypeId() == TYPEID_PLAYER)
         {


### PR DESCRIPTION
### Motivation
- Provide a gameplay hook so that when a warrior has aura `81413`, their Overpower attacks bypass all target armor mitigation for that hit.

### Description
- Added a conditional in `Unit::CalcArmorReducedDamage` to detect if the `attacker` is a player with aura `81413` and the `spellInfo->Id` matches Overpower (`7384`, `7887`, `11584`, `11585`), and force `armor = 0.0f` for mitigation calculation.
- The change is implemented in `src/server/game/Entities/Unit/Unit.cpp` and only affects physical damage mitigation path when the attacker is a player and the spell is one of the Overpower ranks.

### Testing
- Ran `git diff --check` which reported no issues. 
- Change was committed to the repository (`src/server/game/Entities/Unit/Unit.cpp`) after verification of the diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16a2a83a083278a519d51e4a840b0)