### PR TITLE
playerbot: avoid interrupting mounts/aimed‑shot and skip stealth freedom targets

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1215,35 +1215,38 @@ bool HasDotAura(Unit const* unit)
         unit->HasAuraType(SPELL_AURA_PERIODIC_DAMAGE_PERCENT);
 }
 
-bool IsMountOrAimedShotCast(SpellInfo const* spellInfo)
-{
-    if (!spellInfo)
-        return false;
-
-    if (spellInfo->HasAura(SPELL_AURA_MOUNTED) || spellInfo->Mechanic == MECHANIC_MOUNT)
-        return true;
-
-    SpellInfo const* firstRank = spellInfo->GetFirstRankSpell();
-    return firstRank && firstRank->Id == 19434; // Aimed Shot
-}
-
-bool ShouldIgnoreInterruptCast(Unit const* unit)
+bool IsInterruptibleCast(Unit const* unit)
 {
     if (!unit)
-        return true;
+        return false;
 
-    auto shouldIgnoreCurrent = [&](CurrentSpellTypes spellType)
+    auto isInterruptibleCurrentSpell = [&](CurrentSpellTypes spellType)
     {
-        Spell const* current = unit->GetCurrentSpell(spellType);
-        if (!current)
+        Spell const* currentSpell = unit->GetCurrentSpell(spellType);
+        if (!currentSpell)
             return false;
 
-        return IsMountOrAimedShotCast(current->GetSpellInfo());
+        SpellInfo const* spellInfo = currentSpell->GetSpellInfo();
+        if (!spellInfo || spellInfo->PreventionType != SPELL_PREVENTION_TYPE_SILENCE)
+            return false;
+
+        SpellState const state = currentSpell->getState();
+        bool const isInInterruptiblePhase = state == SPELL_STATE_CASTING ||
+            (state == SPELL_STATE_PREPARING && currentSpell->GetCastTime() > 0.0f);
+        if (!isInInterruptiblePhase)
+            return false;
+
+        if (spellType == CURRENT_GENERIC_SPELL)
+            return (spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_INTERRUPT) != 0;
+
+        if (spellType == CURRENT_CHANNELED_SPELL)
+            return (spellInfo->ChannelInterruptFlags & CHANNEL_INTERRUPT_FLAG_INTERRUPT) != 0;
+
+        return false;
     };
 
-    return shouldIgnoreCurrent(CURRENT_GENERIC_SPELL) ||
-        shouldIgnoreCurrent(CURRENT_CHANNELED_SPELL) ||
-        shouldIgnoreCurrent(CURRENT_AUTOREPEAT_SPELL);
+    return isInterruptibleCurrentSpell(CURRENT_GENERIC_SPELL) ||
+        isInterruptibleCurrentSpell(CURRENT_CHANNELED_SPELL);
 }
 
 bool IsTargetInvalidByImmunity(Player const* player, Unit const* target)
@@ -1316,7 +1319,7 @@ Unit const* SelectEnemyCastingTarget(Player const* player, float maxDistance, Un
         return HasHostileTarget(player, candidate) &&
             !IsTargetInvalidByImmunity(player, candidate) &&
             candidate->HasUnitState(UNIT_STATE_CASTING) &&
-            !ShouldIgnoreInterruptCast(candidate) &&
+            IsInterruptibleCast(candidate) &&
             player->IsWithinLOSInMap(candidate) &&
             player->IsWithinDistInMap(candidate, maxDistance);
     };

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1215,6 +1215,37 @@ bool HasDotAura(Unit const* unit)
         unit->HasAuraType(SPELL_AURA_PERIODIC_DAMAGE_PERCENT);
 }
 
+bool IsMountOrAimedShotCast(SpellInfo const* spellInfo)
+{
+    if (!spellInfo)
+        return false;
+
+    if (spellInfo->HasAura(SPELL_AURA_MOUNTED) || spellInfo->Mechanic == MECHANIC_MOUNT)
+        return true;
+
+    SpellInfo const* firstRank = spellInfo->GetFirstRankSpell();
+    return firstRank && firstRank->Id == 19434; // Aimed Shot
+}
+
+bool ShouldIgnoreInterruptCast(Unit const* unit)
+{
+    if (!unit)
+        return true;
+
+    auto shouldIgnoreCurrent = [&](CurrentSpellTypes spellType)
+    {
+        Spell const* current = unit->GetCurrentSpell(spellType);
+        if (!current)
+            return false;
+
+        return IsMountOrAimedShotCast(current->GetSpellInfo());
+    };
+
+    return shouldIgnoreCurrent(CURRENT_GENERIC_SPELL) ||
+        shouldIgnoreCurrent(CURRENT_CHANNELED_SPELL) ||
+        shouldIgnoreCurrent(CURRENT_AUTOREPEAT_SPELL);
+}
+
 bool IsTargetInvalidByImmunity(Player const* player, Unit const* target)
 {
     if (!player || !target)
@@ -1285,6 +1316,7 @@ Unit const* SelectEnemyCastingTarget(Player const* player, float maxDistance, Un
         return HasHostileTarget(player, candidate) &&
             !IsTargetInvalidByImmunity(player, candidate) &&
             candidate->HasUnitState(UNIT_STATE_CASTING) &&
+            !ShouldIgnoreInterruptCast(candidate) &&
             player->IsWithinLOSInMap(candidate) &&
             player->IsWithinDistInMap(candidate, maxDistance);
     };
@@ -1776,6 +1808,9 @@ Unit const* SelectFriendlySnaredTarget(Player const* player, float maxDistance)
 
     auto isSnared = [](Unit const* target)
     {
+        if (!target || target->HasStealthAura())
+            return false;
+
         return target && (target->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED) || target->HasAuraWithMechanic(1 << MECHANIC_ROOT));
     };
 


### PR DESCRIPTION
### Motivation
- Playerbots were attempting to interrupt mount casts and Hunter Aimed Shot casts and were using Paladin `Hand of Freedom` on allies who are stealthed/prowled because stealth applies a movement slow aura; both behaviors are undesirable in PvP/utility logic.
- The change ensures interrupt logic does not target mount/aimed-shot casts and that Paladin freedom selection ignores stealth movement penalties.
- Changes were applied in the active playerbot source at `src/server/scripts/Playerbot/` (not in the `playerbot reference/` mirror) to follow repository conventions.

### Description
- Added `IsMountOrAimedShotCast(SpellInfo const*)` to detect mount spells and Aimed Shot (checks aura/mechanic and first-rank id `19434`).
- Added `ShouldIgnoreInterruptCast(Unit const*)` which inspects a unit's current spells and returns true for mount/aimed-shot casts.
- Integrated `ShouldIgnoreInterruptCast` into `SelectEnemyCastingTarget` candidate filtering so bots skip interrupting these casts (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`).
- Updated `SelectFriendlySnaredTarget` to ignore units with `HasStealthAura()` so Paladin freedom targeting excludes rogues in Stealth and druids in Prowl.

### Testing
- Ran static checks using `git diff --check` which passed without issues.
- Verified the modified file changes are limited to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` via repository status checks; no automated build/test was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b7c239308327a3e53be5cf3738f7)