### PR TITLE
Fix playerbot compile errors in PvP class actions and loader

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -57,6 +57,7 @@ char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
 bool CanIssueFollowCommands(Player const* player);
 bool IsEffectivelyOutdoors(Player const* player);
 bool IsStrictlyOutdoorsForMount(Player const* player);
+bool IsPrimaryMeleeClassForSpacing(uint8 classId);
 
 bool IsEffectivelyOutdoors(Player const* player)
 {
@@ -86,6 +87,21 @@ bool IsStrictlyOutdoorsForMount(Player const* player)
     map->GetFullTerrainStatusForPosition(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(),
         terrainStatus, MAP_ALL_LIQUIDS, player->GetCollisionHeight());
     return player->IsOutdoors() && terrainStatus.outdoors;
+}
+
+bool IsPrimaryMeleeClassForSpacing(uint8 classId)
+{
+    switch (classId)
+    {
+        case CLASS_WARRIOR:
+        case CLASS_ROGUE:
+        case CLASS_PALADIN:
+        case CLASS_DRUID:
+        case CLASS_DEATH_KNIGHT:
+            return true;
+        default:
+            return false;
+    }
 }
 
 bool RequiresStrictHumanPathing(Player const* player)

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -26,6 +26,7 @@
 #include "RBAC.h"
 #include "ScriptMgr.h"
 #include "SpellInfo.h"
+#include "SpellHistory.h"
 #include "SpellMgr.h"
 
 #include <algorithm>
@@ -204,7 +205,7 @@ std::string BuildManagedBotDiagnosticLine(Player* bot)
            << " wand_ready=" << (wandReady ? "yes" : "no")
            << " lifetap_ready=" << (lifeTapReady ? "yes" : "no")
            << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
-           << " hard_cc=" << (bot->HasAuraWithMechanic((1 << MECHANIC_STUN) | (1 << MECHANIC_FEAR) | (1 << MECHANIC_CHARM) | (1 << MECHANIC_CONFUSED)) ? "yes" : "no");
+           << " hard_cc=" << (bot->HasAuraWithMechanic((1 << MECHANIC_STUN) | (1 << MECHANIC_FEAR) | (1 << MECHANIC_CHARM) | (1 << MECHANIC_DISORIENTED)) ? "yes" : "no");
 
     if (Unit* victim = bot->GetVictim())
         status << " victim=" << victim->GetName() << " dist=" << bot->GetDistance(victim);


### PR DESCRIPTION
### Motivation
- Resolve compile errors introduced by undefined/undelared symbols used by playerbot PvP and loader code so the project can build cleanly.

### Description
- Add a local `IsPrimaryMeleeClassForSpacing(uint8)` helper in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` to declare and define the melee-class spacing check used by PvP movement logic.
- Include `SpellHistory.h` in `src/server/scripts/Playerbot/playerbot_loader.cpp` so `GetSpellHistory()->HasCooldown(...)` operates on a complete type.
- Replace the invalid enum `MECHANIC_CONFUSED` with the correct `MECHANIC_DISORIENTED` in the managed-bot diagnostic hard-CC mask in `playerbot_loader.cpp`.

### Testing
- Ran the build with `cmake --build build --target game -- -k 1`; the build progressed and the previously reported translation-unit errors for the playerbot PvP actions and loader no longer appear during compilation of those units.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ed3fdf508327891282770bbf40ea)