### PR TITLE
Add wand fallback and low-mana melee fallback for PvP bots; respect gap-closers when spacing

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -165,6 +165,26 @@ bool IsClassSpellGateEnabled(playerbot::PvpCoreConfig const& config)
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpClassSpellsEnabled;
 }
 
+bool IsLowOrOutOfManaForFallback(Player const* player)
+{
+    if (!player || player->GetPowerType() != POWER_MANA)
+        return false;
+
+    return player->GetPowerPct(POWER_MANA) <= 10.0f || player->GetPower(POWER_MANA) < 250;
+}
+
+bool HasWandEquipped(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Item const* ranged = player->GetWeaponForAttack(RANGED_ATTACK, true);
+    if (!ranged || !ranged->GetTemplate())
+        return false;
+
+    return ranged->GetTemplate()->SubClass == ITEM_SUBCLASS_WEAPON_WAND;
+}
+
 bool IsFlagCarrierNear(Player const* player, ObjectGuid const& carrierGuid, float maxDistance)
 {
     if (!player || carrierGuid.IsEmpty())
@@ -2029,8 +2049,12 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
         { "priest shadow word pain", "fallback pressure on non-breakable crowd-controlled or open targets", 27605, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, controlledTarget && !HasAuraFromSpellChain(controlledTarget, 27605), 18.0f,
         { "priest shadow word pain", "fallback pressure on non-breakable crowd-controlled targets", 27605, playerbot::PvpClassSpellContext::TargetMode::Enemy, controlledTarget ? controlledTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates, hasHostileTarget && target && IsLowOrOutOfManaForFallback(player) && HasWandEquipped(player) && IsSpellReady(player, 5019), 18.5f,
+        { "priest shoot wand", "fallback to wand pressure while low on mana", 5019, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, IsSpellReady(player, 10917) && player->HealthBelowPct(85), 17.0f,
         { "priest flash heal", "fallback self-healing while under pressure", 10917, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, hasHostileTarget && target && !HasBreakableCrowdControl(target) && HasWandEquipped(player) && IsSpellReady(player, 5019), 8.0f,
+        { "priest shoot wand", "default offensive fallback when no better priest action is available", 5019, playerbot::PvpClassSpellContext::TargetMode::Enemy });
 
     return SelectHighestPriorityCastableDecision(candidates, player, target, allyTarget);
 }
@@ -2120,6 +2144,8 @@ SpellDecision SelectPaladinSpell(Player const* player, Unit const* target)
         { "paladin flash of light", "heal injured allies efficiently", 19943, flashHealTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, flashHealTarget ? flashHealTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, holyLightTarget, 47.0f,
         { "paladin holy light", "large heal for heavily injured ally", 635, holyLightTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, holyLightTarget ? holyLightTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates, executeTarget && IsSpellReady(player, 20271), 46.0f,
+        { "paladin judgement", "default offensive pressure when healing is not required", 20271, playerbot::PvpClassSpellContext::TargetMode::Enemy, executeTarget ? executeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !player->HasAura(19746) && IsSpellReady(player, 19746), 20.0f,
         { "paladin concentration aura", "maintain concentration aura", 19746, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, !player->IsInCombat() && !player->HasAura(25898) && IsSpellReady(player, 25898), 19.0f,
@@ -2174,10 +2200,14 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
         { "warlock death coil", "peel melee or finish low enemy target", 17926, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, player->GetPower(POWER_MANA) < 400 && IsSpellReady(player, 11689), 32.0f,
         { "warlock life tap", "convert health to mana for sustained casting", 11689, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, IsLowOrOutOfManaForFallback(player) && HasWandEquipped(player) && IsSpellReady(player, 5019), 31.5f,
+        { "warlock shoot wand", "fallback to wand pressure while low on mana", 5019, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, player->HasAura(17941) && IsSpellReady(player, 25307), 20.0f,
         { "warlock shadow bolt", "consume nightfall proc for instant pressure", 25307, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, IsSpellReady(player, 25307), 19.0f,
         { "warlock shadow bolt", "default ranged pressure", 25307, playerbot::PvpClassSpellContext::TargetMode::Enemy });
+    AddDecisionCandidate(candidates, HasHostileTarget(player, target) && target && !HasBreakableCrowdControl(target) && HasWandEquipped(player) && IsSpellReady(player, 5019), 8.0f,
+        { "warlock shoot wand", "default offensive fallback when no better warlock action is available", 5019, playerbot::PvpClassSpellContext::TargetMode::Enemy });
 
     return SelectHighestPriorityCastableDecision(candidates, player, target, nullptr);
 }
@@ -2346,7 +2376,12 @@ SpellDecision SelectClassicClassSpell(Player const* player, Unit const* target, 
     case CLASS_HUNTER:
         return SelectHunterSpell(player, target, inMelee);
     case CLASS_MAGE:
-        return SelectMageSpell(player, target, inMelee);
+    {
+        SpellDecision mageDecision = SelectMageSpell(player, target, inMelee);
+        if (!mageDecision.spellId && HasHostileTarget(player, target) && IsLowOrOutOfManaForFallback(player) && HasWandEquipped(player) && IsSpellReady(player, 5019))
+            return { "mage shoot wand", "fallback to wand pressure while low on mana", 5019, playerbot::PvpClassSpellContext::TargetMode::Enemy };
+        return mageDecision;
+    }
     case CLASS_PRIEST:
         return SelectPriestSpell(player, target, allyTarget, profileSelection);
     case CLASS_PALADIN:
@@ -2865,7 +2900,8 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     if (context.spellId && context.targetMode == PvpClassSpellContext::TargetMode::Enemy && IsPrimaryMeleeClassForSpacing(player->GetClass()))
     {
         Unit const* meleeTarget = resolveTargetByGuid(context.targetGuid);
-        if (meleeTarget && !player->IsWithinMeleeRange(meleeTarget))
+        bool const isGapCloser = context.spellId == 11578 || context.spellId == 20617;
+        if (meleeTarget && !player->IsWithinMeleeRange(meleeTarget) && !isGapCloser)
         {
             ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, meleeTarget->GetGUID(),
                 std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "enemy out of melee", 85.0f);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1378,6 +1378,17 @@ bool IsActivelyPressuringInMelee(Unit const* attacker, Player const* bot)
     return attacker->IsWithinMeleeRange(bot) || bot->IsWithinMeleeRange(attacker);
 }
 
+bool ShouldForceMeleeFallbackOnLowMana(Player const* player)
+{
+    if (!player || player->GetPowerType() != POWER_MANA)
+        return false;
+
+    if (player->GetClass() != CLASS_SHAMAN && player->GetClass() != CLASS_PALADIN)
+        return false;
+
+    return player->GetPowerPct(POWER_MANA) <= 10.0f || player->GetPower(POWER_MANA) < 250;
+}
+
 struct CombatPositioningProfile
 {
     float preferredMinRange = 0.0f;
@@ -1996,6 +2007,14 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
     if (profile.primarilyRanged)
     {
+        if (ShouldForceMeleeFallbackOnLowMana(player))
+        {
+            if (!CanIssueMovementCommand(player, 500))
+                return true;
+
+            return MoveTowardUnit(player, target, std::max(1.0f, playerbot::PvpCore::GetConfig().meleeRange - 1.0f));
+        }
+
         if (player->GetClass() == CLASS_HUNTER)
         {
             uint32 const nowMs = GameTime::GetGameTimeMS();


### PR DESCRIPTION
### Motivation

- Allow caster bots to fall back to wand attacks when low or nearly out of mana so they can continue to pressure without consuming mana.
- Ensure ranged healers (Shaman/Paladin) will close to melee fallback when mana is critically low to continue contributing rather than staying out of range.
- Avoid forcing movement to reach melee range when the selected spell is a gap-closer so bots don't unnecessarily cancel casts or movement.

### Description

- Added helper functions `IsLowOrOutOfManaForFallback` and `HasWandEquipped` to detect low-mana and wand availability for fallback logic. 
- Added `ShouldForceMeleeFallbackOnLowMana` and used it in `DriveCombatPositioning` to move ranged healers into melee fallback range when low on mana. 
- Inserted wand-fallback decision candidates for Priest and Warlock spell selection, and added a default low-priority wand fallback for those classes when no better action exists. 
- Modified Mage selection to return a wand-fallback decision if no mage spell was selected and the bot is low on mana with a wand equipped. 
- Added a paladin offensive fallback decision (`judgement` id `20271`) to use when healing is not required. 
- In `BuildClassSpellContext` changed melee spacing logic to avoid forcing movement when the selected spell is a known gap-closer (`11578`, `20617`). 

### Testing

- Performed a full project build with `cmake --build .` which completed successfully. 
- Ran automated test suite with `ctest` and the tests passed with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e163d2f1248327a1cf125f742a491d)