### PR TITLE
Tighten hunter melee checks and add cushion for minimum-range spacing

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2095,8 +2095,12 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
         { "hunter scatter shot", "scatter interrupt against nearby cast", 19503, playerbot::PvpClassSpellContext::TargetMode::Enemy, enemyOnTopTarget ? enemyOnTopTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, nearbyCastingTarget && IsSpellReady(player, 19503), 23.0f,
         { "hunter scatter shot", "scatter interrupt against nearby cast", 19503, playerbot::PvpClassSpellContext::TargetMode::Enemy, nearbyCastingTarget ? nearbyCastingTarget->GetGUID() : ObjectGuid::Empty });
-    AddDecisionCandidate(candidates, enemyOnTop && IsSpellReady(player, 14268) && !HasAuraFromSpellChain(enemyOnTopTarget, 14268), 21.0f,
-        { "hunter wing clip", "close-range fallback snare", 14268, playerbot::PvpClassSpellContext::TargetMode::Enemy, enemyOnTopTarget ? enemyOnTopTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates,
+        enemyOnTop && enemyOnTopTarget && player->IsWithinMeleeRange(enemyOnTopTarget) &&
+            IsSpellReady(player, 14268) && !HasAuraFromSpellChain(enemyOnTopTarget, 14268),
+        21.0f,
+        { "hunter wing clip", "close-range fallback snare", 14268, playerbot::PvpClassSpellContext::TargetMode::Enemy,
+            enemyOnTopTarget ? enemyOnTopTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !targetClose && !targetSnaredOrStunned && IsSpellReady(player, 5116), 20.0f,
         { "hunter concussive shot", "kite or chase control", 5116, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, rogueTarget && !HasAuraFromSpellChain(rogueTarget, 25295) && IsSpellReady(player, 25295), 19.5f,
@@ -3256,8 +3260,12 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             }
             else if (minRange > 0.0f && distance < std::max(0.0f, minRange - kRangedSpacingEnterTooCloseBuffer))
             {
+                // Keep an extra cushion over strict spell minimum range so ranged
+                // weapon casts (e.g. Hunter Auto Shot at 8y min range) do not
+                // immediately re-enter the dead-zone from minor pathing drift.
+                float const fleeFollowRange = std::max(std::max(1.0f, GetConfiguredCloseRange()), minRange + 2.0f);
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, spacingTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredCloseRange()), "flee", "selected spell minimum range violation", 84.0f);
+                    fleeFollowRange, "flee", "selected spell minimum range violation", 84.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;


### PR DESCRIPTION
### Motivation
- Prevent selecting melee spells for a missing or out-of-range nearby target and avoid potential null-dereference when evaluating `enemyOnTopTarget` for hunter decisions.
- Avoid ranged bots oscillating into a spell "dead-zone" caused by strict minimum-range checks (for example, `Auto Shot` with a non-zero min range) due to minor pathing drift.
- Improve overall spell spacing behavior so bots choose movement directives that lead to robust casting ranges.

### Description
- Add an explicit `enemyOnTopTarget` null check and require `player->IsWithinMeleeRange(enemyOnTopTarget)` before adding the hunter `wing clip` candidate to ensure the target is actually in melee range.
- Introduce `fleeFollowRange` in `PvpCore::BuildClassSpellContext` computed as `std::max(std::max(1.0f, GetConfiguredCloseRange()), minRange + 2.0f)` and use it for the `FleeTooCloseForSpell` movement directive to keep an extra cushion over the strict spell minimum range.
- Add a clarifying comment explaining the rationale for the extra minimum-range cushion to avoid re-entering dead-zones from minor pathing drift.

### Testing
- Built the project successfully with the modified files and no compile errors reported.
- Ran the automated unit/test suite for the server codebase and all tests passed.
- Executed automated integration/smoke tests covering spell selection and movement directives which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ad3020348327a51aa1f782573357)