### PR TITLE
Prefer strict-human pathing for stealth openers and fallback to chase to avoid idling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -336,9 +336,19 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
     {
         // Stealth openers (e.g., Cheap Shot) are very sensitive to smooth
         // closing movement. Strict-human segmented MovePoint updates can look
-        // like start/stop inching while approaching. Keep a continuous follow
-        // command here so rogues fluidly close to opener distance.
-        motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
+        // like start/stop inching while approaching.
+        //
+        // Still prefer strict-human pathing when required (e.g. battleground
+        // base exits/ramps), otherwise the chase generator can fail to produce
+        // travel from long-range anchor points.
+        if (RequiresStrictHumanPathing(player) && IssueStrictHumanFollow(player, target, 1.5f))
+            return;
+        // If strict pathing did not produce a segment this tick, use chase for
+        // hostile opener targets so rogues keep closing instead of idling.
+        if (player->IsValidAttackTarget(target))
+            motionMaster->MoveChase(target);
+        else
+            motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
         return;
     }
 


### PR DESCRIPTION
### Motivation

- Improve melee approach for stealth openers so bots use strict-human pathing when required (e.g., battleground exits/ramps) and avoid idling when that pathing does not produce movement.

### Description

- For stealth cases, call `RequiresStrictHumanPathing(player)` and `IssueStrictHumanFollow(player, target, 1.5f)` and return if strict-human follow produced a movement segment.
- If strict pathing did not produce a segment, use `MoveChase(target)` for valid attack targets or `MoveFollow(target, 1.5f, player->GetFollowAngle())` otherwise.
- Updated inline comments to clarify the fallback behavior and reasoning.

### Testing

- Built the server and compiled the modified file `src/server/scripts/Playerbot/PlayerbotPvpClassActions.cpp` with no compiler errors.
- Executed the project's automated test suite and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49f633d288327b183e471236fbe19)