### PR TITLE
Improve PvP bot movement, target fallbacks, and low-mana behavior

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -358,9 +358,17 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         return;
 
     if (player->IsValidAttackTarget(target))
+    {
+        // Ensure hostile ranged approach can engage chase generators even when
+        // the bot is currently out of combat.
+        if (player->GetVictim() != target || !player->HasUnitState(UNIT_STATE_MELEE_ATTACKING))
+            player->Attack(target, true);
         motionMaster->MoveChase(target, safeDistance);
+    }
     else
+    {
         motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+    }
 }
 
 void IssueMeleeApproachMovement(Player* player, Unit* target)
@@ -1354,6 +1362,16 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
             context.movementDirective == PvpClassSpellContext::MovementDirective::ReachSpellRange ||
             context.movementDirective == PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell ||
             context.movementDirective == PvpClassSpellContext::MovementDirective::FaceSpellTarget;
+        if (directiveNeedsTarget && (!movementTarget || !movementTarget->IsAlive()))
+        {
+            // Defensive fallback: if GUID resolution fails for this tick, use
+            // currently selected/victim targets so movement directives do not
+            // silently drop to idle.
+            if (Unit* selectedTarget = player->GetSelectedUnit(); selectedTarget && selectedTarget->IsAlive())
+                movementTarget = selectedTarget;
+            else if (Unit* victimTarget = player->GetVictim(); victimTarget && victimTarget->IsAlive())
+                movementTarget = victimTarget;
+        }
         if (directiveNeedsTarget && (!movementTarget || !movementTarget->IsAlive()))
             return false;
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -407,6 +407,17 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     if (minRange > 0.0f && player->IsWithinDistInMap(resolvedTarget, minRange))
         return false;
 
+    // Skip decisions we cannot currently pay for so the fallback chain can
+    // choose a castable alternative (wand, movement, etc.) instead of
+    // repeatedly selecting an OOM support spell.
+    if (spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
+    {
+        Powers const powerType = Powers(spellInfo->PowerType);
+        int32 const powerCost = spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask());
+        if (powerCost > 0 && player->GetPower(powerType) < powerCost)
+            return false;
+    }
+
     return true;
 }
 
@@ -2550,6 +2561,15 @@ bool CanUseHealRangeSpacing(uint8 classId)
     }
 }
 
+float ComputeApproachFollowRange(float nominalRange)
+{
+    // Keep an extra movement buffer so ranged bots do not settle in a
+    // dead-zone where spell-selection still reports out-of-range but chase
+    // motion does not re-engage because the desired distance is too close to
+    // edge tolerances.
+    return std::max(1.0f, nominalRange - 3.0f);
+}
+
 bool IsPrimaryMeleeClassForSpacing(uint8 classId)
 {
     switch (classId)
@@ -2853,6 +2873,47 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         (!selectedTargetByGuid || !HasHostileTarget(player, selectedTargetByGuid));
     ObjectGuid const selectedAllyGuid = SelectAllyTargetGuid(player);
     bool const hasValidAllyTarget = resolveTargetByGuid(selectedAllyGuid) != nullptr;
+    bool const criticalLowMana = player->GetMaxPower(POWER_MANA) > 0 && player->GetPowerPct(POWER_MANA) < 10.0f;
+
+    // Hard-priority mana preservation policy: below 10% mana, disengage from
+    // combat above all other class behavior, then drink as soon as combat drops.
+    if (criticalLowMana)
+    {
+        if (player->IsInCombat())
+        {
+            Unit const* disengageTarget = resolveTargetByGuid(activeTargetGuid);
+            if (!disengageTarget)
+                disengageTarget = resolveTargetByGuid(selectedTargetGuid);
+            if (!disengageTarget && player->GetVictim() && player->GetVictim()->IsAlive())
+                disengageTarget = player->GetVictim();
+
+            if (disengageTarget)
+            {
+                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, disengageTarget->GetGUID(),
+                    std::max(GetConfiguredLongRange(), GetConfiguredCloseRange() + 8.0f),
+                    "flee", "critical low mana disengage", 99.0f);
+                return context;
+            }
+
+            context.movementDirective = PvpClassSpellContext::MovementDirective::ResetCombatState;
+            context.actionName = "reset";
+            context.reason = "critical low mana force combat reset";
+            context.shouldExecute = true;
+            return context;
+        }
+
+        if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK))
+        {
+            context.actionName = "drink";
+            context.reason = "critical low mana recover";
+            context.spellId = SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK;
+            context.targetMode = PvpClassSpellContext::TargetMode::Self;
+            context.targetGuid = player->GetGUID();
+            context.selfCast = true;
+            context.shouldExecute = true;
+            return context;
+        }
+    }
 
     if (player->IsInCombat() && !hasValidTarget && !hasValidAllyTarget)
     {
@@ -3036,7 +3097,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (maxRange > 0.0f && distance > maxRange)
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
-                    std::max(1.0f, maxRange - 1.0f), "reach spell", "selected spell out of range", 84.0f);
+                    ComputeApproachFollowRange(maxRange), "reach spell", "selected spell out of range", 84.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3061,7 +3122,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
                 // selecting enemy casts. Keep a config-based engage floor so
                 // they always step in to practical casting distance.
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy outside configured cast distance", 82.0f);
+                    ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy outside configured cast distance", 82.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3083,7 +3144,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (distance > (GetConfiguredSpellRange() + kRangedSpacingEnterOutOfRangeBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, movementTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredSpellRange() - 1.0f), "reach spell", "enemy out of spell range", 70.0f);
+                    ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy out of spell range", 70.0f);
             }
             else if (distance < std::max(0.0f, GetConfiguredMeleeRange() - kRangedSpacingEnterTooCloseBuffer))
             {
@@ -3114,7 +3175,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             if (distance > GetConfiguredHealRange())
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, allyMovementTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredHealRange() - 1.0f), "reach party member to heal", "party member to heal out of spell range", 68.0f);
+                    ComputeApproachFollowRange(GetConfiguredHealRange()), "reach party member to heal", "party member to heal out of spell range", 68.0f);
             }
         }
     }
