### PR TITLE
Prevent account banker interactions from falling back to personal bank

### DIFF
--- a/src/server/game/Accounts/AccountBankMgr.cpp
+++ b/src/server/game/Accounts/AccountBankMgr.cpp
@@ -38,6 +38,12 @@ namespace AccountBank
 {
 namespace
 {
+    uint32 GetAccountBankerScriptId()
+    {
+        static uint32 const scriptId = sObjectMgr->GetScriptId("npc_account_banker");
+        return scriptId;
+    }
+
     void CleanupRemovedItem(Player* player, Item* item)
     {
         if (!player || !item)
@@ -620,6 +626,11 @@ bool IsAccountBanker(Player const* player, ObjectGuid bankerGuid)
         return false;
 
     return session->BankerGuid == bankerGuid;
+}
+
+bool IsAccountBankerCreature(Creature const* creature)
+{
+    return creature && creature->GetScriptId() == GetAccountBankerScriptId();
 }
 
 void UpdateAccountBankSessions()

--- a/src/server/game/Accounts/AccountBankMgr.h
+++ b/src/server/game/Accounts/AccountBankMgr.h
@@ -24,6 +24,7 @@
 #include "ObjectGuid.h"
 
 class ChatHandler;
+class Creature;
 class Item;
 class Player;
 
@@ -46,6 +47,7 @@ namespace AccountBank
     void HandleLogin(Player* player);
     bool IsAccountBankOpen(Player const* player);
     bool IsAccountBankAccessible(Player const* player);
+    bool IsAccountBankerCreature(Creature const* creature);
     bool IsAccountBanker(Player const* player, ObjectGuid bankerGuid);
 }
 

--- a/src/server/game/Handlers/BankHandler.cpp
+++ b/src/server/game/Handlers/BankHandler.cpp
@@ -57,6 +57,12 @@ void WorldSession::HandleBankerActivateOpcode(WorldPackets::NPC::Hello& packet)
     if (GetPlayer()->HasUnitState(UNIT_STATE_DIED))
         GetPlayer()->RemoveAurasByType(SPELL_AURA_FEIGN_DEATH);
 
+    if (AccountBank::IsAccountBankerCreature(unit) && !AccountBank::OpenAccountBank(GetPlayer(), packet.Unit))
+    {
+        SendNotification("Unable to open the shared account bank.");
+        return;
+    }
+
     SendShowBank(packet.Unit);
 }
 
@@ -68,6 +74,15 @@ void WorldSession::HandleAutoBankItemOpcode(WorldPackets::Bank::AutoBankItem& pa
     {
         TC_LOG_DEBUG("network", "WORLD: HandleAutoBankItemOpcode - Unit ({}) not found or you can't interact with him.", m_currentBankerGUID.ToString());
         return;
+    }
+
+    if (Creature* banker = GetPlayer()->GetNPCIfCanInteractWith(m_currentBankerGUID, UNIT_NPC_FLAG_BANKER))
+    {
+        if (AccountBank::IsAccountBankerCreature(banker) && !AccountBank::IsAccountBankOpen(_player))
+        {
+            SendNotification("Shared account bank is no longer active. Please reopen it.");
+            return;
+        }
     }
 
     Item* item = _player->GetItemByPos(packet.Bag, packet.Slot);
@@ -101,6 +116,15 @@ void WorldSession::HandleAutoStoreBankItemOpcode(WorldPackets::Bank::AutoStoreBa
     {
         TC_LOG_DEBUG("network", "WORLD: HandleAutoStoreBankItemOpcode - Unit ({}) not found or you can't interact with him.", m_currentBankerGUID.ToString());
         return;
+    }
+
+    if (Creature* banker = GetPlayer()->GetNPCIfCanInteractWith(m_currentBankerGUID, UNIT_NPC_FLAG_BANKER))
+    {
+        if (AccountBank::IsAccountBankerCreature(banker) && !AccountBank::IsAccountBankOpen(_player))
+        {
+            SendNotification("Shared account bank is no longer active. Please reopen it.");
+            return;
+        }
     }
 
     Item* item = _player->GetItemByPos(packet.Bag, packet.Slot);


### PR DESCRIPTION
### Motivation

- Fix a bug where interacting with the shared account banker could end up operating on the player's personal bank, allowing unintended deposits or leaving the bank UI in an inconsistent state. 
- Ensure interactions with the special `npc_account_banker` are explicit: either open the account-bank view or deny actions and close the flow. 

### Description

- Add `AccountBank::IsAccountBankerCreature` and `GetAccountBankerScriptId()` to reliably identify the account banker NPC by script id and forward-declare `Creature` in the header (`AccountBankMgr.h`).
- When receiving banker activation (`HandleBankerActivateOpcode`), explicitly attempt to open an account-bank session for account bankers and notify the player if opening fails instead of falling back to personal bank behavior (`BankHandler.cpp`).
- Add guards to `HandleAutoBankItemOpcode` and `HandleAutoStoreBankItemOpcode` to deny auto-deposit/auto-store operations when the player is still interacting with an account banker but the account-bank session is not active, with a player notification to reopen the shared bank (`BankHandler.cpp`).
- Small header/source updates in `src/server/game/Accounts/AccountBankMgr.*` and `src/server/game/Handlers/BankHandler.cpp` to implement the above logic.

### Testing

- Built the modified translation units with Ninja: `ninja -C build src/server/game/CMakeFiles/game.dir/Accounts/AccountBankMgr.cpp.o src/server/game/CMakeFiles/game.dir/Handlers/BankHandler.cpp.o`, which completed successfully.
- Started a full build via `cmake --build build --target game -j4` which progressed deeply through compile steps in this environment but was not relied on as the single verification due to runtime constraints in the CI environment; no compile errors related to the changes were observed during the attempted build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e898e0a16c83278aa66870aafdb401)