### PR TITLE
Handle stealth melee openers with MoveFollow and reorder AttackStop to preserve chase intent

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -309,7 +309,13 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
     if (!motionMaster)
         return;
 
-    if (player->IsValidAttackTarget(target))
+    if (player->HasStealthAura())
+    {
+        // MoveChase can stall for non-swinging stealth openers. Use follow so
+        // rogues consistently close to opener distance while preserving stealth.
+        motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
+    }
+    else if (player->IsValidAttackTarget(target))
         motionMaster->MoveChase(target);
     else
         motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
@@ -801,15 +807,18 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             // While stealthed, keep auto-attack disabled so we do not break
             // stealth early, but keep chase active so rogues continue
             // closing distance instead of idling in place during openers.
+            //
+            // AttackStop can clear chase intent in some movement states, so
+            // disable melee swing first and then (re)issue the movement order.
+            player->AttackStop();
+
             if (CanIssueFollowCommands(player))
             {
                 if (RequiresStrictHumanPathing(player))
                     IssueStrictHumanFollow(player, target, std::max(1.0f, playerbot::PvpCore::GetConfig().meleeRange - 1.0f));
                 else
-                    player->GetMotionMaster()->MoveChase(target);
+                    player->GetMotionMaster()->MoveFollow(target, std::max(1.0f, playerbot::PvpCore::GetConfig().meleeRange - 1.0f), player->GetFollowAngle());
             }
-
-            player->AttackStop();
         }
         else if (player->GetVictim() != target)
             player->Attack(target, false);


### PR DESCRIPTION
### Motivation

- Prevent melee bots (especially rogues) from stalling or breaking stealth when initiating openers by adjusting movement and attack state handling.  

### Description

- In `IssueMeleeApproachMovement` added a stealth-special case that uses `MoveFollow` instead of `MoveChase` so non-swinging stealth openers reliably close distance while preserving stealth.  
- In `CastDirectSpell` when preserving stealth for an opener, call `AttackStop()` before issuing follow/chase to avoid clearing chase intent in some movement states and switch the follow logic to `MoveFollow` with the configured melee range; removed a now-redundant trailing `AttackStop()`.  
- Preserved existing strict human pathing branch by continuing to call `IssueStrictHumanFollow` when required.  
- Added explanatory comments describing why `MoveFollow` and the `AttackStop()` reordering are needed.  

### Testing

- Built the server code with `make` and the build completed successfully.  
- Ran the project's automated tests via `make test` and existing unit tests related to playerbot movement and PVP spell casting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c52377e48327a806fb8557f95476)