### PR TITLE
Scarlet Chapel: lower kill cap to 30, scale honor to 2/5, add max-kills worldstate

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -102,7 +102,7 @@ uint32 BattlegroundSCM::GetHonorRewardForTeam() const
     if (!_humanFaceoffEverHappened)
         reward /= 2;
 
-    return reward;
+    return (reward * 2) / 5;
 }
 
 void BattlegroundSCM::ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, uint32& winnerHonor, uint32& /*loserHonor*/) const
@@ -115,6 +115,8 @@ void BattlegroundSCM::ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, u
 
     if (!_humanFaceoffEverHappened)
         winnerHonor /= 2;
+
+    winnerHonor = (winnerHonor * 2) / 5;
 }
 
 bool BattlegroundSCM::SetupBattleground()
@@ -283,6 +285,7 @@ void BattlegroundSCM::UpdateTeamScoreWorldStates()
     UpdateWorldState(BG_SCM_WORLDSTATE_ALLIANCE_SCORE, _allianceKills);
     UpdateWorldState(BG_SCM_WORLDSTATE_HORDE_SCORE, _hordeKills);
     UpdateWorldState(BG_SCM_WORLDSTATE_MAX_SCORE, BG_SCM_KILL_LIMIT);
+    UpdateWorldState(BG_SCM_WORLDSTATE_MAX_KILLS_UI, BG_SCM_KILL_LIMIT);
 }
 
 void BattlegroundSCM::HandleKillPlayer(Player* victim, Player* killer)
@@ -329,6 +332,7 @@ void BattlegroundSCM::FillInitialWorldStates(WorldPackets::WorldState::InitWorld
     packet.Worldstates.emplace_back(BG_SCM_WORLDSTATE_ALLIANCE_SCORE, _allianceKills);
     packet.Worldstates.emplace_back(BG_SCM_WORLDSTATE_HORDE_SCORE, _hordeKills);
     packet.Worldstates.emplace_back(BG_SCM_WORLDSTATE_MAX_SCORE, BG_SCM_KILL_LIMIT);
+    packet.Worldstates.emplace_back(BG_SCM_WORLDSTATE_MAX_KILLS_UI, BG_SCM_KILL_LIMIT);
     packet.Worldstates.emplace_back(BG_SCM_WORLDSTATE_TIMER_ACTIVE, 0);
     packet.Worldstates.emplace_back(BG_SCM_WORLDSTATE_TIMER, 0);
 }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
@@ -18,7 +18,8 @@ enum BG_SCM_WorldStates
     BG_SCM_WORLDSTATE_MAX_SCORE      = 9002,
     BG_SCM_WORLDSTATE_TIMER_ACTIVE   = 9003,
     BG_SCM_WORLDSTATE_TIMER          = 9004,
-    BG_SCM_WORLDSTATE_SHOW           = 9005
+    BG_SCM_WORLDSTATE_SHOW           = 9005,
+    BG_SCM_WORLDSTATE_MAX_KILLS_UI   = 9006
 };
 
 enum BG_SCM_Graveyards
@@ -71,7 +72,7 @@ enum BG_SCM_ObjectEntries
 
 enum BG_SCM_Constants
 {
-    BG_SCM_KILL_LIMIT        = 50,
+    BG_SCM_KILL_LIMIT        = 30,
     BG_SCM_BUFF_RESPAWN_TIME = 60
 };
 


### PR DESCRIPTION
### Motivation

- Implement requested battleground tuning: reduce Scarlet Chapel max kills from 50 to 30, reduce honor payouts by 3/5th, and expose a dedicated max-kills UI worldstate for the client.

### Description

- Changed `BG_SCM_KILL_LIMIT` from `50` to `30` in `src/server/game/Battlegrounds/Zones/BattlegroundSCM.h`.
- Added a new worldstate `BG_SCM_WORLDSTATE_MAX_KILLS_UI = 9006` and populated/updated it in `UpdateTeamScoreWorldStates` and `FillInitialWorldStates` in `src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp` so the max-kills value is sent to clients alongside current scores.
- Reduced periodic 10-kill team honor rewards by scaling `GetHonorRewardForTeam()` to return `(reward * 2) / 5` in `BattlegroundSCM.cpp`.
- Reduced end-of-match winner honor by applying `winnerHonor = (winnerHonor * 2) / 5` in `ModifyEndOfMatchHonorRewards` in `BattlegroundSCM.cpp`.
- Committed changes with message: "Adjust Scarlet Chapel kill cap, honor rewards, and max-kills worldstate".

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee2c1899c83278ab51f4de6047732)