### PR TITLE
Add safety checks to Druid Innervate and return honor reward in SCM battleground

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -101,6 +101,8 @@ uint32 BattlegroundSCM::GetHonorRewardForTeam() const
 
     if (!_humanFaceoffEverHappened)
         reward /= 2;
+
+    return reward;
 }
 
 void BattlegroundSCM::ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, uint32& winnerHonor, uint32& /*loserHonor*/) const

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -822,26 +822,28 @@ class spell_dru_innervate : public AuraScript
     {
         Unit* caster = GetCaster();
         Unit* target = GetTarget();
-        if (caster->HasAura(81418))
+        if (!caster || !target)
+            return;
+
+        if (!caster->HasAura(81418))
+            return;
+
+        if (caster->GetGUID() == target->GetGUID())
+            return;
+
+        caster->AddAura(SPELL_DRUID_INNERVATE, caster);
+        if (Aura* innervate = caster->GetAura(SPELL_DRUID_INNERVATE))
         {
-            if (caster->GetGUID() != target->GetGUID())
-            {
-                CastSpellExtraArgs args(aurEff);
-                caster->AddAura(SPELL_DRUID_INNERVATE, caster);
-                if (Aura* innervate = caster->GetAura(SPELL_DRUID_INNERVATE))
-                {
-                    int32 newDuration = innervate->GetDuration() / 2;
-                    int32 newMaxDuration = innervate->GetMaxDuration() / 2;
+            int32 newDuration = innervate->GetDuration() / 2;
+            int32 newMaxDuration = innervate->GetMaxDuration() / 2;
 
-                    if (newDuration <= 0)
-                        newDuration = 1;
-                    if (newMaxDuration < newDuration)
-                        newMaxDuration = newDuration;
+            if (newDuration <= 0)
+                newDuration = 1;
+            if (newMaxDuration < newDuration)
+                newMaxDuration = newDuration;
 
-                    innervate->SetMaxDuration(newMaxDuration);
-                    innervate->SetDuration(newDuration);
-                }
-            }
+            innervate->SetMaxDuration(newMaxDuration);
+            innervate->SetDuration(newDuration);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent null-deref crashes and ensure correct return behavior in battleground honor calculation by adding missing checks and an explicit return.

### Description
- Added an explicit `return` to `BattlegroundSCM::GetHonorRewardForTeam()` so the computed `reward` is returned.
- Hardened `spell_dru_innervate::HandleApply` with null checks for `caster` and `target`, simplified the conditional flow, and ensured the handler only proceeds when the caster has the required aura and is not targeting themself before applying `SPELL_DRUID_INNERVATE` and adjusting its duration.
- Removed an unused intermediate `CastSpellExtraArgs` usage and cleaned up nested conditionals for clarity.

### Testing
- Project build (compile) was executed and completed successfully (`build`/`make`).
- Automated unit/test suite was run (`ctest`/`make test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5203e0108327b886cce8c623cba9)