### PR TITLE
Fix playerbot PvP compile regressions

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2320,7 +2320,8 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
         return decision;
 
     Pet const* pet = player->GetPet();
-    bool const needsPetSummon = !pet || !pet->IsAlive();
+    bool const hasLivingPet = pet && pet->IsAlive();
+    bool const needsPetSummon = !hasLivingPet;
     bool const hasHostileTarget = HasHostileTarget(player, target);
 
     if (!hasHostileTarget)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -57,6 +57,8 @@
 
 namespace
 {
+bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> const& botAccounts);
+
 bool IsCrowdControlledForLifecyclePause(Player const* player)
 {
     if (!player)


### PR DESCRIPTION
### Motivation

- Resolve compile errors caused by an out-of-order function definition and a missing local variable used in decision candidates so the Playerbot PvP scripts compile cleanly.

### Description

- Add a forward declaration `bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> const& botAccounts);` near the top of `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp` so earlier helper functions can call it before its definition.
- Define `bool const hasLivingPet = pet && pet->IsAlive();` and derive `bool const needsPetSummon = !hasLivingPet;` in `SelectWarlockSpell` inside `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` so the `hasLivingPet` expression used by decision candidates is available.

### Testing

- Ran symbol searches with `rg` to confirm `IsManagedRandomBotImpl` and `hasLivingPet` usages and declarations were resolved, which succeeded.
- Started a full build with `ninja -C build -j4`; compilation progressed through many translation units and made significant progress before being stopped due to runtime/time constraints (partial build progress observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75a5df6d08327bb84a01e11af77e0)