### PR TITLE
Fix ranged playerbots stalling on reach-spell directives

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -380,20 +380,20 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
     }
 
-    // Some battleground edge-cases can drop the requested chase/follow order
-    // and leave the active generator idle for a tick while we are still out of
-    // range. Fall back to a direct MovePoint so "reach spell" does not loop
-    // forever with no actual motion.
+    // Some battleground edge-cases keep a stale chase/follow generator active
+    // without producing displacement while we are still out of range. Fall
+    // back to a direct MovePoint so "reach spell" does not loop forever with
+    // no actual motion.
     float const postIssueDistance = player->GetDistance(target);
-    if (!player->isMoving() &&
-        postIssueDistance > (safeDistance + 1.0f) &&
-        motionMaster->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE)
+    if (!player->isMoving() && postIssueDistance > (safeDistance + 1.0f))
     {
+        motionMaster->Clear(MOTION_SLOT_ACTIVE);
         Position const fallbackDestination = BuildFollowDestination(player, target, safeDistance);
         motionMaster->MovePoint(0, fallbackDestination, true);
         TC_LOG_DEBUG("playerbots.pvp.classspell",
-            "Ranged approach fallback MovePoint: guid={} target={} desiredRange={} currentDistance={}.",
-            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+            "Ranged approach forced MovePoint fallback: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance,
+            static_cast<uint32>(motionMaster->GetCurrentMovementGeneratorType()));
     }
 }
 


### PR DESCRIPTION
### Motivation
- Ranged bots (e.g., warlock) could repeatedly select `reach spell` while remaining stationary when a chase/follow generator was present but not producing displacement, causing them to stall.
- Provide a more robust recovery so ranged approach directives do not loop without actual motion.

### Description
- Change `IssueRangedApproachMovement` fallback trigger to force recovery whenever the bot is not moving and remains outside the desired range, instead of requiring `IDLE_MOTION_TYPE` to be active.  
- Clear `MOTION_SLOT_ACTIVE` before issuing the fallback `MovePoint` to break stale chase/follow generators.  
- Expand fallback debug logging to include the active movement generator type for easier diagnosis.  
- Updated comments to reflect the new fallback rationale.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea87859d30832782218d54166aa95f)