### PR TITLE
Improve PvP bot movement fallbacks, LOS recovery, and movement directive handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -23,6 +23,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "Movement/AbstractFollower.h"
 #include "Player.h"
 #include "Battleground.h"
 #include "PathGenerator.h"
@@ -431,6 +432,25 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     // no actual motion.
     float const postIssueDistance = player->GetDistance(target);
     uint32 const nowMs = GameTime::GetGameTimeMS();
+    if (!player->isMoving() &&
+        postIssueDistance > (safeDistance + 1.0f) &&
+        (stallState.lastFallbackMs == 0 || nowMs >= (stallState.lastFallbackMs + 350)))
+    {
+        Position const forcedDestination = BuildFollowDestination(player, target, std::max(1.0f, safeDistance - 2.0f));
+        bool forcedMoveIssued = false;
+        if (RequiresStrictHumanPathing(player))
+            forcedMoveIssued = IssueStrictHumanMove(player, forcedDestination, 1.5f, 0);
+
+        if (!forcedMoveIssued)
+            motionMaster->MovePoint(0, BuildCollisionSafeDestination(player, forcedDestination), true);
+
+        stallState.lastFallbackMs = nowMs;
+        stallState.stagnantSamples = 0;
+        TC_LOG_DEBUG("playerbots.pvp.classspell",
+            "Ranged approach forced point fallback from idle: guid={} target={} desiredRange={} currentDistance={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+    }
+
     bool const targetChanged = stallState.targetGuid != target->GetGUID();
     bool const recentlySampled = !targetChanged && stallState.lastSampleMs != 0 && nowMs <= (stallState.lastSampleMs + 1500);
     bool const distanceStagnant = recentlySampled && std::fabs(postIssueDistance - stallState.lastDistance) < 0.35f;
@@ -482,6 +502,37 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             "Ranged approach forced chase/follow fallback: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
             player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
     }
+}
+
+void EnsureActiveChaseTracksTarget(Player* player, Unit* target)
+{
+    if (!player || !target || !target->IsAlive())
+        return;
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    MovementGeneratorType const movementType = motionMaster->GetCurrentMovementGeneratorType();
+    if (movementType != CHASE_MOTION_TYPE && movementType != FOLLOW_MOTION_TYPE)
+        return;
+
+    MovementGenerator* movement = motionMaster->GetCurrentMovementGenerator();
+    AbstractFollower* follower = movement ? dynamic_cast<AbstractFollower*>(movement) : nullptr;
+    Unit* activeTarget = follower ? follower->GetTarget() : nullptr;
+    if (activeTarget == target)
+        return;
+
+    float const reanchorRange = std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 3.0f);
+    if (player->IsValidAttackTarget(target))
+        motionMaster->MoveChase(target, reanchorRange);
+    else
+        motionMaster->MoveFollow(target, reanchorRange, player->GetFollowAngle());
+
+    TC_LOG_DEBUG("playerbots.pvp.classspell",
+        "Reanchored active movement target: guid={} from={} to={} movementType={}.",
+        player->GetGUID().ToString(), activeTarget ? activeTarget->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+        target->GetGUID().ToString(), static_cast<uint32>(movementType));
 }
 
 void IssueMeleeApproachMovement(Player* player, Unit* target)
@@ -545,7 +596,17 @@ float ComputeLosRecoveryRange(Player const* player, Unit const* target, float ma
     if (closeFloor > upperBound)
         desiredRange = upperBound;
 
-    return desiredRange;
+    // Always bias LOS recovery to move inward at least slightly. Holding a
+    // follow distance >= current separation can leave casters repeating LOS
+    // failures while standing still.
+    float const currentDistance = player->GetDistance(target);
+    if (currentDistance > 0.0f)
+    {
+        float const inwardRecoveryCap = std::max(1.0f, currentDistance - 2.0f);
+        desiredRange = std::min(desiredRange, inwardRecoveryCap);
+    }
+
+    return std::max(1.0f, desiredRange);
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -1208,6 +1269,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         else if (player->GetVictim() != target)
             player->Attack(target, false);
         CommandPetAttackTarget(player, target);
+        EnsureActiveChaseTracksTarget(player, target);
 
         // Virtual sessions can visually "turn" while server-side facing checks
         // still fail for the immediate cast tick. SetInFront updates orientation
@@ -1793,6 +1855,23 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                     }
                 }
                 IssueRangedApproachMovement(player, approachTarget, desiredRange);
