### PR TITLE
Make playerbots stand when casting after eat/drink

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -1044,6 +1044,12 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     {
         player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT);
         player->RemoveAurasDueToSpell(SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK);
+
+        // Virtual sessions do not emit client stand-state opcodes before
+        // casting. Explicitly stand when transitioning out of drink/eat casts
+        // so bots do not remain visually seated while spellcasting.
+        if (player->IsSitState())
+            player->SetStandState(UNIT_STAND_STATE_STAND);
     }
 
     // Auto-repeat ranged attacks (e.g., wand Shoot) and Life Tap are validated


### PR DESCRIPTION
### Motivation
- Virtual playerbot sessions can remain visually seated after finishing `SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT`/`SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK` because the client stand-state opcode is not emitted, so bots should be explicitly set to standing when beginning non-recovery casts.

### Description
- When transitioning out of eat/drink recovery in `CastDirectSpell` (in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`) remove the recovery auras and call `SetStandState(UNIT_STAND_STATE_STAND)` if `IsSitState()` so virtual-session bots are not left visually seated.

### Testing
- Ran `git diff --check` and `git status --short` after the change and both returned without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c4d3564483278d4b60f23062bb36)