### PR TITLE
Preserve Charge/Intercept targets and treat EFFECT_MOTION_TYPE as active during movement/throttle

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -1376,6 +1376,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     }
 
     bool hasTeleportEffect = false;
+    bool hasChargeEffect = false;
     for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
     {
         switch (spellInfo->GetEffect(SpellEffIndex(effectIndex)).Effect)
@@ -1389,6 +1390,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             case SPELL_EFFECT_CHARGE:
             case SPELL_EFFECT_CHARGE_DEST:
                 hasTeleportEffect = true;
+                hasChargeEffect = true;
                 break;
             default:
                 break;
@@ -1419,6 +1421,20 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             if (player->IsBeingTeleportedNear())
                 FinalizeVirtualNearTeleport(player);
         }
+    }
+
+    // Charge/Intercept target switching: when bots are already attacking one
+    // unit and gap-close a different unit, preserve the charge destination by
+    // immediately promoting the spell target to combat/selection context.
+    // Otherwise downstream pursuit logic can snap movement back to the old
+    // victim in the same tick, which looks like "stun/sound with no charge".
+    if (hasChargeEffect &&
+        context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
+        target && target->IsAlive())
+    {
+        player->SetSelection(target->GetGUID());
+        if (player->GetVictim() != target || !player->HasUnitState(UNIT_STATE_MELEE_ATTACKING))
+            player->Attack(target, true);
     }
 
     // Avoid immediate reapplication loops after quick dispels by imposing

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -984,7 +984,10 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     else if (!botCurrentlyMoving && player->InBattleground() &&
         currentMovement != IDLE_MOTION_TYPE &&
         currentMovement != CHASE_MOTION_TYPE &&
-        currentMovement != POINT_MOTION_TYPE)
+        currentMovement != POINT_MOTION_TYPE &&
+        // Charge/Intercept movement is issued through effect generators.
+        // Do not treat those as stale while they are resolving.
+        currentMovement != EFFECT_MOTION_TYPE)
     {
         EmitBattlegroundGmDebug(player,
             "movepoint=clear-stale-generator motionType=" + std::to_string(uint32(currentMovement)), 1000);
@@ -2830,6 +2833,8 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         case CHASE_MOTION_TYPE:
         case POINT_MOTION_TYPE:
         case FOLLOW_MOTION_TYPE:
+        // Charge/Intercept traverse through EFFECT_MOTION_TYPE.
+        case EFFECT_MOTION_TYPE:
             break;
         default:
         {


### PR DESCRIPTION
### Motivation
- Prevent cases where a bot performs a gap-close (Charge/Intercept) against a new enemy but movement/pursuit logic immediately snaps back to the old victim, making the charge appear to not land. 
- Avoid clearing or treating as stale the special movement generator used for Charge/Intercept while it is resolving. 

### Description
- Add `hasChargeEffect` detection for spells with `SPELL_EFFECT_CHARGE`/`_CHARGE_DEST` and, when charging an enemy, immediately promote the spell target into selection/combat by calling `player->SetSelection(...)` and `player->Attack(...).`
- Synthesize charge-aware behavior only for `TargetMode::Enemy` and when the resolved `target` is alive. 
- Exclude `EFFECT_MOTION_TYPE` from stale-generator clearing in `IssueMovePointThrottled` so charge/intercept movement is not mistaken for stale navigation. 
- Treat `EFFECT_MOTION_TYPE` as an allowed motion generator in `MoveToObjectivePrimitive` so objective movement does not clear an in-progress Charge/Intercept generator. 

### Testing
- Performed a full project build with the changes applied using the normal build pipeline (`make`), and the build completed successfully. 
- Ran the existing automated unit/integration test suite, and all tests passed without regressions. 
- Exercised PvP playerbot scenarios in automated PvP bot smoke tests that exercise charge/teleport behaviors, and the charge-target switching issue was resolved in those runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb554e0868832782b0d47f88250b32)