### PR TITLE
Treat direct physical hits on sitting players as critical strikes

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1080,6 +1080,11 @@ void Unit::CalculateSpellDamageTaken(SpellNonMeleeDamage* damageInfo, int32 dama
         if (Unit::IsDamageReducedByArmor(damageSchoolMask, spellInfo))
             damage = Unit::CalcArmorReducedDamage(this, victim, damage, spellInfo, attackType);
 
+        // Sitting player targets should take a critical strike from any direct physical hit
+        // (includes melee/ranged damage-class spells such as Ambush/Backstab/Auto Shot).
+        if (!crit && victim->IsPlayer() && !victim->IsStandState() && !damageInfo->periodicLog && (damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
+            crit = true;
+
         // Per-school calc
         switch (spellInfo->DmgClass)
         {


### PR DESCRIPTION
### Motivation
- Ensure direct physical attacks (melee/ranged damage-class spells) on players who are sitting are treated as critical hits to match expected game behavior for abilities like Ambush/Backstab/Auto Shot.

### Description
- Added a check in `Unit::CalculateSpellDamageTaken` that sets `crit = true` for player victims that are not in standing state (`!IsStandState()`), for non-periodic damage (`!damageInfo->periodicLog`), and when the damage school includes normal physical damage (`SPELL_SCHOOL_MASK_NORMAL`), evaluating after armor reduction and before per-school crit handling.

### Testing
- Project built successfully and existing automated tests covering spell/damage calculations were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49e52a0848327a4e8cde9075ad3bc)