### PR TITLE
Add `.tele map` GM command for direct map teleports (bypasses BG/arena restriction)

### DIFF
--- a/src/server/scripts/Commands/cs_tele.cpp
+++ b/src/server/scripts/Commands/cs_tele.cpp
@@ -58,6 +58,7 @@ public:
         {
             { "add",    HandleTeleAddCommand,   rbac::RBAC_PERM_COMMAND_TELE_ADD,   Console::No },
             { "del",    HandleTeleDelCommand,   rbac::RBAC_PERM_COMMAND_TELE_DEL,   Console::Yes },
+            { "map",    HandleTeleMapCommand,   rbac::RBAC_PERM_COMMAND_TELE,       Console::No },
             { "name",   teleNameCommandTable },
             { "group",  HandleTeleGroupCommand, rbac::RBAC_PERM_COMMAND_TELE_GROUP, Console::No },
             { "",       HandleTeleCommand,      rbac::RBAC_PERM_COMMAND_TELE,       Console::No },
@@ -313,6 +314,50 @@ public:
             player->SaveRecallPosition(); // save only in non-flight case
 
         player->TeleportTo(tele->mapId, tele->position_x, tele->position_y, tele->position_z, tele->orientation);
+        return true;
+    }
+
+    static bool HandleTeleMapCommand(ChatHandler* handler, uint32 mapId, Optional<float> x, Optional<float> y, Optional<float> z, Optional<float> orientation)
+    {
+        Player* player = handler->GetSession()->GetPlayer();
+
+        MapEntry const* map = sMapStore.LookupEntry(mapId);
+        if (!map)
+        {
+            handler->SendSysMessage(LANG_COMMAND_NOMAPFOUND);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        Position destination;
+        if (x && y)
+        {
+            destination.Relocate(*x, *y, z.value_or(player->GetPositionZ()), orientation.value_or(player->GetOrientation()));
+        }
+        else
+        {
+            float centerX = 0.0f;
+            float centerY = 0.0f;
+            Map const* baseMap = sMapMgr->CreateBaseMap(mapId);
+            float groundZ = baseMap->GetHeight(centerX, centerY, MAX_HEIGHT);
+            float waterZ = baseMap->GetWaterLevel(centerX, centerY);
+            float centerZ = groundZ > waterZ ? groundZ : waterZ;
+            destination.Relocate(centerX, centerY, centerZ, orientation.value_or(player->GetOrientation()));
+        }
+
+        if (!MapManager::IsValidMapCoord(mapId, destination) || sObjectMgr->IsTransportMap(mapId))
+        {
+            handler->PSendSysMessage(LANG_INVALID_TARGET_COORD, destination.GetPositionX(), destination.GetPositionY(), mapId);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (player->IsInFlight())
+            player->FinishTaxiFlight();
+        else
+            player->SaveRecallPosition();
+
+        player->TeleportTo({ mapId, destination });
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Provide a simple GM command to inspect battleground/arena maps (or any map) directly without being blocked by the normal BG/arena teleport restriction.

### Description
- Added a new `tele map` subcommand to the `tele` command table and implemented `HandleTeleMapCommand` in `src/server/scripts/Commands/cs_tele.cpp` to accept `mapId` and optional `x y [z] [orientation]` parameters.
- The handler validates the `mapId` (`sMapStore.LookupEntry`), computes a default center Z using `sMapMgr->CreateBaseMap(...)->GetHeight`/`GetWaterLevel` when coordinates are not provided, and uses `MapManager::IsValidMapCoord` and `sObjectMgr->IsTransportMap` for safety checks before teleporting.
- Reused the existing in-flight handling and recall save logic and replaced the earlier `LANG_COMMAND_MAPIDINVALID` usage with `LANG_COMMAND_NOMAPFOUND` for missing maps.

### Testing
- Launched `cmake --build build --target game -- -j4` to validate compile paths and observed many targets building without immediate compile errors related to the modified file, but the full build did not complete due to environment runtime limits.
- Launched `ninja -C build scripts -j4` for the scripts build and observed the build start and progress without immediate errors for the changed command file, but the run was also interrupted before completion due to environment constraints.
- No automated unit tests were added; the automated build runs showed no immediate compile errors for `cs_tele.cpp` in the captured logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c180965083278c29c66bf8d8a454)