### PR TITLE
Fix .tele map arena spawn lookup by map id

### DIFF
--- a/src/server/scripts/Commands/cs_tele.cpp
+++ b/src/server/scripts/Commands/cs_tele.cpp
@@ -320,30 +320,18 @@ public:
 
     static Position const* GetBattlegroundMapSpawnPosition(uint32 mapId, uint32 team)
     {
-        for (uint32 i = 1; i < sBattlemasterListStore.GetNumRows(); ++i)
+        for (uint32 bgTypeValue = 1; bgTypeValue < MAX_BATTLEGROUND_TYPE_ID; ++bgTypeValue)
         {
-            BattlemasterListEntry const* battlemasterEntry = sBattlemasterListStore.LookupEntry(i);
-            if (!battlemasterEntry)
+            Battleground* battlegroundTemplate = sBattlegroundMgr->GetBattlegroundTemplate(BattlegroundTypeId(bgTypeValue));
+            if (!battlegroundTemplate || battlegroundTemplate->GetMapId() != mapId)
                 continue;
 
-            for (int32 battlegroundMapId : battlemasterEntry->MapID)
-            {
-                if (battlegroundMapId == -1)
-                    break;
+            TeamId preferredTeam = Battleground::GetTeamIndexByTeamId(team);
+            if (Position const* preferredSpawn = battlegroundTemplate->GetTeamStartPosition(preferredTeam))
+                return preferredSpawn;
 
-                if (uint32(battlegroundMapId) != mapId)
-                    continue;
-
-                if (Battleground* battlegroundTemplate = sBattlegroundMgr->GetBattlegroundTemplate(BattlegroundTypeId(battlemasterEntry->ID)))
-                {
-                    TeamId preferredTeam = Battleground::GetTeamIndexByTeamId(team);
-                    if (Position const* preferredSpawn = battlegroundTemplate->GetTeamStartPosition(preferredTeam))
-                        return preferredSpawn;
-
-                    TeamId fallbackTeam = preferredTeam == TEAM_ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE;
-                    return battlegroundTemplate->GetTeamStartPosition(fallbackTeam);
-                }
-            }
+            TeamId fallbackTeam = preferredTeam == TEAM_ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE;
+            return battlegroundTemplate->GetTeamStartPosition(fallbackTeam);
         }
 
         return nullptr;


### PR DESCRIPTION
### Motivation
- The `.tele map` command failed to find team spawn points for some arena/battleground maps because it relied on `BattlemasterList` rows rather than the loaded battleground templates matched by map id.

### Description
- Updated `GetBattlegroundMapSpawnPosition` in `src/server/scripts/Commands/cs_tele.cpp` to iterate battleground templates via `sBattlegroundMgr->GetBattlegroundTemplate(...)` and match by `GetMapId()` instead of scanning `sBattlemasterListStore` and its `MapID` array.
- The function now returns the preferred team start (`GetTeamStartPosition`) and falls back to the opposite team start if the preferred is missing, preserving existing behavior.
- This change allows arena maps (example: `980`) to resolve correct team spawns for `HandleTeleMapCommand` when no explicit coordinates are provided.

### Testing
- Ran the build command `cmake --build build --target worldserver -j2`, which started successfully and progressed through compilation without errors in the observed output, though the full build did not complete within the session window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75dc785008327bdff98c241b1e184)