### PR TITLE
Improve bot movement fallbacks and diagnostics for ranged/strict pathing

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -269,7 +269,12 @@ bool IssueStrictHumanMove(Player* player, Position const& destination, float des
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
 
     if (!destinationChanged && !canReissueByTime)
-        return true;
+    {
+        // Treat strict move as unsuccessful when the throttled order is stale
+        // and we are not currently moving; callers can then fall back to
+        // alternate movement instead of assuming progress.
+        return player->isMoving();
+    }
 
     MotionMaster* motionMaster = player->GetMotionMaster();
     if (!motionMaster)
@@ -340,9 +345,37 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     if (!player || !target)
         return;
 
+    struct RangedApproachStallState
+    {
+        ObjectGuid targetGuid = ObjectGuid::Empty;
+        float lastDistance = 0.0f;
+        uint32 lastSampleMs = 0;
+        uint32 lastFallbackMs = 0;
+        uint8 stagnantSamples = 0;
+    };
+
+    static std::unordered_map<uint64, RangedApproachStallState> stallStateByGuid;
+    RangedApproachStallState& stallState = stallStateByGuid[player->GetGUID().GetRawValue()];
+
     float const safeDistance = std::max(1.0f, desiredDistance);
     if (RequiresStrictHumanPathing(player) && IssueStrictHumanFollow(player, target, safeDistance))
-        return;
+    {
+        float const postStrictDistance = player->GetDistance(target);
+        stallState.stagnantSamples = 0;
+        stallState.targetGuid = target->GetGUID();
+        stallState.lastDistance = postStrictDistance;
+        stallState.lastSampleMs = GameTime::GetGameTimeMS();
+
+        // Strict-human segmented movement uses point generators. If that order
+        // does not result in movement while still far outside desired range,
+        // immediately fall through to generic chase/follow recovery.
+        if (player->isMoving() || postStrictDistance <= (safeDistance + 1.0f))
+            return;
+
+        TC_LOG_DEBUG("playerbots.pvp.classspell",
+            "Strict ranged follow issued but stalled this tick: guid={} target={} desiredRange={} currentDistance={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postStrictDistance);
+    }
 
     // Fallback: if strict-human segment pathing cannot resolve a route this
     // tick (common around dynamic battleground geometry), still issue regular
@@ -380,20 +413,62 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
     }
 
-    // Some battleground edge-cases can drop the requested chase/follow order
-    // and leave the active generator idle for a tick while we are still out of
-    // range. Fall back to a direct MovePoint so "reach spell" does not loop
-    // forever with no actual motion.
+    // Some battleground edge-cases keep a stale chase/follow generator active
+    // without producing displacement while we are still out of range. Fall
+    // back to a direct MovePoint so "reach spell" does not loop forever with
+    // no actual motion.
     float const postIssueDistance = player->GetDistance(target);
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    bool const targetChanged = stallState.targetGuid != target->GetGUID();
+    bool const recentlySampled = !targetChanged && stallState.lastSampleMs != 0 && nowMs <= (stallState.lastSampleMs + 1500);
+    bool const distanceStagnant = recentlySampled && std::fabs(postIssueDistance - stallState.lastDistance) < 0.35f;
+
+    if (targetChanged || !distanceStagnant)
+        stallState.stagnantSamples = 0;
+
+    if (!player->isMoving() && postIssueDistance > (safeDistance + 1.0f) && distanceStagnant)
+        ++stallState.stagnantSamples;
+
+    stallState.targetGuid = target->GetGUID();
+    stallState.lastDistance = postIssueDistance;
+    stallState.lastSampleMs = nowMs;
+
+    // Avoid clearing active movement every tick; only recover when we have
+    // repeated stagnant samples and throttle the fallback issue rate.
     if (!player->isMoving() &&
         postIssueDistance > (safeDistance + 1.0f) &&
-        motionMaster->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE)
+        stallState.stagnantSamples >= 2 &&
+        (stallState.lastFallbackMs == 0 || nowMs >= (stallState.lastFallbackMs + 500)))
     {
-        Position const fallbackDestination = BuildFollowDestination(player, target, safeDistance);
-        motionMaster->MovePoint(0, fallbackDestination, true);
+        MovementGeneratorType const motionType = motionMaster->GetCurrentMovementGeneratorType();
+        if (motionType == POINT_MOTION_TYPE)
+        {
+            // If we are already in a stalled point movement, prefer reissuing
+            // chase/follow instead of chaining another point destination.
+            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+            if (player->IsValidAttackTarget(target))
+                motionMaster->MoveChase(target, std::max(1.0f, safeDistance - 2.0f));
+            else
+                motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+
+            stallState.lastFallbackMs = nowMs;
+            TC_LOG_DEBUG("playerbots.pvp.classspell",
+                "Ranged approach fallback reissued chase/follow from stalled point: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
+                player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
+            return;
+        }
+
+        if (motionType == CHASE_MOTION_TYPE || motionType == FOLLOW_MOTION_TYPE || motionType == IDLE_MOTION_TYPE)
+            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+
+        if (player->IsValidAttackTarget(target))
+            motionMaster->MoveChase(target, std::max(1.0f, safeDistance - 2.0f));
+        else
+            motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+        stallState.lastFallbackMs = nowMs;
         TC_LOG_DEBUG("playerbots.pvp.classspell",
-            "Ranged approach fallback MovePoint: guid={} target={} desiredRange={} currentDistance={}.",
-            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+            "Ranged approach forced chase/follow fallback: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
     }
 }
 
@@ -1623,9 +1698,23 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                 destination.RelocateOffset({ std::cos(angleToTarget + static_cast<float>(M_PI)) * fleeDistance,
                     std::sin(angleToTarget + static_cast<float>(M_PI)) * fleeDistance, 0.0f, 0.0f });
                 if (RequiresStrictHumanPathing(player))
-                    IssueStrictHumanMove(player, destination);
+                {
+                    if (!IssueStrictHumanMove(player, destination))
+                    {
+                        // Strict segment pathing can fail to resolve around
+                        // battleground geometry. Fall back to a direct point
+                        // move so flee directives never devolve into idle.
+                        MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
+                        if (fallbackMotionMaster)
+                            fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                    }
+                }
                 else
-                    player->GetMotionMaster()->MovePoint(0, destination, true);
+                {
+                    MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
+                    if (fallbackMotionMaster)
+                        fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                }
                 break;
             }
             case PvpClassSpellContext::MovementDirective::FaceSpellTarget:

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -107,6 +107,34 @@ char const* ToString(playerbot::PvpClassSpellContext::TargetMode mode)
     }
 }
 
