### PR TITLE
Fix WorldSocket async callback lifetime

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -49,7 +49,10 @@ void WorldSocket::Start()
     LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_SEL_IP_INFO);
     stmt->setString(0, ip_address);
 
-    _queryProcessor.AddCallback(LoginDatabase.AsyncQuery(stmt).WithPreparedCallback(std::bind(&WorldSocket::CheckIpCallback, this, std::placeholders::_1)));
+    _queryProcessor.AddCallback(LoginDatabase.AsyncQuery(stmt).WithPreparedCallback([self = shared_from_this()](PreparedQueryResult result)
+    {
+        self->CheckIpCallback(std::move(result));
+    }));
 }
 
 void WorldSocket::CheckIpCallback(PreparedQueryResult result)
@@ -444,9 +447,9 @@ void WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     stmt->setInt32(0, int32(realm.Id.Realm));
     stmt->setString(1, authSession->Account);
 
-    _queryProcessor.AddCallback(LoginDatabase.AsyncQuery(stmt).WithPreparedCallback([this, authSession = std::move(authSession)](PreparedQueryResult result) mutable
+    _queryProcessor.AddCallback(LoginDatabase.AsyncQuery(stmt).WithPreparedCallback([self = shared_from_this(), authSession = std::move(authSession)](PreparedQueryResult result) mutable
     {
-        HandleAuthSessionCallback(std::move(authSession), std::move(result));
+        self->HandleAuthSessionCallback(std::move(authSession), std::move(result));
     }));
 }
 
@@ -616,7 +619,10 @@ void WorldSocket::HandleAuthSessionCallback(std::shared_ptr<AuthSession> authSes
     if (wardenActive)
         _worldSession->InitWarden(account.SessionKey, account.OS);
 
-    _queryProcessor.AddCallback(_worldSession->LoadPermissionsAsync().WithPreparedCallback(std::bind(&WorldSocket::LoadSessionPermissionsCallback, this, std::placeholders::_1)));
+    _queryProcessor.AddCallback(_worldSession->LoadPermissionsAsync().WithPreparedCallback([self = shared_from_this()](PreparedQueryResult result)
+    {
+        self->LoadSessionPermissionsCallback(std::move(result));
+    }));
     AsyncRead();
 }
 


### PR DESCRIPTION
### Motivation
- Crash reports pointed to the networking update/dequeue path and jemalloc activity, which is consistent with a use-after-free where async DB callbacks could run after a `WorldSocket` was destroyed.

### Description
- Replace async DB callback bindings that captured raw `this` with lambdas capturing `shared_from_this()` so callbacks hold a strong `shared_ptr` to the socket while executing.
- Updated callback in `WorldSocket::Start()` to capture `self = shared_from_this()` and call `self->CheckIpCallback(...)`.
- Updated the account lookup callback in `WorldSocket::HandleAuthSession()` to capture `self = shared_from_this()` and call `self->HandleAuthSessionCallback(...)`.
- Updated the permissions-load callback after authentication to capture `self = shared_from_this()` and call `self->LoadSessionPermissionsCallback(...)`.

### Testing
- Ran `git diff --check` to validate whitespace and patch sanity, which completed without issues.
- Ran `git status --short` to verify that only the intended source file was modified, which showed the expected change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab76910288327a8618472d3670deb)