### PR TITLE
Druid travel-form recovery repositioning and PvP spell decision adjustments

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -39,6 +39,7 @@
 #include <cmath>
 #include <algorithm>
 #include <chrono>
+#include <limits>
 #include <sstream>
 #include <unordered_map>
 
@@ -845,6 +846,47 @@ void FaceTargetForInstantCast(Player* player, Unit* target, SpellInfo const* spe
     player->SetInFront(target);
 }
 
+void RepositionDruidAfterTravelFormRecovery(Player* player)
+{
+    if (!player || !player->GetMap() || !CanIssueFollowCommands(player))
+        return;
+
+    Unit* nearestEnemy = nullptr;
+    float nearestDistance = std::numeric_limits<float>::max();
+    Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!candidate || candidate == player || !candidate->IsAlive())
+            continue;
+        if (!player->IsValidAttackTarget(candidate))
+            continue;
+        if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, 20.0f))
+            continue;
+
+        float const distance = player->GetDistance(candidate);
+        if (distance < nearestDistance)
+        {
+            nearestDistance = distance;
+            nearestEnemy = candidate;
+        }
+    }
+
+    if (!nearestEnemy)
+        return;
+
+    Position destination = player->GetPosition();
+    float const retreatDistance = std::max(8.0f, std::min(16.0f, nearestDistance + 6.0f));
+    float const angleToEnemy = player->GetAbsoluteAngle(nearestEnemy->GetPosition());
+    destination.RelocateOffset({ std::cos(angleToEnemy + static_cast<float>(M_PI)) * retreatDistance,
+        std::sin(angleToEnemy + static_cast<float>(M_PI)) * retreatDistance, 0.0f, 0.0f });
+
+    if (RequiresStrictHumanPathing(player))
+        IssueStrictHumanMove(player, destination);
+    else
+        player->GetMotionMaster()->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+}
+
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
 {
     failureReason.clear();
@@ -1626,7 +1668,11 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         casted,
         context.reason ? context.reason : "none");
     if (casted)
+    {
+        if (context.spellId == 783 && context.reason && std::string_view(context.reason) == "recovering from polymorph by travel-form reposition")
+            RepositionDruidAfterTravelFormRecovery(player);
         SetLastExecutionStatus(player, "cast_executed");
+    }
     else
         SetLastExecutionStatus(player, "cast_failed_" + failureReason);
     return casted;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2153,7 +2153,7 @@ SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inM
             { "mage ice barrier", "maintain defensive absorb shield", 13033, playerbot::PvpClassSpellContext::TargetMode::Self } },
         { "enemy low health", hasHostileTarget && target && target->HealthBelowPct(20) && IsSpellReady(player, 10199), 30.0f,
             { "mage fire blast", "instant execute pressure on low health target", 10199, playerbot::PvpClassSpellContext::TargetMode::Enemy } },
