### PR TITLE
Fix playerbot PvP helper call signatures

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -230,7 +230,7 @@ bool TryRefillManagedScmSlots(Player* player, Battleground* battleground)
     g_LastScmSlotRefillAttemptMs = nowMs;
 
     bool const rebalanceTriggered = playerbot::RandomBotParticipationManager::TriggerImmediateRebalance();
-    uint32 const queuedCount = QueueEligibleManagedBotsForBattleground(BATTLEGROUND_SCM, 0);
+    uint32 const queuedCount = playerbot::QueueEligibleManagedBotsForBattleground(BATTLEGROUND_SCM, 0);
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
         "Playerbot PvP SCM refill attempt: guid={} instanceId={} players={} maxPlayers={} rebalanceTriggered={} queuedCount={}.",
         player->GetGUID().ToString(), battleground->GetInstanceID(), playersInInstance, maxPlayers, rebalanceTriggered ? 1 : 0, queuedCount);
@@ -2175,7 +2175,7 @@ Unit* AcquireCombatTarget(Player* player, float scanDistance)
             target = duelOpponent;
     }
     if (!isAttackableTarget(target) && player->InBattleground())
-        target = FindNearestEnemyBattlegroundPlayer(player, scanDistance);
+        target = FindNearestEnemyBattlegroundPlayer(player, scanDistance, nullptr, nullptr);
     if (!isAttackableTarget(target))
         return nullptr;
 
@@ -2865,7 +2865,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
             if (EngageNearestEnemyPlayer(player, engageDistance))
                 return true;
 
-            if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max()))
+            if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
                 return MoveTowardUnit(player, nearestEnemy, 20.0f);
         }
 
@@ -2909,7 +2909,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
                 if (EngageNearestEnemyPlayer(player, engageDistance))
                     return true;
 
-                if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max()))
+                if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
                     return MoveTowardUnit(player, nearestEnemy, 20.0f);
             }
 
@@ -2942,7 +2942,7 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
-    if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max()))
+    if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
         return MoveTowardUnit(player, nearestEnemy, 20.0f);
 
     return false;


### PR DESCRIPTION
### Motivation
- Resolve Clang compile errors caused by mismatched helper call signatures in PvP playerbot code. 

### Description
- Qualify the SCM refill helper call as `playerbot::QueueEligibleManagedBotsForBattleground(...)` so the declaration from the header is resolved. 
- Update call sites of `FindNearestEnemyBattlegroundPlayer` to pass explicit `nullptr` values for the optional out-parameters so the 4-argument signature is matched. 
- Changes are contained in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and adjust the target acquisition and SCM refill paths. 
- Committed the changes with a concise message to the current branch. 

### Testing
- Ran `git diff --check` with no issues reported. 
- Kicked off `cmake --build build --target scripts -j2`; the build started and compiled many translation units successfully in this environment but a full, final build result was not captured here. 
- Verified the edited file via `git status` and `git diff` before committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5da50f3e083279d516af88d5a39c5)