### PR TITLE
Improve ranged approach spacing and expand managed-bot status output

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2550,6 +2550,15 @@ bool CanUseHealRangeSpacing(uint8 classId)
     }
 }
 
+float ComputeApproachFollowRange(float nominalRange)
+{
+    // Keep an extra movement buffer so ranged bots do not settle in a
+    // dead-zone where spell-selection still reports out-of-range but chase
+    // motion does not re-engage because the desired distance is too close to
+    // edge tolerances.
+    return std::max(1.0f, nominalRange - 3.0f);
+}
+
 bool IsPrimaryMeleeClassForSpacing(uint8 classId)
 {
     switch (classId)
@@ -3036,7 +3045,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (maxRange > 0.0f && distance > maxRange)
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
-                    std::max(1.0f, maxRange - 1.0f), "reach spell", "selected spell out of range", 84.0f);
+                    ComputeApproachFollowRange(maxRange), "reach spell", "selected spell out of range", 84.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3061,7 +3070,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
                 // selecting enemy casts. Keep a config-based engage floor so
                 // they always step in to practical casting distance.
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy outside configured cast distance", 82.0f);
+                    ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy outside configured cast distance", 82.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3083,7 +3092,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (distance > (GetConfiguredSpellRange() + kRangedSpacingEnterOutOfRangeBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, movementTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy out of spell range", 70.0f);
+                    ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy out of spell range", 70.0f);
             }
             else if (distance < std::max(0.0f, GetConfiguredMeleeRange() - kRangedSpacingEnterTooCloseBuffer))
             {
@@ -3114,7 +3123,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (distance > GetConfiguredHealRange())
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, allyMovementTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredHealRange() - 1.0f), "reach party member to heal", "party member to heal out of spell range", 68.0f);
+                    ComputeApproachFollowRange(GetConfiguredHealRange()), "reach party member to heal", "party member to heal out of spell range", 68.0f);
             }
         }
     }

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -113,15 +113,33 @@ std::string BuildManagedBotStatusLine(Player* bot)
     playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(bot, values);
     playerbot::BattlegroundLifecycleContext const lifecycleContext = playerbot::PvpCore::BuildBattlegroundLifecycleContext(bot, values);
     playerbot::RandomBotParticipationHooks const hooks = playerbot::PvpCore::BuildRandomBotParticipationHooks(bot, values);
+    bool const lifecycleEnabled = lifecycleContext.lifecycleEnabled;
+    bool const managedRandomBot = playerbot::IsManagedRandomBot(bot);
+    bool const canFollowCommands = bot->IsAlive() &&
+        !bot->HasUnitState(UNIT_STATE_ROOT) &&
+        !bot->HasUnitState(UNIT_STATE_STUNNED) &&
+        !bot->HasUnitState(UNIT_STATE_CONFUSED) &&
+        !bot->HasUnitState(UNIT_STATE_FLEEING) &&
+        !bot->HasUnitState(UNIT_STATE_LOST_CONTROL);
 
     std::ostringstream status;
     status << "PB status: "
+           << "lifecycle=" << (lifecycleEnabled ? "on" : "off")
+           << " managed=" << (managedRandomBot ? "yes" : "no")
            << "combat=" << (bot->IsInCombat() ? "yes" : "no")
            << " alive=" << (bot->IsAlive() ? "yes" : "no")
            << " moving=" << (bot->isMoving() ? "yes" : "no")
+           << " can_follow=" << (canFollowCommands ? "yes" : "no")
+           << " rooted=" << (bot->HasUnitState(UNIT_STATE_ROOT) ? "yes" : "no")
+           << " stunned=" << (bot->HasUnitState(UNIT_STATE_STUNNED) ? "yes" : "no")
+           << " confused=" << (bot->HasUnitState(UNIT_STATE_CONFUSED) ? "yes" : "no")
+           << " fleeing=" << (bot->HasUnitState(UNIT_STATE_FLEEING) ? "yes" : "no")
+           << " lost_control=" << (bot->HasUnitState(UNIT_STATE_LOST_CONTROL) ? "yes" : "no")
            << " stealth=" << (bot->HasStealthAura() ? "yes" : "no")
            << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
            << " bg_state=" << ToString(values.battlegroundState)
+           << " class_gate=" << (classContext.classSpellsEnabled ? "on" : "off")
+           << " class_exec=" << (classContext.shouldExecute ? "yes" : "no")
            << " class_action=" << (classContext.actionName ? classContext.actionName : "none")
            << " spell=" << classContext.spellId
            << " reason=" << (classContext.reason ? classContext.reason : "none")


### PR DESCRIPTION
### Motivation
- Prevent ranged bots from getting stuck in a spacing "dead-zone" where spells report out-of-range but chase motion does not re-engage due to tight follow tolerances.
- Provide more useful diagnostic information for managed/random bots and whether a bot can accept follow/movement commands in the status line.

### Description
- Add `ComputeApproachFollowRange(float nominalRange)` which returns `std::max(1.0f, nominalRange - 3.0f)` and document why a larger approach buffer is needed for ranged approaches.
- Replace several ad-hoc `std::max(... - 1.0f)` follow-range calculations in `PlayerbotPvpCore.cpp` with calls to `ComputeApproachFollowRange(...)` for spell, configured cast, and heal approach directives.
- Enhance `BuildManagedBotStatusLine` in `playerbot_loader.cpp` to include lifecycle enabled state, managed-random-bot flag, a computed `can_follow` field (based on alive/root/stunned/confused/fleeing/lost-control states), and class gating/execution flags in the status output.

### Testing
- Project build completed locally using the standard build (`cmake`/`make`) and the server binary links successfully with the changes applied.
- Ran the automated test/validation harness (`make test` / CI unit tests) and observed no regressions in the test suite related to movement or status-output checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bb9797548327b203fb27cbdfd9f8)