### PR TITLE
Fix playerbot_loader compile error on Player::GetUnitState

### DIFF
--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -157,7 +157,6 @@ std::string BuildManagedBotStatusLine(Player* bot)
 
     std::ostringstream status;
     MovementGeneratorType const motionType = bot->GetMotionMaster()->GetCurrentMovementGeneratorType();
-    uint32 const unitState = bot->GetUnitState();
     uint32 const movementFlags = bot->GetUnitMovementFlags();
     status << "PB status: "
            << "lifecycle=" << (lifecycleEnabled ? "on" : "off")
@@ -193,8 +192,7 @@ std::string BuildManagedBotStatusLine(Player* bot)
            << " strict_pathing=" << (bot->InBattleground() ? "on" : "off")
            << " motion=" << uint32(motionType)
            << "/" << ToString(motionType)
-           << " unit_state=0x" << std::hex << unitState
-           << " move_flags=0x" << movementFlags << std::dec
+           << " move_flags=0x" << std::hex << movementFlags << std::dec
            << " pos=(" << bot->GetMapId() << ":" << bot->GetPositionX() << "," << bot->GetPositionY() << "," << bot->GetPositionZ() << ")"
            << " o=" << bot->GetOrientation();
 


### PR DESCRIPTION
### Motivation
- Resolve a compile failure caused by calling `Player::GetUnitState()` which is unavailable in this codebase's `Player` API while retaining movement diagnostics.

### Description
- Remove the `unitState` local and the `"unit_state=0x..."` output from `BuildManagedBotStatusLine` in `src/server/scripts/Playerbot/playerbot_loader.cpp` and continue printing `GetUnitMovementFlags()` in hex.

### Testing
- Ran `rg "GetUnitState\(" src/server/scripts/Playerbot/playerbot_loader.cpp` to verify the call was removed, which returned no matches and succeeded.
- Performed a dry-run build with `cmake --build build --target worldserver -- -n` which completed successfully, and started a full `cmake --build build --target worldserver -j2` which was begun but not completed due to runtime constraints in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7956e34483278ea17064ba3a1777)