### PR TITLE
Fix Spell::getState type mismatch in Playerbot PvP core

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1270,7 +1270,7 @@ bool IsInterruptibleCast(Unit const* unit)
         if (!spellInfo || spellInfo->PreventionType != SPELL_PREVENTION_TYPE_SILENCE)
             return false;
 
-        SpellState const state = currentSpell->getState();
+        uint32 const state = currentSpell->getState();
         bool const isInInterruptiblePhase = state == SPELL_STATE_CASTING ||
             (state == SPELL_STATE_PREPARING && currentSpell->GetCastTime() > 0.0f);
         if (!isInInterruptiblePhase)


### PR DESCRIPTION
### Motivation
- Fix a Clang compile error in the PvP interruptibility check where `Spell::getState()` (which returns `uint32`) was being assigned to a `SpellState` variable in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`.

### Description
- Replace the local declaration `SpellState const state` with `uint32 const state` in `IsInterruptibleCast` to match `currentSpell->getState()` and preserve the existing interrupt-phase checks and logic.

### Testing
- No automated tests or full build were run in this environment; this is a single-line compile-time type fix intended to resolve the reported error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b99ce4408327905a642dc63e0a0c)