### PR TITLE
Add GM command to force managed playerbots into the caller's battleground queue

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -88,7 +88,6 @@ uint32 g_LastHumanInterestPopulationRebalanceAttemptMs = 0;
 uint32 g_LastScmSlotRefillAttemptMs = 0;
 uint64 BuildBattlegroundInstanceKey(Battleground const* battleground);
 bool BattlegroundHasAnyRealHumanPlayers(Player const* player);
-uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint8 arenaType);
 bool RemoveMatchingQueues(Player* player, bool arenaOnly, bool invitedOnly, bool scheduleNonArenaUpdate);
 
 bool IsScmManagedBotCandidate(Player const* player)
@@ -1886,6 +1885,15 @@ uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint
     }
 
     return queuedCount;
+}
+
+}
+
+namespace playerbot
+{
+uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint8 arenaType)
+{
+    return ::QueueEligibleManagedBotsForBattleground(bgTypeId, arenaType);
 }
 
 void FinalizeVirtualBotTeleportIfPending(Player* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
@@ -25,6 +25,7 @@ class Player;
 namespace playerbot
 {
 bool NormalizeLifecycleQueueState(Player* player);
+uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint8 arenaType);
 
 class BattlegroundLifecycleActions
 {

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -27,6 +27,7 @@
 #include "BattlegroundQueue.h"
 #include "Playerbot/Pvp/PlayerbotPvpClassActions.h"
 #include "Playerbot/Pvp/PlayerbotPvpCore.h"
+#include "Playerbot/Pvp/PlayerbotPvpLifecycleActions.h"
 #include "Playerbot/Pvp/PlayerbotRandomBotParticipation.h"
 #include "RBAC.h"
 #include "ScriptMgr.h"
@@ -274,6 +275,31 @@ std::string BuildManagedBotScmQueueDiagnosticLine(Player* bot)
     return diag.str();
 }
 
+BattlegroundTypeId ResolveCurrentBgTypeFromPlayerContext(Player const* player)
+{
+    if (!player)
+        return BATTLEGROUND_TYPE_NONE;
+
+    if (player->InBattleground())
+        return player->GetBattlegroundTypeId();
+
+    for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+    {
+        BattlegroundQueueTypeId const queueTypeId = player->GetBattlegroundQueueTypeId(i);
+        if (queueTypeId == BATTLEGROUND_QUEUE_NONE)
+            continue;
+
+        if (BattlegroundMgr::BGArenaType(queueTypeId) != 0)
+            continue;
+
+        BattlegroundTypeId const queueBgTypeId = BattlegroundMgr::BGTemplateId(queueTypeId);
+        if (queueBgTypeId != BATTLEGROUND_TYPE_NONE)
+            return queueBgTypeId;
+    }
+
+    return BATTLEGROUND_TYPE_NONE;
+}
+
 class PlayerbotBootstrapWorldScript final : public WorldScript
 {
 public:
@@ -387,6 +413,7 @@ public:
         static ChatCommandTable playerbotPvpTable =
         {
             { "lifecycle", playerbotPvpLifecycleTable },
+            { "forcequeue", HandlePlayerbotPvpForceQueueCurrentCommand, rbac::RBAC_PERM_COMMAND_GM, Console::No },
         };
 
         static ChatCommandTable playerbotRandomPopulationTable =
@@ -426,6 +453,27 @@ public:
         handler->PSendSysMessage(" - noLifecycleHooksActive: " UI64FMTD, snapshot.noLifecycleHooksActive);
         handler->PSendSysMessage(" - battlegroundLifecycleExecuted: " UI64FMTD, snapshot.battlegroundLifecycleExecuted);
         handler->PSendSysMessage(" - arenaLifecycleExecuted: " UI64FMTD, snapshot.arenaLifecycleExecuted);
+        return true;
+    }
+
+    static bool HandlePlayerbotPvpForceQueueCurrentCommand(ChatHandler* handler)
+    {
+        if (!handler || !handler->GetSession())
+            return false;
+
+        Player* player = handler->GetPlayer();
+        if (!player)
+            return false;
+
+        BattlegroundTypeId const bgTypeId = ResolveCurrentBgTypeFromPlayerContext(player);
+        if (bgTypeId == BATTLEGROUND_TYPE_NONE)
+        {
+            handler->PSendSysMessage("You must be inside a battleground or queued for one before using this command.");
+            return false;
+        }
+
+        uint32 const queuedCount = playerbot::QueueEligibleManagedBotsForBattleground(bgTypeId, 0);
+        handler->PSendSysMessage("Forced managed playerbots to queue for battleground type %u. Queued bots: %u", uint32(bgTypeId), queuedCount);
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Provide a GM command to force managed playerbots to queue for the same battleground the GM is currently in or queued for instead of always targeting SCM.
- Allow ops to trigger mass-queueing for the GM's context without duplicating lifecycle queue logic or changing reference-only code.

### Description
- Added `QueueEligibleManagedBotsForBattleground` declaration to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h` to expose the internal mass-queue helper.
- Added a `playerbot::` wrapper in `PlayerbotPvpLifecycleActions.cpp` that forwards to the internal implementation so scripts can call it safely.
- Implemented `ResolveCurrentBgTypeFromPlayerContext` in `src/server/scripts/Playerbot/playerbot_loader.cpp` to resolve the caller's battleground context by preferring the BG the player is inside, then the first non-arena queued BG.
- Registered a new GM chat command `playerbot pvp forcequeue` and handler `HandlePlayerbotPvpForceQueueCurrentCommand` in `playerbot_loader.cpp` which resolves the BG type and calls `playerbot::QueueEligibleManagedBotsForBattleground(bgTypeId, 0)`; the handler reports success or a helpful error when no context is found.
- Kept all playerbot reference code untouched (no changes under `playerbot reference/`).

### Testing
- Started a build of the server and scripts with `cmake --build build --target worldserver -j2` and later `cmake --build build --target scripts -j2`; compilation progressed through many targets and script compilation, producing warnings unrelated to the changes, but full completion of the scripts build was not observed within the session.
- No automated unit/integration tests were run; changes compiled through the project build steps were exercised but not fully completed within the interaction window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cc7a50f08327861d58fd658db2b9)