### PR TITLE
Propagate pet combat to owners for all player classes

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -194,23 +194,11 @@ namespace
 {
 bool ShouldPropagateCombatToOwner(Unit* owner, Unit* controlled)
 {
-    if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
+    if (!owner || !controlled)
         return true;
 
-    if (!controlled || !controlled->IsPet())
+    if (controlled->GetCharmerOrOwnerGUID() != owner->GetGUID())
         return true;
-
-    if (controlled->GetOwnerGUID() != owner->GetGUID())
-        return true;
-
-    switch (owner->ToPlayer()->GetClass())
-    {
-        case CLASS_HUNTER:
-        case CLASS_WARLOCK:
-            return false;
-        default:
-            break;
-    }
 
     return true;
 }


### PR DESCRIPTION
### Motivation
- Ensure owners (including playerbots) are treated as in-combat when their controlled/pet units are fighting, avoiding cases where the owner can perform out-of-combat actions (e.g. drinking) while their pet is engaged.

### Description
- Simplified `ShouldPropagateCombatToOwner` in `src/server/game/Combat/CombatManager.cpp` to only validate presence and ownership via `GetCharmerOrOwnerGUID()` and removed the previous hunter/warlock-specific exception so combat propagates from controlled units to their owner for all player classes.

### Testing
- No automated build or unit tests were executed in this environment; the change was inspected with `git diff` and committed as `Propagate pet combat to owners for all player classes`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75e3708388327b92432bf2cd7cdab)