### PR TITLE
Add diagnostics to random bot population rebalance and human-interest checks

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -522,6 +522,11 @@ bool IsRandomBotCandidate(Player const* player, std::unordered_set<uint32> const
     return IsManagedRandomBotImpl(player, botAccounts);
 }
 
+bool ShouldEmitRebalanceErrorDiagnostics(RandomBotPopulationState const& state)
+{
+    return state.rebalanceTicks <= 10 || (state.rebalanceTicks % 50) == 0;
+}
+
 struct OnlineRandomBotMetrics
 {
     uint32 total = 0;
@@ -530,34 +535,52 @@ struct OnlineRandomBotMetrics
     std::vector<ObjectGuid> guids;
 };
 
-bool HasAnyRealHumanInterestInBattleground(BattlegroundTypeId targetBgType)
+bool HasAnyRealHumanInterestInBattleground(BattlegroundTypeId targetBgType, std::unordered_set<uint32> const& botAccounts)
 {
     if (targetBgType == BATTLEGROUND_TYPE_NONE)
         return false;
 
     BattlegroundQueueTypeId const targetQueueType = BattlegroundMgr::BGQueueTypeId(targetBgType, 0);
+    TC_LOG_ERROR("playerbots.population",
+        "DIAG startup-hang: Begin HasAnyRealHumanInterestInBattleground bgTypeId={} botAccounts={}.",
+        uint32(targetBgType), botAccounts.size());
 
     std::shared_lock<std::shared_mutex> lock(*HashMapHolder<Player>::GetLock());
+    uint32 scannedParticipants = 0;
     for (auto const& [guid, participant] : ObjectAccessor::GetPlayers())
     {
+        ++scannedParticipants;
         if (!participant)
             continue;
 
         WorldSession const* session = participant->GetSession();
         bool const isVirtualSession = session && session->IsVirtualSession();
-        if (isVirtualSession || playerbot::IsManagedRandomBot(participant))
+        if (isVirtualSession || IsManagedRandomBotImpl(participant, botAccounts))
             continue;
 
         if (participant->InBattleground() && participant->GetBattlegroundTypeId() == targetBgType)
+        {
+            TC_LOG_ERROR("playerbots.population",
+                "DIAG startup-hang: Human battleground interest found from active participant guid={} bgTypeId={} scanned={}.",
+                participant->GetGUID().ToString(), uint32(targetBgType), scannedParticipants);
             return true;
+        }
 
         for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
         {
             if (participant->GetBattlegroundQueueTypeId(i) == targetQueueType)
+            {
+                TC_LOG_ERROR("playerbots.population",
+                    "DIAG startup-hang: Human battleground interest found from queue participant guid={} bgTypeId={} scanned={}.",
+                    participant->GetGUID().ToString(), uint32(targetBgType), scannedParticipants);
                 return true;
+            }
         }
     }
 
+    TC_LOG_ERROR("playerbots.population",
+        "DIAG startup-hang: End HasAnyRealHumanInterestInBattleground bgTypeId={} scanned={} no-interest.",
+        uint32(targetBgType), scannedParticipants);
     return false;
 }
 
@@ -862,8 +885,22 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
     state.rebalanceEpoch++;
     state.rebalanceTicks++;
     state.lastRebalanceUnixTime = static_cast<uint64>(GameTime::GetGameTime());
+    bool const emitDiag = ShouldEmitRebalanceErrorDiagnostics(state);
+    if (emitDiag)
+    {
+        TC_LOG_ERROR("playerbots.population",
+            "DIAG startup-hang: Rebalance start epoch={} tick={} runtimeEnabled={} configEnabled={} accountPool={}.",
+            state.rebalanceEpoch, state.rebalanceTicks, state.runtimeEnabled ? 1 : 0, state.config.enabled ? 1 : 0,
+            state.config.botAccountIds.size());
+    }
 
     OnlineRandomBotMetrics const online = CollectOnlineRandomBotMetrics(state.config.botAccountIds);
+    if (emitDiag)
+    {
+        TC_LOG_ERROR("playerbots.population",
+            "DIAG startup-hang: Rebalance after CollectOnlineRandomBotMetrics total={} alliance={} horde={}.",
+            online.total, online.alliance, online.horde);
+    }
 
     uint32 target = state.config.targetMin;
     if (state.config.targetMax > state.config.targetMin)
@@ -873,7 +910,9 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
     }
 
     constexpr BattlegroundTypeId kManagedBattleground = BATTLEGROUND_SCM;
-    if (HasAnyRealHumanInterestInBattleground(kManagedBattleground))
+    if (emitDiag)
+        TC_LOG_ERROR("playerbots.population", "DIAG startup-hang: Rebalance before human-interest check bgTypeId={}.", uint32(kManagedBattleground));
+    if (HasAnyRealHumanInterestInBattleground(kManagedBattleground, state.config.botAccountIds))
     {
         if (Battleground* battlegroundTemplate = sBattlegroundMgr->GetBattlegroundTemplate(kManagedBattleground))
         {
@@ -882,6 +921,8 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
                 target = fillTarget;
         }
     }
+    if (emitDiag)
+        TC_LOG_ERROR("playerbots.population", "DIAG startup-hang: Rebalance after human-interest check target={}.", target);
 
     TC_LOG_INFO("playerbots.population", "Random bot population rebalance tick={} online={} target={} range=[{}, {}] enabled={} runtime={}",
         state.rebalanceTicks, online.total, target, state.config.targetMin, state.config.targetMax,


### PR DESCRIPTION
### Motivation
- Add diagnostic logging to investigate a startup-hang / rebalance problem in the random bot population manager.
- Make the human-interest check deterministic with respect to the current managed bot account set to avoid false positives from global lookup timing.
- Emit periodic diagnostic snapshots of rebalance state to help track when and why rebalances are skipped or altered.

### Description
- Added `ShouldEmitRebalanceErrorDiagnostics` helper to control when verbose diagnostics are emitted.
- Changed `HasAnyRealHumanInterestInBattleground` to accept the managed `botAccounts` set and added diagnostic logs at start, on any discovered human interest (with scanned participant counts), and on completion when no interest is found.
- Added intermediate `scannedParticipants` counting and extra `TC_LOG_ERROR` calls inside the search loops to trace why a human-interest decision was made.
- Emitted diagnostics in `RebalanceRandomPopulation` around the start of rebalance, after collecting online metrics, and before/after the human-interest check, gated by `ShouldEmitRebalanceErrorDiagnostics`.

### Testing
- Project was built successfully using the normal build (`cmake`/`make`) and compilation succeeded.
- Automated test suite run with `ctest` completed and returned success for unit/integration tests covering the playerbot population components.
- Targeted tests exercising the rebalance code path were executed and passed, and diagnostic logs were observed in CI/dev runs as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d69c14308327a15443c79af96815)