### PR TITLE
Improve teleport handling: allow GMs into BGs, use map entrance triggers, and surface failed teleports

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1716,9 +1716,8 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
 
     MapEntry const* mEntry = sMapStore.LookupEntry(mapid);
 
-    // don't let enter battlegrounds without assigned battleground id (for example through areatrigger)...
-    // don't let gm level > 1 either
-    if (!InBattleground() && mEntry->IsBattlegroundOrArena())
+    // don't let regular players enter battlegrounds without assigned battleground id (for example through areatrigger)
+    if (!InBattleground() && mEntry->IsBattlegroundOrArena() && !IsGameMaster())
         return false;
 
     // client without expansion support

--- a/src/server/scripts/Commands/cs_tele.cpp
+++ b/src/server/scripts/Commands/cs_tele.cpp
@@ -362,6 +362,10 @@ public:
                 if (orientation)
                     destination.Relocate(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), *orientation);
             }
+            else if (AreaTrigger const* entrance = sObjectMgr->GetMapEntranceTrigger(mapId))
+            {
+                destination.Relocate(entrance->target_X, entrance->target_Y, entrance->target_Z, orientation.value_or(entrance->target_Orientation));
+            }
             else
             {
                 handler->SendSysMessage(LANG_CANNOT_TELE_TO_BG);
@@ -371,13 +375,20 @@ public:
         }
         else
         {
-            float centerX = 0.0f;
-            float centerY = 0.0f;
-            Map const* baseMap = sMapMgr->CreateBaseMap(mapId);
-            float groundZ = baseMap->GetHeight(centerX, centerY, MAX_HEIGHT);
-            float waterZ = baseMap->GetWaterLevel(centerX, centerY);
-            float centerZ = groundZ > waterZ ? groundZ : waterZ;
-            destination.Relocate(centerX, centerY, centerZ, orientation.value_or(player->GetOrientation()));
+            if (AreaTrigger const* entrance = sObjectMgr->GetMapEntranceTrigger(mapId))
+            {
+                destination.Relocate(entrance->target_X, entrance->target_Y, entrance->target_Z, orientation.value_or(entrance->target_Orientation));
+            }
+            else
+            {
+                float centerX = 0.0f;
+                float centerY = 0.0f;
+                Map const* baseMap = sMapMgr->CreateBaseMap(mapId);
+                float groundZ = baseMap->GetHeight(centerX, centerY, MAX_HEIGHT);
+                float waterZ = baseMap->GetWaterLevel(centerX, centerY);
+                float centerZ = groundZ > waterZ ? groundZ : waterZ;
+                destination.Relocate(centerX, centerY, centerZ, orientation.value_or(player->GetOrientation()));
+            }
         }
 
         if (!MapManager::IsValidMapCoord(mapId, destination) || sObjectMgr->IsTransportMap(mapId))
@@ -392,7 +403,14 @@ public:
         else
             player->SaveRecallPosition();
 
-        player->TeleportTo({ mapId, destination });
+        if (!player->TeleportTo({ mapId, destination }))
+        {
+            handler->PSendSysMessage("Map %u exists, but teleport failed at (%f, %f, %f). The destination may be inaccessible for your character state or map type.",
+                mapId, destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent regular players from entering battleground or arena maps unless they have an assigned battleground, while allowing Game Masters to bypass that restriction.
- Use configured map entrance AreaTriggers when resolving map destinations for teleport commands so teleports go to intended entry points instead of map center.
- Provide clearer feedback to command users when a teleport attempt fails at the resolved destination.

### Description
- Adjusted `Player::TeleportTo` to only block entry to battleground/arena maps for non-GM players by adding an `IsGameMaster()` check. 
- Updated `cs_tele.cpp` `HandleTeleMapCommand` to consult `sObjectMgr->GetMapEntranceTrigger(mapId)` for both battlegrounds and regular maps before falling back to map center or team spawn positions, and to apply entrance trigger orientation when present. 
- Changed teleport command behavior to check the boolean return of `player->TeleportTo(...)` and send a descriptive error message via `handler->PSendSysMessage` and mark the handler as having an error when the teleport fails.

### Testing
- Built the project with `make` after the changes and the build completed successfully. 
- Ran the project's automated test suite with `make test` and observed no failing tests. 
- Executed automated teleport-related command checks to confirm that entrance triggers are used and that failed teleports produce the new error message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e902480ba88327a90b0e9364ac15c0)