### PR TITLE
Fix silent failure for `.tele map` teleport attempts

### DIFF
--- a/src/server/scripts/Commands/cs_tele.cpp
+++ b/src/server/scripts/Commands/cs_tele.cpp
@@ -392,7 +392,13 @@ public:
         else
             player->SaveRecallPosition();
 
-        player->TeleportTo({ mapId, destination });
+        if (!player->TeleportTo({ mapId, destination }))
+        {
+            handler->PSendSysMessage(LANG_INVALID_TARGET_COORD, destination.GetPositionX(), destination.GetPositionY(), mapId);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
### Motivation

- The `.tele map` command could fail at runtime without informing the user, leaving the command appearing to do nothing.

### Description

- Added a runtime check of `player->TeleportTo({ mapId, destination })` in `src/server/scripts/Commands/cs_tele.cpp` and report an explicit error when it returns false.
- When teleport fails the command now sends `LANG_INVALID_TARGET_COORD`, calls `SetSentErrorMessage(true)`, and returns `false` to indicate command failure.
- Existing destination selection and `MapManager::IsValidMapCoord` validation were kept intact and only the post-selection teleport result handling was added.

### Testing

- Ran a build attempt with `cmake --build build --target game -j2`, which compiled a large portion of targets but did not complete within the session due to time/output constraints (build was partial and therefore not fully validated).
- No automated unit tests were executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e902480ba88327a90b0e9364ac15c0)