### PR TITLE
Playerbot PvP: fix pet-casts, rogue Blind selection, priest SW:P targeting and wand fallback

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -706,6 +706,27 @@ uint32 ResolveKnownSpellInChain(Player const* player, uint32 baseSpellId)
     return resolvedSpellId;
 }
 
+uint32 ResolveKnownPetSpellInChain(Player const* player, uint32 baseSpellId)
+{
+    if (!player || !baseSpellId)
+        return 0;
+
+    Pet const* pet = player->GetPet();
+    if (!pet || !pet->IsAlive())
+        return 0;
+
+    SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(baseSpellId);
+    if (!baseSpellInfo)
+        return 0;
+
+    uint32 resolvedSpellId = 0;
+    for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
+        if (pet->HasSpell(chainSpellId))
+            resolvedSpellId = chainSpellId;
+
+    return resolvedSpellId;
+}
+
 void CommandPetAttackTarget(Player* player, Unit* target)
 {
     if (!player || !target || !target->IsAlive())
@@ -947,7 +968,19 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
-    uint32 const resolvedSpellId = ResolveKnownSpellInChain(player, context.spellId);
+    uint32 resolvedSpellId = ResolveKnownSpellInChain(player, context.spellId);
+    bool castFromPet = false;
+    Pet* petCaster = nullptr;
+    if (!resolvedSpellId)
+    {
+        resolvedSpellId = ResolveKnownPetSpellInChain(player, context.spellId);
+        if (resolvedSpellId)
+        {
+            petCaster = player->GetPet();
+            castFromPet = petCaster && petCaster->IsAlive();
+        }
+    }
+
     if (!resolvedSpellId)
     {
         failureReason = "missing_spell";
@@ -959,6 +992,53 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     {
         failureReason = "spell_info_missing";
         return false;
+    }
+
+    Unit* target = ResolveTarget(player, context);
+    if ((!target || !target->IsAlive()))
+    {
+        failureReason = "target_invalid_or_dead";
+        return false;
+    }
+
+    if (castFromPet)
+    {
+        if (!petCaster)
+        {
+            failureReason = "pet_missing";
+            return false;
+        }
+
+        if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy)
+        {
+            if (!petCaster->IsValidAttackTarget(target, spellInfo))
+            {
+                failureReason = "invalid_enemy_target";
+                return false;
+            }
+
+            if (!petCaster->IsWithinLOSInMap(target))
+            {
+                failureReason = "no_los";
+                return false;
+            }
+
+            float const maxRange = spellInfo->GetMaxRange(false);
+            if (maxRange > 0.0f && !petCaster->IsWithinDistInMap(target, maxRange))
+            {
+                failureReason = "out_of_range";
+                return false;
+            }
+        }
+
+        SpellCastResult const petCastResult = petCaster->CastSpell(target, resolvedSpellId, false);
+        if (petCastResult != SPELL_CAST_OK)
+        {
+            failureReason = "pet_cast_failed";
+            return false;
+        }
+
+        return true;
     }
 
     if (IsCrowdControlledForAction(player))
@@ -1033,8 +1113,6 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             return false;
         }
     }
-
-    Unit* target = ResolveTarget(player, context);
 
     if ((!target || !target->IsAlive()) && !itemTarget)
     {
@@ -1269,7 +1347,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // not have client-side stop-cast behavior, explicitly stop movement before
     // attempting non-instant casts.
     bool const isFoodOrDrinkSpell = resolvedSpellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT || resolvedSpellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK;
-    if (spellInfo->CalcCastTime() > 0 || isFoodOrDrinkSpell)
+    if (spellInfo->CalcCastTime() > 0 || spellInfo->IsAutoRepeatRangedSpell() || isFoodOrDrinkSpell)
     {
         player->StopMoving();
         if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -588,6 +588,30 @@ bool IsSpellReady(Player const* player, uint32 spellId)
     return !player->GetSpellHistory()->HasCooldown(resolvedSpellId);
 }
 
+bool IsPetSpellReady(Player const* player, uint32 spellId)
+{
+    if (!player || !spellId)
+        return false;
+
+    Pet const* pet = player->GetPet();
+    if (!pet || !pet->IsAlive())
+        return false;
+
+    SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!baseSpellInfo)
+        return false;
+
+    uint32 resolvedSpellId = 0;
+    for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
+        if (pet->HasSpell(chainSpellId))
+            resolvedSpellId = chainSpellId;
+
+    if (!resolvedSpellId)
+        return false;
+
+    return !pet->GetSpellHistory()->HasCooldown(resolvedSpellId);
+}
+
 bool IsEffectivelyOutdoors(Player const* player)
 {
     if (!player)
@@ -1626,13 +1650,13 @@ Unit const* SelectRogueBlindTarget(Player const* player, Unit const* primaryTarg
             return false;
         if (HasAnyAura(candidate, { 2893 })) // Abolish Poison
             return false;
+        if (HasBreakableCrowdControl(candidate) || HasDotAura(candidate))
+            return false;
         return true;
     };
 
     Unit const* bestSecondary = nullptr;
     float bestSecondaryDistance = std::numeric_limits<float>::max();
-    Unit const* fallbackPrimary = nullptr;
-    float fallbackPrimaryDistance = std::numeric_limits<float>::max();
     Map::PlayerList const& mapPlayers = player->GetMap()->GetPlayers();
     for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
     {
@@ -1642,14 +1666,7 @@ Unit const* SelectRogueBlindTarget(Player const* player, Unit const* primaryTarg
 
         float const distance = player->GetDistance(candidate);
         if (primaryTarget && candidate->GetGUID() == primaryTarget->GetGUID())
-        {
-            if (distance < fallbackPrimaryDistance)
-            {
-                fallbackPrimary = candidate;
-                fallbackPrimaryDistance = distance;
-            }
             continue;
-        }
 
         if (distance < bestSecondaryDistance)
         {
@@ -1658,7 +1675,7 @@ Unit const* SelectRogueBlindTarget(Player const* player, Unit const* primaryTarg
         }
     }
 
-    return bestSecondary ? bestSecondary : fallbackPrimary;
+    return bestSecondary;
 }
 
 Unit const* SelectWarlockFearTarget(Player const* player, float maxDistance)
@@ -2241,6 +2258,7 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
     Unit const* casterAlly = (player->IsInCombat() && IsSpellReady(player, 10060)) ? SelectFriendlyHealthTarget(player, GetConfiguredHealRange(), 100.0f) : nullptr;
     Unit const* controlledTarget = IsSpellReady(player, 27605) ? SelectEnemyNonBreakableCrowdControlTarget(player, 30.0f) : nullptr;
     Unit const* manaBurnTarget = IsSpellReady(player, 10876) ? SelectNearbyEnemyManaTarget(player, target, GetConfiguredLongRange(), 25.0f) : nullptr;
+    Unit const* rogueTarget = IsSpellReady(player, 27605) ? SelectEnemyClassTarget(player, CLASS_ROGUE, GetConfiguredLongRange()) : nullptr;
 
     std::vector<PrioritizedSpellDecision> candidates;
 
@@ -2266,8 +2284,8 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
             { "priest flash heal", "heal party with flash heal", 10917, healTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, healTarget ? healTarget->GetGUID() : ObjectGuid::Empty });
     }
 
