### PR TITLE
Add throttled follow movement for stealth openers and expose motion target diagnostics

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -294,6 +294,46 @@ bool IssueStrictHumanFollow(Player* player, Unit* target, float desiredDistance)
     return IssueStrictHumanMove(player, BuildFollowDestination(player, target, desiredDistance));
 }
 
+bool IssueThrottledFollowMovement(Player* player, Unit* target, float desiredDistance, uint32 minReissueMs = 250, float rangeChangeThreshold = 0.2f)
+{
+    if (!player || !target || !target->IsAlive())
+        return false;
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return false;
+
+    struct FollowOrderState
+    {
+        ObjectGuid targetGuid = ObjectGuid::Empty;
+        float range = 0.0f;
+        uint32 lastIssueMs = 0;
+    };
+
+    static std::unordered_map<uint64, FollowOrderState> stateByGuid;
+    FollowOrderState& state = stateByGuid[player->GetGUID().GetRawValue()];
+    // Follow distance should allow true melee contact for stealth openers.
+    // Clamping to >= 1.0f can leave bots hovering outside melee reach
+    // depending on hitbox combinations.
+    float const safeDistance = std::max(0.1f, desiredDistance);
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+
+    bool const targetChanged = state.targetGuid != target->GetGUID();
+    bool const rangeChanged = std::fabs(state.range - safeDistance) >= rangeChangeThreshold;
+    bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
+    if (!targetChanged && !rangeChanged && !canReissueByTime &&
+        motionMaster->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
+    {
+        return true;
+    }
+
+    motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+    state.targetGuid = target->GetGUID();
+    state.range = safeDistance;
+    state.lastIssueMs = nowMs;
+    return true;
+}
+
 void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDistance)
 {
     if (!player || !target)
@@ -338,7 +378,7 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
         // closing movement. Strict-human segmented MovePoint updates can look
         // like start/stop inching while approaching. Keep a continuous follow
         // command here so rogues fluidly close to opener distance.
-        motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
+        IssueThrottledFollowMovement(player, target, 0.1f);
         return;
     }
 
@@ -845,21 +885,22 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         if (preserveStealthForOpener)
         {
             // While stealthed, keep auto-attack disabled so we do not break
-            // stealth early, but keep chase active so rogues continue
-            // closing distance instead of idling in place during openers.
+            // stealth early, but continue issuing movement so rogues still
+            // close to opener distance instead of idling in place.
             //
-            // AttackStop can clear chase intent in some movement states, so
-            // only call it when we are actively swinging a victim and then
-            // (re)issue chase immediately afterwards.
+            // AttackStop can clear active movement intent in some states, so
+            // only call it when we are actively swinging a victim.
             if (player->GetVictim())
                 player->AttackStop();
 
             if (CanIssueFollowCommands(player))
             {
-                // In stealth opener states, favor direct chase over strict
-                // segmented follow to avoid stop/start stalls around ~6-10y.
-                if (MotionMaster* motionMaster = player->GetMotionMaster())
-                    motionMaster->MoveChase(target);
+                // In stealth opener states, favor continuous follow over
+                // chase. Chase movement pauses when owner->GetVictim() no
+                // longer matches the chased unit, and stealth openers
+                // intentionally avoid setting/keeping a victim so stealth is
+                // preserved.
+                IssueThrottledFollowMovement(player, target, 0.1f);
             }
         }
         else if (player->GetVictim() != target)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -2254,17 +2254,30 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 
     if (distance > profile.preferredMaxPressureRange || !player->IsWithinMeleeRange(target))
     {
-        bool const forceStealthRogueChase = player->GetClass() == CLASS_ROGUE && player->HasStealthAura();
-        if (!forceStealthRogueChase && !CanIssueMovementCommand(player, 500))
+        bool const isStealthedRogue = player->GetClass() == CLASS_ROGUE && player->HasStealthAura();
+        if (!isStealthedRogue && !CanIssueMovementCommand(player, 500))
             return true;
-        // Use core chase movement for melee stickiness instead of repeatedly
-        // recomputing follow points around the target. This avoids oscillation
-        // where rogues can appear to peel away before re-engaging.
+
         ClearEatDrinkAurasForMovement(player);
+
+        if (isStealthedRogue)
+        {
+            // Stealth openers intentionally run without a committed victim for
+            // part of the engage. MoveChase can pause when victim linkage is
+            // absent, so use follow semantics to keep continuous closing.
+            player->GetMotionMaster()->MoveFollow(target, 0.1f, player->GetFollowAngle());
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP distance band: bot={} profile={} decision=stealth-melee-close-follow distance={} max={}.",
+                player->GetGUID().ToString(), profile.label, distance, profile.preferredMaxPressureRange);
+            return true;
+        }
+
+        // Use core chase movement for non-stealth melee stickiness instead of
+        // repeatedly recomputing follow points around the target.
         player->GetMotionMaster()->MoveChase(target);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP distance band: bot={} profile={} decision=melee-close distance={} max={} forceStealthRogueChase={}.",
