### PR TITLE
Playerbot: avoid kiting dead‑zone at ranged minimum range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3256,8 +3256,12 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             }
             else if (minRange > 0.0f && distance < std::max(0.0f, minRange - kRangedSpacingEnterTooCloseBuffer))
             {
+                // Keep an extra cushion over strict spell minimum range so ranged
+                // weapon casts (e.g. Hunter Auto Shot at 8y min range) do not
+                // immediately re-enter the dead-zone from minor pathing drift.
+                float const fleeFollowRange = std::max(std::max(1.0f, GetConfiguredCloseRange()), minRange + 2.0f);
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, spacingTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredCloseRange()), "flee", "selected spell minimum range violation", 84.0f);
+                    fleeFollowRange, "flee", "selected spell minimum range violation", 84.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;


### PR DESCRIPTION
### Motivation
- Ranged bots (notably Hunters) could stop inside a strict spell minimum radius (e.g. Auto Shot min 8y) and immediately reattempt the attack, causing a stuttery stop/retry kiting loop.
- The change ensures flee movement for minimum-range violations moves the bot to a safer follow distance to avoid rapid re-entry into the dead-zone.

### Description
- In `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` adjust the `FleeTooCloseForSpell` movement directive to use `fleeFollowRange = max(max(1.0f, GetConfiguredCloseRange()), minRange + 2.0f)` instead of the prior `max(1.0f, GetConfiguredCloseRange())` so the bot retreats past the spell's minimum range plus a 2-yard cushion.
- Added an inline comment explaining the rationale for the extra cushion for ranged weapon casts (e.g., Hunter Auto Shot).

### Testing
- Applied the patch with an automated replacement script (`python`), and the patch step completed successfully.
- Ran `git diff --check` which returned clean (no whitespace errors) and succeeded.
- Committed the modified file via `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ad3020348327a51aa1f782573357)