### PR TITLE
Playerbot: prioritize healer movement toward injured allies before enemies

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3173,10 +3173,27 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
+    bool const healerHasLivingAllyTarget = hasValidAllyTarget && CanUseHealRangeSpacing(player->GetClass());
+
+    if (!context.spellId && context.movementDirective == PvpClassSpellContext::MovementDirective::None &&
+        healerHasLivingAllyTarget)
+    {
+        Unit const* allyMovementTarget = resolveTargetByGuid(selectedAllyGuid);
+        if (allyMovementTarget)
+        {
+            float const distance = player->GetDistance(allyMovementTarget);
+            if (distance > GetConfiguredHealRange())
+            {
+                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, allyMovementTarget->GetGUID(),
+                    ComputeApproachFollowRange(GetConfiguredHealRange()), "reach party member to heal", "party member to heal out of spell range", 72.0f);
+            }
+        }
+    }
+
     // Reference parity bridge: provide trigger-like movement directives even
     // when we do not have a castable spell yet ("enemy out of spell" / "enemy
     // too close for spell"). Keep classic spell IDs untouched.
-    if (!context.spellId && hasValidTarget && IsPrimaryRangedClassForSpacing(player->GetClass()))
+    if (!context.spellId && hasValidTarget && IsPrimaryRangedClassForSpacing(player->GetClass()) && !healerHasLivingAllyTarget)
     {
         Unit const* movementTarget = resolveTargetByGuid(activeTargetGuid);
         if (movementTarget)
@@ -3203,21 +3220,6 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         {
             ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, meleeMovementTarget->GetGUID(),
                 std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "enemy out of melee", 69.0f);
-        }
-    }
-
-    if (!context.spellId && context.movementDirective == PvpClassSpellContext::MovementDirective::None &&
-        hasValidAllyTarget && CanUseHealRangeSpacing(player->GetClass()))
-    {
-        Unit const* allyMovementTarget = resolveTargetByGuid(selectedAllyGuid);
-        if (allyMovementTarget)
-        {
-            float const distance = player->GetDistance(allyMovementTarget);
-            if (distance > GetConfiguredHealRange())
-            {
-                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, allyMovementTarget->GetGUID(),
-                    ComputeApproachFollowRange(GetConfiguredHealRange()), "reach party member to heal", "party member to heal out of spell range", 68.0f);
-            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Healer playerbots should close to injured allies first so they can cast heals, instead of moving toward enemy targets when no castable spell is available.  
- Mirror reference behavior: only pursue enemy spacing movement when no ally-heal target is available or alive.

### Description
- Add `healerHasLivingAllyTarget = hasValidAllyTarget && CanUseHealRangeSpacing(player->GetClass())` and, when set and no spell/movement is active, emit a `ReachSpellRange` movement directive toward `selectedAllyGuid` to `reach party member to heal`.  
- Suppress the existing ranged enemy spacing fallback by requiring `!healerHasLivingAllyTarget` before issuing enemy `reach spell` / `flee` movement directives.  
- Remove the duplicate later ally-heal movement block and consolidate the ally-first logic earlier in the decision chain in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`.

### Testing
- Ran `git diff --check` and it reported no whitespace/patch issues (success).  
- Verified repository status with `git status --short` to confirm only the intended file `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` was modified (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7586e44888327a114111fc126f30f)