### PR TITLE
Preserve chase intent and prefer melee movement for short-range PvP spells

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -801,6 +801,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             // While stealthed, keep auto-attack disabled so we do not break
             // stealth early, but keep chase active so rogues continue
             // closing distance instead of idling in place during openers.
+            //
+            // AttackStop can clear chase intent in some movement states, so
+            // only call it when we are actively swinging a victim and then
+            // (re)issue chase immediately afterwards.
+            if (player->GetVictim())
+                player->AttackStop();
+
             if (CanIssueFollowCommands(player))
             {
                 if (RequiresStrictHumanPathing(player))
@@ -808,8 +815,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 else
                     player->GetMotionMaster()->MoveChase(target);
             }
-
-            player->AttackStop();
         }
         else if (player->GetVictim() != target)
             player->Attack(target, false);
@@ -836,12 +841,21 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     }
 
     float const maxRange = spellInfo->GetMaxRange(false);
+    bool const shouldUseMeleeApproachForEnemySpell =
+        context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
+        IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
+        maxRange > 0.0f && maxRange <= 5.5f;
     if (!itemTarget && !player->IsWithinLOSInMap(target))
     {
         if (CanIssueFollowCommands(player))
         {
-            float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
-            IssueRangedApproachMovement(player, target, desiredRange);
+            if (shouldUseMeleeApproachForEnemySpell)
+                IssueMeleeApproachMovement(player, target);
+            else
+            {
+                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                IssueRangedApproachMovement(player, target, desiredRange);
+            }
         }
 
         failureReason = "no_los";
@@ -859,8 +873,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         // close the gap instead of idling and repeating failed cast attempts.
         if (CanIssueFollowCommands(player) && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
         {
-            float const desiredRange = std::max(1.0f, maxRange - 1.0f);
-            IssueRangedApproachMovement(player, target, desiredRange);
+            if (shouldUseMeleeApproachForEnemySpell)
+                IssueMeleeApproachMovement(player, target);
+            else
+            {
+                float const desiredRange = std::max(1.0f, maxRange - 1.0f);
+                IssueRangedApproachMovement(player, target, desiredRange);
+            }
         }
         else if (CanIssueFollowCommands(player) && context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Ally)
         {
@@ -986,8 +1005,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         {
             if (castResult == SPELL_FAILED_OUT_OF_RANGE)
             {
-                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
-                IssueRangedApproachMovement(player, target, desiredRange);
+                if (shouldUseMeleeApproachForEnemySpell)
+                    IssueMeleeApproachMovement(player, target);
+                else
+                {
+                    float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                    IssueRangedApproachMovement(player, target, desiredRange);
+                }
             }
             else if (castResult == SPELL_FAILED_TOO_CLOSE)
             {
@@ -999,8 +1023,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             }
             else if (castResult == SPELL_FAILED_LINE_OF_SIGHT)
             {
-                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
-                IssueRangedApproachMovement(player, target, desiredRange);
+                if (shouldUseMeleeApproachForEnemySpell)
+                    IssueMeleeApproachMovement(player, target);
+                else
+                {
+                    float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                    IssueRangedApproachMovement(player, target, desiredRange);
+                }
             }
         }
 


### PR DESCRIPTION
### Motivation
- Prevent `AttackStop()` from unintentionally clearing chase intent during stealth openers by only calling it when the player currently has a victim. 
- Improve movement behavior for melee bots when casting short-range enemy-targeted spells so they use melee-specific approach logic instead of ranged approach. 
- Make follow/approach decisions more consistent across LOS, out-of-range, and cast-failure paths for close-range melee spells. 

### Description
- Only call `player->AttackStop()` when `player->GetVictim()` is non-null to avoid clearing chase intent in movement states. 
- Introduce `shouldUseMeleeApproachForEnemySpell` to detect enemy-targeted spells with `maxRange` ≤ 5.5 and primary melee classes, and use it to choose approach behavior. 
- Replace several `IssueRangedApproachMovement` calls with conditional logic that calls `IssueMeleeApproachMovement` for close-range melee spells and falls back to ranged approach otherwise. 
- Apply the melee-approach selection in LOS checks, out-of-range handling, and cast-failure handling for `SPELL_FAILED_OUT_OF_RANGE` and `SPELL_FAILED_LINE_OF_SIGHT`. 

### Testing
- Project was rebuilt after the changes using the standard build (`cmake`/`make`) and the build completed successfully. 
- Existing automated unit tests and PvP-related integration tests were executed and completed without failures. 
- No new test failures were observed in the bot PvP behavior smoke tests run after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c52377e48327a806fb8557f95476)