### PR TITLE
Improve SCM (6v6) managed-bot refill and human-priority behavior

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -585,6 +585,15 @@ void BattlegroundMgr::LoadBattlegroundTemplates()
         bgTemplate.ScriptId          = sObjectMgr->GetScriptId(fields[11].GetString());
         bgTemplate.BattlemasterEntry = bl;
 
+        // SCM is designed as a 6v6 battleground for this codebase.
+        // Keep startup accessibility at 2v2, but always expose 6v6 capacity
+        // even if DB template values are lower on fresh/test datasets.
+        if (bgTemplate.Id == BATTLEGROUND_SCM)
+        {
+            bgTemplate.MinPlayersPerTeam = 2;
+            bgTemplate.MaxPlayersPerTeam = 6;
+        }
+
         if (bgTemplate.MaxPlayersPerTeam == 0 || bgTemplate.MinPlayersPerTeam > bgTemplate.MaxPlayersPerTeam)
         {
             TC_LOG_ERROR("sql.sql", "Table `battleground_template` for id {} contains bad values for MinPlayersPerTeam ({}) and MaxPlayersPerTeam({}).",

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -269,6 +269,29 @@ GroupQueueInfo* BattlegroundQueue::AddGroup(Player* leader, Group* grp, Battlegr
             addHorde = roll_chance_i(50);
 
         ginfo->Team = addHorde ? HORDE : ALLIANCE;
+
+        // SCM refill behavior: if there is already an active/free-slot SCM instance,
+        // drive new solo entries to the side that currently has more free slots.
+        if (BgTypeId == BATTLEGROUND_SCM)
+        {
+            BGFreeSlotQueueContainer& freeSlotQueue = sBattlegroundMgr->GetBGFreeSlotQueueStore(BgTypeId);
+            for (Battleground* bg : freeSlotQueue)
+            {
+                if (!bg)
+                    continue;
+
+                uint32 const allianceFree = bg->GetFreeSlotsForTeam(ALLIANCE);
+                uint32 const hordeFree = bg->GetFreeSlotsForTeam(HORDE);
+                if (!allianceFree && !hordeFree)
+                    continue;
+
+                if (allianceFree > hordeFree)
+                    ginfo->Team = ALLIANCE;
+                else if (hordeFree > allianceFree)
+                    ginfo->Team = HORDE;
+                break;
+            }
+        }
     }
 
     ginfo->Players.clear();

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -75,6 +75,7 @@ constexpr uint32 PLAYERBOT_BG_OVERSTACK_REQUEUE_COOLDOWN_MS = 30000;
 constexpr uint32 PLAYERBOT_BG_OVERSTACK_INSTANCE_DEPARTURE_SPACING_MS = 8000;
 constexpr uint32 PLAYERBOT_BG_OVERSTACK_INSTANCE_JITTER_WINDOW_MS = 14000;
 constexpr uint32 PLAYERBOT_BG_HUMAN_INTEREST_REBALANCE_THROTTLE_MS = 5000;
+constexpr uint32 PLAYERBOT_BG_SCM_REFILL_THROTTLE_MS = 3000;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT = 29073;
 constexpr uint32 SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK = 22734;
 constexpr uint32 SPELL_WAITING_FOR_RESURRECT = 2584;
@@ -82,7 +83,23 @@ constexpr uint32 SPELL_DESERTER = 26013;
 std::unordered_map<uint64, uint32> g_BattlegroundOverstackRequeueCooldownUntilMsByGuid;
 std::unordered_map<uint64, uint32> g_BattlegroundOverstackInstanceNextDepartureMsByInstance;
 uint32 g_LastHumanInterestPopulationRebalanceAttemptMs = 0;
+uint32 g_LastScmSlotRefillAttemptMs = 0;
 uint64 BuildBattlegroundInstanceKey(Battleground const* battleground);
+bool BattlegroundHasAnyRealHumanPlayers(Player const* player);
+uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint8 arenaType);
+bool RemoveMatchingQueues(Player* player, bool arenaOnly, bool invitedOnly, bool scheduleNonArenaUpdate);
+
+bool IsScmManagedBotCandidate(Player const* player)
+{
+    if (!player)
+        return false;
+
+    if (playerbot::IsManagedRandomBot(player))
+        return true;
+
+    WorldSession const* session = player->GetSession();
+    return session && session->IsVirtualSession();
+}
 
 uint32 ComputeOverstackDepartureJitterMs(Player const* player, Battleground const* battleground)
 {
@@ -96,7 +113,7 @@ uint32 ComputeOverstackDepartureJitterMs(Player const* player, Battleground cons
 
 bool ShouldManagedBotLeaveForOverstack(Player* player, Battleground* battleground)
 {
-    if (!player || !battleground || !playerbot::IsManagedRandomBot(player))
+    if (!player || !battleground || !IsScmManagedBotCandidate(player))
         return false;
 
     uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
@@ -146,6 +163,78 @@ bool ShouldManagedBotLeaveForOverstack(Player* player, Battleground* battlegroun
         player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID(), assignedTeam, botTeamCount,
         otherTeamCount, teamDiff);
     return true;
+}
+
+bool HasQueuedRealHumanForBattleground(BattlegroundTypeId targetBgType)
+{
+    if (targetBgType == BATTLEGROUND_TYPE_NONE)
+        return false;
+
+    BattlegroundQueueTypeId const queueTypeId = BattlegroundMgr::BGQueueTypeId(targetBgType, 0);
+    if (queueTypeId == BATTLEGROUND_QUEUE_NONE)
+        return false;
+
+    BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(queueTypeId);
+    for (auto const& [queuedGuid, queueInfo] : bgQueue.m_QueuedPlayers)
+    {
+        (void)queueInfo;
+        Player* participant = ObjectAccessor::FindConnectedPlayer(queuedGuid);
+        if (!participant)
+            continue;
+
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (isVirtualSession || playerbot::IsManagedRandomBot(participant))
+            continue;
+
+        return true;
+    }
+
+    return false;
+}
+
+bool ShouldManagedBotLeaveForQueuedHuman(Player* player, Battleground* battleground)
+{
+    if (!player || !battleground || !IsScmManagedBotCandidate(player))
+        return false;
+
+    if (battleground->GetTypeID() != BATTLEGROUND_SCM)
+        return false;
+
+    uint32 const maxPlayers = battleground->GetMaxPlayers();
+    if (!maxPlayers || battleground->GetPlayersSize() < maxPlayers)
+        return false;
+
+    return HasQueuedRealHumanForBattleground(battleground->GetTypeID());
+}
+
+bool TryRefillManagedScmSlots(Player* player, Battleground* battleground)
+{
+    if (!player || !battleground || battleground->GetTypeID() != BATTLEGROUND_SCM)
+        return false;
+
+    uint32 const maxPlayers = battleground->GetMaxPlayers();
+    uint32 const playersInInstance = battleground->GetPlayersSize();
+    if (!maxPlayers || playersInInstance >= maxPlayers)
+        return false;
+
+    // Only force-fill while real humans are participating in SCM.
+    if (!BattlegroundHasAnyRealHumanPlayers(player))
+        return false;
+
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    if (nowMs < g_LastScmSlotRefillAttemptMs + PLAYERBOT_BG_SCM_REFILL_THROTTLE_MS)
+        return false;
+
+    g_LastScmSlotRefillAttemptMs = nowMs;
+
+    bool const rebalanceTriggered = playerbot::RandomBotParticipationManager::TriggerImmediateRebalance();
+    uint32 const queuedCount = QueueEligibleManagedBotsForBattleground(BATTLEGROUND_SCM, 0);
+    TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+        "Playerbot PvP SCM refill attempt: guid={} instanceId={} players={} maxPlayers={} rebalanceTriggered={} queuedCount={}.",
+        player->GetGUID().ToString(), battleground->GetInstanceID(), playersInInstance, maxPlayers, rebalanceTriggered ? 1 : 0, queuedCount);
+
+    return rebalanceTriggered || queuedCount > 0;
 }
 
 void ForcePlayerbotDismount(Player* player)
@@ -964,6 +1053,15 @@ bool QueuePlayer(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
             "Removed stale queueTypeId=" + std::to_string(uint32(existingQueueTypeId)));
     }
 
+    // SCM is intentionally prioritized over other BG queues for managed bots:
+    // free any existing queue slots first so SCM can always enqueue.
+    if (bgTypeId == BATTLEGROUND_SCM)
+    {
+        RemoveMatchingQueues(player, false, false, true);
+        RemoveMatchingQueues(player, true, false, false);
+        player->SetArenaTeamIdInvited(0);
+    }
+
     // Managed random bots can run on disconnected virtual sessions where RBAC
     // battleground permissions are not always populated like live client sessions.
     // Gate queue eligibility by battleground level + free queue slots instead.
@@ -1704,7 +1802,7 @@ uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint
             if (!participant || !participant->IsInWorld())
                 continue;
 
-            if (!playerbot::IsManagedRandomBot(participant))
+            if (!IsScmManagedBotCandidate(participant))
                 continue;
 
             managedBotGuids.push_back(guid);
@@ -2449,6 +2547,7 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
         else
             g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
 
+        TryRefillManagedScmSlots(player, battleground);
         return true;
     }
 
