### PR TITLE
Stabilize LOS recovery ranges and tighten movement directives; preserve drinking utility

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -409,6 +409,32 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
         motionMaster->MoveFollow(target, 1.5f, player->GetFollowAngle());
 }
 
+float ComputeLosRecoveryRange(Player const* player, Unit const* target, float maxRange)
+{
+    if (!player || !target)
+        return std::max(1.0f, playerbot::PvpCore::GetConfig().closeRange);
+
+    // LOS recovery should use a stable follow band. If desired range changes
+    // every tick from "current distance - X", bots can bounce between movement
+    // directives (approach/flee) and look like they are stutter-looping.
+    float const closeFloor = std::max(3.0f, playerbot::PvpCore::GetConfig().closeRange);
+    float const upperBound = maxRange > 0.0f
+        ? std::max(1.0f, maxRange - 3.0f)
+        : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+
+    // Keep recovery closer than max cast distance to re-acquire LOS, but avoid
+    // forcing a near-melee collapse that causes immediate spacing corrections.
+    float const stableRecoveryBand = upperBound * 0.65f;
+    float desiredRange = std::max(closeFloor, std::clamp(stableRecoveryBand, 1.0f, upperBound));
+
+    // If config floors exceed spell upper bounds, prefer the spell bound to
+    // avoid selecting an impossible follow distance.
+    if (closeFloor > upperBound)
+        desiredRange = upperBound;
+
+    return desiredRange;
+}
+
 bool IsCrowdControlledForAction(Player const* player)
 {
     if (!player)
@@ -983,7 +1009,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 IssueMeleeApproachMovement(player, target);
             else
             {
-                float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                float const desiredRange = ComputeLosRecoveryRange(player, target, maxRange);
                 IssueRangedApproachMovement(player, target, desiredRange);
             }
         }
@@ -1177,7 +1203,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                     IssueMeleeApproachMovement(player, target);
                 else
                 {
-                    float const desiredRange = maxRange > 0.0f ? std::max(1.0f, maxRange - 1.0f) : std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 1.0f);
+                    float const desiredRange = ComputeLosRecoveryRange(player, target, maxRange);
                     IssueRangedApproachMovement(player, target, desiredRange);
                 }
             }
@@ -1462,8 +1488,18 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                 break;
             case PvpClassSpellContext::MovementDirective::ReachSpellRange:
             {
-                float const desiredRange = std::max(1.0f,
+                float desiredRange = std::max(1.0f,
                     context.movementFollowRange > 0.0f ? context.movementFollowRange : (PvpCore::GetConfig().spellRange - 1.0f));
+                if (movementTarget)
+                {
+                    float const currentDistance = player->GetDistance(movementTarget);
+                    // ReachSpellRange must always request an actual "close the
+                    // gap" distance. If desiredRange is >= current distance,
+                    // chase movement can idle and repeatedly reissue the same
+                    // directive (visible as bow-raise stutter loops).
+                    float const closingRange = std::max(1.0f, currentDistance - 2.0f);
+                    desiredRange = std::min(desiredRange, closingRange);
+                }
                 IssueRangedApproachMovement(player, movementTarget, desiredRange);
             }
                 break;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -271,9 +271,19 @@ SpellDecision MaybeSelectUtilitySpell(Player const* player, Unit const* hostileT
     if (!player)
         return {};
 
+    constexpr uint32 kPlayerbotDrinkSpell = 22734;
+    bool const maintainExistingDrink = !player->IsInCombat() &&
+        player->GetMaxPower(POWER_MANA) > 0 &&
+        player->HasAura(kPlayerbotDrinkSpell) &&
+        player->GetPowerPct(POWER_MANA) < 50.0f;
+
     // Match reference behavior more closely: do not let out-of-combat utility
     // preempt combat spell trees while a valid hostile target exists.
-    if (HasHostileTarget(player, hostileTarget))
+    //
+    // Exception: if the bot is already drinking and still below the 50% mana
+    // floor, keep utility selection available so drink remains sticky instead
+    // of immediately breaking back into combat posture.
+    if (HasHostileTarget(player, hostileTarget) && !maintainExistingDrink)
         return {};
 
     return SelectOutOfCombatEatDrinkOrMountSpell(player);


### PR DESCRIPTION
### Motivation
- Prevent bots from stuttering or issuing non-closing chase directives when recovering line-of-sight or reaching spell range, and avoid breaking an existing out-of-combat drink action prematurely.

### Description
- Add `ComputeLosRecoveryRange` to centralize LOS recovery range calculation and replace duplicated ad-hoc math with a stable follow band based on config and spell range.
- Use `ComputeLosRecoveryRange` wherever LOS recovery previously computed `maxRange - 1` to reduce oscillation and avoid forcing near-melee collapse.
- Constrain `ReachSpellRange` movement requests so the requested follow distance never exceeds a short "closing" distance (`currentDistance - 2`) to ensure chase directives actually close the gap.
- Allow the out-of-combat drink utility to remain selectable when the bot is currently drinking (`spellId 22734`) and mana is below 50%, preventing immediate re-entry into combat spell selection.

### Testing
- Built the project using `make` and verified compilation succeeded. 
- Ran the project's automated unit/integration tests via `ctest` and observed all tests passing. 
- Executed PvP movement/playback scenarios in automated test harnesses and confirmed LOS recovery and chase directives behaved more stable (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4defb5ac883279988909c6295f4c3)