### PR TITLE
Improve PvP bot casting/movement logic and expand managed-bot status output

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -407,6 +407,17 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     if (minRange > 0.0f && player->IsWithinDistInMap(resolvedTarget, minRange))
         return false;
 
+    // Skip decisions we cannot currently pay for so the fallback chain can
+    // choose a castable alternative (wand, movement, etc.) instead of
+    // repeatedly selecting an OOM support spell.
+    if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
+    {
+        Powers const powerType = Powers(spellInfo->PowerType);
+        int32 const powerCost = spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask());
+        if (powerCost > 0 && player->GetPower(powerType) < powerCost)
+            return false;
+    }
+
     return true;
 }
 
@@ -2550,6 +2561,15 @@ bool CanUseHealRangeSpacing(uint8 classId)
     }
 }
 
+float ComputeApproachFollowRange(float nominalRange)
+{
+    // Keep an extra movement buffer so ranged bots do not settle in a
+    // dead-zone where spell-selection still reports out-of-range but chase
+    // motion does not re-engage because the desired distance is too close to
+    // edge tolerances.
+    return std::max(1.0f, nominalRange - 3.0f);
+}
+
 bool IsPrimaryMeleeClassForSpacing(uint8 classId)
 {
     switch (classId)
@@ -3036,7 +3056,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (maxRange > 0.0f && distance > maxRange)
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
-                    std::max(1.0f, maxRange - 1.0f), "reach spell", "selected spell out of range", 84.0f);
+                    ComputeApproachFollowRange(maxRange), "reach spell", "selected spell out of range", 84.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3061,7 +3081,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
                 // selecting enemy casts. Keep a config-based engage floor so
                 // they always step in to practical casting distance.
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy outside configured cast distance", 82.0f);
+                    ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy outside configured cast distance", 82.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3083,7 +3103,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (distance > (GetConfiguredSpellRange() + kRangedSpacingEnterOutOfRangeBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, movementTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy out of spell range", 70.0f);
+                    ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy out of spell range", 70.0f);
             }
             else if (distance < std::max(0.0f, GetConfiguredMeleeRange() - kRangedSpacingEnterTooCloseBuffer))
             {
@@ -3114,7 +3134,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (distance > GetConfiguredHealRange())
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, allyMovementTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredHealRange() - 1.0f), "reach party member to heal", "party member to heal out of spell range", 68.0f);
+                    ComputeApproachFollowRange(GetConfiguredHealRange()), "reach party member to heal", "party member to heal out of spell range", 68.0f);
             }
         }
     }
@@ -3136,8 +3156,16 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             }
             else
             {
-                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, fallbackTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "low mana fallback to auto-attack", 67.0f);
+                if (IsPrimaryRangedClassForSpacing(player->GetClass()))
+                {
+                    ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, fallbackTarget->GetGUID(),
+                        std::max(1.0f, GetConfiguredCloseRange()), "flee", "low mana fallback disengage to recover", 67.0f);
+                }
+                else
+                {
+                    ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, fallbackTarget->GetGUID(),
+                        std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "low mana fallback to auto-attack", 67.0f);
+                }
             }
         }
     }

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -113,15 +113,33 @@ std::string BuildManagedBotStatusLine(Player* bot)
     playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(bot, values);
     playerbot::BattlegroundLifecycleContext const lifecycleContext = playerbot::PvpCore::BuildBattlegroundLifecycleContext(bot, values);
     playerbot::RandomBotParticipationHooks const hooks = playerbot::PvpCore::BuildRandomBotParticipationHooks(bot, values);
+    bool const lifecycleEnabled = lifecycleContext.lifecycleEnabled;
+    bool const managedRandomBot = playerbot::IsManagedRandomBot(bot);
+    bool const canFollowCommands = bot->IsAlive() &&
+        !bot->HasUnitState(UNIT_STATE_ROOT) &&
+        !bot->HasUnitState(UNIT_STATE_STUNNED) &&
+        !bot->HasUnitState(UNIT_STATE_CONFUSED) &&
+        !bot->HasUnitState(UNIT_STATE_FLEEING) &&
+        !bot->HasUnitState(UNIT_STATE_LOST_CONTROL);
 
     std::ostringstream status;
     status << "PB status: "
+           << "lifecycle=" << (lifecycleEnabled ? "on" : "off")
+           << " managed=" << (managedRandomBot ? "yes" : "no")
            << "combat=" << (bot->IsInCombat() ? "yes" : "no")
            << " alive=" << (bot->IsAlive() ? "yes" : "no")
            << " moving=" << (bot->isMoving() ? "yes" : "no")
+           << " can_follow=" << (canFollowCommands ? "yes" : "no")
+           << " rooted=" << (bot->HasUnitState(UNIT_STATE_ROOT) ? "yes" : "no")
+           << " stunned=" << (bot->HasUnitState(UNIT_STATE_STUNNED) ? "yes" : "no")
+           << " confused=" << (bot->HasUnitState(UNIT_STATE_CONFUSED) ? "yes" : "no")
+           << " fleeing=" << (bot->HasUnitState(UNIT_STATE_FLEEING) ? "yes" : "no")
+           << " lost_control=" << (bot->HasUnitState(UNIT_STATE_LOST_CONTROL) ? "yes" : "no")
            << " stealth=" << (bot->HasStealthAura() ? "yes" : "no")
            << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
            << " bg_state=" << ToString(values.battlegroundState)
+           << " class_gate=" << (classContext.classSpellsEnabled ? "on" : "off")
+           << " class_exec=" << (classContext.shouldExecute ? "yes" : "no")
            << " class_action=" << (classContext.actionName ? classContext.actionName : "none")
            << " spell=" << classContext.spellId
            << " reason=" << (classContext.reason ? classContext.reason : "none")


### PR DESCRIPTION
### Motivation
- Prevent bots from repeatedly selecting support spells they cannot pay for so fallback logic can pick usable alternatives. 
- Avoid a spacing dead-zone where ranged bots neither cast nor re-engage movement due to tight follow-range tolerances. 
- Make ranged bots disengage to recover mana instead of always closing for melee when out of mana. 
- Provide richer runtime status for managed bots to aid debugging of lifecycle, execution gating, and movement capability.

### Description
- Added a power-cost affordability check to `IsDecisionImmediatelyCastable` that returns false when the caster lacks the required `Powers` to cast a spell. 
- Introduced `ComputeApproachFollowRange(float)` to provide an engagement buffer (`max(1.0f, nominalRange - 3.0f)`) and replaced several ad-hoc `std::max(..., range - 1.0f)` occurrences with this helper when deciding movement follow ranges. 
- Changed low-mana fallback behavior so ranged classes use `FleeTooCloseForSpell` (disengage to recover) instead of always issuing `ReachMeleeRange` to auto-attack. 
- Extended `BuildManagedBotStatusLine` to include `lifecycleEnabled`, `managedRandomBot`, `canFollowCommands`, and class execution/gating flags (`class_gate`, `class_exec`) and to show these in the status string along with existing motion/position and unit-state fields.

### Testing
- Project build was executed (`cmake` / build) and completed successfully. 
- Automated unit/integration tests (`ctest` / test suite) were run and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bb9797548327b203fb27cbdfd9f8)