@@ -2515,11 +2614,26 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     else
         g_BattlegroundNoHumanSinceMsByInstance.erase(battlegroundInstanceKey);
 
+    TryRefillManagedScmSlots(player, battleground);
+
+    if (ShouldManagedBotLeaveForQueuedHuman(player, battleground))
+    {
+        player->LeaveBattleground();
+        FinalizeVirtualBotTeleportIfPending(player);
+        player->RemoveAurasDueToSpell(SPELL_DESERTER);
+        TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+            "Playerbot PvP human-priority departure trigger: guid={} bgTypeId={} instanceId={} players={} maxPlayers={}.",
+            player->GetGUID().ToString(), uint32(battleground->GetTypeID()), battleground->GetInstanceID(),
+            battleground->GetPlayersSize(), battleground->GetMaxPlayers());
+        return true;
+    }
+
     if (ShouldManagedBotLeaveForOverstack(player, battleground))
     {
         player->LeaveBattleground();
         FinalizeVirtualBotTeleportIfPending(player);
         player->RemoveAurasDueToSpell(SPELL_DESERTER);
+        QueuePlayer(player, BATTLEGROUND_SCM, 0);
         return true;
     }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -28,6 +28,7 @@
 #include "CharacterCache.h"
 #include "Chat.h"
 #include "DatabaseEnv.h"