@@ -3136,8 +3197,16 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             }
             else
             {
-                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, fallbackTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "low mana fallback to auto-attack", 67.0f);
+                if (IsPrimaryRangedClassForSpacing(player->GetClass()))
+                {
+                    ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, fallbackTarget->GetGUID(),
+                        std::max(1.0f, GetConfiguredCloseRange()), "flee", "low mana fallback disengage to recover", 67.0f);
+                }
+                else
+                {
+                    ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, fallbackTarget->GetGUID(),
+                        std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "low mana fallback to auto-attack", 67.0f);
+                }
             }
         }
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -381,6 +381,14 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     playerbot::PvpValues const values = playerbot::PvpCore::CollectValues(player);
     playerbot::BattlegroundTacticalContext const tacticalContext = playerbot::PvpCore::BuildBattlegroundTacticalContext(player, values);
     bool const didExecuteTactical = playerbot::BattlegroundTacticalActions::Execute(player, tacticalContext);
+    playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(player, values);
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    bool const movementIdle = !motionMaster || motionMaster->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE;
+    bool const shouldForceClassMovementTick = classContext.classSpellsEnabled &&
+        classContext.shouldExecute &&
+        classContext.movementDirective != playerbot::PvpClassSpellContext::MovementDirective::None &&
+        movementIdle;
+    bool const didExecuteClassSpell = shouldForceClassMovementTick && playerbot::PvpClassActions::Execute(player, classContext);
 
     playerbot::BattlegroundLifecycleContext inProgressContext;
     inProgressContext.lifecycleEnabled = true;
@@ -393,6 +401,10 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     uint32 const bgTeam = player->GetBGTeam();
     uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
     tickDetail << "bg-fasttick tactical=" << (didExecuteTactical ? 1 : 0)
+               << " class_force=" << (shouldForceClassMovementTick ? 1 : 0)
+               << " class_exec=" << (didExecuteClassSpell ? 1 : 0)
+               << " class_directive=" << static_cast<uint32>(classContext.movementDirective)
+               << " class_spell=" << classContext.spellId
                << " lifecycle=" << (didExecuteLifecycle ? 1 : 0)
                << " alive=" << (player->IsAlive() ? 1 : 0)
                << " rooted=" << (player->HasUnitState(UNIT_STATE_ROOT) ? 1 : 0)

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -18,6 +18,7 @@
 #include "Log.h"
 #include "Chat.h"
 #include "GameTime.h"
+#include "Globals/ObjectAccessor.h"
 #include "Item.h"
 #include "MotionMaster.h"
 #include "Movement/AbstractFollower.h"
@@ -113,15 +114,34 @@ std::string BuildManagedBotStatusLine(Player* bot)
     playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(bot, values);
     playerbot::BattlegroundLifecycleContext const lifecycleContext = playerbot::PvpCore::BuildBattlegroundLifecycleContext(bot, values);
     playerbot::RandomBotParticipationHooks const hooks = playerbot::PvpCore::BuildRandomBotParticipationHooks(bot, values);
+    Unit* directiveTarget = classContext.movementTargetGuid.IsEmpty() ? nullptr : ObjectAccessor::GetUnit(*bot, classContext.movementTargetGuid);
+    bool const lifecycleEnabled = lifecycleContext.lifecycleEnabled;
+    bool const managedRandomBot = playerbot::IsManagedRandomBot(bot);
+    bool const canFollowCommands = bot->IsAlive() &&
+        !bot->HasUnitState(UNIT_STATE_ROOT) &&
+        !bot->HasUnitState(UNIT_STATE_STUNNED) &&
+        !bot->HasUnitState(UNIT_STATE_CONFUSED) &&
+        !bot->HasUnitState(UNIT_STATE_FLEEING) &&
+        !bot->HasUnitState(UNIT_STATE_LOST_CONTROL);
 
     std::ostringstream status;
     status << "PB status: "
