### PR TITLE
Do not throttle travel directives when stationary with stale chase/follow generators

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -565,12 +565,13 @@ bool ShouldThrottleDirective(Player const* player, playerbot::PvpClassSpellConte
 
     // If we intended to travel but currently have no movement momentum, do not
     // suppress directive execution. This keeps ranged spacing directives from
-    // idling when another system briefly clears active motion between ticks.
+    // idling when another system leaves us stationary with either idle or stale
+    // chase/follow generators between ticks.
     if (isTravelDirective && !player->isMoving())
     {
         MotionMaster const* motionMaster = player->GetMotionMaster();
         MovementGeneratorType const movementType = motionMaster ? motionMaster->GetCurrentMovementGeneratorType() : IDLE_MOTION_TYPE;
-        if (movementType == IDLE_MOTION_TYPE)
+        if (movementType == IDLE_MOTION_TYPE || movementType == CHASE_MOTION_TYPE || movementType == FOLLOW_MOTION_TYPE)
             return false;
     }
 


### PR DESCRIPTION
### Motivation
- Ranged/warlock bots could repeatedly select movement directives like `reach spell` yet remain still because the throttle suppressed reissuing movement when the bot was stationary but had an idle or stale chase/follow movement generator.

### Description
- Adjusted `ShouldThrottleDirective` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` so travel directives (`ReachMeleeRange`, `ReachSpellRange`, `FleeTooCloseForSpell`) are not considered throttled when the bot is stationary and the current movement generator is `IDLE_MOTION_TYPE`, `CHASE_MOTION_TYPE`, or `FOLLOW_MOTION_TYPE` (previously only `IDLE_MOTION_TYPE`).
- Updated the inline comment to document the stale chase/follow generator case.

### Testing
- Ran `cmake --build build --target game -j2`; the build started and progressed without compilation errors observed for the modified file in this environment.
- Ran `cmake --build build --target scripts -j2`; the build started and progressed without compilation errors observed for the modified file in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7651a3f508327ac9652adf3f48a12)