### PR TITLE
Playerbot: fallback MovePoint for ranged approach when chase/follow is idle

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -378,6 +378,22 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     {
         motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
     }
+
+    // Some battleground edge-cases can drop the requested chase/follow order
+    // and leave the active generator idle for a tick while we are still out of
+    // range. Fall back to a direct MovePoint so "reach spell" does not loop
+    // forever with no actual motion.
+    float const postIssueDistance = player->GetDistance(target);
+    if (!player->isMoving() &&
+        postIssueDistance > (safeDistance + 1.0f) &&
+        motionMaster->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE)
+    {
+        Position const fallbackDestination = BuildFollowDestination(player, target, safeDistance);
+        motionMaster->MovePoint(0, fallbackDestination, true);
+        TC_LOG_DEBUG("playerbots.pvp.classspell",
+            "Ranged approach fallback MovePoint: guid={} target={} desiredRange={} currentDistance={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+    }
 }
 
 void IssueMeleeApproachMovement(Player* player, Unit* target)


### PR DESCRIPTION
### Motivation
- Bots performing ranged "reach spell" movement could issue chase/follow orders but remain idle when the active movement generator drops, producing a visible stuck/looping behavior in some battleground/pathing edge cases.
- Provide a deterministic fallback so bots actually close the gap instead of repeatedly selecting reach-spell directives with no motion.

### Description
- Added a post-order safety fallback in `IssueRangedApproachMovement` that detects when the bot is not moving, remains beyond the requested `safeDistance`, and the motion generator is `IDLE_MOTION_TYPE`, and then issues a direct `MovePoint` toward a computed follow destination.
- The fallback reuses the existing `BuildFollowDestination` helper and emits a `TC_LOG_DEBUG` entry to aid diagnosis when the path is taken.
- Preserves existing strict-human pathing, repath clearing, and chase/follow logic when those mechanisms succeed.

### Testing
- Ran `git diff --check` to validate whitespace/patch sanity and the check passed.
- Ran `git status --short` to confirm the working tree changes were staged/committed as expected.
- No unit tests or CI jobs were executed as part of this change; behavior was validated via code review and static checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e895f7d6888327bdcb81dfb522ba43)