### PR TITLE
Fix rogue stealth opener movement by reordering AttackStop and chase

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -801,6 +801,11 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             // While stealthed, keep auto-attack disabled so we do not break
             // stealth early, but keep chase active so rogues continue
             // closing distance instead of idling in place during openers.
+            //
+            // AttackStop can clear chase intent in some movement states, so
+            // disable melee swing first and then (re)issue the movement order.
+            player->AttackStop();
+
             if (CanIssueFollowCommands(player))
             {
                 if (RequiresStrictHumanPathing(player))
@@ -808,8 +813,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 else
                     player->GetMotionMaster()->MoveChase(target);
             }
-
-            player->AttackStop();
         }
         else if (player->GetVictim() != target)
             player->Attack(target, false);


### PR DESCRIPTION
### Motivation
- Rogue playerbots sometimes remained stationary in stealth while attempting openers like Cheap Shot because subsequent melee stop cleared newly issued chase intent.
- The change ensures stealthed openers consistently re-establish movement toward the target instead of idling.

### Description
- Call `player->AttackStop()` before issuing follow/chase movement in the stealthed enemy-target path in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`.
- Add an inline comment documenting that `AttackStop()` can clear chase intent in some movement states, explaining the ordering.

### Testing
- Ran repository cleanliness check (`git diff --check`) which succeeded.
- Verified workspace status (`git status --short`) to confirm only the intended file was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c52377e48327a806fb8557f95476)