### PR TITLE
Playerbot: move closer after LOS cast failures

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -409,6 +409,26 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
         motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
 }
 
+float ComputeLosRecoveryRange(Player const* player, Unit const* target, float maxRange)
+{
+    if (!player || !target)
+        return std::max(1.0f, playerbot::PvpCore::GetConfig().closeRange);
+
+    // LOS failures at "near max range" can repeatedly reissue follow distances
+    // that are already satisfied (e.g., 27y away with desired 29y), leaving
+    // ranged bots stationary. Bias recovery movement to a noticeably closer
+    // band so bots strafe/reposition to regain visibility.
+    float const currentDistance = player->GetDistance(target);
+    float desiredRange = std::max(1.0f, std::min(
+        std::max(3.0f, playerbot::PvpCore::GetConfig().closeRange),
+        currentDistance > 2.0f ? currentDistance - 2.0f : 1.0f));
+
+    if (maxRange > 0.0f)
+        desiredRange = std::min(desiredRange, std::max(1.0f, maxRange - 3.0f));
+
+    return desiredRange;
+}
+
 bool IsCrowdControlledForAction(Player const* player)
 {
     if (!player)
@@ -983,7 +1003,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 IssueMeleeApproachMovement(player, target);
             else
             {
-                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                float const desiredRange = ComputeLosRecoveryRange(player, target, maxRange);
                 IssueRangedApproachMovement(player, target, desiredRange);
             }
         }
@@ -1177,7 +1197,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                     IssueMeleeApproachMovement(player, target);
                 else
                 {
-                    float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                    float const desiredRange = ComputeLosRecoveryRange(player, target, maxRange);
                     IssueRangedApproachMovement(player, target, desiredRange);
                 }
             }


### PR DESCRIPTION
### Motivation
- Prevent ranged bots from idling at near-max spell range and repeatedly failing with `SPELL_FAILED_LINE_OF_SIGHT` without repositioning.

### Description
- Add `ComputeLosRecoveryRange(Player const*, Unit const*, float)` to compute a closer recovery follow distance biased toward re-acquiring LOS (implemented in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`).
- Use `ComputeLosRecoveryRange(...)` in the pre-cast LOS validation path and in the `SPELL_FAILED_LINE_OF_SIGHT` cast-failure handler so ranged approach movement issues a noticeably closer reposition command.

### Testing
- Ran `cmake --build build --target game -j2` in this environment; the build progressed through many targets and produced no immediate errors for the modified translation unit, but a full rebuild/verification was not completed in-session.
- No additional automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4defb5ac883279988909c6295f4c3)