### PR TITLE
Improve melee approach movement and stealth opener handling for playerbots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -332,13 +332,39 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
     if (!motionMaster)
         return;
 
+    switch (motionMaster->GetCurrentMovementGeneratorType())
+    {
+        case IDLE_MOTION_TYPE:
+        case CHASE_MOTION_TYPE:
+        case POINT_MOTION_TYPE:
+        case FOLLOW_MOTION_TYPE:
+            break;
+        default:
+            // Battleground transitions can occasionally leave players parked in
+            // a non-combat generator (e.g. flight) while stationary. Clear it
+            // so reach-melee directives can issue fresh pursuit movement.
+            if (!player->isMoving())
+                motionMaster->Clear();
+            break;
+    }
+
     if (player->HasStealthAura())
     {
         // Stealth openers (e.g., Cheap Shot) are very sensitive to smooth
         // closing movement. Strict-human segmented MovePoint updates can look
-        // like start/stop inching while approaching. Keep a continuous follow
-        // command here so rogues fluidly close to opener distance.
-        motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
+        // like start/stop inching while approaching.
+        //
+        // Still prefer strict-human pathing when required (e.g. battleground
+        // base exits/ramps), otherwise the chase generator can fail to produce
+        // travel from long-range anchor points.
+        if (RequiresStrictHumanPathing(player) && IssueStrictHumanFollow(player, target, 1.5f))
+            return;
+        // If strict pathing did not produce a segment this tick, use chase for
+        // hostile opener targets so rogues keep closing instead of idling.
+        if (player->IsValidAttackTarget(target))
+            motionMaster->MoveChase(target);
+        else
+            motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
         return;
     }
 


### PR DESCRIPTION
### Motivation

- Increase robustness of melee approach movement when players are left in non-combat movement generators (e.g., flight) so bots resume pursuit correctly.  
- Make stealth opener movement (rogue-style) smoother by preferring strict human pathing when appropriate while preserving chase fallback so openers keep closing.  

### Description

- In `IssueMeleeApproachMovement` add a check on `motionMaster->GetCurrentMovementGeneratorType()` and clear the motion master when the player is stationary in a non-idle/non-chase/non-point/non-follow generator to allow fresh pursuit movement.  
- Change stealth opener logic to attempt `IssueStrictHumanFollow(player, target, 1.5f)` first and return if it produced a movement segment, otherwise use `MoveChase` for valid attack targets or `MoveFollow` for non-hostile targets.  
- Preserve existing fallbacks and debug logging when strict-human pathing fails so bots still use generic chase/follow behavior.  

### Testing

- Project compiled successfully.  
- Ran unit tests and automated test suite related to movement and playerbot behaviors, which completed without failures.  
- Verified movement behavior in bot movement/integration scenarios to confirm melee pursuit and stealth openers fall back appropriately and do not get stuck; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49f633d288327b183e471236fbe19)