### PR TITLE
Remove nonexistent CHARGE_MOTION_TYPE references in Playerbot PvP code

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -984,8 +984,7 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     else if (!botCurrentlyMoving && player->InBattleground() &&
         currentMovement != IDLE_MOTION_TYPE &&
         currentMovement != CHASE_MOTION_TYPE &&
-        currentMovement != POINT_MOTION_TYPE &&
-        currentMovement != CHARGE_MOTION_TYPE)
+        currentMovement != POINT_MOTION_TYPE)
     {
         EmitBattlegroundGmDebug(player,
             "movepoint=clear-stale-generator motionType=" + std::to_string(uint32(currentMovement)), 1000);
@@ -2831,7 +2830,6 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         case CHASE_MOTION_TYPE:
         case POINT_MOTION_TYPE:
         case FOLLOW_MOTION_TYPE:
-        case CHARGE_MOTION_TYPE:
             break;
         default:
         {


### PR DESCRIPTION
### Motivation
- Fix compiler errors caused by references to the undeclared `CHARGE_MOTION_TYPE` enum value and the resulting duplicate-case error in battleground movement handling.

### Description
- Removed `CHARGE_MOTION_TYPE` checks from `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` so the stale-generator guard and the `MoveToObjectivePrimitive` `switch` only reference valid `MovementGeneratorType` enums.

### Testing
- Ran `rg -n "CHARGE_MOTION_TYPE" src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp || true` to verify no occurrences remain and the command returned no matches.
- Performed a commit with `git commit` to record the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb60d941e08327aafa72cdf4e80f2c)