### PR TITLE
Playerbot: preserve CHARGE_MOTION_TYPE during battleground tactical movement

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -984,7 +984,8 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     else if (!botCurrentlyMoving && player->InBattleground() &&
         currentMovement != IDLE_MOTION_TYPE &&
         currentMovement != CHASE_MOTION_TYPE &&
-        currentMovement != POINT_MOTION_TYPE)
+        currentMovement != POINT_MOTION_TYPE &&
+        currentMovement != CHARGE_MOTION_TYPE)
     {
         EmitBattlegroundGmDebug(player,
             "movepoint=clear-stale-generator motionType=" + std::to_string(uint32(currentMovement)), 1000);
@@ -2830,6 +2831,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         case CHASE_MOTION_TYPE:
         case POINT_MOTION_TYPE:
         case FOLLOW_MOTION_TYPE:
+        case CHARGE_MOTION_TYPE:
             break;
         default:
         {


### PR DESCRIPTION
### Motivation
- Battleground tactical movement recovery logic could clear a bot's active `CHARGE_MOTION_TYPE` generator while the bot was briefly stationary, cancelling Charge/Intercept displacement while still playing the effects.

### Description
- Updated `IssueMovePointThrottled` logic to treat `CHARGE_MOTION_TYPE` as a valid (non-stale) motion generator and avoid clearing it in battleground tactical reissue checks by excluding `CHARGE_MOTION_TYPE` from the stale-generator branch in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.
- Added `CHARGE_MOTION_TYPE` to the allowed motion-generator set in `MoveToObjectivePrimitive` so charge movement is preserved during objective movement handling in the same file.

### Testing
- Launched a build with `cmake --build build --target worldserver -j2` to validate compilation; the build progressed through many dependency compilation steps and produced no compile errors in the captured output, although full build completion was not captured within the session window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb554e0868832782b0d47f88250b32)