### PR TITLE
Allow Life Tap and auto-repeat ranged spells to bypass local power precheck; add managed-bot diagnostics and chat trigger

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -44,6 +44,15 @@
 
 namespace
 {
+bool IsLifeTapSpell(SpellInfo const* spellInfo)
+{
+    if (!spellInfo)
+        return false;
+
+    SpellInfo const* firstRank = spellInfo->GetFirstRankSpell();
+    return firstRank && firstRank->Id == 1454; // Life Tap (rank 1)
+}
+
 char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode);
 bool CanIssueFollowCommands(Player const* player);
 bool IsEffectivelyOutdoors(Player const* player);
@@ -943,7 +952,12 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK);
     }
 
-    if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
+    // Auto-repeat ranged attacks (e.g., wand Shoot) and Life Tap are validated
+    // by the core cast pipeline and should not be blocked by this local
+    // pre-check. For low-mana caster fallbacks we intentionally allow entering
+    // the cast flow so the server can apply the spell-specific resource rules.
+    bool const bypassPowerPrecheck = spellInfo->IsAutoRepeatRangedSpell() || IsLifeTapSpell(spellInfo);
+    if (!bypassPowerPrecheck && spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
         {
             failureReason = "insufficient_power";

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -18,13 +18,18 @@
 #include "Log.h"
 #include "Chat.h"
 #include "GameTime.h"
+#include "Item.h"
 #include "MotionMaster.h"
 #include "Player.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
 #include "RBAC.h"
 #include "ScriptMgr.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
 
+#include <algorithm>
+#include <cctype>
 #include <sstream>
 
 using namespace Trinity::ChatCommands;
@@ -146,6 +151,76 @@ std::string BuildManagedBotStatusLine(Player* bot)
     return status.str();
 }
 
+bool IsManagedBotSpellKnownAndOffCooldown(Player const* bot, uint32 spellId)
+{
+    if (!bot || !spellId)
+        return false;
+
+    SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!baseSpellInfo)
+        return false;
+
+    uint32 resolvedSpellId = 0;
+    for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
+    {
+        if (bot->HasSpell(chainSpellId))
+            resolvedSpellId = chainSpellId;
+    }
+
+    if (!resolvedSpellId)
+        return false;
+
+    return !bot->GetSpellHistory()->HasCooldown(resolvedSpellId);
+}
+
+bool ManagedBotHasWandEquipped(Player const* bot)
+{
+    if (!bot)
+        return false;
+
+    Item const* ranged = bot->GetWeaponForAttack(RANGED_ATTACK, true);
+    if (!ranged || !ranged->GetTemplate())
+        return false;
+
+    return ranged->GetTemplate()->SubClass == ITEM_SUBCLASS_WEAPON_WAND;
+}
+
+std::string BuildManagedBotDiagnosticLine(Player* bot)
+{
+    if (!bot)
+        return "PB diag unavailable.";
+
+    float const manaPct = bot->GetPowerType() == POWER_MANA ? bot->GetPowerPct(POWER_MANA) : 0.0f;
+    uint32 const manaNow = bot->GetPowerType() == POWER_MANA ? bot->GetPower(POWER_MANA) : 0;
+    uint32 const manaMax = bot->GetPowerType() == POWER_MANA ? bot->GetMaxPower(POWER_MANA) : 0;
+    bool const wandReady = IsManagedBotSpellKnownAndOffCooldown(bot, 5019);
+    bool const lifeTapReady = IsManagedBotSpellKnownAndOffCooldown(bot, 11689);
+
+    std::ostringstream status;
+    status << "PB diag: "
+           << "hp=" << bot->GetHealthPct() << "%"
+           << " mana=" << manaNow << "/" << manaMax << " (" << manaPct << "%)"
+           << " wand_equipped=" << (ManagedBotHasWandEquipped(bot) ? "yes" : "no")
+           << " wand_ready=" << (wandReady ? "yes" : "no")
+           << " lifetap_ready=" << (lifeTapReady ? "yes" : "no")
+           << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
+           << " hard_cc=" << (bot->HasAuraWithMechanic((1 << MECHANIC_STUN) | (1 << MECHANIC_FEAR) | (1 << MECHANIC_CHARM) | (1 << MECHANIC_CONFUSED)) ? "yes" : "no");
+
+    if (Unit* victim = bot->GetVictim())
+        status << " victim=" << victim->GetName() << " dist=" << bot->GetDistance(victim);
+    else
+        status << " victim=none";
+
+    return status.str();
+}
+
+bool WantsExtendedManagedBotDiag(std::string const& msg)
+{
+    std::string lowered = msg;
+    std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return lowered.find("diag") != std::string::npos || lowered.find("debug") != std::string::npos || lowered.find("status") != std::string::npos;
+}
+
 class PlayerbotBootstrapWorldScript final : public WorldScript
 {
 public:
@@ -224,7 +299,7 @@ public:
         challenger->SendDuelCountdown(3000);
     }
 
-    void OnChat(Player* sender, uint32 type, uint32 lang, std::string& /*msg*/, Player* receiver) override
+    void OnChat(Player* sender, uint32 type, uint32 lang, std::string& msg, Player* receiver) override
     {
         if (!sender || !receiver)
             return;
@@ -235,13 +310,12 @@ public:
         if (lang == LANG_ADDON)
             return;
 
-        if (!sender->IsGameMaster())
-            return;
-
         if (!playerbot::IsManagedRandomBot(receiver))
             return;
 
         receiver->Whisper(BuildManagedBotStatusLine(receiver), LANG_UNIVERSAL, sender);
+        if (WantsExtendedManagedBotDiag(msg))
+            receiver->Whisper(BuildManagedBotDiagnosticLine(receiver), LANG_UNIVERSAL, sender);
     }
 };
 


### PR DESCRIPTION
### Motivation

- Prevent the local pre-check from blocking valid server-side spell flows such as auto-repeat ranged attacks and `Life Tap`, allowing the core cast pipeline to enforce spell-specific resource rules.
- Provide richer runtime diagnostics for managed/random playerbots to aid debugging of mana, wand readiness, cooldowns and combat state.
- Expose the diagnostics via whisper messages so operators can request extended status from managed bots without requiring GM-only privileges.

### Description

- Added `IsLifeTapSpell(SpellInfo const*)` and updated the local power pre-check to bypass when `spellInfo->IsAutoRepeatRangedSpell()` or `IsLifeTapSpell(...)` is true, keeping the existing `insufficient_power` failure for other spells. 
- Introduced helper functions and diagnostics in `playerbot_loader.cpp`: `IsManagedBotSpellKnownAndOffCooldown`, `ManagedBotHasWandEquipped`, `BuildManagedBotDiagnosticLine`, and `WantsExtendedManagedBotDiag` along with required includes (`Item.h`, `SpellInfo.h`, `SpellMgr.h`, `<algorithm>`, `<cctype>`).
- Enhanced the `OnChat` whisper handler to accept the incoming `msg` parameter, always whisper the short managed-bot status, and conditionally whisper the extended diagnostic line when the incoming message contains `diag`, `debug`, or `status` (case-insensitive).
- Diagnostic output includes health/mana, wand equipped/readiness, life tap readiness, casting/hard-CC state, and current victim with distance.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1de0eec3c83279ef7cb14d545027b)