### PR TITLE
Fix startup deadlock in random bot battleground interest check

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -536,6 +536,7 @@ bool HasAnyRealHumanInterestInBattleground(BattlegroundTypeId targetBgType)
         return false;
 
     BattlegroundQueueTypeId const targetQueueType = BattlegroundMgr::BGQueueTypeId(targetBgType, 0);
+    std::unordered_set<uint32> const botAccounts = GetManagedBotAccountIdsSnapshot();
 
     std::shared_lock<std::shared_mutex> lock(*HashMapHolder<Player>::GetLock());
     for (auto const& [guid, participant] : ObjectAccessor::GetPlayers())
@@ -545,7 +546,7 @@ bool HasAnyRealHumanInterestInBattleground(BattlegroundTypeId targetBgType)
 
         WorldSession const* session = participant->GetSession();
         bool const isVirtualSession = session && session->IsVirtualSession();
-        if (isVirtualSession || playerbot::IsManagedRandomBot(participant))
+        if (isVirtualSession || IsManagedRandomBotImpl(participant, botAccounts))
             continue;
 
         if (participant->InBattleground() && participant->GetBattlegroundTypeId() == targetBgType)


### PR DESCRIPTION
### Motivation
- Remove a lock-order self-deadlock observed at startup when `RebalanceRandomPopulation` holds `g_RandomPopulationLock` and `HasAnyRealHumanInterestInBattleground` re-acquires it via `playerbot::IsManagedRandomBot(...)` while iterating the global player map.

### Description
- Snapshot managed bot account IDs once via `GetManagedBotAccountIdsSnapshot()` before taking the global player map shared lock and replace the in-loop call to `playerbot::IsManagedRandomBot(...)` with `IsManagedRandomBotImpl(..., botAccounts)` to avoid re-locking `g_RandomPopulationLock` during iteration.

### Testing
- Ran `git diff --check`, `rg`/search checks and repository inspection commands used during development and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d69c14308327a15443c79af96815)