### PR TITLE
Improve LOS recovery positioning and preserve out-of-combat drinking in PvP bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -409,6 +409,26 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
         motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
 }
 
+float ComputeLosRecoveryRange(Player const* player, Unit const* target, float maxRange)
+{
+    if (!player || !target)
+        return std::max(1.0f, playerbot::PvpCore::GetConfig().closeRange);
+
+    // LOS failures at "near max range" can repeatedly reissue follow distances
+    // that are already satisfied (e.g., 27y away with desired 29y), leaving
+    // ranged bots stationary. Bias recovery movement to a noticeably closer
+    // band so bots strafe/reposition to regain visibility.
+    float const currentDistance = player->GetDistance(target);
+    float desiredRange = std::max(1.0f, std::min(
+        std::max(3.0f, playerbot::PvpCore::GetConfig().closeRange),
+        currentDistance > 2.0f ? currentDistance - 2.0f : 1.0f));
+
+    if (maxRange > 0.0f)
+        desiredRange = std::min(desiredRange, std::max(1.0f, maxRange - 3.0f));
+
+    return desiredRange;
+}
+
 bool IsCrowdControlledForAction(Player const* player)
 {
     if (!player)
@@ -983,7 +1003,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 IssueMeleeApproachMovement(player, target);
             else
             {
-                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                float const desiredRange = ComputeLosRecoveryRange(player, target, maxRange);
                 IssueRangedApproachMovement(player, target, desiredRange);
             }
         }
@@ -1177,7 +1197,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                     IssueMeleeApproachMovement(player, target);
                 else
                 {
-                    float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                    float const desiredRange = ComputeLosRecoveryRange(player, target, maxRange);
                     IssueRangedApproachMovement(player, target, desiredRange);
                 }
             }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -271,9 +271,19 @@ SpellDecision MaybeSelectUtilitySpell(Player const* player, Unit const* hostileT
     if (!player)
         return {};
 
+    constexpr uint32 kPlayerbotDrinkSpell = 22734;
+    bool const maintainExistingDrink = !player->IsInCombat() &&
+        player->GetMaxPower(POWER_MANA) > 0 &&
+        player->HasAura(kPlayerbotDrinkSpell) &&
+        player->GetPowerPct(POWER_MANA) < 50.0f;
+
     // Match reference behavior more closely: do not let out-of-combat utility
     // preempt combat spell trees while a valid hostile target exists.
-    if (HasHostileTarget(player, hostileTarget))
+    //
+    // Exception: if the bot is already drinking and still below the 50% mana
+    // floor, keep utility selection available so drink remains sticky instead
+    // of immediately breaking back into combat posture.
+    if (HasHostileTarget(player, hostileTarget) && !maintainExistingDrink)
         return {};
 
     return SelectOutOfCombatEatDrinkOrMountSpell(player);


### PR DESCRIPTION
### Motivation

- Ranged bots could remain stationary when losing line-of-sight because follow distances were computed near the target max range and did not force noticeable repositioning. 
- Out-of-combat eating/drinking could be immediately preempted by combat decision logic even when the bot was currently drinking and still below a mana floor.

### Description

- Add `ComputeLosRecoveryRange(Player const*, Unit const*, float)` to bias LOS recovery movement toward a noticeably closer band and cap it with `maxRange` when provided. 
- Replace inline LOS recovery distance calculations with calls to `ComputeLosRecoveryRange` in `PlayerbotPvpClassActions.cpp` for both initial no-LOS handling and `SPELL_FAILED_LINE_OF_SIGHT` handling. 
- Introduce `kPlayerbotDrinkSpell = 22734` and add `maintainExistingDrink` logic in `MaybeSelectUtilitySpell` inside `PlayerbotPvpCore.cpp` so an out-of-combat drinking aura is allowed to persist while mana is below 50%. 

### Testing

- Project was built with the changes and the automated test suite was executed; the automated tests completed and passed. 
- PvP-related automated checks covering spell cast failure handling and utility selection were included in the test run and did not regress.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4defb5ac883279988909c6295f4c3)