### PR TITLE
playerbot: avoid warrior charge/intercept at min-range and improve ranged/healer target acquisition

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2388,6 +2388,12 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
     bool const inBattleStance = player->HasAura(2457);
     bool const inDefensiveStance = player->HasAura(71);
     bool const inBerserkerStance = player->HasAura(2458);
+    SpellInfo const* chargeInfo = sSpellMgr->GetSpellInfo(11578);
+    SpellInfo const* interceptInfo = sSpellMgr->GetSpellInfo(20617);
+    float const chargeMinRange = chargeInfo ? chargeInfo->GetMinRange(false) : 8.0f;
+    float const interceptMinRange = interceptInfo ? interceptInfo->GetMinRange(false) : 8.0f;
+    bool const canChargeByRange = !player->IsWithinDistInMap(activeTarget, chargeMinRange);
+    bool const canInterceptByRange = !player->IsWithinDistInMap(activeTarget, interceptMinRange);
     Unit const* nearbyMeleeTarget = SelectNearbyMeleeTarget(player, activeTarget, 8.0f);
     Unit const* nearbyCastingTarget = SelectEnemyCastingTarget(player, 8.0f, activeTarget);
     bool const hasNearbyMeleeThreat = HasHostileTarget(player, nearbyMeleeTarget);
@@ -2411,11 +2417,11 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
         { "warrior berserker stance", "leave defensive stance when disarm is unavailable or no melee threat is nearby", 2458, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && !player->IsInCombat() && !inBattleStance && IsSpellReady(player, 2457), 52.5f,
         { "warrior battle stance", "switch to battle stance before out-of-combat charge", 2457, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && !player->IsInCombat() && IsSpellReady(player, 11578), 52.0f,
+    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && !player->IsInCombat() && canChargeByRange && IsSpellReady(player, 11578), 52.0f,
         { "warrior charge", "close gap to target from out of combat", 11578, playerbot::PvpClassSpellContext::TargetMode::Enemy, activeTarget ? activeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && player->IsInCombat() && !inBerserkerStance && IsSpellReady(player, 2458), 51.5f,
         { "warrior berserker stance", "switch to berserker stance before intercept gap close", 2458, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && player->IsInCombat() && IsSpellReady(player, 20617), 51.0f,
+    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && player->IsInCombat() && canInterceptByRange && IsSpellReady(player, 20617), 51.0f,
         { "warrior intercept", "close gap to target while in combat", 20617, playerbot::PvpClassSpellContext::TargetMode::Enemy, activeTarget ? activeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, player->IsWithinMeleeRange(activeTarget) && !inBerserkerStance &&
             IsSpellReady(player, 1680) && IsSpellReady(player, 2458), 50.4f,
@@ -2916,8 +2922,13 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         if (Unit const* combatVictim = player->GetVictim(); HasHostileTarget(player, combatVictim))
             activeTargetGuid = combatVictim->GetGUID();
     if (activeTargetGuid.IsEmpty())
-        if (Unit const* fallbackTarget = SelectClosestEnemyTarget(player, true))
+    {
+        bool const allowLongAcquire =
+            IsPrimaryRangedClassForSpacing(player->GetClass()) ||
+            CanUseHealRangeSpacing(player->GetClass());
+        if (Unit const* fallbackTarget = SelectClosestEnemyTarget(player, !allowLongAcquire))
             activeTargetGuid = fallbackTarget->GetGUID();
+    }
 
     auto resolveTargetByGuid = [&](ObjectGuid const& guid) -> Unit const*
     {


### PR DESCRIPTION
### Motivation
- Warriors were repeatedly attempting gap-closers (Charge/Intercept) while already inside each spell's minimum range, causing failed casts and spacing spam.
- Ranged and healer bots could remain idle when no nearby selected hostile existed because fallback acquisition required a strict short reachable filter.

### Description
- Added min-range gating for warrior gap closers by resolving each spell's `GetMinRange(false)` and skipping `charge`/`intercept` decisions when the target is inside that minimum range in `SelectWarriorSpell`.
- Adjusted fallback enemy acquisition in `BuildClassSpellContext` so ranged classes and classes that use heal-range spacing (`IsPrimaryRangedClassForSpacing` or `CanUseHealRangeSpacing`) may acquire from a longer distance instead of always requiring the previous reachable filter.
- All edits are contained in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and do not modify the `playerbot reference/` directory.

### Testing
- Ran `git -C /workspace/TrinityCore112 diff --check` which reported no whitespace errors and succeeded.
- Ran `git -C /workspace/TrinityCore112 status --short` to verify the working tree and succeeded.
- Committed the change to the current branch successfully (commit message: "playerbot: tighten warrior gap-closer range and healer target acquire").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77050439083279f4fc43dd444c086)