### PR TITLE
Fix hunter dead-zone idle by forcing melee collapse in 5-8y band

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -55,6 +55,7 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player);
 constexpr float kReferenceHunterSwitchDistance = 8.0f;
 constexpr float kRangedSpacingEnterOutOfRangeBuffer = 2.0f;
 constexpr float kRangedSpacingEnterTooCloseBuffer = 1.0f;
+constexpr uint32 kHunterAutoShotSpellId = 75;
 std::unordered_map<ObjectGuid, bool> g_HunterRangedModeByBot;
 std::mutex g_HunterRangedModeByBotLock;
 std::unordered_map<ObjectGuid, uint8> g_CombatNoTargetTicksByBot;
@@ -122,6 +123,19 @@ void UpdateHunterCombatMode(Player const* player, Unit const* target)
             player->GetGUID().ToString(), target->GetGUID().ToString(), previousRangedMode ? "ranged" : "melee",
             rangedMode ? "ranged" : "melee", distance, target->GetVictim() == player ? 1 : 0);
     }
+}
+
+float GetHunterDeadZoneMaxRange()
+{
+    SpellInfo const* autoShotInfo = sSpellMgr->GetSpellInfo(kHunterAutoShotSpellId);
+    if (!autoShotInfo)
+        return kReferenceHunterSwitchDistance;
+
+    float const minRange = autoShotInfo->GetMinRange(false);
+    if (minRange <= 0.0f)
+        return kReferenceHunterSwitchDistance;
+
+    return minRange;
 }
 
 uint8 IncrementCombatNoTargetTicks(Player const* player)
@@ -2095,8 +2109,12 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
         { "hunter scatter shot", "scatter interrupt against nearby cast", 19503, playerbot::PvpClassSpellContext::TargetMode::Enemy, enemyOnTopTarget ? enemyOnTopTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, nearbyCastingTarget && IsSpellReady(player, 19503), 23.0f,
         { "hunter scatter shot", "scatter interrupt against nearby cast", 19503, playerbot::PvpClassSpellContext::TargetMode::Enemy, nearbyCastingTarget ? nearbyCastingTarget->GetGUID() : ObjectGuid::Empty });
-    AddDecisionCandidate(candidates, enemyOnTop && IsSpellReady(player, 14268) && !HasAuraFromSpellChain(enemyOnTopTarget, 14268), 21.0f,
-        { "hunter wing clip", "close-range fallback snare", 14268, playerbot::PvpClassSpellContext::TargetMode::Enemy, enemyOnTopTarget ? enemyOnTopTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates,
+        enemyOnTop && enemyOnTopTarget && player->IsWithinMeleeRange(enemyOnTopTarget) &&
+            IsSpellReady(player, 14268) && !HasAuraFromSpellChain(enemyOnTopTarget, 14268),
+        21.0f,
+        { "hunter wing clip", "close-range fallback snare", 14268, playerbot::PvpClassSpellContext::TargetMode::Enemy,
+            enemyOnTopTarget ? enemyOnTopTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !targetClose && !targetSnaredOrStunned && IsSpellReady(player, 5116), 20.0f,
         { "hunter concussive shot", "kite or chase control", 5116, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, rogueTarget && !HasAuraFromSpellChain(rogueTarget, 25295) && IsSpellReady(player, 25295), 19.5f,
@@ -3254,10 +3272,35 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
                 context.targetGuid = ObjectGuid::Empty;
                 context.selfCast = false;
             }
-            else if (minRange > 0.0f && distance < std::max(0.0f, minRange - kRangedSpacingEnterTooCloseBuffer))
+            else if (minRange > 0.0f && distance < std::max(0.0f, minRange + kRangedSpacingEnterTooCloseBuffer))
             {
-                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, spacingTarget->GetGUID(),
-                    std::max(1.0f, GetConfiguredCloseRange()), "flee", "selected spell minimum range violation", 84.0f);
+                bool collapseToMelee = false;
+                if (player->GetClass() == CLASS_HUNTER)
+                {
+                    float const meleeEnterRange = std::max(0.0f, GetConfiguredMeleeRange() + kRangedSpacingEnterTooCloseBuffer);
+                    if (distance > meleeEnterRange)
+                    {
+                        // Hunters in the 5-8y dead-zone cannot use either
+                        // ranged weapon shots or reliable melee pressure.
+                        // Collapse into melee first, then resume normal
+                        // hunter mode logic on subsequent ticks.
+                        ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, spacingTarget->GetGUID(),
+                            std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "selected spell dead-zone collapse", 84.0f);
+                        collapseToMelee = true;
+                    }
+                }
+
+                if (!collapseToMelee)
+                {
+                    // Enter too-close movement before strict dead-zone boundaries so
+                    // ranged users do not idle in 5-8y style min-range gaps.
+                    // Keep an extra cushion over strict spell minimum range so ranged
+                    // weapon casts (e.g. Hunter Auto Shot at 8y min range) do not
+                    // immediately re-enter the dead-zone from minor pathing drift.
+                    float const fleeFollowRange = std::max(std::max(1.0f, GetConfiguredCloseRange()), minRange + 2.0f);
+                    ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, spacingTarget->GetGUID(),
+                        fleeFollowRange, "flee", "selected spell minimum range violation", 84.0f);
+                }
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3313,7 +3356,17 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, movementTarget->GetGUID(),
                     ComputeApproachFollowRange(GetConfiguredSpellRange()), "reach spell", "enemy out of spell range", 70.0f);
             }
