### PR TITLE
Exclude bot-earned honor from weekly warchief tracking

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7188,6 +7188,11 @@ void Player::AddWeeklyHonorPoints(uint32 value, CharacterDatabaseTransaction tra
     if (!value)
         return;
 
+    // Managed playerbots use virtual sessions; exclude their honor from the
+    // weekly warchief race tracking.
+    if (WorldSession const* session = GetSession(); session && session->IsVirtualSession())
+        return;
+
     CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_WEEKLY_HONOR_POINTS);
     stmt->setUInt32(0, GetGUID().GetCounter());
     stmt->setUInt32(1, value);


### PR DESCRIPTION
### Motivation
- Prevent managed playerbot (virtual-session) honor from influencing the weekly warchief race by excluding bot-earned honor from weekly honor aggregation.

### Description
- Add an early return in `Player::AddWeeklyHonorPoints` that checks the player's session with `IsVirtualSession` and skips inserting into the `character_honor_weekly` table when true.

### Testing
- Ran repository code searches to verify related virtual-session checks and ran `git diff --check` to ensure there are no style/diff issues, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fc0d855083279335cac1f6e3ba91)