### PR TITLE
Improve PvP bot movement: LOS recovery, stalled movement fallbacks, and movement target reanchoring

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -23,6 +23,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "Movement/AbstractFollower.h"
 #include "Player.h"
 #include "Battleground.h"
 #include "PathGenerator.h"
@@ -431,6 +432,25 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     // no actual motion.
     float const postIssueDistance = player->GetDistance(target);
     uint32 const nowMs = GameTime::GetGameTimeMS();
+    if (!player->isMoving() &&
+        postIssueDistance > (safeDistance + 1.0f) &&
+        (stallState.lastFallbackMs == 0 || nowMs >= (stallState.lastFallbackMs + 350)))
+    {
+        Position const forcedDestination = BuildFollowDestination(player, target, std::max(1.0f, safeDistance - 2.0f));
+        bool forcedMoveIssued = false;
+        if (RequiresStrictHumanPathing(player))
+            forcedMoveIssued = IssueStrictHumanMove(player, forcedDestination, 1.5f, 0);
+
+        if (!forcedMoveIssued)
+            motionMaster->MovePoint(0, BuildCollisionSafeDestination(player, forcedDestination), true);
+
+        stallState.lastFallbackMs = nowMs;
+        stallState.stagnantSamples = 0;
+        TC_LOG_DEBUG("playerbots.pvp.classspell",
+            "Ranged approach forced point fallback from idle: guid={} target={} desiredRange={} currentDistance={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+    }
+
     bool const targetChanged = stallState.targetGuid != target->GetGUID();
     bool const recentlySampled = !targetChanged && stallState.lastSampleMs != 0 && nowMs <= (stallState.lastSampleMs + 1500);
     bool const distanceStagnant = recentlySampled && std::fabs(postIssueDistance - stallState.lastDistance) < 0.35f;
@@ -482,6 +502,37 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             "Ranged approach forced chase/follow fallback: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
             player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
     }
+}
+
+void EnsureActiveChaseTracksTarget(Player* player, Unit* target)
+{
+    if (!player || !target || !target->IsAlive())
+        return;
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    MovementGeneratorType const movementType = motionMaster->GetCurrentMovementGeneratorType();
+    if (movementType != CHASE_MOTION_TYPE && movementType != FOLLOW_MOTION_TYPE)
+        return;
+
+    MovementGenerator* movement = motionMaster->GetCurrentMovementGenerator();
+    AbstractFollower* follower = movement ? dynamic_cast<AbstractFollower*>(movement) : nullptr;
+    Unit* activeTarget = follower ? follower->GetTarget() : nullptr;
+    if (activeTarget == target)
+        return;
+
+    float const reanchorRange = std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 3.0f);
+    if (player->IsValidAttackTarget(target))
+        motionMaster->MoveChase(target, reanchorRange);
+    else
+        motionMaster->MoveFollow(target, reanchorRange, player->GetFollowAngle());
+
+    TC_LOG_DEBUG("playerbots.pvp.classspell",
+        "Reanchored active movement target: guid={} from={} to={} movementType={}.",
+        player->GetGUID().ToString(), activeTarget ? activeTarget->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+        target->GetGUID().ToString(), static_cast<uint32>(movementType));
 }
 
 void IssueMeleeApproachMovement(Player* player, Unit* target)
