### PR TITLE
Don't throttle travel movement directives when bot is idle

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -523,6 +523,22 @@ bool ShouldThrottleDirective(Player const* player, playerbot::PvpClassSpellConte
     if (!player || context.movementDirective == playerbot::PvpClassSpellContext::MovementDirective::None)
         return false;
 
+    bool const isTravelDirective =
+        context.movementDirective == playerbot::PvpClassSpellContext::MovementDirective::ReachMeleeRange ||
+        context.movementDirective == playerbot::PvpClassSpellContext::MovementDirective::ReachSpellRange ||
+        context.movementDirective == playerbot::PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell;
+
+    // If we intended to travel but currently have no movement momentum, do not
+    // suppress directive execution. This keeps ranged spacing directives from
+    // idling when another system briefly clears active motion between ticks.
+    if (isTravelDirective && !player->isMoving())
+    {
+        MotionMaster const* motionMaster = player->GetMotionMaster();
+        MovementGeneratorType const movementType = motionMaster ? motionMaster->GetCurrentMovementGeneratorType() : IDLE_MOTION_TYPE;
+        if (movementType == IDLE_MOTION_TYPE)
+            return false;
+    }
+
     auto& state = g_LastDirectiveByBot[player->GetGUID()];
     std::chrono::steady_clock::time_point const now = GameTime::Now();
     if (state.directive == context.movementDirective &&


### PR DESCRIPTION
### Motivation
- Bots could become stuck: spacing logic selects travel directives (`ReachMeleeRange`, `ReachSpellRange`, `FleeTooCloseForSpell`) but the duplicate-directive throttle could suppress reissuing movement while `motion=0`, producing repeated `last_exec=move_throttled` and leaving the bot idle.

### Description
- Update `ShouldThrottleDirective` to treat travel directives specially and, when `!player->isMoving()` and the current motion generator is `IDLE_MOTION_TYPE`, return `false` so the travel directive is not throttled.
- Preserve the existing 500ms duplicate-directive throttle behavior for non-idle movement to keep anti-spam protections.

### Testing
- Ran `git diff --check` which reported no issues.
- Verified repository state with `git status --short` and committed the change (`Fix playerbot movement directive throttle idle stall`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d78046b0832799379d045e9aa4bf)