### PR TITLE
Improve playerbot low-mana behavior: allow urgent drinking and melee fallback

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -1054,6 +1054,15 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     if (!bypassPowerPrecheck && spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
         {
+            // If we cannot pay for the selected enemy spell, immediately
+            // transition to melee pressure so bots do not idle while OOM.
+            if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy && target && CanIssueFollowCommands(player))
+            {
+                IssueMeleeApproachMovement(player, target);
+                if (player->GetVictim() != target || !player->HasUnitState(UNIT_STATE_MELEE_ATTACKING))
+                    player->Attack(target, true);
+            }
+
             failureReason = "insufficient_power";
             return false;
         }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -707,9 +707,17 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     if (IsHardControlled(player))
         return decision;
 
+    bool const usesMana = player->GetMaxPower(POWER_MANA) > 0;
+    bool const needsDrink = usesMana && player->GetPowerPct(POWER_MANA) < 100.0f;
+    bool const urgentlyNeedsDrink = needsDrink && (player->GetPowerPct(POWER_MANA) < 35.0f || IsLowOrOutOfManaForFallback(player));
+
     // Keep a single nearby-enemy boundary for "switch to combat posture".
     // Inside this range we should avoid out-of-combat utility behaviors
     // (eat/drink/mount), so movement + combat targeting can take over cleanly.
+    //
+    // Exception: when mana is critically low and the bot is already out of
+    // combat, allow drink selection so they can recover instead of idling in a
+    // perpetual "combat posture" loop.
     float const nearbyHostileCombatBoundary = std::max(GetConfiguredLongRange(), 35.0f);
     if (player->GetMap())
     {
@@ -722,13 +730,14 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
             if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, nearbyHostileCombatBoundary))
                 continue;
 
-            return decision;
+            if (!urgentlyNeedsDrink)
+                return decision;
+
+            break;
         }
     }
 
     bool const needsFood = player->GetHealthPct() < 100.0f;
-    bool const usesMana = player->GetMaxPower(POWER_MANA) > 0;
-    bool const needsDrink = usesMana && player->GetPowerPct(POWER_MANA) < 100.0f;
     bool const hasEatAura = player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT);
     bool const hasDrinkAura = player->HasAura(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK);
 


### PR DESCRIPTION
### Motivation
- Bots can become stuck idling when out of mana because nearby hostiles block out-of-combat recovery and failed cast attempts leave them doing nothing. 
- The intent is for playerbots to recover (drink) when mana is critically low or to fall back to melee pressure when a selected enemy spell cannot be paid for.

### Description
- Allow urgent out-of-combat drink selection by adding `urgentlyNeedsDrink` logic in `SelectOutOfCombatEatDrinkOrMountSpell` so nearby-hostile gating is bypassed for critically low mana in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`.
- When a local power precheck fails for an enemy-targeted spell in `CastDirectSpell`, issue melee approach movement and trigger melee auto-attack to avoid idling, implemented in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`.
- Changes are limited to two functions: `SelectOutOfCombatEatDrinkOrMountSpell` and the precheck block in `CastDirectSpell`, and include explanatory comments and conservative gating to preserve normal behavior.

### Testing
- Verified diffs with `git diff -- src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` which reported the intended changes and succeeded. 
- Committed changes with `git commit -m "Improve playerbot OOM fallback to drink or melee"` which completed successfully. 
- No CI/build or unit tests were executed in this rollout; compilation and runtime validation were not performed automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b3f886c48327b667218ed972381f)