@@ -545,7 +596,17 @@ float ComputeLosRecoveryRange(Player const* player, Unit const* target, float ma
     if (closeFloor > upperBound)
         desiredRange = upperBound;
 
-    return desiredRange;
+    // Always bias LOS recovery to move inward at least slightly. Holding a
+    // follow distance >= current separation can leave casters repeating LOS
+    // failures while standing still.
+    float const currentDistance = player->GetDistance(target);
+    if (currentDistance > 0.0f)
+    {
+        float const inwardRecoveryCap = std::max(1.0f, currentDistance - 2.0f);
+        desiredRange = std::min(desiredRange, inwardRecoveryCap);
+    }
+
+    return std::max(1.0f, desiredRange);
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -1208,6 +1269,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         else if (player->GetVictim() != target)
             player->Attack(target, false);
         CommandPetAttackTarget(player, target);
+        EnsureActiveChaseTracksTarget(player, target);
 
         // Virtual sessions can visually "turn" while server-side facing checks
         // still fail for the immediate cast tick. SetInFront updates orientation

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3282,6 +3282,30 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     if (context.spellId &&
         (context.targetMode == PvpClassSpellContext::TargetMode::Enemy || context.targetMode == PvpClassSpellContext::TargetMode::Ally))
     {
+        Unit const* losRecoveryTarget = resolveTargetByGuid(context.targetGuid);
+        if (losRecoveryTarget && !player->IsWithinLOSInMap(losRecoveryTarget))
+        {
+            SpellInfo const* recoverySpellInfo = sSpellMgr->GetSpellInfo(context.spellId);
+            float const spellMaxRange = recoverySpellInfo ? recoverySpellInfo->GetMaxRange(false) : 0.0f;
+            float const currentDistance = player->GetDistance(losRecoveryTarget);
+            float const maxFollowRange = spellMaxRange > 0.0f
+                ? std::max(1.5f, spellMaxRange - 1.0f)
+                : std::max(1.5f, GetConfiguredSpellRange() - 1.0f);
+            float const desiredRange = std::clamp(currentDistance - 2.0f, 1.5f, maxFollowRange);
+
+            ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, losRecoveryTarget->GetGUID(),
+                desiredRange, "recover los", "selected spell target out of line of sight", 86.0f);
+            context.spellId = 0;
+            context.itemEntry = 0;
+            context.targetMode = PvpClassSpellContext::TargetMode::None;
+            context.targetGuid = ObjectGuid::Empty;
+            context.selfCast = false;
+        }
+    }
+
+    if (context.spellId &&
+        (context.targetMode == PvpClassSpellContext::TargetMode::Enemy || context.targetMode == PvpClassSpellContext::TargetMode::Ally))
+    {
         Unit const* facingTarget = resolveTargetByGuid(context.targetGuid);
         if (facingTarget && !player->HasInArc(static_cast<float>(M_PI), facingTarget))
         {
@@ -3520,7 +3544,37 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    context.shouldExecute = context.shouldExecute || context.spellId != 0;
+    auto const movementDirectiveNeedsTarget = [](PvpClassSpellContext::MovementDirective directive) -> bool
+    {
+        switch (directive)
+        {
+            case PvpClassSpellContext::MovementDirective::ReachSpellRange:
+            case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
+            case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
+            case PvpClassSpellContext::MovementDirective::FaceSpellTarget:
+                return true;
+            default:
+                return false;
+        }
+    };
+
+    if (movementDirectiveNeedsTarget(context.movementDirective) && context.movementTargetGuid.IsEmpty())
+    {
+        // Defensive target backfill: stale snapshot races can occasionally
+        // leave movement directives with an empty target guid, which causes
+        // strict-path follower movement to no-op and the bot to idle in place.
+        if (Unit const* movementFallbackTarget = resolveTargetByGuid(activeTargetGuid))
+            context.movementTargetGuid = movementFallbackTarget->GetGUID();
+        else if (Unit const* movementSelectedTarget = resolveTargetByGuid(selectedTargetGuid))
+            context.movementTargetGuid = movementSelectedTarget->GetGUID();
+        else if (Unit const* movementVictim = player->GetVictim(); movementVictim && movementVictim->IsAlive())
+            context.movementTargetGuid = movementVictim->GetGUID();
+        else
+            context.movementDirective = PvpClassSpellContext::MovementDirective::None;
+    }
+
+    context.shouldExecute = context.shouldExecute || context.spellId != 0 ||
+        context.movementDirective != PvpClassSpellContext::MovementDirective::None;
 
     char const* targetModeLabel = "none";
     switch (context.targetMode)


### PR DESCRIPTION
### Motivation
- Reduce cases where PvP bots stall or loop without closing to cast range due to stale movement generators or empty movement targets.
- Improve line-of-sight (LOS) recovery so bots actively move to re-acquire targets for spells and avoid repeating failed casts.
- Ensure active chase/follow generators remain anchored to the intended target to avoid following stale targets.

### Description
- Added include for `Movement/AbstractFollower.h` and implemented `EnsureActiveChaseTracksTarget(Player*, Unit*)` to re-anchor an active `CHASE`/`FOLLOW` movement generator to the intended target by calling `MoveChase`/`MoveFollow` when the follower's active target differs from the desired one, and added debug logging.  (file: `PlayerbotPvpClassActions.cpp`)
- In `IssueRangedApproachMovement`, added an immediate point-move fallback when the bot is idle and out-of-range, throttled by time, and preserved existing stalled-sample fallback logic; added debug logs for forced fallback cases. (file: `PlayerbotPvpClassActions.cpp`)
- Call `EnsureActiveChaseTracksTarget` when preparing to cast direct spells so active movement always tracks the spell target. (file: `PlayerbotPvpClassActions.cpp`)
- Change `ComputeLosRecoveryRange` to bias LOS recovery inward slightly by capping the desired follow distance relative to the current separation (`currentDistance - 2.0f`) to avoid choosing a follow distance that is >= current separation. (file: `PlayerbotPvpClassActions.cpp`)
- In `PvpCore::BuildClassSpellContext`, add proactive LOS-recovery movement directive creation when a selected spell target is out of LOS by computing an appropriate `desiredRange`, issuing `ConsiderMovementDirective` for `ReachSpellRange`, and clearing spell selection. (file: `PlayerbotPvpCore.cpp`)
- Add defensive backfill for movement directives that require a target: if `movementTargetGuid` is empty, attempt to populate it from `activeTargetGuid`, `selectedTargetGuid`, or `player->GetVictim()`, otherwise clear the movement directive; treat movement directives as execution-worthy when present. (file: `PlayerbotPvpCore.cpp`)

### Testing
- Performed a full build of the server with the modified PvP scripts and the build completed successfully. 
- Ran the automated test suite for scripting/PvP behaviors and core unit tests; all executed tests passed. 
- Verified through automated script-driven PvP scenarios that bots issue LOS recovery movement directives and that stalled movement fallbacks trigger without causing excessive repeat commands (logs indicate expected fallback debug messages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7ca6c06c8327bedd3ed777be5654)