### PR TITLE
Pvp: improve ranged approach/movement, spell affordability gating, and status telemetry

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -357,10 +357,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     if (!motionMaster)
         return;
 
-    if (player->IsValidAttackTarget(target))
-        motionMaster->MoveChase(target, safeDistance);
-    else
-        motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+    // Reach-spell movement should not depend on combat/chase state. Using
+    // follow for both hostile and friendly targets prevents edge cases where
+    // chase fails to engage while the bot is out of combat but still needs to
+    // close range for spellcasting.
+    motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
 }
 
 void IssueMeleeApproachMovement(Player* player, Unit* target)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -407,6 +407,17 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     if (minRange > 0.0f && player->IsWithinDistInMap(resolvedTarget, minRange))
         return false;
 
+    // Skip decisions we cannot currently pay for so the fallback chain can
+    // choose a castable alternative (wand, movement, etc.) instead of
+    // repeatedly selecting an OOM support spell.
+    if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
+    {
+        Powers const powerType = Powers(spellInfo->PowerType);
+        int32 const powerCost = spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask());
+        if (powerCost > 0 && player->GetPower(powerType) < powerCost)
+            return false;
+    }
+
     return true;
 }
 
@@ -2550,6 +2561,15 @@ bool CanUseHealRangeSpacing(uint8 classId)
     }
 }
 
+float ComputeApproachFollowRange(float nominalRange)
+{
+    // Keep an extra movement buffer so ranged bots do not settle in a
+    // dead-zone where spell-selection still reports out-of-range but chase
+    // motion does not re-engage because the desired distance is too close to
+    // edge tolerances.
+    return std::max(1.0f, nominalRange - 3.0f);
+}
+
 bool IsPrimaryMeleeClassForSpacing(uint8 classId)
 {
     switch (classId)
@@ -3036,7 +3056,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (maxRange > 0.0f && distance > maxRange)
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
-                    std::max(1.0f, maxRange - 1.0f), "reach spell", "selected spell out of range", 84.0f);
+                    ComputeApproachFollowRange(maxRange), "reach spell", "selected spell out of range", 84.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3061,7 +3081,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
                 // selecting enemy casts. Keep a config-based engage floor so
                 // they always step in to practical casting distance.
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy outside configured cast distance", 82.0f);
+                    ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy outside configured cast distance", 82.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3083,7 +3103,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (distance > (GetConfiguredSpellRange() + kRangedSpacingEnterOutOfRangeBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, movementTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy out of spell range", 70.0f);
+                    ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy out of spell range", 70.0f);
             }
             else if (distance < std::max(0.0f, GetConfiguredMeleeRange() - kRangedSpacingEnterTooCloseBuffer))
             {
@@ -3114,7 +3134,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (distance > GetConfiguredHealRange())
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, allyMovementTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredHealRange() - 1.0f), "reach party member to heal", "party member to heal out of spell range", 68.0f);
+                    ComputeApproachFollowRange(GetConfiguredHealRange()), "reach party member to heal", "party member to heal out of spell range", 68.0f);
             }
         }
     }
@@ -3136,8 +3156,16 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             }
             else
             {
-                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, fallbackTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "low mana fallback to auto-attack", 67.0f);
+                if (IsPrimaryRangedClassForSpacing(player->GetClass()))
+                {
+                    ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, fallbackTarget->GetGUID(),
+                        std::max(1.0f, GetConfiguredCloseRange()), "flee", "low mana fallback disengage to recover", 67.0f);
+                }
+                else
+                {
+                    ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, fallbackTarget->GetGUID(),
+                        std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "low mana fallback to auto-attack", 67.0f);
+                }
             }
         }
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -381,6 +381,14 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     playerbot::PvpValues const values = playerbot::PvpCore::CollectValues(player);
     playerbot::BattlegroundTacticalContext const tacticalContext = playerbot::PvpCore::BuildBattlegroundTacticalContext(player, values);
     bool const didExecuteTactical = playerbot::BattlegroundTacticalActions::Execute(player, tacticalContext);
+    playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(player, values);
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    bool const movementIdle = !motionMaster || motionMaster->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE;
+    bool const shouldForceClassMovementTick = classContext.classSpellsEnabled &&
+        classContext.shouldExecute &&
+        classContext.movementDirective != playerbot::PvpClassSpellContext::MovementDirective::None &&
+        movementIdle;
+    bool const didExecuteClassSpell = shouldForceClassMovementTick && playerbot::PvpClassActions::Execute(player, classContext);
 
     playerbot::BattlegroundLifecycleContext inProgressContext;
     inProgressContext.lifecycleEnabled = true;
@@ -393,6 +401,10 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     uint32 const bgTeam = player->GetBGTeam();
     uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
     tickDetail << "bg-fasttick tactical=" << (didExecuteTactical ? 1 : 0)
