### PR TITLE
Playerbot PvP: avoid cast interruptions and facing jitter from face directives

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -1460,10 +1460,13 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
             // Defensive fallback: if GUID resolution fails for this tick, use
             // currently selected/victim targets so movement directives do not
             // silently drop to idle.
-            if (Unit* selectedTarget = player->GetSelectedUnit(); selectedTarget && selectedTarget->IsAlive())
-                movementTarget = selectedTarget;
-            else if (Unit* victimTarget = player->GetVictim(); victimTarget && victimTarget->IsAlive())
-                movementTarget = victimTarget;
+            if (context.movementDirective != PvpClassSpellContext::MovementDirective::FaceSpellTarget)
+            {
+                if (Unit* selectedTarget = player->GetSelectedUnit(); selectedTarget && selectedTarget->IsAlive())
+                    movementTarget = selectedTarget;
+                else if (Unit* victimTarget = player->GetVictim(); victimTarget && victimTarget->IsAlive())
+                    movementTarget = victimTarget;
+            }
         }
         if (directiveNeedsTarget && (!movementTarget || !movementTarget->IsAlive()))
         {
@@ -1477,6 +1480,16 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                 ClearActiveMovementForControlLoss(player);
             SetLastExecutionStatus(player, "move_skipped_cannot_follow");
             return false;
+        }
+
+        // Re-facing while a non-melee spellcast is in progress can interrupt
+        // channels/cast bars and manifests as abrupt facing flips. Defer this
+        // directive until cast completion.
+        if (context.movementDirective == PvpClassSpellContext::MovementDirective::FaceSpellTarget &&
+            player->IsNonMeleeSpellCast(false, false, true))
+        {
+            SetLastExecutionStatus(player, "move_skipped_face_while_casting");
+            return true;
         }
 
         switch (context.movementDirective)


### PR DESCRIPTION
### Motivation
- Bots were canceling or interrupting non-melee casts when server-side facing updates (face directives) were applied during an active cast. 
- Face-directive fallback to selected/victim targets could produce rapid alternating facings when the original face target GUID was unresolved.

### Description
- Stop substituting selected/victim targets for the original face directive when `movementDirective == FaceSpellTarget`, so face directives no longer re-target to fallback units. 
- Defer execution of `FaceSpellTarget` directives when the player is currently performing a non-melee spell cast by returning early and setting `move_skipped_face_while_casting`. 
- Added a distinct last-execution status string for the deferred face-while-casting case and kept change localized to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`.

### Testing
- Launched a local build with `cmake --build build --target worldserver -j2`, which started compiling successfully (build progressed through many translation units but was not waited to full completion in this run). 
- Verified the source diff and committed the change with message `Playerbot PvP: avoid cast interrupts from face directives`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c878c84c8327b31958533b0bf3d1)