### PR TITLE
Improve ranged approach fallback and strict-pathing fallbacks to prevent stalled movement

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -340,9 +340,27 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     if (!player || !target)
         return;
 
+    struct RangedApproachStallState
+    {
+        ObjectGuid targetGuid = ObjectGuid::Empty;
+        float lastDistance = 0.0f;
+        uint32 lastSampleMs = 0;
+        uint32 lastFallbackMs = 0;
+        uint8 stagnantSamples = 0;
+    };
+
+    static std::unordered_map<uint64, RangedApproachStallState> stallStateByGuid;
+    RangedApproachStallState& stallState = stallStateByGuid[player->GetGUID().GetRawValue()];
+
     float const safeDistance = std::max(1.0f, desiredDistance);
     if (RequiresStrictHumanPathing(player) && IssueStrictHumanFollow(player, target, safeDistance))
+    {
+        stallState.stagnantSamples = 0;
+        stallState.targetGuid = target->GetGUID();
+        stallState.lastDistance = player->GetDistance(target);
+        stallState.lastSampleMs = GameTime::GetGameTimeMS();
         return;
+    }
 
     // Fallback: if strict-human segment pathing cannot resolve a route this
     // tick (common around dynamic battleground geometry), still issue regular
@@ -380,20 +398,60 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
     }
 
-    // Some battleground edge-cases can drop the requested chase/follow order
-    // and leave the active generator idle for a tick while we are still out of
-    // range. Fall back to a direct MovePoint so "reach spell" does not loop
-    // forever with no actual motion.
+    // Some battleground edge-cases keep a stale chase/follow generator active
+    // without producing displacement while we are still out of range. Fall
+    // back to a direct MovePoint so "reach spell" does not loop forever with
+    // no actual motion.
     float const postIssueDistance = player->GetDistance(target);
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    bool const targetChanged = stallState.targetGuid != target->GetGUID();
+    bool const recentlySampled = !targetChanged && stallState.lastSampleMs != 0 && nowMs <= (stallState.lastSampleMs + 1500);
+    bool const distanceStagnant = recentlySampled && std::fabs(postIssueDistance - stallState.lastDistance) < 0.35f;
+
+    if (targetChanged || !distanceStagnant)
+        stallState.stagnantSamples = 0;
+
+    if (!player->isMoving() && postIssueDistance > (safeDistance + 1.0f) && distanceStagnant)
+        ++stallState.stagnantSamples;
+
+    stallState.targetGuid = target->GetGUID();
+    stallState.lastDistance = postIssueDistance;
+    stallState.lastSampleMs = nowMs;
+
+    // Avoid clearing active movement every tick; only recover when we have
+    // repeated stagnant samples and throttle the fallback issue rate.
     if (!player->isMoving() &&
         postIssueDistance > (safeDistance + 1.0f) &&
-        motionMaster->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE)
+        stallState.stagnantSamples >= 2 &&
+        (stallState.lastFallbackMs == 0 || nowMs >= (stallState.lastFallbackMs + 500)))
     {
+        MovementGeneratorType const motionType = motionMaster->GetCurrentMovementGeneratorType();
+        if (motionType == POINT_MOTION_TYPE)
+        {
+            // If we are already in a stalled point movement, prefer reissuing
+            // chase/follow instead of chaining another point destination.
+            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+            if (player->IsValidAttackTarget(target))
+                motionMaster->MoveChase(target, std::max(1.0f, safeDistance - 2.0f));
+            else
+                motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+
+            stallState.lastFallbackMs = nowMs;
+            TC_LOG_DEBUG("playerbots.pvp.classspell",
+                "Ranged approach fallback reissued chase/follow from stalled point: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
+                player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
+            return;
+        }
+
+        if (motionType == CHASE_MOTION_TYPE || motionType == FOLLOW_MOTION_TYPE || motionType == IDLE_MOTION_TYPE)
+            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+
         Position const fallbackDestination = BuildFollowDestination(player, target, safeDistance);
         motionMaster->MovePoint(0, fallbackDestination, true);
+        stallState.lastFallbackMs = nowMs;
         TC_LOG_DEBUG("playerbots.pvp.classspell",
-            "Ranged approach fallback MovePoint: guid={} target={} desiredRange={} currentDistance={}.",
-            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+            "Ranged approach forced MovePoint fallback: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
     }
 }
 
@@ -1623,9 +1681,23 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                 destination.RelocateOffset({ std::cos(angleToTarget + static_cast<float>(M_PI)) * fleeDistance,
                     std::sin(angleToTarget + static_cast<float>(M_PI)) * fleeDistance, 0.0f, 0.0f });
                 if (RequiresStrictHumanPathing(player))
-                    IssueStrictHumanMove(player, destination);
+                {
+                    if (!IssueStrictHumanMove(player, destination))
+                    {
+                        // Strict segment pathing can fail to resolve around
+                        // battleground geometry. Fall back to a direct point
+                        // move so flee directives never devolve into idle.
+                        MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
+                        if (fallbackMotionMaster)
+                            fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                    }
+                }
                 else
-                    player->GetMotionMaster()->MovePoint(0, destination, true);
+                {
+                    MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
+                    if (fallbackMotionMaster)
+                        fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                }
                 break;
             }
             case PvpClassSpellContext::MovementDirective::FaceSpellTarget:


### PR DESCRIPTION
### Motivation
- Prevent ranged bots from getting stuck when chase/follow generators become stale or strict segmented pathing fails around complex battleground geometry. 
- Avoid repeatedly clearing active movement every tick and reduce MovePoint fallback churning while still recovering from true stalls. 
- Ensure flee directives do not idle when `IssueStrictHumanMove` cannot resolve a route.

### Description
- Add `RangedApproachStallState` and a static `stallStateByGuid` map to track per-player samples, stagnant counts, last fallback time, and target GUID used by `IssueRangedApproachMovement`.
- Integrate with strict segmented pathing so successful `IssueStrictHumanFollow` resets the stall sampling state, and detect distance stagnation across samples to decide when to fallback.
- Throttle and condition fallbacks by requiring repeated stagnant samples (`stagnantSamples >= 2`) and a `500ms` minimum between fallback reissues, and special-case `POINT_MOTION_TYPE` to reissue chase/follow instead of chaining extra points.
- Use `MovePoint` fallback to a collision-safe follow destination when appropriate and add debug logging for fallback decisions; also update flee handling to attempt `IssueStrictHumanMove` and fall back to a collision-safe `MovePoint` if that fails.

### Testing
- Project was built successfully with these changes and existing automated test suite executed with no failures reported for unit tests.
- Exercised playerbot PvP movement scenarios that trigger strict pathing and fallback logic and observed expected debug logs reporting fallback and reissue behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea87859d30832782218d54166aa95f)