### PR TITLE
Move PvP helper functions into playerbot namespace and update call sites

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -64,6 +64,13 @@
 #include <vector>
 #include <list>
 
+namespace playerbot
+{
+uint64 BuildBattlegroundInstanceKey(Battleground const* battleground);
+Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance, uint32* scannedPlayers = nullptr, uint32* attackableEnemies = nullptr);
+bool EngageNearestEnemyPlayer(Player* player, float scanDistance);
+}
+
 namespace
 {
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
@@ -86,7 +93,6 @@ std::unordered_map<uint64, uint32> g_BattlegroundOverstackInstanceNextDepartureM
 std::unordered_map<uint64, uint32> g_BattlegroundQueuedNoInviteSinceMsByGuid;
 uint32 g_LastHumanInterestPopulationRebalanceAttemptMs = 0;
 uint32 g_LastScmSlotRefillAttemptMs = 0;
-uint64 BuildBattlegroundInstanceKey(Battleground const* battleground);
 bool BattlegroundHasAnyRealHumanPlayers(Player const* player);
 bool RemoveMatchingQueues(Player* player, bool arenaOnly, bool invitedOnly, bool scheduleNonArenaUpdate);
 
@@ -147,7 +153,7 @@ bool ShouldManagedBotLeaveForOverstack(Player* player, Battleground* battlegroun
     if (cooldownUntilMs && nowMs < cooldownUntilMs)
         return false;
 
-    uint64 const instanceKey = BuildBattlegroundInstanceKey(battleground);
+    uint64 const instanceKey = playerbot::BuildBattlegroundInstanceKey(battleground);
     uint32 const nextDepartureEarliestMs = g_BattlegroundOverstackInstanceNextDepartureMsByInstance[instanceKey];
     if (nextDepartureEarliestMs && nowMs < nextDepartureEarliestMs)
         return false;
@@ -230,7 +236,7 @@ bool TryRefillManagedScmSlots(Player* player, Battleground* battleground)
     g_LastScmSlotRefillAttemptMs = nowMs;
 
     bool const rebalanceTriggered = playerbot::RandomBotParticipationManager::TriggerImmediateRebalance();
-    uint32 const queuedCount = QueueEligibleManagedBotsForBattleground(BATTLEGROUND_SCM, 0);
+    uint32 const queuedCount = playerbot::QueueEligibleManagedBotsForBattleground(BATTLEGROUND_SCM, 0);
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
         "Playerbot PvP SCM refill attempt: guid={} instanceId={} players={} maxPlayers={} rebalanceTriggered={} queuedCount={}.",
         player->GetGUID().ToString(), battleground->GetInstanceID(), playersInInstance, maxPlayers, rebalanceTriggered ? 1 : 0, queuedCount);
@@ -375,9 +381,7 @@ TeamId ResolveBotTeamId(Player const* player)
     return ResolveTeamId(player->GetTeam());
 }
 
-Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance, uint32* scannedPlayers = nullptr, uint32* attackableEnemies = nullptr);
 bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance);
-bool EngageNearestEnemyPlayer(Player* player, float scanDistance);
 float GetAggressiveCombatScanDistance(Player const* player, float fallbackDistance);
 bool CanIssueBotMovement(Player* player);
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000);
@@ -436,7 +440,7 @@ bool TryPursueNearestEnemyInWarsong(Player* player)
 
     uint32 scannedPlayers = 0;
     uint32 attackableEnemies = 0;
-    Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), &scannedPlayers, &attackableEnemies);
+    Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), &scannedPlayers, &attackableEnemies);
     uint64 const botGuid = player->GetGUID().GetRawValue();
     uint32 const nowMs = GameTime::GetGameTimeMS();
     Player* selectedEnemy = nearestEnemy;
@@ -489,7 +493,7 @@ bool TryPursueNearestEnemyInWarsong(Player* player)
             " scan=" + std::to_string(scannedPlayers) +
             " attackable=" + std::to_string(attackableEnemies) +
             " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0), 1200);
-        return EngageNearestEnemyPlayer(player, combatEngageDistance);
+        return playerbot::EngageNearestEnemyPlayer(player, combatEngageDistance);
     }
 
     bool chaseIssued = MoveTowardUnit(player, selectedEnemy, 20.0f);
@@ -2175,7 +2179,7 @@ Unit* AcquireCombatTarget(Player* player, float scanDistance)
             target = duelOpponent;
     }
     if (!isAttackableTarget(target) && player->InBattleground())
-        target = FindNearestEnemyBattlegroundPlayer(player, scanDistance);
+        target = FindNearestEnemyBattlegroundPlayer(player, scanDistance, nullptr, nullptr);
     if (!isAttackableTarget(target))
         return nullptr;
 
@@ -2865,7 +2869,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
             if (EngageNearestEnemyPlayer(player, engageDistance))
                 return true;
 
-            if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max()))
+            if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
                 return MoveTowardUnit(player, nearestEnemy, 20.0f);
         }
 
@@ -2909,7 +2913,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
                 if (EngageNearestEnemyPlayer(player, engageDistance))
                     return true;
 
-                if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max()))
+                if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
                     return MoveTowardUnit(player, nearestEnemy, 20.0f);
             }
 
@@ -2942,7 +2946,7 @@ bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, Battle
     if (EngageNearestEnemyPlayer(player, engageDistance))
         return true;
 
-    if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max()))
+    if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
         return MoveTowardUnit(player, nearestEnemy, 20.0f);
 
     return false;


### PR DESCRIPTION
### Motivation

- Reduce global namespace pollution and group Playerbot PvP helper functions under the `playerbot` namespace to clarify ownership and prepare for further refactors.

### Description

- Add forward declarations for `BuildBattlegroundInstanceKey`, `FindNearestEnemyBattlegroundPlayer`, and `EngageNearestEnemyPlayer` inside the `playerbot` namespace and remove the redundant global prototype.
- Update call sites to reference the namespaced helpers with `playerbot::` qualifiers and pass explicit `nullptr` arguments where the signature requires them.
- Qualify the call to `QueueEligibleManagedBotsForBattleground` as `playerbot::QueueEligibleManagedBotsForBattleground` to match the target namespace.

### Testing

- Built the project successfully using the normal build (e.g. `cmake --build .`) with no compile errors.
- Ran automated test suite with `ctest` and all tests passed.
- Ran PvP-related integration/unit tests that exercise battleground helper paths and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5da50f3e083279d516af88d5a39c5)