### PR TITLE
Clear stale active motion for ranged approach to prevent idle bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -357,6 +357,15 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     if (!motionMaster)
         return;
 
+    float const currentDistance = player->GetDistance(target);
+    bool const shouldForceActiveRepath = !player->isMoving() && currentDistance > (safeDistance + 1.5f);
+    if (shouldForceActiveRepath)
+    {
+        // Recover from stale active movement generators that can leave ranged
+        // bots idling while repeatedly selecting "reach spell" directives.
+        motionMaster->Clear(MOTION_SLOT_ACTIVE);
+    }
+
     if (player->IsValidAttackTarget(target))
     {
         // Ensure hostile ranged approach can engage chase generators even when


### PR DESCRIPTION
### Motivation
- Ranged playerbots can become idle when an outdated active movement generator prevents repathing while the bot is stationary and still out of range. This change recovers from that state so ranged bots resume approach behavior.

### Description
- In `IssueRangedApproachMovement` compute `currentDistance` and when the bot is not moving and `currentDistance > (safeDistance + 1.5f)` clear the active motion slot via `motionMaster->Clear(MOTION_SLOT_ACTIVE)` to force an active repath.
- Preserve existing strict-human pathing logic and the fallback debug log, and otherwise retain the original `MoveChase`/`MoveFollow` behavior.
- Added a short comment explaining the recovery from stale active movement generators.

### Testing
- Project was compiled with the change and the server binary built successfully.  
- Existing automated unit and integration tests covering movement/playerbot scenarios were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75edfc64c8327aa48d5e0b18217ff)