### PR TITLE
Fix QuestRelationResult iterator lifetime by snapshotting quest IDs

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -8712,15 +8712,9 @@ void ObjectMgr::LoadCreatureQuestEnders()
     }
 }
 
-void QuestRelationResult::Iterator::_skip()
-{
-    while ((_it != _end) && !Quest::IsTakingQuestEnabled(_it->second))
-        ++_it;
-}
-
 bool QuestRelationResult::HasQuest(uint32 questId) const
 {
-    return (std::find_if(_begin, _end, [questId](QuestRelations::value_type const& pair) { return (pair.second == questId); }) != _end) && (!_onlyActive || Quest::IsTakingQuestEnabled(questId));
+    return std::find(_questIds.begin(), _questIds.end(), questId) != _questIds.end();
 }
 
 void ObjectMgr::LoadReservedPlayersNames()

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -588,48 +588,25 @@ typedef std::multimap<uint32, uint32> QuestRelations; // unit/go -> quest
 struct QuestRelationResult
 {
     public:
-        struct Iterator
-        {
-            public:
-                using iterator_category = std::forward_iterator_tag;
-                using value_type = QuestRelations::mapped_type;
-                using pointer = value_type const*;
-                using reference = value_type const&;
-                using difference_type = void;
+        using Container = std::vector<QuestRelations::mapped_type>;
+        using Iterator = Container::const_iterator;
 
-                Iterator(QuestRelations::const_iterator it, QuestRelations::const_iterator end, bool onlyActive)
-                    : _it(it), _end(end), _onlyActive(onlyActive)
-                {
-                    skip();
-                }
-
-                bool operator==(Iterator const& other) const { return _it == other._it; }
-
-                Iterator& operator++() { ++_it; skip(); return *this; }
-                Iterator operator++(int) { Iterator t = *this; ++*this; return t; }
-
-                value_type operator*() const { return _it->second; }
-
-            private:
-                void skip() { if (_onlyActive) _skip(); }
-                void _skip();
-
-                QuestRelations::const_iterator _it, _end;
-                bool _onlyActive;
-        };
-
-        QuestRelationResult() : _onlyActive(false) {}
+        QuestRelationResult() = default;
         QuestRelationResult(std::pair<QuestRelations::const_iterator, QuestRelations::const_iterator> range, bool onlyActive)
-            : _begin(range.first), _end(range.second), _onlyActive(onlyActive) {}
+        {
+            _questIds.reserve(std::distance(range.first, range.second));
+            for (QuestRelations::const_iterator itr = range.first; itr != range.second; ++itr)
+                if (!onlyActive || Quest::IsTakingQuestEnabled(itr->second))
+                    _questIds.push_back(itr->second);
+        }
 
-        Iterator begin() const { return { _begin, _end, _onlyActive }; }
-        Iterator end() const { return { _end, _end, _onlyActive }; }
+        Iterator begin() const { return _questIds.begin(); }
+        Iterator end() const { return _questIds.end(); }
 
         bool HasQuest(uint32 questId) const;
 
     private:
-        QuestRelations::const_iterator _begin, _end;
-        bool _onlyActive;
+        Container _questIds;
 };
 
 struct PlayerCreateInfoItem


### PR DESCRIPTION
### Motivation
- Prevent use-after-free/invalid-iterator crashes when code (e.g. `Player::PrepareQuestMenu`) iterates quest relations while the underlying `QuestRelations` multimaps may be cleared/reloaded. 

### Description
- Replaced the custom `QuestRelationResult::Iterator` that held iterators into the `QuestRelations` multimap with a snapshot container (`std::vector`) of quest IDs stored inside `QuestRelationResult` in `src/server/game/Globals/ObjectMgr.h`.
- Materialize and apply the `onlyActive` filter at construction time so callers iterate a stable snapshot rather than referencing the original multimap iterators.
- Simplified `begin()`/`end()` to return the snapshot's iterators and updated `HasQuest` in `src/server/game/Globals/ObjectMgr.cpp` to search the snapshot vector.
- Updated code removes the `_skip` helper and the `_onlyActive`/iterator state that could outlive the source container.

### Testing
- Ran `git diff --check` to validate whitespace and trivial issues, which succeeded.
- Started a full build with `cmake --build build --target worldserver -j2`, and compilation began successfully (the full build is long-running and was still in progress in the environment when changes were finalized).
- Performed local code inspection and compilation progress observation to ensure the modified translation units compile with the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee34e7e244832793b0da1eb7f607d6)