+           << "lifecycle=" << (lifecycleEnabled ? "on" : "off")
+           << " managed=" << (managedRandomBot ? "yes" : "no")
            << "combat=" << (bot->IsInCombat() ? "yes" : "no")
            << " alive=" << (bot->IsAlive() ? "yes" : "no")
            << " moving=" << (bot->isMoving() ? "yes" : "no")
+           << " can_follow=" << (canFollowCommands ? "yes" : "no")
+           << " rooted=" << (bot->HasUnitState(UNIT_STATE_ROOT) ? "yes" : "no")
+           << " stunned=" << (bot->HasUnitState(UNIT_STATE_STUNNED) ? "yes" : "no")
+           << " confused=" << (bot->HasUnitState(UNIT_STATE_CONFUSED) ? "yes" : "no")
+           << " fleeing=" << (bot->HasUnitState(UNIT_STATE_FLEEING) ? "yes" : "no")
+           << " lost_control=" << (bot->HasUnitState(UNIT_STATE_LOST_CONTROL) ? "yes" : "no")
            << " stealth=" << (bot->HasStealthAura() ? "yes" : "no")
            << " casting=" << (bot->IsNonMeleeSpellCast(false, false, true) ? "yes" : "no")
            << " bg_state=" << ToString(values.battlegroundState)
+           << " class_gate=" << (classContext.classSpellsEnabled ? "on" : "off")
+           << " class_exec=" << (classContext.shouldExecute ? "yes" : "no")
            << " class_action=" << (classContext.actionName ? classContext.actionName : "none")
            << " spell=" << classContext.spellId
            << " reason=" << (classContext.reason ? classContext.reason : "none")
@@ -129,6 +149,7 @@ std::string BuildManagedBotStatusLine(Player* bot)
            << " target_guid=" << classContext.targetGuid.ToString()
            << " move_directive=" << ToString(classContext.movementDirective)
            << " move_target=" << classContext.movementTargetGuid.ToString()
+           << " move_target_resolved=" << (directiveTarget ? "yes" : "no")
            << " move_range=" << classContext.movementFollowRange
            << " lifecycle_q=" << ToString(lifecycleContext.queueOperation)
            << " lifecycle_invite=" << ToString(lifecycleContext.invitationResponse)


### PR DESCRIPTION
### Motivation

- Reduce cases where bots idle or choose uncastable spells by improving movement engagement, target fallback resolution, and mana-aware behavior. 
- Make ranged approach distances more robust to edge-of-range dead-zones and ensure chase/follow generators engage consistently.
- Surface more useful status/debug info for managed bots and enable forced class movement on battleground fast ticks when movement is idle.

### Description

- Ensure `Attack(target, true)` is issued when a hostile ranged approach must chase an out-of-combat target so chase generators will engage (`PlayerbotPvpClassActions.cpp`).
- Add defensive fallback target resolution for movement directives so unresolved GUIDs fall back to selected or victim targets for the current tick (`PlayerbotPvpClassActions.cpp`).
- Prevent selecting out-of-mana spells by checking a spell's power cost against the player's current power in `IsDecisionImmediatelyCastable` (`PlayerbotPvpCore.cpp`).
- Add `ComputeApproachFollowRange` helper to add a movement buffer for ranged approach follow ranges and replace several `std::max(... - 1.0f)` callsites with it to avoid dead-zone spacing (`PlayerbotPvpCore.cpp`).
- Introduce a hard-priority low-mana policy that causes bots under 10% mana to disengage from combat and attempt out-of-combat drinking, including movement directives to flee or reset combat as appropriate (`PlayerbotPvpCore.cpp`).
- When low on mana and without a wand fallback, ranged classes now prefer a disengage/flee directive instead of forcing melee approach (`PlayerbotPvpCore.cpp`).
- In battleground fast-tick processing add a forced class movement execution when class spell context requests movement but motion is idle, and log directive/spell/movement details to debug output (`PlayerbotPvpRandomBotParticipation.cpp`).
- Improve managed bot status output and add safe target resolution in the status line, plus additional flags for followability and crowd-control states (`playerbot_loader.cpp`).
- Add missing include `Globals/ObjectAccessor.h` needed for GUID resolution in `playerbot_loader.cpp`.

### Testing

- Performed a full project build which completed successfully with these changes and no compile errors. 
- Ran the project's automated unit/test suite and core smoke checks; all tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bb9797548327b203fb27cbdfd9f8)