### PR TITLE
Track human players in SCM and reduce honor rewards when no human faceoff

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -842,6 +842,8 @@ void Battleground::EndBattleground(uint32 winner)
             loser_money *= arenaMultiplier;
         }
 
+        ModifyEndOfMatchHonorRewards(winner, team, winner_honor, loser_honor);
+
         // Rewards
         // only grant rewards if battle has lasted 15 seconds
         if (GetStartDelayTime() <= 0 && GetStartTime() >= 15 * IN_MILLISECONDS)

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -549,6 +549,7 @@ class TC_GAME_API Battleground
         BattlegroundScoreMap PlayerScores;                // Player scores
         // must be implemented in BG subclass
         virtual void RemovePlayer(Player* /*player*/, ObjectGuid /*guid*/, uint32 /*team*/) { }
+        virtual void ModifyEndOfMatchHonorRewards(uint32 /*winner*/, uint32 /*team*/, uint32& /*winnerHonor*/, uint32& /*loserHonor*/) const { }
 
         // Player lists, those need to be accessible by inherited classes
         BattlegroundPlayerMap m_Players;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -9,6 +9,7 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
+#include "WorldSession.h"
 
 void BattlegroundSCMScore::BuildObjectivesBlock(WorldPacket& data)
 {
@@ -21,12 +22,17 @@ BattlegroundSCM::BattlegroundSCM()
     BgCreatures.resize(BG_SCM_CREATURE_MAX);
     _allianceKills = 0;
     _hordeKills = 0;
+    _allianceHumanParticipants = 0;
+    _hordeHumanParticipants = 0;
+    _humanFaceoffEverHappened = false;
     m_BuffChange = true;
 }
 
 void BattlegroundSCM::AddPlayer(Player* player)
 {
     bool const isInBattleground = IsPlayerInBattleground(player->GetGUID());
+    TrackHumanParticipantAdded(player, isInBattleground);
+
     Battleground::AddPlayer(player);
 
     if (!isInBattleground)
@@ -36,11 +42,79 @@ void BattlegroundSCM::AddPlayer(Player* player)
     }
 }
 
+void BattlegroundSCM::RemovePlayer(Player* player, ObjectGuid /*guid*/, uint32 team)
+{
+    TrackHumanParticipantRemoved(player, team);
+}
+
 void BattlegroundSCM::Reset()
 {
     Battleground::Reset();
     _allianceKills = 0;
     _hordeKills = 0;
+    _allianceHumanParticipants = 0;
+    _hordeHumanParticipants = 0;
+    _humanFaceoffEverHappened = false;
+}
+
+void BattlegroundSCM::TrackHumanParticipantAdded(Player const* player, bool isInBattleground)
+{
+    if (!player || isInBattleground)
+        return;
+
+    WorldSession const* session = player->GetSession();
+    if (!session || session->IsVirtualSession())
+        return;
+
+    if (player->GetBGTeam() == ALLIANCE)
+        ++_allianceHumanParticipants;
+    else if (player->GetBGTeam() == HORDE)
+        ++_hordeHumanParticipants;
+
+    UpdateHumanFaceoffState();
+}
+
+void BattlegroundSCM::TrackHumanParticipantRemoved(Player const* player, uint32 team)
+{
+    if (!player)
+        return;
+
+    WorldSession const* session = player->GetSession();
+    if (!session || session->IsVirtualSession())
+        return;
+
+    if (team == ALLIANCE && _allianceHumanParticipants > 0)
+        --_allianceHumanParticipants;
+    else if (team == HORDE && _hordeHumanParticipants > 0)
+        --_hordeHumanParticipants;
+}
+
+void BattlegroundSCM::UpdateHumanFaceoffState()
+{
+    if (_allianceHumanParticipants > 0 && _hordeHumanParticipants > 0)
+        _humanFaceoffEverHappened = true;
+}
+
+uint32 BattlegroundSCM::GetHonorRewardForTeam() const
+{
+    uint32 reward = sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP) / 2;
+
+    if (!_humanFaceoffEverHappened)
+        reward /= 2;
+
+    return reward;
+}
+
+void BattlegroundSCM::ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, uint32& winnerHonor, uint32& /*loserHonor*/) const
+{
+    if (winner != ALLIANCE && winner != HORDE)
+        return;
+
+    if (team != winner)
+        return;
+
+    if (!_humanFaceoffEverHappened)
+        winnerHonor /= 2;
 }
 
 bool BattlegroundSCM::SetupBattleground()
@@ -230,7 +304,7 @@ void BattlegroundSCM::HandleKillPlayer(Player* victim, Player* killer)
         m_TeamScores[TEAM_ALLIANCE] = _allianceKills;
 
         if ((_allianceKills % 10) == 0)
-            RewardHonorToTeam(sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP) / 2, ALLIANCE);
+            RewardHonorToTeam(GetHonorRewardForTeam(), ALLIANCE);
     }
     else if (killerTeam == HORDE)
     {
@@ -238,7 +312,7 @@ void BattlegroundSCM::HandleKillPlayer(Player* victim, Player* killer)
         m_TeamScores[TEAM_HORDE] = _hordeKills;
 
         if ((_hordeKills % 10) == 0)
-            RewardHonorToTeam(sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP) / 2, HORDE);
+            RewardHonorToTeam(GetHonorRewardForTeam(), HORDE);
     }
 
     UpdateTeamScoreWorldStates();

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
@@ -94,6 +94,7 @@ public:
     ~BattlegroundSCM() override = default;
 
     void AddPlayer(Player* player) override;
+    void RemovePlayer(Player* player, ObjectGuid guid, uint32 team) override;
     void Reset() override;
     bool SetupBattleground() override;
 
@@ -112,9 +113,17 @@ private:
     void UpdateTeamScoreWorldStates();
     void ApplyNonInteractableObjectFlags();
     void SpawnRandomBuffSet(uint32 speedTypeIndex);
+    uint32 GetHonorRewardForTeam() const;
+    void ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, uint32& winnerHonor, uint32& loserHonor) const override;
+    void TrackHumanParticipantAdded(Player const* player, bool isInBattleground);
+    void TrackHumanParticipantRemoved(Player const* player, uint32 team);
+    void UpdateHumanFaceoffState();
 
     uint32 _allianceKills;
     uint32 _hordeKills;
+    uint32 _allianceHumanParticipants;
+    uint32 _hordeHumanParticipants;
+    bool _humanFaceoffEverHappened;
 };
 
 #endif


### PR DESCRIPTION
### Motivation
- Prevent excessive honor payouts for Strand/Crypt-like SCM battlegrounds when players are bots/virtual sessions by reducing rewards if no human faceoff occurred.

### Description
- Added a virtual `ModifyEndOfMatchHonorRewards` hook to `Battleground` and invoked it from `Battleground::EndBattleground` to allow per-battleground end-of-match honor adjustments. 
- Implemented human participant tracking in `BattlegroundSCM` with `_allianceHumanParticipants`, `_hordeHumanParticipants`, and `_humanFaceoffEverHappened` members and associated tracking methods. 
- Adjusted per-kill and end-of-match honor calculations in `BattlegroundSCM` to use `GetHonorRewardForTeam()` and to halve winner honor when no cross-team human faceoff ever occurred. 
- Overrode `RemovePlayer` in `BattlegroundSCM` to decrement human participant counts, added `Reset` updates, and included `WorldSession.h` for session checks.

### Testing
- Built the server codebase successfully after changes with no compile errors. 
- Ran the automated unit/integration test suite including battleground-related tests and confirmed all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c14f35e08327be43087c45e31419)