### PR TITLE
Qualify IsManagedRandomBot call with playerbot:: to fix compile error

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -545,7 +545,7 @@ bool HasAnyRealHumanInterestInBattleground(BattlegroundTypeId targetBgType)
 
         WorldSession const* session = participant->GetSession();
         bool const isVirtualSession = session && session->IsVirtualSession();
-        if (isVirtualSession || IsManagedRandomBot(participant))
+        if (isVirtualSession || playerbot::IsManagedRandomBot(participant))
             continue;
 
         if (participant->InBattleground() && participant->GetBattlegroundTypeId() == targetBgType)


### PR DESCRIPTION
### Motivation
- Resolve a compilation error caused by an unqualified call to `IsManagedRandomBot` so the call matches the function declared in the `playerbot` namespace.

### Description
- Replace the unqualified call in `HasAnyRealHumanInterestInBattleground` with `playerbot::IsManagedRandomBot(participant)` in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` to align with the function declaration and other call sites.

### Testing
- Verified the change by searching the source with `rg -n "\bIsManagedRandomBot\(participant\)"` to confirm the qualified call is present; search succeeded.
- No full build (`cmake --build`) was executed in this environment (single-line namespace qualification fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d0ff0e4883278753aebff898960e)