### PR TITLE
Playerbot: remove distance check from ally target selection

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2093,7 +2093,7 @@ ObjectGuid SelectAllyTargetGuid(Player const* player)
     if (!IsFriendlySupportTarget(player, selected))
         return ObjectGuid::Empty;
 
-    if (!player->IsWithinLOSInMap(selected) || !player->IsWithinDistInMap(selected, GetConfiguredHealRange()))
+    if (!player->IsWithinLOSInMap(selected))
         return ObjectGuid::Empty;
 
     return selectedGuid;


### PR DESCRIPTION
### Motivation
- Allow the playerbot to select friendly targets for support even when they are beyond the configured heal range so the bot can plan movement, target evaluation, or range-specific decision logic elsewhere instead of being filtered here.

### Description
- In `SelectAllyTargetGuid` removed the distance requirement by deleting the `IsWithinDistInMap(selected, GetConfiguredHealRange())` check and leaving only the line that verifies line-of-sight with `IsWithinLOSInMap`.

### Testing
- Built the project and ran the server test suite including Playerbot-related unit tests; the build and automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb56cbf88083279f28d0cf2f98b586)