### PR TITLE
Skip already-invited groups during battleground refill to fix SCM invite starvation

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -671,6 +671,12 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
     uint32 aliIndex = 0;
     for (; aliIndex < aliCount; aliIndex++)
     {
+        if ((*Ali_itr)->IsInvitedToBGInstanceGUID)
+        {
+            ++Ali_itr;
+            continue;
+        }
+
         int32 projectedHordeInGame = numHordeInGame + int32(m_SelectionPools[TEAM_HORDE].GetPlayerCount());
         int32 projectedAliInGame = numAliInGame + int32(m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount());
         int32 hordeFree = bg->GetMaxPlayersPerTeam() - projectedHordeInGame;
@@ -707,6 +713,12 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
     uint32 hordeIndex = 0;
     for (; hordeIndex < hordeCount; hordeIndex++)
     {
+        if ((*Horde_itr)->IsInvitedToBGInstanceGUID)
+        {
+            ++Horde_itr;
+            continue;
+        }
+
         int32 projectedHordeInGame = numHordeInGame + int32(m_SelectionPools[TEAM_HORDE].GetPlayerCount());
         int32 projectedAliInGame = numAliInGame + int32(m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount());
         int32 hordeFree = bg->GetMaxPlayersPerTeam() - projectedHordeInGame;


### PR DESCRIPTION
### Motivation
- Queued players were not being invited to open slots when earlier queue entries were already marked as invited, causing refill selection to break and leaving available SCM slots unused.
- The refill loop in `BattlegroundQueue::FillPlayersToBG` must ignore entries that are already invited so later eligible groups can be considered.

### Description
- Added checks in `src/server/game/Battlegrounds/BattlegroundQueue.cpp` inside `BattlegroundQueue::FillPlayersToBG` to skip groups with `IsInvitedToBGInstanceGUID` set before performing selection-pool logic for both Alliance and Horde iterations.
- This prevents an invited entry from causing the selection logic to attempt to re-add it and trigger an early `break`, allowing queued non-invited players to be selected and invited.

### Testing
- Ran the game build with `cmake --build build --target game -- -j4`, which compiled the modified sources and progressed through the build without surface compile errors in the changed module; the full build continued beyond the interaction window.
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe6d4bf148327bac0b0ec4431ffc1)