### PR TITLE
Treat fully-absorbed direct damage as damage for aura interrupts

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -794,7 +794,9 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
         if (player->GetCommandStatus(CHEAT_GOD))
             return 0;
 
-    if (damagetype != NODAMAGE && (damage != 0 || cleanDamage->absorbed_damage > 0))
+    bool const hasAbsorbedDamage = cleanDamage && cleanDamage->absorbed_damage > 0;
+
+    if (damagetype != NODAMAGE && (damage != 0 || hasAbsorbedDamage))
     {
         // interrupting auras with AURA_INTERRUPT_FLAG_DAMAGE before checking !damage (absorbed damage breaks that type of auras)
         if (spellProto)
@@ -806,7 +808,7 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
             victim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TAKE_DAMAGE, 0);
 
         // interrupt spells with SPELL_INTERRUPT_FLAG_ABORT_ON_DMG on absorbed damage (no dots)
-        if (!damage && damagetype != DOT && cleanDamage && cleanDamage->absorbed_damage)
+        if (!damage && damagetype != DOT && hasAbsorbedDamage)
         {
             if (victim != attacker && victim->GetTypeId() == TYPEID_PLAYER)
             {
@@ -819,6 +821,10 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
                     }
             }
         }
+
+        // direct damage should also interrupt direct-damage-sensitive auras when fully absorbed
+        if (!damage && (damagetype == DIRECT_DAMAGE || damagetype == SPELL_DIRECT_DAMAGE) && hasAbsorbedDamage)
+            victim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_DIRECT_DAMAGE, spellProto ? spellProto->Id : 0);
 
         // We're going to call functions which can modify content of the list during iteration over it's elements
         // Let's copy the list so we can prevent iterator invalidation
@@ -888,7 +894,7 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
     if (!damage)
     {
         // Rage from absorbed damage
-        if (cleanDamage && cleanDamage->absorbed_damage && victim->GetPowerType() == POWER_RAGE)
+        if (hasAbsorbedDamage && victim->GetPowerType() == POWER_RAGE)
             victim->RewardRage(cleanDamage->absorbed_damage, 0, false);
 
         return 0;


### PR DESCRIPTION
### Motivation
- Fully-absorbed hits were not being treated as damage for some interrupt paths, causing damage-based triggers and direct-damage aura interrupts (e.g. breaking stealth on Frost Nova while Power Word: Shield is active) to not fire.

### Description
- Add a local helper `hasAbsorbedDamage` in `Unit::DealDamage` to detect when a hit carried absorbed damage (`cleanDamage->absorbed_damage > 0`) and use it consistently.
- Use `hasAbsorbedDamage` so absorbed hits are considered by the existing `AURA_INTERRUPT_FLAG_TAKE_DAMAGE` and `SPELL_INTERRUPT_FLAG_ABORT_ON_DMG` logic.
- Ensure fully-absorbed direct damage (both `DIRECT_DAMAGE` and `SPELL_DIRECT_DAMAGE`) also removes auras with `AURA_INTERRUPT_FLAG_DIRECT_DAMAGE` so direct-damage-sensitive auras break even when damage is fully absorbed.
- Replace scattered `cleanDamage` null checks with `hasAbsorbedDamage` for clearer and safer conditions (including rage reward from absorbed damage).
- Modified file: `src/server/game/Entities/Unit/Unit.cpp` (changes around `Unit::DealDamage`).

### Testing
- Invoked a debug build via `cmake --build build --target worldserver -j2`; CMake reconfigured and the build started and began compiling successfully (compile progress observed but full build completion was not captured in this run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76cb1085483278edd75f9d9d77327)