### PR TITLE
Use navmesh-driven movement for Warsong graveyard exits

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -607,65 +607,44 @@ bool TryJumpOffWarsongGraveyard(Player* player)
     if (!state.active)
         return false;
 
-    static Position const hordeGraveyardTip(1066.0946404f, 1380.843994f, 340.612305f, 0.0f);
-    static Position const allianceGraveyardTip(1406.597412f, 1553.099121f, 343.533295f, 0.0f);
     static Position const midPoint(1258.810181f, 1463.801758f, 312.229401f, 0.0f);
-    // Per-side anchors that point off the graveyard ledge into the field.
-    static Position const hordeForwardAnchor(978.20f, 1427.10f, 335.20f, 0.0f);
-    static Position const allianceForwardAnchor(1498.60f, 1484.30f, 340.20f, 0.0f);
+    uint32 const nowMs = GameTime::GetGameTimeMS();
 
-    TeamId const teamId = ResolveBotTeamId(player);
-    Position const& graveyardTip = (teamId == TEAM_HORDE) ? hordeGraveyardTip : allianceGraveyardTip;
-    Position const& forwardAnchor = (teamId == TEAM_HORDE) ? hordeForwardAnchor : allianceForwardAnchor;
-
+    // Replace rigid graveyard jump anchors with navmesh-driven pursuit:
+    // build movement toward the nearest enemy immediately after resurrection
+    // and keep issuing path segments for a short bootstrap window so bots do
+    // not tunnel through floor/wall geometry while leaving spawn platforms.
     if (state.phase == 0)
     {
-        if (!player->IsWithinDist3d(graveyardTip.GetPositionX(), graveyardTip.GetPositionY(), graveyardTip.GetPositionZ(), 2.5f))
-        {
-            IssueMovePointThrottled(player, graveyardTip, 1.0f, 300);
-            return true;
-        }
-
+        if (!state.forwardBurstEndMs)
+            state.forwardBurstEndMs = nowMs + 7000;
         state.phase = 1;
     }
 
     if (state.phase == 1)
     {
-        uint32 const nowMs = GameTime::GetGameTimeMS();
-        if (!state.forwardBurstEndMs)
-            state.forwardBurstEndMs = nowMs + 1000;
+        bool issuedMovement = false;
 
-        // Push straight off the graveyard ledge first, then route to mid.
-        float const dx = forwardAnchor.GetPositionX() - graveyardTip.GetPositionX();
-        float const dy = forwardAnchor.GetPositionY() - graveyardTip.GetPositionY();
-        float const len = std::sqrt(dx * dx + dy * dy);
-        if (len <= 0.001f)
+        if (Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
         {
-            state.phase = 2;
-            return true;
+            issuedMovement = MoveTowardUnit(player, nearestEnemy, 20.0f) ||
+                IssueMovePointThrottled(player, nearestEnemy->GetPosition(), 12.0f, 500);
+            if (issuedMovement)
+                return true;
         }
 
-        float const forwardDistance = player->GetSpeed(MOVE_RUN) * 1.0f;
-        Position forwardPoint(
-            graveyardTip.GetPositionX() + (dx / len) * forwardDistance,
-            graveyardTip.GetPositionY() + (dy / len) * forwardDistance,
-            graveyardTip.GetPositionZ(),
-            player->GetAbsoluteAngle(forwardAnchor.GetPositionX(), forwardAnchor.GetPositionY()));
-
-        IssueMovePointThrottled(player, forwardPoint, 0.5f, 100);
-
+        issuedMovement = IssueMovePointThrottled(player, midPoint, 4.0f, 500);
         if (nowMs >= state.forwardBurstEndMs)
             state.phase = 2;
-        return true;
+        return issuedMovement;
     }
 
     if (state.phase == 2)
     {
-        IssueMovePointThrottled(player, midPoint, 1.0f, 300);
-
-        if (player->IsWithinDist3d(midPoint.GetPositionX(), midPoint.GetPositionY(), midPoint.GetPositionZ(), 6.0f))
-            state.active = false;
-        return true;
+        state.active = false;
+        state.phase = 0;
+        state.forwardBurstEndMs = 0;
+        return false;
     }
 
     return true;


### PR DESCRIPTION
### Motivation

- Improve bot navigation when leaving the Warsong graveyard by replacing rigid, per-side jump anchors with dynamic, navmesh-driven movement to prevent tunneling through geometry. 

### Description

- Reworked `TryJumpOffWarsongGraveyard` to remove hardcoded graveyard tip and forward anchor positions and to use a midpoint plus navmesh pursuit instead. 
- After resurrection the code now bootstraps movement for a short burst (`forwardBurstEndMs`) and attempts to move toward the nearest enemy via `MoveTowardUnit` or `IssueMovePointThrottled`, falling back to the `midPoint` when no enemy is found. 
- Extended the forward burst window and simplified phase handling so phase 2 immediately resets state and deactivates the lifecycle action. 
- Minor rearrangement of time sampling (`nowMs`) and returned movement issuance status to avoid unnecessary issuing when no path could be started. 

### Testing

- Built the server with the change applied and confirmed successful compilation. 
- Ran the project's automated unit test suite via `ctest` and observed no regressions. 
- Executed automated PvP/bot integration checks (bot movement/pathing scenarios) and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc393e5088327b8e43c0df3449729)