-    AddDecisionCandidate(candidates, hasHostileTarget && target && target->GetClass() == CLASS_ROGUE && !HasAuraFromSpellChain(target, 27605) && IsSpellReady(player, 27605), 22.0f,
-        { "priest shadow word pain", "maintain dot pressure on rogues", 27605, playerbot::PvpClassSpellContext::TargetMode::Enemy });
+    AddDecisionCandidate(candidates, rogueTarget && !HasAuraFromSpellChain(rogueTarget, 27605), 22.0f,
+        { "priest shadow word pain", "maintain dot pressure on rogues", 27605, playerbot::PvpClassSpellContext::TargetMode::Enemy, rogueTarget ? rogueTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, manaBurnTarget, 21.0f,
         { "priest mana burn", "burn mana from enemy casters", 10876, playerbot::PvpClassSpellContext::TargetMode::Enemy, manaBurnTarget ? manaBurnTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, CountNearbyEnemies(player, 10.0f) >= 2 && CountNearbyFriendlyPlayers(player, 10.0f) >= 2 && IsSpellReady(player, 27801), 20.0f,
@@ -2427,10 +2445,10 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target)
     Unit const* fearTarget = IsSpellReady(player, 6215) ? SelectWarlockFearTarget(player, 20.0f) : nullptr;
 
     std::vector<PrioritizedSpellDecision> candidates;
-    AddDecisionCandidate(candidates, player->HealthBelowPct(45) && hasLivingPet && IsSpellReady(player, 19443), 55.0f,
-        { "warlock sacrifice", "consume voidwalker shield under low health pressure", 19443, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, target->HasUnitState(UNIT_STATE_CASTING) && IsSpellReady(player, 19647), 54.0f,
-        { "warlock spell lock", "pet interrupt when available", 19647, playerbot::PvpClassSpellContext::TargetMode::Enemy });
+    AddDecisionCandidate(candidates, player->HealthBelowPct(45) && hasLivingPet && IsPetSpellReady(player, 7812), 55.0f,
+        { "warlock sacrifice", "consume voidwalker shield under low health pressure", 7812, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, target->HasUnitState(UNIT_STATE_CASTING) && IsPetSpellReady(player, 19244), 54.0f,
+        { "warlock spell lock", "pet interrupt when available", 19244, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, fearTarget, 53.0f,
         { "warlock fear", "prioritize fear control on paladin/priest targets in range", 6215, playerbot::PvpClassSpellContext::TargetMode::Enemy, fearTarget ? fearTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, player->IsInCombat() && needsPetSummon && !player->HasAura(18708) && IsSpellReady(player, 18708), 52.0f,


### PR DESCRIPTION
### Motivation

- Fix playerbot PvP behavior where pet-only spells were not executed by pets and some class target-selection/casting fallbacks were incorrect.

### Description

- Add pet spell utilities `IsPetSpellReady` and `ResolveKnownPetSpellInChain` and use them so pet spell chains (e.g., Voidwalker Sacrifice / Spell Lock) are recognized when the owner lacks the player-cast rank. (files: `PlayerbotPvpCore.cpp`, `PlayerbotPvpClassActions.cpp`).
- Implement a direct pet-cast execution path inside `CastDirectSpell` that resolves pet-known ranks, validates pet LOS/range/target and issues the cast via the pet so voidwalker actions are actually performed by the pet.
- Tighten rogue Blind target selection in `SelectRogueBlindTarget` to avoid the primary target and to skip targets already under breakable CC or already dotted, matching the intended secondary-target-only behavior.
- Make priest SW:P pressure explicitly select rogue-class enemies in range so priests will apply `Shadow Word: Pain` on rogues, and adjust priest decision candidates to target the resolved rogue GUID.
- Improve wand/auto-repeat handling by stopping movement for auto-repeat ranged spells (including wand `Shoot`) before casting so the wand startup sound reliably results in the actual wand cast.

### Testing

- Ran `git diff --check` with no issues detected.
- Started an incremental build with `cmake --build build --target scripts -- -j4`; compilation progressed and no immediate compile errors were reported during the run, though the full scripts target is large and the complete build was not finished within the session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5d321a2c8327bffb4142c7bbd676)