### PR TITLE
Playerbots: allow wand auto-repeat casts at zero mana

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -943,7 +943,12 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK);
     }
 
-    if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
+    // Auto-repeat ranged attacks (e.g., wand Shoot) are validated by the core
+    // cast pipeline and should not be blocked by this pre-check. For low-mana
+    // caster fallbacks we intentionally allow entering the cast flow so the
+    // server can start/maintain auto-shoot behavior.
+    bool const bypassPowerPrecheck = spellInfo->IsAutoRepeatRangedSpell();
+    if (!bypassPowerPrecheck && spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
         {
             failureReason = "insufficient_power";


### PR DESCRIPTION
### Motivation
- Playerbots were selecting wand fallback actions but being rejected by a local pre-cast `insufficient_power` check and idling at 0 mana instead of starting the wand (auto-repeat) cast flow.

### Description
- Skip the local power pre-check for auto-repeat ranged spells by adding a `bypassPowerPrecheck` guard that uses `spellInfo->IsAutoRepeatRangedSpell()` in `CastDirectSpell` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`.
- Added inline comments explaining that auto-repeat ranged attacks (e.g., wand `Shoot`) are validated by the core cast pipeline and must be allowed to enter the cast flow even when caster mana is low.

### Testing
- Started a full `cmake --build build --target worldserver -j4` build to validate compile impact; the build progressed and the modified file was included in the ongoing compilation without immediate fatal errors (build not waited to full completion in this environment).
- Attempted a targeted compile (`cmake --build ...` for the single object) which failed because the requested object target name was invalid; no unit tests were run beyond the build attempts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1de0eec3c83279ef7cb14d545027b)