### PR TITLE
Only queue managed bots for battlegrounds with real human interest; add detection and rebalance logic

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -2328,8 +2328,9 @@ bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!hasHumanInterest)
     {
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP lifecycle queue join proceeding without explicit real human interest: guid={} bgTypeId={}.",
+            "Playerbot PvP lifecycle queue join blocked: no real human interest detected: guid={} bgTypeId={}.",
             player->GetGUID().ToString(), uint32(kManagedBattleground));
+        return false;
     }
 
     // When real human interest exists (especially right after startup), force
@@ -2397,6 +2398,16 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     {
         ForceHoldPlayerAtStartDuringWaitJoin(player);
 
+        if (!HasAnyRealHumanInterestInBattleground(battleground->GetTypeID()))
+        {
+            battleground->EndBattleground(PVP_TEAM_NEUTRAL);
+            g_BattlegroundNoHumanSinceMsByInstance.erase(BuildBattlegroundInstanceKey(battleground));
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP lifecycle wait-join end due to no real human battleground interest: guid={} bgTypeId={} instanceId={}.",
+                player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+            return true;
+        }
+
         uint64 const battlegroundInstanceKey = BuildBattlegroundInstanceKey(battleground);
         if (!BattlegroundHasAnyRealHumanPlayers(player))
         {
@@ -2454,6 +2465,16 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     // shutdown treats any non-virtual session as human, so these matches can
     // persist indefinitely after real humans leave.
     uint64 const battlegroundInstanceKey = BuildBattlegroundInstanceKey(battleground);
+    if (!HasAnyRealHumanInterestInBattleground(battleground->GetTypeID()))
+    {
+        battleground->EndBattleground(PVP_TEAM_NEUTRAL);
+        g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP lifecycle end due to no real human battleground interest: guid={} bgTypeId={} instanceId={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID());
+        return true;
+    }
+
     if (!BattlegroundHasAnyRealHumanPlayers(player))
     {
         uint32 const nowMs = GameTime::GetGameTimeMS();

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -23,6 +23,7 @@
 
 #include "AccountMgr.h"
 #include "Battleground.h"
+#include "BattlegroundMgr.h"
 #include "Configuration/Config.h"
 #include "CharacterCache.h"
 #include "Chat.h"
@@ -529,6 +530,37 @@ struct OnlineRandomBotMetrics
     std::vector<ObjectGuid> guids;
 };
 
+bool HasAnyRealHumanInterestInBattleground(BattlegroundTypeId targetBgType)
+{
+    if (targetBgType == BATTLEGROUND_TYPE_NONE)
+        return false;
+
+    BattlegroundQueueTypeId const targetQueueType = BattlegroundMgr::BGQueueTypeId(targetBgType, 0);
+
+    std::shared_lock<std::shared_mutex> lock(*HashMapHolder<Player>::GetLock());
+    for (auto const& [guid, participant] : ObjectAccessor::GetPlayers())
+    {
+        if (!participant)
+            continue;
+
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (isVirtualSession || IsManagedRandomBot(participant))
+            continue;
+
+        if (participant->InBattleground() && participant->GetBattlegroundTypeId() == targetBgType)
+            return true;
+
+        for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+        {
+            if (participant->GetBattlegroundQueueTypeId(i) == targetQueueType)
+                return true;
+        }
+    }
+
+    return false;
+}
+
 OnlineRandomBotMetrics CollectOnlineRandomBotMetrics(std::unordered_set<uint32> const& botAccounts)
 {
     OnlineRandomBotMetrics metrics;
@@ -838,6 +870,17 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
     {
         uint64 const span = static_cast<uint64>(state.config.targetMax - state.config.targetMin + 1);
         target = state.config.targetMin + static_cast<uint32>(state.rebalanceEpoch % span);
+    }
+
+    constexpr BattlegroundTypeId kManagedBattleground = BATTLEGROUND_SCM;
+    if (HasAnyRealHumanInterestInBattleground(kManagedBattleground))
+    {
+        if (Battleground* battlegroundTemplate = sBattlegroundMgr->GetBattlegroundTemplate(kManagedBattleground))
+        {
+            uint32 const fillTarget = battlegroundTemplate->GetMaxPlayersPerTeam() * 2u;
+            if (fillTarget > target)
+                target = fillTarget;
+        }
     }
 
     TC_LOG_INFO("playerbots.population", "Random bot population rebalance tick={} online={} target={} range=[{}, {}] enabled={} runtime={}",


### PR DESCRIPTION
### Motivation

- Prevent managed/random bots from joining or sustaining battlegrounds when no real human players are interested, avoiding wasteful bot-only matches and server churn.
- Ensure lifecycle code ends matches early when human interest is absent so instances do not persist indefinitely.
- Adjust random-bot population rebalancer to prioritize filling an entire battleground when there is explicit human interest.

### Description

- Added `HasAnyRealHumanInterestInBattleground` to `PlayerbotRandomBotParticipation.cpp` to detect real human players either in a battleground or queued for the corresponding queue type, excluding virtual sessions and managed bot accounts.
- Updated `JoinQueuePrimitive` to block mass or individual queue joins when no real human interest exists and emit a debug log instead of proceeding.
- In `HandleInProgressStatusPrimitive` added early exits that call `EndBattleground` and clean up bookkeeping when no real human interest is detected during `STATUS_WAIT_JOIN` and `STATUS_IN_PROGRESS` phases, with debug logging.
- Modified the `RebalanceRandomPopulation` logic to bump the target population up to the full battleground fill if real human interest exists by querying the battleground template via `sBattlegroundMgr`.
- Added required `BattlegroundMgr` include and adjusted related debug messages.

### Testing

- Automated project build was executed and completed successfully.
- Automated PvP/playerbot unit and integration test suites were run and passed without regressions.
- Automated static checks/linting were executed and reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e17a97cddc832783bc50554f8ef753)