+                if (approachTarget)
+                {
+                    float const postIssueDistance = player->GetDistance(approachTarget);
+                    if (!player->isMoving() && postIssueDistance > (desiredRange + 1.0f))
+                    {
+                        MotionMaster* motionMaster = player->GetMotionMaster();
+                        if (motionMaster)
+                        {
+                            Position const forcedDestination = BuildFollowDestination(player, approachTarget, std::max(1.0f, desiredRange - 2.0f));
+                            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+                            motionMaster->MovePoint(0, BuildCollisionSafeDestination(player, forcedDestination), true);
+                            TC_LOG_DEBUG("playerbots.pvp.classspell",
+                                "ReachSpellRange post-exec forced point move: guid={} target={} desiredRange={} distance={}.",
+                                player->GetGUID().ToString(), approachTarget->GetGUID().ToString(), desiredRange, postIssueDistance);
+                        }
+                    }
+                }
             }
                 break;
             case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3282,6 +3282,30 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     if (context.spellId &&
         (context.targetMode == PvpClassSpellContext::TargetMode::Enemy || context.targetMode == PvpClassSpellContext::TargetMode::Ally))
     {
+        Unit const* losRecoveryTarget = resolveTargetByGuid(context.targetGuid);
+        if (losRecoveryTarget && !player->IsWithinLOSInMap(losRecoveryTarget))
+        {
+            SpellInfo const* recoverySpellInfo = sSpellMgr->GetSpellInfo(context.spellId);
+            float const spellMaxRange = recoverySpellInfo ? recoverySpellInfo->GetMaxRange(false) : 0.0f;
+            float const currentDistance = player->GetDistance(losRecoveryTarget);
+            float const maxFollowRange = spellMaxRange > 0.0f
+                ? std::max(1.5f, spellMaxRange - 1.0f)
+                : std::max(1.5f, GetConfiguredSpellRange() - 1.0f);
+            float const desiredRange = std::clamp(currentDistance - 2.0f, 1.5f, maxFollowRange);
+
+            ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, losRecoveryTarget->GetGUID(),
+                desiredRange, "recover los", "selected spell target out of line of sight", 86.0f);
+            context.spellId = 0;
+            context.itemEntry = 0;
+            context.targetMode = PvpClassSpellContext::TargetMode::None;
+            context.targetGuid = ObjectGuid::Empty;
+            context.selfCast = false;
+        }
+    }
+
+    if (context.spellId &&
+        (context.targetMode == PvpClassSpellContext::TargetMode::Enemy || context.targetMode == PvpClassSpellContext::TargetMode::Ally))
+    {
         Unit const* facingTarget = resolveTargetByGuid(context.targetGuid);
         if (facingTarget && !player->HasInArc(static_cast<float>(M_PI), facingTarget))
         {
@@ -3342,6 +3366,21 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             {
                 ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
                     ComputeApproachFollowRange(maxRange), "reach spell", "selected spell out of range", 84.0f);
+                context.spellId = 0;
+                context.itemEntry = 0;
+                context.targetMode = PvpClassSpellContext::TargetMode::None;
+                context.targetGuid = ObjectGuid::Empty;
+                context.selfCast = false;
+            }
+            else if (maxRange > 0.0f &&
+                spellInfo->CalcCastTime() > 0 &&
+                distance > std::max(1.0f, maxRange - 2.0f))
+            {
+                // Hard-cast edge guard: repeated casts at the absolute spell
+                // ceiling can stutter on movement jitter and LOS drift. Step
+                // in slightly so caster bots do not idle at max-range fringe.
+                ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, spacingTarget->GetGUID(),
+                    ComputeApproachFollowRange(maxRange), "reach spell", "selected spell near max range edge", 83.0f);
                 context.spellId = 0;
                 context.itemEntry = 0;
                 context.targetMode = PvpClassSpellContext::TargetMode::None;
@@ -3520,7 +3559,37 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    context.shouldExecute = context.shouldExecute || context.spellId != 0;
+    auto const movementDirectiveNeedsTarget = [](PvpClassSpellContext::MovementDirective directive) -> bool
+    {
+        switch (directive)
+        {
+            case PvpClassSpellContext::MovementDirective::ReachSpellRange:
+            case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
+            case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
+            case PvpClassSpellContext::MovementDirective::FaceSpellTarget:
+                return true;
+            default:
+                return false;
+        }
+    };
+
+    if (movementDirectiveNeedsTarget(context.movementDirective) && context.movementTargetGuid.IsEmpty())
+    {
+        // Defensive target backfill: stale snapshot races can occasionally
+        // leave movement directives with an empty target guid, which causes
+        // strict-path follower movement to no-op and the bot to idle in place.
+        if (Unit const* movementFallbackTarget = resolveTargetByGuid(activeTargetGuid))
+            context.movementTargetGuid = movementFallbackTarget->GetGUID();
+        else if (Unit const* movementSelectedTarget = resolveTargetByGuid(selectedTargetGuid))
+            context.movementTargetGuid = movementSelectedTarget->GetGUID();
+        else if (Unit const* movementVictim = player->GetVictim(); movementVictim && movementVictim->IsAlive())
+            context.movementTargetGuid = movementVictim->GetGUID();
+        else
+            context.movementDirective = PvpClassSpellContext::MovementDirective::None;
+    }
+
+    context.shouldExecute = context.shouldExecute || context.spellId != 0 ||
+        context.movementDirective != PvpClassSpellContext::MovementDirective::None;
 
     char const* targetModeLabel = "none";
     switch (context.targetMode)


### PR DESCRIPTION
### Motivation
- Reduce cases where ranged/melee PvP bots idle or stutter at cast-range/LOS edges by forcing more robust fallback movement and reanchoring active followers.
- Ensure movement directives are actionable by backfilling missing targets to avoid no-op strict-path followers.
- Bias LOS recovery to move slightly inward so casters do not repeatedly fail LOS while standing at the spell ceiling.

### Description
- Added `#include "Movement/AbstractFollower.h"` and a new helper `EnsureActiveChaseTracksTarget` to reanchor chase/follow generators to the intended `target` when the active follower is tracking a different unit.
- Enhanced `IssueRangedApproachMovement` to issue an immediate `MovePoint` fallback when the player is idle and still outside the desired range, including debug logging and throttle logic to avoid repeated spamming.
- After issuing ranged approach movement in `Execute`, added a defensive post-issue forced `MovePoint` if the player remains idle and out of range to cover additional stall scenarios.
- Called `EnsureActiveChaseTracksTarget` from `CastDirectSpell` to ensure active chase/follow movement actually tracks the current cast target.
- Modified `ComputeLosRecoveryRange` to bias recovery inward relative to the current distance and ensure the returned follow distance is at least `1.0f` to avoid impossible targets.
- In `PvpCore::BuildClassSpellContext` added LOS-recovery movement directive when a selected target is out-of-LOS, and added a near-`maxRange` hard-cast guard that creates a `ReachSpellRange` directive for casts that are hard-cast near the range ceiling.
- Added defensive backfill logic for movement directives with empty target GUIDs and updated `shouldExecute` to also consider movement directives so movement-only contexts are executed.

### Testing
- Built the project with `cmake`/`make` successfully with no compile errors after the changes.
- Ran the Playerbot PvP unit/integration tests and existing test suite for playerbot movement, and all tests completed successfully.
- Launched a headless server smoke test to exercise movement directives and observed expected debug log entries for forced move fallbacks with no crashes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7ca6c06c8327bedd3ed777be5654)