### PR TITLE
SCM: restore depleted marks on wins and grant honor every 10 kills

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -857,7 +857,7 @@ void Battleground::EndBattleground(uint32 winner)
                 player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_WIN_BG, player->GetMapId());
                 player->ModifyMoney(winner_money);
 
-                bool canRestoreMark = isArena() || GetTypeID(true) == BATTLEGROUND_WS;
+                bool canRestoreMark = isArena() || GetTypeID(true) == BATTLEGROUND_WS || GetTypeID(true) == BATTLEGROUND_SCM;
                 if (canRestoreMark && Trinity::Custom::ConsumeEligibleDepletedMarks(player, 1))
                     player->AddItem(Trinity::Custom::ITEM_RESTORED_MARK_OF_HONOR, 1); // restored mark of honor
             }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -227,11 +227,17 @@ void BattlegroundSCM::HandleKillPlayer(Player* victim, Player* killer)
     {
         ++_allianceKills;
         m_TeamScores[TEAM_ALLIANCE] = _allianceKills;
+
+        if ((_allianceKills % 10) == 0)
+            RewardHonorToTeam(sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP) / 2, ALLIANCE);
     }
     else if (killerTeam == HORDE)
     {
         ++_hordeKills;
         m_TeamScores[TEAM_HORDE] = _hordeKills;
+
+        if ((_hordeKills % 10) == 0)
+            RewardHonorToTeam(sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP) / 2, HORDE);
     }
 
     UpdateTeamScoreWorldStates();


### PR DESCRIPTION
### Motivation
- Treat Scarlet Chapel Murderball (SCM) winners like Warsong/Arena winners so they can restore an eligible depleted `Mark of Honor` when the battleground ends. 
- Give SCM teams periodic honor payouts as a small reward during long matches by paying out at every 10-team-kill threshold.

### Description
- Include `BATTLEGROUND_SCM` in the restore-eligibility check inside `Battleground::EndBattleground`, so SCM winners can restore a depleted mark the same way `BATTLEGROUND_WS` and arenas do. (`src/server/game/Battlegrounds/Battleground.cpp`)
- In `BattlegroundSCM::HandleKillPlayer`, award the team half of `Centurion.Battleground.RewardHonorFlagCap` every time that team's kill count reaches a multiple of 10. (`src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp`)

### Testing
- Invoked `cmake --build build --target game -j2` to build the game target; the build progressed successfully in this environment but did not finish within the session time window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2cfafc8808327b2457f1c937064f2)