### PR TITLE
Hard-disable AuctionHouseBot: remove usage and set AHBot timers/config to 0

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -24,7 +24,6 @@
 #include "AchievementMgr.h"
 #include "AddonMgr.h"
 #include "ArenaTeamMgr.h"
-#include "AuctionHouseBot.h"
 #include "AuctionHouseMgr.h"
 #include "BattlefieldMgr.h"
 #include "BattlegroundMgr.h"
@@ -1570,8 +1569,8 @@ void World::LoadConfigSettings(bool reload)
 
     m_bool_configs[CONFIG_IP_BASED_ACTION_LOGGING] = sConfigMgr->GetBoolDefault("Allow.IP.Based.Action.Logging", false);
 
-    // AHBot
-    m_int_configs[CONFIG_AHBOT_UPDATE_INTERVAL] = sConfigMgr->GetIntDefault("AuctionHouseBot.Update.Interval", 20);
+    // AHBot is hard-disabled in this fork.
+    m_int_configs[CONFIG_AHBOT_UPDATE_INTERVAL] = 0;
 
     m_bool_configs[CONFIG_CALCULATE_CREATURE_ZONE_AREA_DATA] = sConfigMgr->GetBoolDefault("Calculate.Creature.Zone.Area.Data", false);
     m_bool_configs[CONFIG_CALCULATE_GAMEOBJECT_ZONE_AREA_DATA] = sConfigMgr->GetBoolDefault("Calculate.Gameoject.Zone.Area.Data", false);
@@ -2184,8 +2183,8 @@ void World::SetInitialWorldSettings()
     m_timers[WUPDATE_AUTOBROADCAST].SetInterval(getIntConfig(CONFIG_AUTOBROADCAST_INTERVAL));
     m_timers[WUPDATE_DELETECHARS].SetInterval(DAY*IN_MILLISECONDS); // check for chars to delete every day
 
-    // for AhBot
-    m_timers[WUPDATE_AHBOT].SetInterval(getIntConfig(CONFIG_AHBOT_UPDATE_INTERVAL) * IN_MILLISECONDS); // every 20 sec
+    // AHBot is hard-disabled in this fork.
+    m_timers[WUPDATE_AHBOT].SetInterval(0);
 
     m_timers[WUPDATE_PINGDB].SetInterval(getIntConfig(CONFIG_DB_PING_INTERVAL)*MINUTE*IN_MILLISECONDS);    // Mysql ping time in minutes
 
@@ -2219,8 +2218,7 @@ void World::SetInitialWorldSettings()
     // Delete all characters which have been deleted X days before
     Player::DeleteOldCharacters();
 
-    TC_LOG_INFO("server.loading", "Initialize AuctionHouseBot...");
-    sAuctionBot->Initialize();
+    TC_LOG_INFO("server.loading", "AuctionHouseBot is hard-disabled in this build.");
 
     TC_LOG_INFO("server.loading", "Initializing chat channels...");
     ChannelMgr::LoadFromDB();
@@ -2463,13 +2461,7 @@ void World::Update(uint32 diff)
         sAuctionMgr->UpdatePendingAuctions();
     }
 
-    /// <li> Handle AHBot operations
-    if (m_timers[WUPDATE_AHBOT].Passed())
-    {
-        TC_METRIC_TIMER("world_update_time", TC_METRIC_TAG("type", "Update AHBot"));
-        sAuctionBot->Update();
-        m_timers[WUPDATE_AHBOT].Reset();
-    }
+    // AHBot is hard-disabled in this fork.
 
     /// <li> Handle file changes
     if (m_timers[WUPDATE_CHECK_FILECHANGES].Passed())


### PR DESCRIPTION
### Motivation
- This fork intentionally disables the AuctionHouseBot feature to remove its runtime behavior and avoid relying on AHBot code paths.
- The change ensures AHBot does not run or consume timer cycles and prevents accidental initialization or updates.

### Description
- Removed the `#include "AuctionHouseBot.h"` dependency and replaced AHBot initialization with a log message stating it is disabled.
- Overrode the AHBot configuration read by forcing `CONFIG_AHBOT_UPDATE_INTERVAL` to `0` instead of reading `AuctionHouseBot.Update.Interval` from the config.
- Set the `WUPDATE_AHBOT` timer interval to `0` and removed the AHBot update call from the main `World::Update` loop, replacing it with a comment indicating AHBot is disabled.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8baa3f68832785644b09808d5393)