### PR TITLE
Expose additional bot lifecycle and state flags in PB status line

### DIFF
--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -113,15 +113,33 @@ std::string BuildManagedBotStatusLine(Player* bot)
     playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(bot, values);
     playerbot::BattlegroundLifecycleContext const lifecycleContext = playerbot::PvpCore::BuildBattlegroundLifecycleContext(bot, values);
     playerbot::RandomBotParticipationHooks const hooks = playerbot::PvpCore::BuildRandomBotParticipationHooks(bot, values);
+    bool const lifecycleEnabled = lifecycleContext.lifecycleEnabled;
+    bool const managedRandomBot = playerbot::IsManagedRandomBot(bot);
+    bool const canFollowCommands = bot->IsAlive() &&
+        !bot->HasUnitState(UNIT_STATE_ROOT) &&
+        !bot->HasUnitState(UNIT_STATE_STUNNED) &&
+        !bot->HasUnitState(UNIT_STATE_CONFUSED) &&
+        !bot->HasUnitState(UNIT_STATE_FLEEING) &&
+        !bot->HasUnitState(UNIT_STATE_LOST_CONTROL);
 
     std::ostringstream status;
     status << "PB status: "
+           << "lifecycle=" << (lifecycleEnabled ? "on" : "off")
+           << " managed=" << (managedRandomBot ? "yes" : "no")
            << "combat=" << (bot->IsInCombat() ? "yes" : "no")
            << " alive=" << (bot->IsAlive() ? "yes" : "no")
            << " moving=" << (bot->isMoving() ? "yes" : "no")
+           << " can_follow=" << (canFollowCommands ? "yes" : "no")
+           << " rooted=" << (bot->HasUnitState(UNIT_STATE_ROOT) ? "yes" : "no")
+           << " stunned=" << (bot->HasUnitState(UNIT_STATE_STUNNED) ? "yes" : "no")
+           << " confused=" << (bot->HasUnitState(UNIT_STATE_CONFUSED) ? "yes" : "no")
+           << " fleeing=" << (bot->HasUnitState(UNIT_STATE_FLEEING) ? "yes" : "no")
+           << " lost_control=" << (bot->HasUnitState(UNIT_STATE_LOST_CONTROL) ? "yes" : "no")
            << " stealth=" << (bot->HasStealthAura() ? "yes" : "no")
            << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
            << " bg_state=" << ToString(values.battlegroundState)
+           << " class_gate=" << (classContext.classSpellsEnabled ? "on" : "off")
+           << " class_exec=" << (classContext.shouldExecute ? "yes" : "no")
            << " class_action=" << (classContext.actionName ? classContext.actionName : "none")
            << " spell=" << classContext.spellId
            << " reason=" << (classContext.reason ? classContext.reason : "none")


### PR DESCRIPTION
### Motivation
- Improve visibility into managed playerbot state for debugging by surfacing lifecycle, management and movement-related flags in the bot status line.

### Description
- Extended `BuildManagedBotStatusLine` to collect and show `lifecycleEnabled`, `managedRandomBot`, and an aggregated `canFollowCommands` flag derived from unit states.
- Added explicit output fields for `lifecycle`, `managed`, `can_follow`, and individual unit states `rooted`, `stunned`, `confused`, `fleeing`, and `lost_control` to the status string.
- Exposed class execution gates as `class_gate` and `class_exec` in the status line and adjusted ordering of existing fields to include the new values.

### Testing
- Project compiled successfully using the normal build (`make`/`cmake` build step) with the changes.
- The automated test suite (`ctest`/`make test`) was executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bb9797548327b203fb27cbdfd9f8)