-        { "polymorph", polymorphTarget, 29.0f,
+        { "polymorph", polymorphTarget && !polymorphTarget->HealthBelowPct(75), 29.0f,
             { "mage polymorph", "priority crowd control on non-dotted paladin/priest targets", 12826, playerbot::PvpClassSpellContext::TargetMode::Enemy, polymorphTarget ? polymorphTarget->GetGUID() : ObjectGuid::Empty } },
         { "default ranged", hasHostileTarget && IsSpellReady(player, 25304), 18.0f,
             { "mage frostbolt", "default ranged pressure", 25304, playerbot::PvpClassSpellContext::TargetMode::Enemy } },
@@ -2209,8 +2209,8 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
 
     AddDecisionCandidate(candidates, hasHostileTarget && target && target->GetClass() == CLASS_ROGUE && !HasAuraFromSpellChain(target, 27605) && IsSpellReady(player, 27605), 22.0f,
         { "priest shadow word pain", "maintain dot pressure on rogues", 27605, playerbot::PvpClassSpellContext::TargetMode::Enemy });
-    AddDecisionCandidate(candidates, hasHostileTarget && target && target->GetPowerType() == POWER_MANA && IsSpellReady(player, 14033), 21.0f,
-        { "priest mana burn", "burn mana from enemy casters", 14033, playerbot::PvpClassSpellContext::TargetMode::Enemy });
+    AddDecisionCandidate(candidates, hasHostileTarget && target && target->GetPowerType() == POWER_MANA && target->GetPowerPct(POWER_MANA) > 25.0f && IsSpellReady(player, 10876), 21.0f,
+        { "priest mana burn", "burn mana from enemy casters", 10876, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, CountNearbyEnemies(player, 10.0f) >= 2 && CountNearbyFriendlyPlayers(player, 10.0f) >= 2 && IsSpellReady(player, 27801), 20.0f,
         { "priest holy nova", "aoe pressure and splash healing in melee cluster", 27801, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, hasHostileTarget && target && IsSpellReady(player, 27605) && !HasBreakableCrowdControl(target) && !HasAuraFromSpellChain(target, 27605), 19.0f,
@@ -2233,6 +2233,12 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target)
     if (!player)
         return decision;
 
+    bool const recoveredFromPolymorph =
+        playerbot::PvpClassActions::GetLastExecutionStatus(player) == "cast_failed_crowd_controlled_polymorph" &&
+        !player->HasUnitState(UNIT_STATE_CONFUSED) &&
+        !player->HasAuraType(SPELL_AURA_MOD_CONFUSE) &&
+        !player->IsPolymorphed();
+
     Unit const* lowManaAlly = IsSpellReady(player, 29166) ? SelectFriendlyLowManaTarget(player, 40.0f, 10.0f) : nullptr;
     Unit const* cursedTarget = IsSpellReady(player, 2782) ? SelectFriendlyDispelTarget(player, DISPEL_CURSE, 40.0f) : nullptr;
     Unit const* poisonedTarget = IsSpellReady(player, 2893) ? SelectFriendlyDispelTarget(player, DISPEL_POISON, 40.0f) : nullptr;
@@ -2243,8 +2249,17 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target)
     Unit const* rejuvTarget = IsSpellReady(player, 25299) ? SelectFriendlyHealthTarget(player, 40.0f, 90.0f) : nullptr;
     Unit const* rogueTarget = SelectEnemyClassTarget(player, CLASS_ROGUE, 30.0f);
     Unit const* meleeThreat = SelectNearbyMeleeTarget(player, target, 8.0f);
+    Unit const* moonfireExecuteTarget = nullptr;
+    if (IsSpellReady(player, 8921))
+    {
+        Unit const* nearbyTarget = SelectNearbyEnemyTarget(player, target, 25.0f);
+        if (nearbyTarget && nearbyTarget->HealthBelowPct(20))
+            moonfireExecuteTarget = nearbyTarget;
+    }
 
     std::vector<PrioritizedSpellDecision> candidates;
+    AddDecisionCandidate(candidates, recoveredFromPolymorph && IsSpellReady(player, 783), 55.0f,
+        { "druid travel form recovery", "recovering from polymorph by travel-form reposition", 783, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, lowManaAlly && !lowManaAlly->HasAura(29166), 50.0f,
         { "druid innervate", "stabilize low-mana ally with innervate", 29166, lowManaAlly == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, lowManaAlly ? lowManaAlly->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, cursedTarget, 49.0f,
@@ -2261,6 +2276,8 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target)
         { "druid regrowth", "maintain regrowth on injured allies", 9858, regrowthTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, regrowthTarget ? regrowthTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, rejuvTarget && !HasAuraFromSpellChain(rejuvTarget, 25299), 43.0f,
         { "druid rejuvenation", "maintain rejuvenation on injured allies", 25299, rejuvTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, rejuvTarget ? rejuvTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates, moonfireExecuteTarget, 42.0f,
+        { "druid moonfire execute", "spam moonfire pressure on nearby low-health enemies", 8921, playerbot::PvpClassSpellContext::TargetMode::Enemy, moonfireExecuteTarget ? moonfireExecuteTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, rogueTarget && !HasAuraFromSpellChain(rogueTarget, 9907) && IsSpellReady(player, 9907), 30.0f,
         { "druid faerie fire", "apply faerie fire to nearby rogues", 9907, playerbot::PvpClassSpellContext::TargetMode::Enemy, rogueTarget ? rogueTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, meleeThreat && IsSpellReady(player, 5487), 29.0f,


### PR DESCRIPTION
### Motivation
- Improve druid behavior after recovering from polymorph by using Travel Form to reposition away from nearby enemies and avoid immediate melee pressure.
- Reduce poor polymorph usage and inappropriate mana-burn targeting by tightening decision conditions for Mage and Priest spells.
- Add opportunistic Druid execute pressure via Moonfire for low-health nearby enemies.

### Description
- Add `RepositionDruidAfterTravelFormRecovery` to compute a retreat destination from the nearest valid enemy and issue a movement command, and include `<limits>` for numeric bounds.
- Call `RepositionDruidAfterTravelFormRecovery` after a successful cast when the spell id is `783` and the decision `reason` equals `"recovering from polymorph by travel-form reposition"` in `CastDirectSpell`.
- Detect `recoveredFromPolymorph` in Druid decision logic via `GetLastExecutionStatus` and add a high-priority decision to cast travel form (`783`) for recovery, and add a moonfire execute candidate (`8921`) for nearby enemies under 20% health.
- Tighten Mage polymorph logic to avoid casting on targets below 75% health, and update Priest mana-burn logic to use spell id `10876` and require target mana percent > 25%.

### Testing
- Project compiled successfully after changes (`make`/build completed without errors).
- PvP-related playerbot decision paths were exercised in automated tests and the relevant test suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ab93920c8327ae08ee26c4d421ce)