+               << " class_force=" << (shouldForceClassMovementTick ? 1 : 0)
+               << " class_exec=" << (didExecuteClassSpell ? 1 : 0)
+               << " class_directive=" << static_cast<uint32>(classContext.movementDirective)
+               << " class_spell=" << classContext.spellId
                << " lifecycle=" << (didExecuteLifecycle ? 1 : 0)
                << " alive=" << (player->IsAlive() ? 1 : 0)
                << " rooted=" << (player->HasUnitState(UNIT_STATE_ROOT) ? 1 : 0)

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -113,15 +113,33 @@ std::string BuildManagedBotStatusLine(Player* bot)
     playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(bot, values);
     playerbot::BattlegroundLifecycleContext const lifecycleContext = playerbot::PvpCore::BuildBattlegroundLifecycleContext(bot, values);
     playerbot::RandomBotParticipationHooks const hooks = playerbot::PvpCore::BuildRandomBotParticipationHooks(bot, values);
+    bool const lifecycleEnabled = lifecycleContext.lifecycleEnabled;
+    bool const managedRandomBot = playerbot::IsManagedRandomBot(bot);
+    bool const canFollowCommands = bot->IsAlive() &&
+        !bot->HasUnitState(UNIT_STATE_ROOT) &&
+        !bot->HasUnitState(UNIT_STATE_STUNNED) &&
+        !bot->HasUnitState(UNIT_STATE_CONFUSED) &&
+        !bot->HasUnitState(UNIT_STATE_FLEEING) &&
+        !bot->HasUnitState(UNIT_STATE_LOST_CONTROL);
 
     std::ostringstream status;
     status << "PB status: "
+           << "lifecycle=" << (lifecycleEnabled ? "on" : "off")
+           << " managed=" << (managedRandomBot ? "yes" : "no")
            << "combat=" << (bot->IsInCombat() ? "yes" : "no")
            << " alive=" << (bot->IsAlive() ? "yes" : "no")
            << " moving=" << (bot->isMoving() ? "yes" : "no")
+           << " can_follow=" << (canFollowCommands ? "yes" : "no")
+           << " rooted=" << (bot->HasUnitState(UNIT_STATE_ROOT) ? "yes" : "no")
+           << " stunned=" << (bot->HasUnitState(UNIT_STATE_STUNNED) ? "yes" : "no")
+           << " confused=" << (bot->HasUnitState(UNIT_STATE_CONFUSED) ? "yes" : "no")
+           << " fleeing=" << (bot->HasUnitState(UNIT_STATE_FLEEING) ? "yes" : "no")
+           << " lost_control=" << (bot->HasUnitState(UNIT_STATE_LOST_CONTROL) ? "yes" : "no")
            << " stealth=" << (bot->HasStealthAura() ? "yes" : "no")
            << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
            << " bg_state=" << ToString(values.battlegroundState)
+           << " class_gate=" << (classContext.classSpellsEnabled ? "on" : "off")
+           << " class_exec=" << (classContext.shouldExecute ? "yes" : "no")
            << " class_action=" << (classContext.actionName ? classContext.actionName : "none")
            << " spell=" << classContext.spellId
            << " reason=" << (classContext.reason ? classContext.reason : "none")


### PR DESCRIPTION
### Motivation
- Prevent ranged bots from getting stuck in edge-case chase/follow transitions and ensure reach-spell movement is reliable for both hostile and friendly targets.
- Avoid repeatedly selecting support spells the bot cannot afford by gating decisions on current power cost.
- Make idle clas­s movement directives actionable during battleground ticks and expose richer telemetry for debugging managed bots.

### Description
- Changed `IssueRangedApproachMovement` to always use `MoveFollow` for reach-spell movement and added a comment explaining the rationale for avoiding combat-dependent `MoveChase` behavior.
- Added affordability gating to `IsDecisionImmediatelyCastable` so decisions whose `spellInfo->CalcPowerCost` exceed the player's current power return `false`.
- Introduced `ComputeApproachFollowRange(float)` to provide an extra movement buffer and replaced several hard-coded range adjustments with calls to this helper for ranged/heal approach logic.
- Adjusted low-mana fallback behavior so primary ranged classes choose to disengage (`FleeTooCloseForSpell`) to recover rather than always forcing melee approach.
- In battleground fast-tick path, build the `PvpClassSpellContext` and force-execute class movement directives when movement is idle, and include class movement execution flags in the tick debug output.
- Expanded the managed-bot status line in `BuildManagedBotStatusLine` to include lifecycle and class gate flags, whether the bot can follow commands (`can_follow`), additional unit-state flags, and more class-context fields for easier diagnostics.

### Testing
- Project built successfully using the usual build (`make`) pipeline without compiler errors.
- Ran the automated playerbot unit tests and the existing test suite covering PVP/playerbot logic, and all tests passed.
- Verified battleground fast-tick logging and managed-bot status output show the new telemetry fields during automated integration checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bb9797548327b203fb27cbdfd9f8)