### PR TITLE
Fix Tiger's Peak arena worldstate UI and spirit-release graveyard behavior

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundTTP.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundTTP.h
@@ -42,6 +42,8 @@ class BattlegroundTTP : public Arena
     public:
         BattlegroundTTP();
 
+        WorldSafeLocsEntry const* GetClosestGraveyard(Player* /*player*/) override { return nullptr; }
+
         /* inherited from BattlegroundClass */
         void StartingEventCloseDoors() override;
         void StartingEventOpenDoors() override;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -9792,6 +9792,10 @@ void Player::SendInitWorldStates(uint32 zoneId, uint32 areaId)
         }
         break;
     default:
+        // Tiger's Peak can report a non-canonical zone ID in some positions.
+        // Fall back to battleground type so arena world states are still initialized.
+        if (battleground && battleground->GetTypeID(true) == BATTLEGROUND_TTP)
+            battleground->FillInitialWorldStates(packet);
         break;
     }
 


### PR DESCRIPTION
### Motivation
- Players reported Tiger's Peak (TTP) missing the top-of-screen alive-player arena frame and being teleported out of the arena when releasing spirit instead of becoming a ghost spectator.
- Investigation showed Tiger's Peak can present non-canonical zone IDs which prevented arena worldstates from being initialized, and the battleground graveyard lookup sent ghosts outside the arena.

### Description
- Added a fallback in `Player::SendInitWorldStates` that calls `battleground->FillInitialWorldStates(packet)` when the current battleground type is `BATTLEGROUND_TTP` to ensure arena UI worldstates are always initialized for Tiger's Peak.
- Overrode `BattlegroundTTP::GetClosestGraveyard(Player*)` in `src/server/game/Battlegrounds/Zones/BattlegroundTTP.h` to return `nullptr`, preventing automatic teleport-to-graveyard on spirit release so players remain ghosts inside the arena for spectating.
- Changes are limited to `src/server/game/Entities/Player/Player.cpp` and `src/server/game/Battlegrounds/Zones/BattlegroundTTP.h` and do not alter other battleground logic.

### Testing
- Ran `git diff --check` and code style checks which returned clean results.
- Verified the patched files with `git diff` to confirm only the intended lines in `Player.cpp` and `BattlegroundTTP.h` were modified.
- Applied patches via the repository tooling (`apply_patch`) and the changes were recorded successfully (no build or unit tests were executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c0acf8888327abcaca0cb2d94165)