### PR TITLE
Fix ranged reach directive over-chasing at cast range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -1518,8 +1518,11 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                     // gap" distance. If desiredRange is >= current distance,
                     // chase movement can idle and repeatedly reissue the same
                     // directive (visible as bow-raise stutter loops).
-                    float const closingRange = std::max(1.0f, currentDistance - 2.0f);
-                    desiredRange = std::min(desiredRange, closingRange);
+                    if (desiredRange >= currentDistance)
+                    {
+                        float const closingRange = std::max(1.0f, currentDistance - 2.0f);
+                        desiredRange = std::min(desiredRange, closingRange);
+                    }
                 }
                 IssueRangedApproachMovement(player, movementTarget, desiredRange);
             }


### PR DESCRIPTION
### Motivation
- Prevent ranged bots (including warlocks) from getting stuck in repeated chase loops by avoiding unnecessary forward movement when they are already within a workable casting distance.

### Description
- Adjusted `ReachSpellRange` handling in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` so the fallback "close the gap" reduction to `desiredRange` is applied only when `desiredRange >= currentDistance`, preserving legitimate out-of-range approach behavior while stopping over-chasing when already inside the cast band.

### Testing
- Verified build environment with `test -d build` and started `cmake --build build -j2 --target game`, which compiled through the updated sources and showed no compile errors for the modified file before the process was stopped due to runtime limits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cd59d70c832786acfd53e5e871e4)