### PR TITLE
Add '/tele map' command with battleground spawn resolution

### DIFF
--- a/src/server/scripts/Commands/cs_tele.cpp
+++ b/src/server/scripts/Commands/cs_tele.cpp
@@ -26,6 +26,7 @@ EndScriptData */
 #include "Chat.h"
 #include "DatabaseEnv.h"
 #include "DBCStores.h"
+#include "BattlegroundMgr.h"
 #include "Group.h"
 #include "Language.h"
 #include "MapManager.h"
@@ -58,6 +59,7 @@ public:
         {
             { "add",    HandleTeleAddCommand,   rbac::RBAC_PERM_COMMAND_TELE_ADD,   Console::No },
             { "del",    HandleTeleDelCommand,   rbac::RBAC_PERM_COMMAND_TELE_DEL,   Console::Yes },
+            { "map",    HandleTeleMapCommand,   rbac::RBAC_PERM_COMMAND_TELE,       Console::No },
             { "name",   teleNameCommandTable },
             { "group",  HandleTeleGroupCommand, rbac::RBAC_PERM_COMMAND_TELE_GROUP, Console::No },
             { "",       HandleTeleCommand,      rbac::RBAC_PERM_COMMAND_TELE,       Console::No },
@@ -313,6 +315,100 @@ public:
             player->SaveRecallPosition(); // save only in non-flight case
 
         player->TeleportTo(tele->mapId, tele->position_x, tele->position_y, tele->position_z, tele->orientation);
+        return true;
+    }
+
+    static Position const* GetBattlegroundMapSpawnPosition(uint32 mapId, uint32 team)
+    {
+        for (uint32 i = 1; i < sBattlemasterListStore.GetNumRows(); ++i)
+        {
+            BattlemasterListEntry const* battlemasterEntry = sBattlemasterListStore.LookupEntry(i);
+            if (!battlemasterEntry)
+                continue;
+
+            for (int32 battlegroundMapId : battlemasterEntry->MapID)
+            {
+                if (battlegroundMapId == -1)
+                    break;
+
+                if (uint32(battlegroundMapId) != mapId)
+                    continue;
+
+                if (Battleground* battlegroundTemplate = sBattlegroundMgr->GetBattlegroundTemplate(BattlegroundTypeId(battlemasterEntry->ID)))
+                {
+                    TeamId preferredTeam = Battleground::GetTeamIndexByTeamId(team);
+                    if (Position const* preferredSpawn = battlegroundTemplate->GetTeamStartPosition(preferredTeam))
+                        return preferredSpawn;
+
+                    TeamId fallbackTeam = preferredTeam == TEAM_ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE;
+                    return battlegroundTemplate->GetTeamStartPosition(fallbackTeam);
+                }
+            }
+        }
+
+        return nullptr;
+    }
+
+    static bool HandleTeleMapCommand(ChatHandler* handler, uint32 mapId, Optional<float> x, Optional<float> y, Optional<float> z, Optional<float> orientation)
+    {
+        Player* player = handler->GetSession()->GetPlayer();
+
+        MapEntry const* map = sMapStore.LookupEntry(mapId);
+        if (!map)
+        {
+            handler->SendSysMessage(LANG_COMMAND_NOMAPFOUND);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        Position destination;
+        if (x && y)
+        {
+            destination.Relocate(*x, *y, z.value_or(player->GetPositionZ()), orientation.value_or(player->GetOrientation()));
+        }
+        else if (map->IsBattlegroundOrArena())
+        {
+            if (Position const* teamSpawn = GetBattlegroundMapSpawnPosition(mapId, HORDE))
+            {
+                destination = *teamSpawn;
+                if (orientation)
+                    destination.Relocate(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), *orientation);
+            }
+            else
+            {
+                float centerX = 0.0f;
+                float centerY = 0.0f;
+                Map const* baseMap = sMapMgr->CreateBaseMap(mapId);
+                float groundZ = baseMap->GetHeight(centerX, centerY, MAX_HEIGHT);
+                float waterZ = baseMap->GetWaterLevel(centerX, centerY);
+                float centerZ = groundZ > waterZ ? groundZ : waterZ;
+                destination.Relocate(centerX, centerY, centerZ, orientation.value_or(player->GetOrientation()));
+            }
+        }
+        else
+        {
+            float centerX = 0.0f;
+            float centerY = 0.0f;
+            Map const* baseMap = sMapMgr->CreateBaseMap(mapId);
+            float groundZ = baseMap->GetHeight(centerX, centerY, MAX_HEIGHT);
+            float waterZ = baseMap->GetWaterLevel(centerX, centerY);
+            float centerZ = groundZ > waterZ ? groundZ : waterZ;
+            destination.Relocate(centerX, centerY, centerZ, orientation.value_or(player->GetOrientation()));
+        }
+
+        if (!MapManager::IsValidMapCoord(mapId, destination) || sObjectMgr->IsTransportMap(mapId))
+        {
+            handler->PSendSysMessage(LANG_INVALID_TARGET_COORD, destination.GetPositionX(), destination.GetPositionY(), mapId);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (player->IsInFlight())
+            player->FinishTaxiFlight();
+        else
+            player->SaveRecallPosition();
+
+        player->TeleportTo({ mapId, destination });
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Provide a direct teleport command for map coordinates and sensible defaults when coordinates are omitted. 
- Ensure teleports to battleground/arena maps pick appropriate team start positions or fall back to a safe center location. 

### Description
- Added `#include "BattlegroundMgr.h"` and registered a new `tele map` entry in the tele command table. 
- Implemented `GetBattlegroundMapSpawnPosition` to find team start positions using `sBattlemasterListStore` and `sBattlegroundMgr`. 
- Implemented `HandleTeleMapCommand` to accept optional `x`, `y`, `z`, and `orientation` parameters, compute destination coordinates (team spawn for BG/arena or map center fallback), validate coordinates with `MapManager::IsValidMapCoord`, and perform teleport while handling flight/recall. 
- Kept existing safety checks to prevent teleporting to invalid or transport maps and reused existing teleport/save logic. 

### Testing
- Built the server code (automated build) with the changes; the build completed successfully. 
- Ran the project's automated test suite after the change and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c180965083278c29c66bf8d8a454)