### PR TITLE
Playerbot PvP: add LOS recovery and movement-target backfill in BuildClassSpellContext

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3282,6 +3282,30 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     if (context.spellId &&
         (context.targetMode == PvpClassSpellContext::TargetMode::Enemy || context.targetMode == PvpClassSpellContext::TargetMode::Ally))
     {
+        Unit const* losRecoveryTarget = resolveTargetByGuid(context.targetGuid);
+        if (losRecoveryTarget && !player->IsWithinLOSInMap(losRecoveryTarget))
+        {
+            SpellInfo const* recoverySpellInfo = sSpellMgr->GetSpellInfo(context.spellId);
+            float const spellMaxRange = recoverySpellInfo ? recoverySpellInfo->GetMaxRange(false) : 0.0f;
+            float const currentDistance = player->GetDistance(losRecoveryTarget);
+            float const maxFollowRange = spellMaxRange > 0.0f
+                ? std::max(1.5f, spellMaxRange - 1.0f)
+                : std::max(1.5f, GetConfiguredSpellRange() - 1.0f);
+            float const desiredRange = std::clamp(currentDistance - 2.0f, 1.5f, maxFollowRange);
+
+            ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, losRecoveryTarget->GetGUID(),
+                desiredRange, "recover los", "selected spell target out of line of sight", 86.0f);
+            context.spellId = 0;
+            context.itemEntry = 0;
+            context.targetMode = PvpClassSpellContext::TargetMode::None;
+            context.targetGuid = ObjectGuid::Empty;
+            context.selfCast = false;
+        }
+    }
+
+    if (context.spellId &&
+        (context.targetMode == PvpClassSpellContext::TargetMode::Enemy || context.targetMode == PvpClassSpellContext::TargetMode::Ally))
+    {
         Unit const* facingTarget = resolveTargetByGuid(context.targetGuid);
         if (facingTarget && !player->HasInArc(static_cast<float>(M_PI), facingTarget))
         {
@@ -3520,7 +3544,37 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    context.shouldExecute = context.shouldExecute || context.spellId != 0;
+    auto const movementDirectiveNeedsTarget = [](PvpClassSpellContext::MovementDirective directive) -> bool
+    {
+        switch (directive)
+        {
+            case PvpClassSpellContext::MovementDirective::ReachSpellRange:
+            case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
+            case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
+            case PvpClassSpellContext::MovementDirective::FaceSpellTarget:
+                return true;
+            default:
+                return false;
+        }
+    };
+
+    if (movementDirectiveNeedsTarget(context.movementDirective) && context.movementTargetGuid.IsEmpty())
+    {
+        // Defensive target backfill: stale snapshot races can occasionally
+        // leave movement directives with an empty target guid, which causes
+        // strict-path follower movement to no-op and the bot to idle in place.
+        if (Unit const* movementFallbackTarget = resolveTargetByGuid(activeTargetGuid))
+            context.movementTargetGuid = movementFallbackTarget->GetGUID();
+        else if (Unit const* movementSelectedTarget = resolveTargetByGuid(selectedTargetGuid))
+            context.movementTargetGuid = movementSelectedTarget->GetGUID();
+        else if (Unit const* movementVictim = player->GetVictim(); movementVictim && movementVictim->IsAlive())
+            context.movementTargetGuid = movementVictim->GetGUID();
+        else
+            context.movementDirective = PvpClassSpellContext::MovementDirective::None;
+    }
+
+    context.shouldExecute = context.shouldExecute || context.spellId != 0 ||
+        context.movementDirective != PvpClassSpellContext::MovementDirective::None;
 
     char const* targetModeLabel = "none";
     switch (context.targetMode)


### PR DESCRIPTION
### Motivation
- Prevent bots from attempting to cast spells on targets that are out of line-of-sight and from idling when movement directives lack a valid target due to stale snapshots.

### Description
- Add an LOS recovery path in `BuildClassSpellContext` that checks `IsWithinLOSInMap` and schedules a `ReachSpellRange` movement via `ConsiderMovementDirective`, then clears the pending spell/action when recovery is queued.
- Compute a `desiredRange` using the spell's `GetMaxRange` or `GetConfiguredSpellRange` as a fallback and clamp it to a safe follow distance before issuing the movement directive.
- Introduce `movementDirectiveNeedsTarget` to identify directives that require a movement target and backfill `context.movementTargetGuid` from `activeTargetGuid`, `selectedTargetGuid`, or `player->GetVictim()` when empty, otherwise clear the movement directive.
- Make `context.shouldExecute` reflect pending movement directives by including a test for `movementDirective != None` in addition to existing spell checks.

### Testing
- Project build was run after the changes (compile) and completed successfully.
- Playerbot-related unit tests and PvP scenario tests were executed and passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7ca6c06c8327bedd3ed777be5654)