### PR TITLE
Fix account bank deposit exploit when player leaves banker range

### DIFF
--- a/src/server/game/Accounts/AccountBankMgr.cpp
+++ b/src/server/game/Accounts/AccountBankMgr.cpp
@@ -597,6 +597,19 @@ bool IsAccountBankOpen(Player const* player)
     return GetSession(player) != nullptr;
 }
 
+bool IsAccountBankAccessible(Player const* player)
+{
+    if (!player || !player->IsInWorld())
+        return false;
+
+    SessionState const* session = GetSession(player);
+    if (!session)
+        return false;
+
+    Creature* banker = ObjectAccessor::GetCreature(*player, session->BankerGuid);
+    return banker && player->IsWithinDistInMap(banker, INTERACTION_DISTANCE, false);
+}
+
 bool IsAccountBanker(Player const* player, ObjectGuid bankerGuid)
 {
     if (!player)

--- a/src/server/game/Accounts/AccountBankMgr.h
+++ b/src/server/game/Accounts/AccountBankMgr.h
@@ -45,6 +45,7 @@ namespace AccountBank
     void UpdateAccountBankSessions();
     void HandleLogin(Player* player);
     bool IsAccountBankOpen(Player const* player);
+    bool IsAccountBankAccessible(Player const* player);
     bool IsAccountBanker(Player const* player, ObjectGuid bankerGuid);
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11958,6 +11958,9 @@ InventoryResult Player::CanBankItem(uint8 bag, uint8 slot, ItemPosCountVec& dest
 
     if (AccountBank::IsAccountBankOpen(this))
     {
+        if (!AccountBank::IsAccountBankAccessible(this))
+            return EQUIP_ERR_CANT_DO_RIGHT_NOW;
+
         bool const usingAutoPlacement = (bag == NULL_BAG) && (slot == NULL_SLOT);
         bool const targetIsAccountSlot = (bag == INVENTORY_SLOT_BAG_0) && (slot >= BANK_SLOT_ITEM_START) &&
             (slot < BANK_SLOT_ITEM_START + AccountBank::MAX_SLOTS);


### PR DESCRIPTION
### Motivation
- Prevent a gameplay exploit where a player opens the account bank, walks out of the NPC interaction range leaving the bank view empty, and continues to deposit items into the account bank when the banker is no longer present.

### Description
- Add `AccountBank::IsAccountBankAccessible(Player const*)` to validate that the account-bank session has a banker in-world and within `INTERACTION_DISTANCE` (`src/server/game/Accounts/AccountBankMgr.h` / `AccountBankMgr.cpp`).
- Update `Player::CanBankItem` to call `AccountBank::IsAccountBankAccessible(this)` and return `EQUIP_ERR_CANT_DO_RIGHT_NOW` when the banker is not accessible, blocking deposits (`src/server/game/Entities/Player/Player.cpp`).
- No other account-bank flows were changed; sessions continue to close normally via existing logic in `UpdateAccountBankSession` and related functions.

### Testing
- Ran `git diff --check` which reported no whitespace issues.
- Verified changed files in `git status --short` before committing and created the commit successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d55b78188327a13405aa424a8e28)