### PR TITLE
Add melee crit from Primal Wisdom (89742) on top of spell crit for Wrath/Regrowth

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7342,21 +7342,14 @@ float Unit::SpellCritChanceDone(SpellInfo const* spellInfo, SpellSchoolMask scho
     if (!isPeriodic && !spellInfo->HasAttribute(SPELL_ATTR0_CU_CAN_CRIT))
         return 0.0f;
 
+    bool addMeleeCritFromPrimalWisdom = false;
     // 89742 - Primal Wisdom
-    // Custom behavior: Regrowth and Wrath use melee crit chance instead of spell crit chance.
+    // Custom behavior: Regrowth and Wrath add melee crit chance on top of spell crit chance.
     if (GetTypeId() == TYPEID_PLAYER && HasAura(89742))
     {
         SpellInfo const* wrathFirstRank = sSpellMgr->AssertSpellInfo(5176);
         SpellInfo const* regrowthFirstRank = sSpellMgr->AssertSpellInfo(8936);
-        if (spellInfo->IsRankOf(wrathFirstRank) || spellInfo->IsRankOf(regrowthFirstRank))
-        {
-            float critChance = GetFloatValue(PLAYER_CRIT_PERCENTAGE);
-
-            if (Player* modOwner = GetSpellModOwner())
-                modOwner->ApplySpellMod(spellInfo->Id, SPELLMOD_CRITICAL_CHANCE, critChance);
-
-            return std::max(critChance, 0.0f);
-        }
+        addMeleeCritFromPrimalWisdom = spellInfo->IsRankOf(wrathFirstRank) || spellInfo->IsRankOf(regrowthFirstRank);
     }
 
     float crit_chance = 0.0f;
@@ -7387,6 +7380,10 @@ float Unit::SpellCritChanceDone(SpellInfo const* spellInfo, SpellSchoolMask scho
         default:
             return 0.0f;
     }
+
+    if (addMeleeCritFromPrimalWisdom)
+        crit_chance += GetFloatValue(PLAYER_CRIT_PERCENTAGE);
+
     // percent done
     // only players use intelligence for critical chance computations
     if (Player* modOwner = GetSpellModOwner())


### PR DESCRIPTION
### Motivation
- Fix incorrect behavior for aura `89742` (Primal Wisdom) where Wrath/Regrowth previously replaced the spell crit calculation with melee crit instead of adding melee crit on top of the existing spell crit.

### Description
- Updated `Unit::SpellCritChanceDone` in `src/server/game/Entities/Unit/Unit.cpp` to preserve the normal spell crit computation and introduced a boolean `addMeleeCritFromPrimalWisdom` to detect Wrath/Regrowth ranks under aura `89742`.
- Removed the early return that replaced the spell crit value and instead add `GetFloatValue(PLAYER_CRIT_PERCENTAGE)` to `crit_chance` after the standard spell crit calculation when the flag is set.
- Updated the inline comment to reflect the new behavior (add melee crit on top of spell crit) and kept `SPELLMOD_CRITICAL_CHANCE` application unchanged.

### Testing
- Ran `git diff --check -- src/server/game/Entities/Unit/Unit.cpp` with no whitespace or diff-check errors (success).
- Examined the produced diff via `git diff -- src/server/game/Entities/Unit/Unit.cpp` to validate the intended code changes (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5ed949c08327b6035f40176db8dc)