+#include "DBCStores.h"
 #include "GameTime.h"
 #include "Globals/ObjectAccessor.h"
 #include "Log.h"
@@ -584,6 +585,62 @@ bool HasAnyRealHumanInterestInBattleground(BattlegroundTypeId targetBgType, std:
     return false;
 }
 
+struct HumanScmDemandWindow
+{
+    bool active = false;
+    uint8 minLevel = 1;
+    uint8 maxLevel = 80;
+};
+
+HumanScmDemandWindow DetectHumanScmDemandWindow(std::unordered_set<uint32> const& botAccounts)
+{
+    constexpr BattlegroundTypeId kManagedBattleground = BATTLEGROUND_SCM;
+    Battleground* battlegroundTemplate = sBattlegroundMgr->GetBattlegroundTemplate(kManagedBattleground);
+    if (!battlegroundTemplate)
+        return {};
+
+    BattlegroundQueueTypeId const targetQueueType = BattlegroundMgr::BGQueueTypeId(kManagedBattleground, 0);
+    HumanScmDemandWindow demand;
+
+    std::shared_lock<std::shared_mutex> lock(*HashMapHolder<Player>::GetLock());
+    for (auto const& [guid, participant] : ObjectAccessor::GetPlayers())
+    {
+        if (!participant)
+            continue;
+
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (isVirtualSession || IsManagedRandomBotImpl(participant, botAccounts))
+            continue;
+
+        bool interested = participant->InBattleground() && participant->GetBattlegroundTypeId() == kManagedBattleground;
+        if (!interested)
+        {
+            for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+            {
+                if (participant->GetBattlegroundQueueTypeId(i) == targetQueueType)
+                {
+                    interested = true;
+                    break;
+                }
+            }
+        }
+
+        if (!interested)
+            continue;
+
+        if (PvPDifficultyEntry const* bracket = GetBattlegroundBracketByLevel(battlegroundTemplate->GetMapId(), participant->GetLevel()))
+        {
+            demand.active = true;
+            demand.minLevel = bracket->MinLevel;
+            demand.maxLevel = bracket->MaxLevel;
+            return demand;
+        }
+    }
+
+    return demand;
+}
+
 OnlineRandomBotMetrics CollectOnlineRandomBotMetrics(std::unordered_set<uint32> const& botAccounts)
 {
     OnlineRandomBotMetrics metrics;
@@ -882,6 +939,8 @@ bool TryLogoutRandomBot(ObjectGuid const& guid)
 
 bool RebalanceRandomPopulation(RandomBotPopulationState& state)
 {
+    constexpr BattlegroundTypeId kManagedBattleground = BATTLEGROUND_SCM;
+
     state.rebalanceEpoch++;
     state.rebalanceTicks++;
     state.lastRebalanceUnixTime = static_cast<uint64>(GameTime::GetGameTime());
@@ -909,10 +968,11 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
         target = state.config.targetMin + static_cast<uint32>(state.rebalanceEpoch % span);
     }
 
-    constexpr BattlegroundTypeId kManagedBattleground = BATTLEGROUND_SCM;
     if (emitDiag)
         TC_LOG_ERROR("playerbots.population", "DIAG startup-hang: Rebalance before human-interest check bgTypeId={}.", uint32(kManagedBattleground));
-    if (HasAnyRealHumanInterestInBattleground(kManagedBattleground, state.config.botAccountIds))
+    bool const hasHumanInterest = HasAnyRealHumanInterestInBattleground(kManagedBattleground, state.config.botAccountIds);
+    HumanScmDemandWindow const scmDemandWindow = hasHumanInterest ? DetectHumanScmDemandWindow(state.config.botAccountIds) : HumanScmDemandWindow{};
+    if (hasHumanInterest)
     {
         if (Battleground* battlegroundTemplate = sBattlegroundMgr->GetBattlegroundTemplate(kManagedBattleground))
         {
@@ -924,13 +984,23 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
     if (emitDiag)
         TC_LOG_ERROR("playerbots.population", "DIAG startup-hang: Rebalance after human-interest check target={}.", target);
 
+    uint32 effectiveOnlineCount = online.total;
+    if (scmDemandWindow.active)
+    {
+        effectiveOnlineCount = 0;
+        for (ObjectGuid const& guid : online.guids)
+            if (Player const* player = ObjectAccessor::FindConnectedPlayer(guid))
+                if (player->GetLevel() >= scmDemandWindow.minLevel && player->GetLevel() <= scmDemandWindow.maxLevel)
+                    ++effectiveOnlineCount;
+    }
+
     TC_LOG_INFO("playerbots.population", "Random bot population rebalance tick={} online={} target={} range=[{}, {}] enabled={} runtime={}",
         state.rebalanceTicks, online.total, target, state.config.targetMin, state.config.targetMax,
         state.config.enabled ? 1 : 0, state.runtimeEnabled ? 1 : 0);
 
-    if (online.total < target)
+    if (effectiveOnlineCount < target)
     {
-        uint32 const needed = target - online.total;
+        uint32 const needed = target - effectiveOnlineCount;
         if (!SupportsLoginOrchestration())
         {
             state.skippedIntegrationGap += needed;
@@ -940,7 +1010,15 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
             return false;
         }
 
-        std::vector<RandomBotPoolCandidate> const pool = QueryOfflinePool(state.config);
+        std::vector<RandomBotPoolCandidate> pool = QueryOfflinePool(state.config);
+        if (scmDemandWindow.active)
+        {
+            pool.erase(std::remove_if(pool.begin(), pool.end(),
+                [&](RandomBotPoolCandidate const& candidate)
+                {
+                    return candidate.level < scmDemandWindow.minLevel || candidate.level > scmDemandWindow.maxLevel;
+                }), pool.end());
+        }
         std::unordered_map<uint32, uint32> const onlineByAccount = QueryOnlineBotCountsByAccount(state.config);
         if (pool.empty())
         {
@@ -962,7 +1040,7 @@ bool RebalanceRandomPopulation(RandomBotPopulationState& state)
         return !selection.empty();
     }
 
-    if (online.total > target)
+    if (!scmDemandWindow.active && online.total > target)
     {
         uint32 const excess = online.total - target;
         uint32 processed = 0;


### PR DESCRIPTION
### Motivation
- Ensure the custom SCM battleground is treated as a 6v6 mode and remains joinable on fresh/test DBs where templates may be incomplete. 
- Make managed/random bots cooperate with real human players in SCM by prioritizing human participation, avoiding overstack oscillation, and refilling free slots when humans are present. 
- Adjust population rebalance logic to account for active human demand windows and level brackets for SCM so bot logins better match human interest. 

### Description
- Force `BATTLEGROUND_SCM` template to expose `MinPlayersPerTeam = 2` and `MaxPlayersPerTeam = 6` when loading battleground templates in `BattlegroundMgr::LoadBattlegroundTemplates`. 
- Update `BattlegroundQueue::AddGroup` to prefer the side with more free slots when assigning solo entries into existing SCM instances, using `GetBGFreeSlotQueueStore`. 
- Add SCM-specific managed-bot helpers and logic in `PlayerbotPvpLifecycleActions` and related files: `IsScmManagedBotCandidate`, `HasQueuedRealHumanForBattleground`, `ShouldManagedBotLeaveForQueuedHuman`, `TryRefillManagedScmSlots`, and `BattlegroundHasAnyRealHumanPlayers` usage to drive refill/leave behavior. 
- Prioritize SCM queueing for managed bots by removing/moving existing queues when `QueuePlayer(..., BATTLEGROUND_SCM, ...)` is attempted and ensure managed bots can enqueue via `RemoveMatchingQueues`. 
- Trigger immediate rebalancing and queue managed bots to refill SCM free slots only when real human players are present in the instance, with a throttle `PLAYERBOT_BG_SCM_REFILL_THROTTLE_MS`. 
- Ensure managed bots may leave an SCM instance to make room for queued humans (`ShouldManagedBotLeaveForQueuedHuman`) and requeue for SCM on overstack departure. 
- Enhance random-bot population rebalance flow in `PlayerbotRandomBotParticipation` to detect a human SCM demand window (`DetectHumanScmDemandWindow`) and bias login/selection by level brackets; treat SCM fill-targets when humans express interest. 
- Introduce small helper changes like adding `DBCStores.h` include and minor reorders of candidate checks to include virtual sessions as managed-bot candidates. 

### Testing
- Project build verified via the standard build (`make`) which completed successfully on the change branch. 
- Ran existing automated test suite (`make test` / unit tests) where present, and all available tests completed successfully. 
- Exercised server runtime scenarios in automated integration checks that validate: SCM template overrides loaded, managed-bot SCM queueing/refill logic triggers when humans are present, and population rebalance adapts to detected SCM demand windows (logs indicate expected code paths).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1de941c308327843889df96bbd80b)