### PR TITLE
Playerbot PvP: block queue joins and end matches when no real human interest

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -2328,8 +2328,9 @@ bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!hasHumanInterest)
     {
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle queue join proceeding without explicit real human interest: guid={} bgTypeId={}.",
+            "Playerbot PvP lifecycle queue join blocked: no real human interest detected: guid={} bgTypeId={}.",
             player->GetGUID().ToString(), uint32(kManagedBattleground));
+        return false;
     }
 
     // When real human interest exists (especially right after startup), force
@@ -2397,6 +2398,16 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     {
         ForceHoldPlayerAtStartDuringWaitJoin(player);
 
+        if (!HasAnyRealHumanInterestInBattleground(battleground->GetTypeID()))
+        {
+            battleground->EndBattleground(PVP_TEAM_NEUTRAL);
+            g_BattlegroundNoHumanSinceMsByInstance.erase(BuildBattlegroundInstanceKey(battleground));
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP lifecycle wait-join end due to no real human battleground interest: guid={} bgTypeId={} instanceId={}.",
+                player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+            return true;
+        }
+
         uint64 const battlegroundInstanceKey = BuildBattlegroundInstanceKey(battleground);
         if (!BattlegroundHasAnyRealHumanPlayers(player))
         {
@@ -2454,6 +2465,16 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     // shutdown treats any non-virtual session as human, so these matches can
     // persist indefinitely after real humans leave.
     uint64 const battlegroundInstanceKey = BuildBattlegroundInstanceKey(battleground);
+    if (!HasAnyRealHumanInterestInBattleground(battleground->GetTypeID()))
+    {
+        battleground->EndBattleground(PVP_TEAM_NEUTRAL);
+        g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle end due to no real human battleground interest: guid={} bgTypeId={} instanceId={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+        return true;
+    }
+
     if (!BattlegroundHasAnyRealHumanPlayers(player))
     {
         uint32 const nowMs = GameTime::GetGameTimeMS();


### PR DESCRIPTION
### Motivation
- Prevent managed playerbots from joining battleground queues when there is no real human interest in that battleground type to avoid unnecessary population and matches.
- Ensure ongoing battlegrounds (both `STATUS_WAIT_JOIN` and `STATUS_IN_PROGRESS`) are terminated promptly if there is no human interest for that battleground type so resources and bot slots are reclaimed.

### Description
- Updated `BattlegroundLifecycleActions::JoinQueuePrimitive` to block queue joins and return `false` when `HasAnyRealHumanInterestInBattleground` reports no human interest, and changed the debug log to indicate the join is blocked.
- Added early-exit checks in `BattlegroundLifecycleActions::HandleInProgressStatusPrimitive` to call `battleground->EndBattleground(PVP_TEAM_NEUTRAL)` and erase instance tracking via `g_BattlegroundNoHumanSinceMsByInstance` when `HasAnyRealHumanInterestInBattleground` is false for the battleground type, with debug logging; this is applied in both the `STATUS_WAIT_JOIN` and the `STATUS_IN_PROGRESS` paths.
- Preserved existing timing-based fallbacks that end matches when no real human players are present, while adding the stronger gate based on overall human interest by battleground type.

### Testing
- Performed a full project build using the usual CMake/make workflow and the build completed successfully.
- Executed automated unit/integration tests via `ctest`/`make test` and observed all tests pass. 
- No new automated tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e17a97cddc832783bc50554f8ef753)