### PR TITLE
Playerbot PvP: SCM slot refill and human-priority queue handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -75,6 +75,7 @@ constexpr uint32 PLAYERBOT_BG_OVERSTACK_REQUEUE_COOLDOWN_MS = 30000;
 constexpr uint32 PLAYERBOT_BG_OVERSTACK_INSTANCE_DEPARTURE_SPACING_MS = 8000;
 constexpr uint32 PLAYERBOT_BG_OVERSTACK_INSTANCE_JITTER_WINDOW_MS = 14000;
 constexpr uint32 PLAYERBOT_BG_HUMAN_INTEREST_REBALANCE_THROTTLE_MS = 5000;
+constexpr uint32 PLAYERBOT_BG_SCM_REFILL_THROTTLE_MS = 3000;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
@@ -82,7 +83,10 @@ constexpr uint32 SPELL_DESERTER = 26013;
 std::unordered_map<uint64, uint32> g_BattlegroundOverstackRequeueCooldownUntilMsByGuid;
 std::unordered_map<uint64, uint32> g_BattlegroundOverstackInstanceNextDepartureMsByInstance;
 uint32 g_LastHumanInterestPopulationRebalanceAttemptMs = 0;
+uint32 g_LastScmSlotRefillAttemptMs = 0;
 uint64 BuildBattlegroundInstanceKey(Battleground const* battleground);
+bool BattlegroundHasAnyRealHumanPlayers(Player const* player);
+uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint8 arenaType);
 
 uint32 ComputeOverstackDepartureJitterMs(Player const* player, Battleground const* battleground)
 {
@@ -146,6 +150,78 @@ bool ShouldManagedBotLeaveForOverstack(Player* player, Battleground* battlegroun
         player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID(), assignedTeam, botTeamCount,
         otherTeamCount, teamDiff);
     return true;
+}
+
+bool HasQueuedRealHumanForBattleground(BattlegroundTypeId targetBgType)
+{
+    if (targetBgType == BATTLEGROUND_TYPE_NONE)
+        return false;
+
+    BattlegroundQueueTypeId const queueTypeId = BattlegroundMgr::BGQueueTypeId(targetBgType, 0);
+    if (queueTypeId == BATTLEGROUND_QUEUE_NONE)
+        return false;
+
+    BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(queueTypeId);
+    for (auto const& [queuedGuid, queueInfo] : bgQueue.m_QueuedPlayers)
+    {
+        (void)queueInfo;
+        Player* participant = ObjectAccessor::FindConnectedPlayer(queuedGuid);
+        if (!participant)
+            continue;
+
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (isVirtualSession || playerbot::IsManagedRandomBot(participant))
+            continue;
+
+        return true;
+    }
+
+    return false;
+}
+
+bool ShouldManagedBotLeaveForQueuedHuman(Player* player, Battleground* battleground)
+{
+    if (!player || !battleground || !playerbot::IsManagedRandomBot(player))
+        return false;
+
+    if (battleground->GetTypeID() != BATTLEGROUND_SCM)
+        return false;
+
+    uint32 const maxPlayers = battleground->GetMaxPlayers();
+    if (!maxPlayers || battleground->GetPlayersSize() < maxPlayers)
+        return false;
+
+    return HasQueuedRealHumanForBattleground(battleground->GetTypeID());
+}
+
+bool TryRefillManagedScmSlots(Player* player, Battleground* battleground)
+{
+    if (!player || !battleground || battleground->GetTypeID() != BATTLEGROUND_SCM)
+        return false;
+
+    uint32 const maxPlayers = battleground->GetMaxPlayers();
+    uint32 const playersInInstance = battleground->GetPlayersSize();
+    if (!maxPlayers || playersInInstance >= maxPlayers)
+        return false;
+
+    // Only force-fill while real humans are participating in SCM.
+    if (!BattlegroundHasAnyRealHumanPlayers(player))
+        return false;
+
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    if (nowMs < g_LastScmSlotRefillAttemptMs + PLAYERBOT_BG_SCM_REFILL_THROTTLE_MS)
+        return false;
+
+    g_LastScmSlotRefillAttemptMs = nowMs;
+
+    bool const rebalanceTriggered = playerbot::RandomBotParticipationManager::TriggerImmediateRebalance();
+    uint32 const queuedCount = QueueEligibleManagedBotsForBattleground(BATTLEGROUND_SCM, 0);
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP SCM refill attempt: guid={} instanceId={} players={} maxPlayers={} rebalanceTriggered={} queuedCount={}.",
+        player->GetGUID().ToString(), battleground->GetInstanceID(), playersInInstance, maxPlayers, rebalanceTriggered ? 1 : 0, queuedCount);
+
+    return rebalanceTriggered || queuedCount > 0;
 }
 
 void ForcePlayerbotDismount(Player* player)
@@ -2449,6 +2525,7 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
         else
             g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
 
+        TryRefillManagedScmSlots(player, battleground);
         return true;
     }
 
@@ -2515,11 +2592,26 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     else
         g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
 
+    TryRefillManagedScmSlots(player, battleground);
+
+    if (ShouldManagedBotLeaveForQueuedHuman(player, battleground))
+    {
+        player->LeaveBattleground();
+        FinalizeVirtualBotTeleportIfPending(player);
+        player->RemoveAurasDueToSpell(SPELL_DESERTER);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP human-priority departure trigger: guid={} bgTypeId={} instanceId={} players={} maxPlayers={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID(),
+            battleground->GetPlayersSize(), battleground->GetMaxPlayers());
+        return true;
+    }
+
     if (ShouldManagedBotLeaveForOverstack(player, battleground))
     {
         player->LeaveBattleground();
         FinalizeVirtualBotTeleportIfPending(player);
         player->RemoveAurasDueToSpell(SPELL_DESERTER);
+        QueuePlayer(player, BATTLEGROUND_SCM, 0);
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Improve managed bot behavior in the Stormwind Coliseum (SCM) battleground to ensure real humans are prioritized and SCM slots can be refilled when humans are present.
- Reduce unnecessary bot retention in full SCM instances and attempt controlled queue refills when real players are participating.

### Description
- Added a throttle and state variable (`PLAYERBOT_BG_SCM_REFILL_THROTTLE_MS`, `g_LastScmSlotRefillAttemptMs`) to rate-limit SCM refill attempts.
- Implemented `HasQueuedRealHumanForBattleground`, `ShouldManagedBotLeaveForQueuedHuman`, and `TryRefillManagedScmSlots` to detect queued human players and trigger managed-bot refill/leave behavior for `BATTLEGROUND_SCM` instances.
- Hooked `TryRefillManagedScmSlots` into battleground lifecycle checks so refill attempts occur during `STATUS_IN_PROGRESS` handling and wait-join handling, and added an early-departure path for managed bots when a queued human exists via `ShouldManagedBotLeaveForQueuedHuman`.
- Added logging and a call to `RandomBotParticipationManager::TriggerImmediateRebalance()` and `QueueEligibleManagedBotsForBattleground` when attempting to refill SCM slots, and restored queueing of bots on overstack departure with `QueuePlayer(player, BATTLEGROUND_SCM, 0)`.

### Testing
- Built the server with the change using the normal build system (`cmake`/build) with no compilation errors. 
- Ran the automated test suite with `ctest` and the battleground lifecycle-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1de941c308327843889df96bbd80b)