### PR TITLE
Respect EFFECT_MOTION_TYPE for PvP bot movement (don't treat charge/intercept as stale)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -984,7 +984,10 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     else if (!botCurrentlyMoving && player->InBattleground() &&
         currentMovement != IDLE_MOTION_TYPE &&
         currentMovement != CHASE_MOTION_TYPE &&
-        currentMovement != POINT_MOTION_TYPE)
+        currentMovement != POINT_MOTION_TYPE &&
+        // Charge/Intercept movement is issued through effect generators.
+        // Do not treat those as stale while they are resolving.
+        currentMovement != EFFECT_MOTION_TYPE)
     {
         EmitBattlegroundGmDebug(player,
             "movepoint=clear-stale-generator motionType=" + std::to_string(uint32(currentMovement)), 1000);
@@ -2830,6 +2833,8 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         case CHASE_MOTION_TYPE:
         case POINT_MOTION_TYPE:
         case FOLLOW_MOTION_TYPE:
+        // Charge/Intercept traverse through EFFECT_MOTION_TYPE.
+        case EFFECT_MOTION_TYPE:
             break;
         default:
         {


### PR DESCRIPTION
### Motivation
- Prevent bots from cancelling or clearing charge/intercept movements that are implemented via effect generators by treating `EFFECT_MOTION_TYPE` as an active movement state rather than a stale generator when issuing movement and when choosing to move to objectives.

### Description
- Do not clear movement when `currentMovement == EFFECT_MOTION_TYPE` in `IssueMovePointThrottled`, and include `EFFECT_MOTION_TYPE` in the allowed switch cases in `MoveToObjectivePrimitive`, with clarifying comments explaining that charge/intercept traverse through effect generators.

### Testing
- Project compiled (`make`) and the relevant automated playerbot test suite ran successfully, with tests covering `Playerbot` movement behavior passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb554e0868832782b0d47f88250b32)