-            player->GetGUID().ToString(), profile.label, distance, profile.preferredMaxPressureRange, forceStealthRogueChase ? 1 : 0);
+            "Playerbot PvP distance band: bot={} profile={} decision=melee-close distance={} max={}.",
+            player->GetGUID().ToString(), profile.label, distance, profile.preferredMaxPressureRange);
         return true;
     }
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -20,6 +20,7 @@
 #include "GameTime.h"
 #include "Item.h"
 #include "MotionMaster.h"
+#include "Movement/AbstractFollower.h"
 #include "Player.h"
 #include "BattlegroundMgr.h"
 #include "BattlegroundQueue.h"
@@ -118,6 +119,7 @@ std::string BuildManagedBotStatusLine(Player* bot)
            << "combat=" << (bot->IsInCombat() ? "yes" : "no")
            << " alive=" << (bot->IsAlive() ? "yes" : "no")
            << " moving=" << (bot->isMoving() ? "yes" : "no")
+           << " stealth=" << (bot->HasStealthAura() ? "yes" : "no")
            << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
            << " bg_state=" << ToString(values.battlegroundState)
            << " class_action=" << (classContext.actionName ? classContext.actionName : "none")
@@ -140,6 +142,26 @@ std::string BuildManagedBotStatusLine(Player* bot)
         status << " victim=" << victim->GetName() << " victim_dist=" << bot->GetDistance(victim);
     else
         status << " victim=none";
+
+    Unit* motionTarget = nullptr;
+    if (MotionMaster* motionMaster = bot->GetMotionMaster())
+        if (MovementGenerator* movement = motionMaster->GetCurrentMovementGenerator())
+            if (AbstractFollower* follower = dynamic_cast<AbstractFollower*>(movement))
+                motionTarget = follower->GetTarget();
+
+    if (motionTarget)
+    {
+        bool const motionTargetMatchesVictim = bot->GetVictim() && bot->GetVictim()->GetGUID() == motionTarget->GetGUID();
+        bool const chaseVictimMismatch = bot->GetMotionMaster()->GetCurrentMovementGeneratorType() == CHASE_MOTION_TYPE && !motionTargetMatchesVictim;
+        status << " motion_target=" << motionTarget->GetName()
+               << " motion_target_dist=" << bot->GetDistance(motionTarget)
+               << " motion_target_is_victim=" << (motionTargetMatchesVictim ? "yes" : "no")
+               << " chase_victim_mismatch=" << (chaseVictimMismatch ? "yes" : "no");
+    }
+    else
+    {
+        status << " motion_target=none";
+    }
 
     if (Unit* selected = bot->GetSelectedUnit())
     {


### PR DESCRIPTION
### Motivation
- Prevent stop/start movement stalls for stealth openers by preferring a smooth, throttled follow instead of repeated chase/follow or strict segmented pathing.
- Improve runtime diagnostics by exposing current motion target and chase/follow mismatch information in the managed-bot status line.

### Description
- Added `IssueThrottledFollowMovement` to implement rate-limited follow commands with target/range change detection to avoid excessive MoveFollow/MoveChase reissues.
- Replaced immediate `MoveFollow`/`MoveChase` usages for stealthed openers with `IssueThrottledFollowMovement` in `PlayerbotPvpClassActions.cpp` and used a small follow distance (0.1f) for stealth melee closing.
- Adjusted melee engagement logic in `PlayerbotPvpLifecycleActions.cpp` to use `MoveFollow` for stealthed rogues and `MoveChase` for non-stealthed melee to maintain continuous closing behavior.
- Enhanced `BuildManagedBotStatusLine` in `playerbot_loader.cpp` to include `stealth` status and, when present, the current motion target (name, distance, whether it matches the victim, and chase-victim mismatch) by inspecting the current `AbstractFollower` movement generator.
- Included the `Movement/AbstractFollower.h` header to access follower internals and added related debug logging and comments.

### Testing
- Project build was executed as an automated step and completed successfully with no compile errors.
- Existing automated test suite (where available) was run and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4aa9146448327b3d84cb45957c705)