### PR TITLE
Fix strict pathing throttle causing stalled ranged bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -268,12 +268,21 @@ bool IssueStrictHumanMove(Player* player, Position const& destination, float des
         state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
 
-    if (!destinationChanged && !canReissueByTime)
-        return true;
-
     MotionMaster* motionMaster = player->GetMotionMaster();
     if (!motionMaster)
         return false;
+
+    if (!destinationChanged && !canReissueByTime)
+    {
+        // Do not suppress strict re-issue while stalled. Battleground pathing
+        // can occasionally leave a stale/idle generator active, which causes
+        // repeated "reach spell" directives to report success while the bot
+        // remains stationary.
+        MovementGeneratorType const movementType = motionMaster->GetCurrentMovementGeneratorType();
+        bool const hasActivePointMove = player->isMoving() && movementType == POINT_MOTION_TYPE;
+        if (hasActivePointMove)
+            return true;
+    }
 
     Position segmentDestination;
     if (!TryBuildStrictHumanSegmentDestination(player, destination, segmentDestination))


### PR DESCRIPTION
### Motivation
- Ranged bots (mage playerbots) could become stuck with `move_directive=reach_spell` while not moving because strict-human movement re-issue was suppressed even when the bot had stalled.  

### Description
- Update `IssueStrictHumanMove` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` to avoid the unconditional early return when destination/time haven't changed.  
- Only suppress re-issuing the strict `MovePoint` when the bot is actually moving with an active `POINT_MOTION_TYPE` generator by checking `player->isMoving()` and `motionMaster->GetCurrentMovementGeneratorType() == POINT_MOTION_TYPE`.  
- This forces a segment rebuild and a fresh `MovePoint` when movement has stalled so bots can recover from idle/stale generators.

### Testing
- Ran `cmake --build build --target worldserver -j2`, which reconfigured and began compilation successfully (build progressed but full completion was not captured due to environment/time limits).  
- Performed `git add`/`git commit` to record the change (commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5a98dc188327852147a1e11e7ec3)