+char const* ToString(MovementGeneratorType motionType)
+{
+    switch (motionType)
+    {
+        case IDLE_MOTION_TYPE: return "idle";
+        case RANDOM_MOTION_TYPE: return "random";
+        case WAYPOINT_MOTION_TYPE: return "waypoint";
+        case CONFUSED_MOTION_TYPE: return "confused";
+        case CHASE_MOTION_TYPE: return "chase";
+        case HOME_MOTION_TYPE: return "home";
+        case FLIGHT_MOTION_TYPE: return "flight";
+        case POINT_MOTION_TYPE: return "point";
+        case FLEEING_MOTION_TYPE: return "fleeing";
+        case DISTRACT_MOTION_TYPE: return "distract";
+        case ASSISTANCE_MOTION_TYPE: return "assist";
+        case ASSISTANCE_DISTRACT_MOTION_TYPE: return "assist_distract";
+        case TIMED_FLEEING_MOTION_TYPE: return "timed_flee";
+        case FOLLOW_MOTION_TYPE: return "follow";
+        case ROTATE_MOTION_TYPE: return "rotate";
+        case EFFECT_MOTION_TYPE: return "effect";
+        case SPLINE_CHAIN_MOTION_TYPE: return "spline_chain";
+        case FORMATION_MOTION_TYPE: return "formation";
+        case MAX_MOTION_TYPE:
+        default:
+            return "unknown";
+    }
+}
+
 std::string BuildManagedBotStatusLine(Player* bot)
 {
     if (!bot)
@@ -128,6 +156,9 @@ std::string BuildManagedBotStatusLine(Player* bot)
         !bot->HasUnitState(UNIT_STATE_LOST_CONTROL);
 
     std::ostringstream status;
+    MovementGeneratorType const motionType = bot->GetMotionMaster()->GetCurrentMovementGeneratorType();
+    uint32 const unitState = bot->GetUnitState();
+    uint32 const movementFlags = bot->GetUnitMovementFlags();
     status << "PB status: "
            << "lifecycle=" << (lifecycleEnabled ? "on" : "off")
            << " managed=" << (managedRandomBot ? "yes" : "no")
@@ -159,7 +190,11 @@ std::string BuildManagedBotStatusLine(Player* bot)
            << " hooks(bg=" << (hooks.battlegroundParticipationHook ? "on" : "off")
            << ",arena=" << (hooks.arenaParticipationHook ? "on" : "off") << ")"
            << " last_exec=" << lastClassExecutionStatus
-           << " motion=" << uint32(bot->GetMotionMaster()->GetCurrentMovementGeneratorType())
+           << " strict_pathing=" << (bot->InBattleground() ? "on" : "off")
+           << " motion=" << uint32(motionType)
+           << "/" << ToString(motionType)
+           << " unit_state=0x" << std::hex << unitState
+           << " move_flags=0x" << movementFlags << std::dec
            << " pos=(" << bot->GetMapId() << ":" << bot->GetPositionX() << "," << bot->GetPositionY() << "," << bot->GetPositionZ() << ")"
            << " o=" << bot->GetOrientation();
 
@@ -186,6 +221,18 @@ std::string BuildManagedBotStatusLine(Player* bot)
     else
     {
         status << " motion_target=none";
+    }
+
+    if (directiveTarget)
+    {
+        status << " directive_target=" << directiveTarget->GetName()
+               << " directive_target_dist=" << bot->GetDistance(directiveTarget)
+               << " directive_target_los=" << (bot->IsWithinLOSInMap(directiveTarget) ? "yes" : "no")
+               << " directive_target_attackable=" << (bot->IsValidAttackTarget(directiveTarget) ? "yes" : "no");
+    }
+    else
+    {
+        status << " directive_target=none";
     }
 
     if (Unit* selected = bot->GetSelectedUnit())


### PR DESCRIPTION
### Motivation
- Prevent bots from silently appearing to succeed when a throttled strict-movement order is stale and no actual displacement occurred.  
- Recover from cases where strict segmented pathing or chase/follow generators become stalled (common around battleground geometry) so ranged bots do not idle while trying to "reach spell".  
- Improve runtime diagnostics to make movement generator state, unit state and directive target visibility clearer for debugging.

### Description
- Change `IssueStrictHumanMove` to return `player->isMoving()` when a reissue is throttled so callers can detect stalled/throttled orders.  
- Add a per-bot `RangedApproachStallState` and logic in `IssueRangedApproachMovement` to sample distance, detect stagnant movement, throttle fallback attempts, and reissue appropriate chase/follow fallbacks instead of repeatedly issuing idle point movements; clear active movement when necessary and prefer chase/follow reissue when already in a stalled point.  
- Add debug logging around strict follow issuance and ranged fallback decisions for easier tracing (`playerbots.pvp.classspell`).  
- Harden flee handling so `FleeTooCloseForSpell` falls back to a collision-safe `MovePoint` when strict segment move fails.  
- Add `ToString(MovementGeneratorType)` helper and enrich `BuildManagedBotStatusLine` to include readable motion type, hex `unit_state`, movement flags, strict pathing indicator, and directive target diagnostics (distance, LOS, attackable).  

### Testing
- Project compiled successfully with `cmake --build` without errors.  
- Ran the test suite with `ctest` and the executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea87859d30832782218d54166aa95f)