### PR TITLE
Recover and finalize pending managed-bot teleports; rename teleport handlers

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1900,9 +1900,12 @@ uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint
     return ::QueueEligibleManagedBotsForBattleground(bgTypeId, arenaType);
 }
 
-void FinalizeVirtualBotTeleportIfPending(Player* player)
+void FinalizeManagedBotTeleportIfPending(Player* player)
 {
     if (!player)
+        return;
+
+    if (!playerbot::IsManagedRandomBot(player))
         return;
 
     WorldSession* session = player->GetSession();
@@ -2659,7 +2662,7 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
             return false;
 
         player->LeaveBattleground();
-        FinalizeVirtualBotTeleportIfPending(player);
+        FinalizeManagedBotTeleportIfPending(player);
         if (playerbot::IsManagedRandomBot(player))
             player->RemoveAurasDueToSpell(SPELL_DESERTER);
         RemoveMatchingQueues(player, false, false, true);
@@ -2718,7 +2721,7 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (ShouldManagedBotLeaveForQueuedHuman(player, battleground))
     {
         player->LeaveBattleground();
-        FinalizeVirtualBotTeleportIfPending(player);
+        FinalizeManagedBotTeleportIfPending(player);
         player->RemoveAurasDueToSpell(SPELL_DESERTER);
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP human-priority departure trigger: guid={} bgTypeId={} instanceId={} players={} maxPlayers={}.",
@@ -2730,7 +2733,7 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     if (ShouldManagedBotLeaveForOverstack(player, battleground))
     {
         player->LeaveBattleground();
-        FinalizeVirtualBotTeleportIfPending(player);
+        FinalizeManagedBotTeleportIfPending(player);
         player->RemoveAurasDueToSpell(SPELL_DESERTER);
         QueuePlayer(player, BATTLEGROUND_SCM, 0);
         return true;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -416,7 +416,7 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     EmitLifecycleGmDebug(player, tickDetail.str(), 1500);
 }
 
-void TryFinalizePendingVirtualBotTeleport(Player* player)
+void TryFinalizePendingManagedBotTeleport(Player* player)
 {
     if (!player || !playerbot::IsManagedRandomBot(player))
         return;
@@ -472,6 +472,32 @@ void TryFinalizePendingVirtualBotTeleport(Player* player)
             player->ProcessDelayedOperations();
         }
     }
+}
+
+void RecoverManagedVirtualBotTeleports(std::unordered_set<uint32> const& botAccounts)
+{
+    std::vector<ObjectGuid> managedTeleportGuids;
+    {
+        std::shared_lock<std::shared_mutex> lock(*HashMapHolder<Player>::GetLock());
+        for (auto const& [guid, player] : ObjectAccessor::GetPlayers())
+        {
+            if (!player || !IsManagedRandomBotImpl(player, botAccounts))
+                continue;
+
+            WorldSession const* session = player->GetSession();
+            if (!session || !session->IsVirtualSession())
+                continue;
+
+            if (!player->IsBeingTeleported())
+                continue;
+
+            managedTeleportGuids.push_back(guid);
+        }
+    }
+
+    for (ObjectGuid const& guid : managedTeleportGuids)
+        if (Player* player = ObjectAccessor::FindConnectedPlayer(guid))
+            TryFinalizePendingManagedBotTeleport(player);
 }
 
 void TryReviveManagedBotAfterStartup(Player* player)
@@ -1181,7 +1207,8 @@ void RandomBotParticipationManager::OnWorldUpdate(uint32 diffMs)
         if (!g_RandomPopulation.config.enabled || !g_RandomPopulation.runtimeEnabled)
             return;
 
-        if (g_RandomPopulation.config.botAccountIds.empty())
+        botAccountsForSweep = g_RandomPopulation.config.botAccountIds;
+        if (botAccountsForSweep.empty())
         {
             g_RandomPopulation.skippedNoCandidatePool++;
             return;
@@ -1191,14 +1218,19 @@ void RandomBotParticipationManager::OnWorldUpdate(uint32 diffMs)
             g_RandomPopulation.rebalanceTimerMs += diffMs;
 
         if (g_RandomPopulation.rebalanceTimerMs < g_RandomPopulation.config.rebalanceIntervalMs && !g_RandomPopulation.rebalanceRequested)
-            return;
-
-        g_RandomPopulation.rebalanceTimerMs = 0;
-        g_RandomPopulation.rebalanceRequested = false;
-        RebalanceRandomPopulation(g_RandomPopulation);
-        botAccountsForSweep = g_RandomPopulation.config.botAccountIds;
-        shouldRunScmSweep = true;
+        {
+            // Still run teleport recovery below even when no rebalance/sweep is due.
+        }
+        else
+        {
+            g_RandomPopulation.rebalanceTimerMs = 0;
+            g_RandomPopulation.rebalanceRequested = false;
+            RebalanceRandomPopulation(g_RandomPopulation);
+            shouldRunScmSweep = true;
+        }
     }
+
+    RecoverManagedVirtualBotTeleports(botAccountsForSweep);
 
     // Avoid running the SCM sweep while holding g_RandomPopulationLock:
     // lifecycle queue operations can call TriggerImmediateRebalance(), which
@@ -1221,7 +1253,7 @@ void RandomBotParticipationManager::OnPlayerLogout(Player const* player)
 void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
 {
     TryReviveManagedBotAfterStartup(player);
-    TryFinalizePendingVirtualBotTeleport(player);
+    TryFinalizePendingManagedBotTeleport(player);
     ProcessActiveBattlegroundTacticalTick(player);
 
     if (!CanProcessPlayerLifecycle(player))


### PR DESCRIPTION
### Motivation
- Ensure pending teleport acknowledgements for managed (random) bots are finalized reliably and only for managed bot accounts to avoid leaving bots in stuck teleport states.
- Clarify naming around "virtual" bots by switching to "managed" terminology and prevent non-managed players from being processed by these helpers.
- Run teleport recovery during world updates even when a population rebalance is not due to avoid lingering virtual-session teleports.

### Description
- Renamed and refactored teleport-finalization helpers from `FinalizeVirtualBotTeleportIfPending` and `TryFinalizePendingVirtualBotTeleport` to `FinalizeManagedBotTeleportIfPending` and `TryFinalizePendingManagedBotTeleport`, and updated all call sites accordingly.
- Added an early guard to `FinalizeManagedBotTeleportIfPending` to return immediately for non-managed players by checking `playerbot::IsManagedRandomBot(player)`.
- Added `RecoverManagedVirtualBotTeleports(std::unordered_set<uint32> const& botAccounts)` which scans connected players under the `HashMapHolder<Player>` lock for managed bots with virtual sessions and pending teleports, and finalizes them outside the lock.
- Adjusted `RandomBotParticipationManager::OnWorldUpdate` to always prepare `botAccountsForSweep`, run teleport recovery via `RecoverManagedVirtualBotTeleports(botAccountsForSweep)` even when no rebalance/sweep is due, and only run the SCM sweep when a rebalance is actually required to avoid deadlocks while holding `g_RandomPopulationLock`.
- Updated lifecycle code paths in battleground handlers to call the renamed finalize function and preserved existing teleport/zone handling logic.

### Testing
- Project compiled successfully after the changes with no build errors for the modified translation units.
- Ran the `playerbot`/PvP lifecycle-related automated test suite and the affected tests completed successfully (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7549893588327ab375315a87bffa5)