### PR TITLE
Avoid movement directives preempting gap-closer spells (Charge/Intercept)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -1441,7 +1441,15 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
     if (!player || !context.classSpellsEnabled || !context.shouldExecute)
         return false;
 
-    if (context.movementDirective != PvpClassSpellContext::MovementDirective::None)
+    bool const hasCastIntent = context.spellId != 0 || context.itemEntry != 0;
+    bool const shouldExecuteMovementBeforeCast =
+        !hasCastIntent || (
+            context.movementDirective != PvpClassSpellContext::MovementDirective::ReachMeleeRange &&
+            context.movementDirective != PvpClassSpellContext::MovementDirective::ReachSpellRange &&
+            context.movementDirective != PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell &&
+            context.movementDirective != PvpClassSpellContext::MovementDirective::FaceSpellTarget);
+
+    if (context.movementDirective != PvpClassSpellContext::MovementDirective::None && shouldExecuteMovementBeforeCast)
     {
         if (ShouldThrottleDirective(player, context))
         {


### PR DESCRIPTION
### Motivation
- Warriors' gap-closers (e.g., Charge/Intercept) could be selected but then not cast because movement directives issued the same tick overrode casting by driving follow/chase movement. 
- Spacing/facing movement directives should not automatically preempt an already-selected class spell or item cast for the tick, while state-management directives still need to run immediately.

### Description
- Updated `PvpClassActions::Execute` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` to detect cast intent via `hasCastIntent` and compute `shouldExecuteMovementBeforeCast` to gate movement-first execution. 
- Movement-first execution is skipped when a cast or item use is queued and the directive is a spacing/facing directive (`ReachMeleeRange`, `ReachSpellRange`, `FleeTooCloseForSpell`, `FaceSpellTarget`), but preserved for state-management directives. 
- The change is a small conditional insertion that preserves existing throttle/target checks and movement handling while preventing movement from shadowing gap-closer casts.

### Testing
- Started an incremental build with `cmake --build build --target worldserver -j2` to verify compile health, and the build progressed through many targets with no compile errors visible in the output. 
- The modified file was staged and committed successfully (`git commit` succeeded) and the local build output showed no immediate compilation failures for the observed targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ca677b9c832796f2e021117e13b5)