### PR TITLE
Fix stealthed rogue playerbots idling during melee openers

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -336,9 +336,13 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
     {
         // Stealth openers (e.g., Cheap Shot) are very sensitive to smooth
         // closing movement. Strict-human segmented MovePoint updates can look
-        // like start/stop inching while approaching. Keep a continuous follow
-        // command here so rogues fluidly close to opener distance.
-        motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
+        // like start/stop inching while approaching. Use chase for hostile
+        // opener targets so rogues actually close distance instead of idling
+        // in a follow generator while out of combat.
+        if (player->IsValidAttackTarget(target))
+            motionMaster->MoveChase(target);
+        else
+            motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
         return;
     }
 


### PR DESCRIPTION
### Motivation
- Stealthed rogue playerbots could select a `reach melee` movement directive but remain stationary because the stealth branch used a `MoveFollow` generator that does not actively close distance to hostile targets for openers.

### Description
- In `IssueMeleeApproachMovement` (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`) change the stealth path to use `motionMaster->MoveChase(target)` when `player->IsValidAttackTarget(target)`, and keep `MoveFollow` as a fallback for non-hostile targets, so stealthed rogues actively close for melee openers.

### Testing
- No automated test suite was run in this environment; the change was applied to the source and the modified file was inspected to verify the new `MoveChase` branch was present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49f633d288327b183e471236fbe19)