### PR TITLE
Fix missing return in BattlegroundSCM::GetHonorRewardForTeam

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -101,6 +101,8 @@ uint32 BattlegroundSCM::GetHonorRewardForTeam() const
 
     if (!_humanFaceoffEverHappened)
         reward /= 2;
+
+    return reward;
 }
 
 void BattlegroundSCM::ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, uint32& winnerHonor, uint32& /*loserHonor*/) const


### PR DESCRIPTION
### Motivation
- Prevent undefined behavior and crashes when honor reward is queried from the Scarlet Chapel battleground by ensuring the computed reward value is actually returned from `BattlegroundSCM::GetHonorRewardForTeam()`.

### Description
- Added `return reward;` to `GetHonorRewardForTeam()` in `src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp` so the function returns the computed honor value instead of falling off the end.

### Testing
- Ran `git diff -- src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp` to verify the change appears in the diff and shows the added `return` line, which it did. 
- Ran `git diff --check` to ensure no whitespace or trivial diff errors were introduced and it completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5203e0108327b886cce8c623cba9)