### PR TITLE
Use exact spell max range for ranged spacing trigger

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2955,7 +2955,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             float const distance = player->GetDistance(spacingTarget);
             float const maxRange = spellInfo->GetMaxRange(false);
             float const minRange = spellInfo->GetMinRange(false);
-            if (maxRange > 0.0f && distance > (maxRange + kRangedSpacingEnterOutOfRangeBuffer))
+            if (maxRange > 0.0f && distance > maxRange)
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
                     std::max(1.0f, maxRange - 1.0f), "reach spell", "selected spell out of range", 84.0f);


### PR DESCRIPTION
### Motivation
- Ensure ranged bots use the spell's actual `maxRange` when deciding to move into cast range and avoid relying on an additional out-of-range buffer that could delay movement decisions.

### Description
- Replace `if (maxRange > 0.0f && distance > (maxRange + kRangedSpacingEnterOutOfRangeBuffer))` with `if (maxRange > 0.0f && distance > maxRange)` so the movement directive triggers as soon as the target is beyond the spell's reported max range.
- No other logic changes were made; the branch still clears the selected spell/context and enqueues a `ReachSpellRange` movement directive when triggered.

### Testing
- Performed a full build of the server source and the project compiled successfully. 
- Executed unit tests and PvP-related automated tests and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b501ffac8327ab11a9ece2418013)