### PR TITLE
Don't clear chase intent with unconditional AttackStop during stealthed openers

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -801,6 +801,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             // While stealthed, keep auto-attack disabled so we do not break
             // stealth early, but keep chase active so rogues continue
             // closing distance instead of idling in place during openers.
+            //
+            // AttackStop can clear chase intent in some movement states, so
+            // only call it when we are actively swinging a victim and then
+            // (re)issue chase immediately afterwards.
+            if (player->GetVictim())
+                player->AttackStop();
+
             if (CanIssueFollowCommands(player))
             {
                 if (RequiresStrictHumanPathing(player))
@@ -808,8 +815,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 else
                     player->GetMotionMaster()->MoveChase(target);
             }
-
-            player->AttackStop();
         }
         else if (player->GetVictim() != target)
             player->Attack(target, false);


### PR DESCRIPTION
### Motivation
- Prevent `AttackStop()` from clearing chase intent in some movement states when a stealthed playerbot is performing an opener so the bot continues closing on the target instead of idling.

### Description
- Only invoke `player->AttackStop()` when preserving stealth if `player->GetVictim()` is non-null, and keep the existing follow/chase issuance (`IssueStrictHumanFollow` / `GetMotionMaster()->MoveChase`) so chase intent is maintained or reissued immediately.

### Testing
- Performed a full build of the server and ran the project's automated test suite; the build completed and automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c52377e48327a806fb8557f95476)