### PR TITLE
playerbot: smooth stealth melee approach for rogue openers

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -328,6 +328,20 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
     if (!player || !target)
         return;
 
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    if (player->HasStealthAura())
+    {
+        // Stealth openers (e.g., Cheap Shot) are very sensitive to smooth
+        // closing movement. Strict-human segmented MovePoint updates can look
+        // like start/stop inching while approaching. Keep a continuous follow
+        // command here so rogues fluidly close to opener distance.
+        motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
+        return;
+    }
+
     if (RequiresStrictHumanPathing(player) && IssueStrictHumanFollow(player, target, 1.5f))
         return;
 
@@ -341,17 +355,7 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
             player->GetGUID().ToString(), target->GetGUID().ToString());
     }
 
-    MotionMaster* motionMaster = player->GetMotionMaster();
-    if (!motionMaster)
-        return;
-
-    if (player->HasStealthAura())
-    {
-        // MoveChase can stall for non-swinging stealth openers. Use follow so
-        // rogues consistently close to opener distance while preserving stealth.
-        motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
-    }
-    else if (player->IsValidAttackTarget(target))
+    if (player->IsValidAttackTarget(target))
         motionMaster->MoveChase(target);
     else
         motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());


### PR DESCRIPTION
### Motivation
- Prevent stealthed melee bots (rogue openers such as Cheap Shot) from inching/starting-and-stopping while closing to opener range caused by segmented strict-human MovePoint updates.

### Description
- In `IssueMeleeApproachMovement` moved `MotionMaster` acquisition to the top and added an early branch for `player->HasStealthAura()` that issues a continuous `MoveFollow(target, 1.5f, player->GetFollowAngle())` and returns, while preserving existing `RequiresStrictHumanPathing` and `MoveChase`/`MoveFollow` behavior for non-stealthed states (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`).

### Testing
- Invoked `cmake --build build --target game -j4` which started configuration and compilation and progressed through many targets without errors in the captured output, but the full build did not complete within the session window; no compiler errors for the changed file were observed in the captured logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f9b4fda48327a18fda0f67fde8fe)