-            else if (distance < std::max(0.0f, GetConfiguredMeleeRange() - kRangedSpacingEnterTooCloseBuffer))
+            else if (player->GetClass() == CLASS_HUNTER &&
+                distance < std::max(0.0f, GetHunterDeadZoneMaxRange() + kRangedSpacingEnterTooCloseBuffer) &&
+                distance > std::max(0.0f, GetConfiguredMeleeRange() + kRangedSpacingEnterTooCloseBuffer))
+            {
+                // No castable spell + hunter dead-zone often left the bot in a
+                // bow-raise idle loop. For this 5-8y band, force a short melee
+                // close to re-enter a valid action envelope.
+                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachMeleeRange, movementTarget->GetGUID(),
+                    std::max(1.0f, GetConfiguredMeleeRange() - 1.0f), "reach melee", "enemy in hunter dead-zone", 71.0f);
+            }
+            else if (distance < std::max(0.0f, GetConfiguredMeleeRange() + kRangedSpacingEnterTooCloseBuffer))
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell, movementTarget->GetGUID(),
                     std::max(1.0f, GetConfiguredCloseRange()), "flee", "enemy too close for spell", 71.0f);


### PR DESCRIPTION
### Motivation

- Hunters were getting stuck in a 5–8 yard dead-zone where ranged Auto Shot min-range and melee reach overlap, causing bots to idle with bow-up and not perform actions.
- Provide an explicit, data-driven dead-zone threshold for hunters (based on Auto Shot min range) and handle it to restore usable action windows.

### Description

- Added `kHunterAutoShotSpellId` and `GetHunterDeadZoneMaxRange()` to derive the hunter dead-zone from Auto Shot min range with a fallback to the existing 8y reference. (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`).
- In `BuildClassSpellContext`, when a selected ranged spell is inside its minimum range, hunters now detect the dead-zone band (outside melee envelope but inside the spell min-range+buffer) and choose `ReachMeleeRange` to collapse into melee instead of issuing `FleeTooCloseForSpell` and idling. (`PlayerbotPvpCore.cpp`).
- Added the same dead-zone handling to the no-spell ranged fallback path so hunters in the 5–8y band force a short melee close (`ReachMeleeRange`, reason `"enemy in hunter dead-zone"`) before normal too-close flee logic.
- Tightened the hunter `wing clip` candidate selection so it is only considered when the nearby enemy target exists and is actually in melee range (`player->IsWithinMeleeRange(enemyOnTopTarget)`).

### Testing

- Ran `git diff --check` which completed successfully. 
- Ran `git status --short` which completed successfully and the change was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ad3020348327a51aa1f782573357)