### PR TITLE
Fix invited-count handling and avoid re-inviting already-invited groups in BG queue

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1189,6 +1189,12 @@ void Battleground::AddPlayer(Player* player)
     if (!isInBattleground)
         UpdatePlayersCountByTeam(team, false);                  // +1 player
 
+    // The invited counters represent pending queue invites. Once the player
+    // actually joins the battleground, consume one invite slot so refill logic
+    // sees the true remaining capacity.
+    if (!isInBattleground)
+        DecreaseInvitedCount(team);
+
     if (WorldSession const* session = player->GetSession(); session && !session->IsVirtualSession())
     {
         m_HasEverHadNonVirtualHumanParticipant = true;

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -333,7 +333,16 @@ class TC_GAME_API Battleground
         void AddToBGFreeSlotQueue();                        //this queue will be useful when more battlegrounds instances will be available
         void RemoveFromBGFreeSlotQueue();                   //this method could delete whole BG instance, if another free is available
 
-        void DecreaseInvitedCount(uint32 team)      { (team == ALLIANCE) ? --m_InvitedAlliance : --m_InvitedHorde; }
+        void DecreaseInvitedCount(uint32 team)
+        {
+            if (team == ALLIANCE)
+            {
+                if (m_InvitedAlliance > 0)
+                    --m_InvitedAlliance;
+            }
+            else if (m_InvitedHorde > 0)
+                --m_InvitedHorde;
+        }
         void IncreaseInvitedCount(uint32 team)      { (team == ALLIANCE) ? ++m_InvitedAlliance : ++m_InvitedHorde; }
 
         void SetRandom(bool isRandom) { m_IsRandom = isRandom; }

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -671,6 +671,12 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
     uint32 aliIndex = 0;
     for (; aliIndex < aliCount; aliIndex++)
     {
+        if ((*Ali_itr)->IsInvitedToBGInstanceGUID)
+        {
+            ++Ali_itr;
+            continue;
+        }
+
         int32 projectedHordeInGame = numHordeInGame + int32(m_SelectionPools[TEAM_HORDE].GetPlayerCount());
         int32 projectedAliInGame = numAliInGame + int32(m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount());
         int32 hordeFree = bg->GetMaxPlayersPerTeam() - projectedHordeInGame;
@@ -707,6 +713,12 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
     uint32 hordeIndex = 0;
     for (; hordeIndex < hordeCount; hordeIndex++)
     {
+        if ((*Horde_itr)->IsInvitedToBGInstanceGUID)
+        {
+            ++Horde_itr;
+            continue;
+        }
+
         int32 projectedHordeInGame = numHordeInGame + int32(m_SelectionPools[TEAM_HORDE].GetPlayerCount());
         int32 projectedAliInGame = numAliInGame + int32(m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount());
         int32 hordeFree = bg->GetMaxPlayersPerTeam() - projectedHordeInGame;
@@ -957,27 +969,6 @@ void BattlegroundQueue::BattlegroundQueueUpdate(uint32 /*diff*/, BattlegroundTyp
                 // intermediate invite wave despite queued managed bots waiting.
                 sBattlegroundMgr->ScheduleQueueUpdate(0, arenaType, BattlegroundMgr::BGQueueTypeId(bgTypeId, arenaType), bgTypeId, bracket_id);
             }
-        }
-    }
-
-    // SCM should always saturate existing free-slot instances before creating another one.
-    // This prevents queue fragmentation where late joiners get split into a second SCM while
-    // the first instance still has open seats.
-    if (bgTypeId == BATTLEGROUND_SCM)
-    {
-        for (Battleground* bg : bgQueues)
-        {
-            if (!bg)
-                continue;
-
-            if (bg->GetTypeID() != bgTypeId || bg->GetBracketId() != bracket_id)
-                continue;
-
-            if (bg->GetStatus() <= STATUS_WAIT_QUEUE || bg->GetStatus() >= STATUS_WAIT_LEAVE)
-                continue;
-
-            if (bg->HasFreeSlots())
-                return;
         }
     }
 


### PR DESCRIPTION
### Motivation

- Ensure invited counters accurately reflect capacity when a player actually joins a battleground and avoid unsigned underflow when decreasing invites.
- Prevent the queue from attempting to invite groups that have already been invited to a battleground instance.
- Remove duplicated SCM saturation check to simplify queue logic.

### Description

- When a player is added in `Battleground::AddPlayer`, consume one pending invite slot by calling `DecreaseInvitedCount` for the team when the player was not previously in the battleground.
- Make `Battleground::DecreaseInvitedCount` defensive by checking `m_InvitedAlliance`/`m_InvitedHorde` are greater than zero before decrementing to avoid underflow.
- In `BattlegroundQueue::FillPlayersToBG`, skip groups whose `IsInvitedToBGInstanceGUID` flag is set when iterating Alliance and Horde queues to avoid re-inviting them.
- Remove a duplicated SCM free-slot saturation check block to keep the saturation logic singular and clear.

### Testing

- Project compiled successfully (CMake/make build) with these changes and produced a working server binary.
- Ran the project's automated test suite and existing regression/unit tests and all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe6d4bf148327bac0b0ec4431ffc1)