### PR TITLE
Prefer chase/follow movement and improve LOS/range handling for PvP bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -23,6 +23,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "Movement/AbstractFollower.h"
 #include "Player.h"
 #include "Battleground.h"
 #include "PathGenerator.h"
@@ -296,12 +297,10 @@ bool IssueStrictHumanMove(Player* player, Position const& destination, float des
     if (!TryBuildStrictHumanSegmentDestination(player, destination, segmentDestination))
         return false;
 
-    motionMaster->Clear(MOTION_SLOT_ACTIVE);
-    motionMaster->MovePoint(0, segmentDestination, true);
-
-    state.lastDestination = segmentDestination;
-    state.lastIssueMs = nowMs;
-    return true;
+    // Policy: avoid direct point-move orders and keep movement anchored to
+    // navmesh-aware chase/follow generators.
+    (void)segmentDestination;
+    return false;
 }
 
 bool IssueStrictHumanFollow(Player* player, Unit* target, float desiredDistance)
@@ -431,6 +430,30 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     // no actual motion.
     float const postIssueDistance = player->GetDistance(target);
     uint32 const nowMs = GameTime::GetGameTimeMS();
+    if (!player->isMoving() &&
+        postIssueDistance > (safeDistance + 1.0f) &&
+        (stallState.lastFallbackMs == 0 || nowMs >= (stallState.lastFallbackMs + 350)))
+    {
+        Position const forcedDestination = BuildFollowDestination(player, target, std::max(1.0f, safeDistance - 2.0f));
+        bool forcedMoveIssued = false;
+        if (RequiresStrictHumanPathing(player))
+            forcedMoveIssued = IssueStrictHumanMove(player, forcedDestination, 1.5f, 0);
+
+        if (!forcedMoveIssued)
+        {
+            if (player->IsValidAttackTarget(target))
+                motionMaster->MoveChase(target, std::max(1.0f, safeDistance - 2.0f));
+            else
+                motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+        }
+
+        stallState.lastFallbackMs = nowMs;
+        stallState.stagnantSamples = 0;
+        TC_LOG_DEBUG("playerbots.pvp.classspell",
+            "Ranged approach forced chase/follow fallback from idle: guid={} target={} desiredRange={} currentDistance={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+    }
+
     bool const targetChanged = stallState.targetGuid != target->GetGUID();
     bool const recentlySampled = !targetChanged && stallState.lastSampleMs != 0 && nowMs <= (stallState.lastSampleMs + 1500);
     bool const distanceStagnant = recentlySampled && std::fabs(postIssueDistance - stallState.lastDistance) < 0.35f;
@@ -482,6 +505,37 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             "Ranged approach forced chase/follow fallback: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
             player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
     }
+}
+
+void EnsureActiveChaseTracksTarget(Player* player, Unit* target)
+{
+    if (!player || !target || !target->IsAlive())
+        return;
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    MovementGeneratorType const movementType = motionMaster->GetCurrentMovementGeneratorType();
+    if (movementType != CHASE_MOTION_TYPE && movementType != FOLLOW_MOTION_TYPE)
+        return;
+
+    MovementGenerator* movement = motionMaster->GetCurrentMovementGenerator();
+    AbstractFollower* follower = movement ? dynamic_cast<AbstractFollower*>(movement) : nullptr;
+    Unit* activeTarget = follower ? follower->GetTarget() : nullptr;
+    if (activeTarget == target)
+        return;
+
+    float const reanchorRange = std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 3.0f);
+    if (player->IsValidAttackTarget(target))
+        motionMaster->MoveChase(target, reanchorRange);
+    else
+        motionMaster->MoveFollow(target, reanchorRange, player->GetFollowAngle());
+
+    TC_LOG_DEBUG("playerbots.pvp.classspell",
+        "Reanchored active movement target: guid={} from={} to={} movementType={}.",
+        player->GetGUID().ToString(), activeTarget ? activeTarget->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+        target->GetGUID().ToString(), static_cast<uint32>(movementType));
 }
 
 void IssueMeleeApproachMovement(Player* player, Unit* target)
@@ -545,7 +599,17 @@ float ComputeLosRecoveryRange(Player const* player, Unit const* target, float ma
     if (closeFloor > upperBound)
         desiredRange = upperBound;
 
-    return desiredRange;
+    // Always bias LOS recovery to move inward at least slightly. Holding a
+    // follow distance >= current separation can leave casters repeating LOS
+    // failures while standing still.
+    float const currentDistance = player->GetDistance(target);
+    if (currentDistance > 0.0f)
+    {
+        float const inwardRecoveryCap = std::max(1.0f, currentDistance - 2.0f);
+        desiredRange = std::min(desiredRange, inwardRecoveryCap);
+    }
+
+    return std::max(1.0f, desiredRange);
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -992,7 +1056,7 @@ void RepositionDruidAfterTravelFormRecovery(Player* player)
     if (RequiresStrictHumanPathing(player))
         IssueStrictHumanMove(player, destination);
     else
-        player->GetMotionMaster()->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+        player->GetMotionMaster()->MoveFollow(nearestEnemy, retreatDistance, angleToEnemy + static_cast<float>(M_PI));
 }
 
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
@@ -1060,7 +1124,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 return false;
             }
 
-            float const maxRange = spellInfo->GetMaxRange(false);
+            float const maxRange = petCaster->GetSpellMaxRangeForTarget(target, spellInfo);
             if (maxRange > 0.0f && !petCaster->IsWithinDistInMap(target, maxRange))
             {
                 failureReason = "out_of_range";
@@ -1208,6 +1272,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         else if (player->GetVictim() != target)
             player->Attack(target, false);
         CommandPetAttackTarget(player, target);
+        EnsureActiveChaseTracksTarget(player, target);
 
         // Virtual sessions can visually "turn" while server-side facing checks
         // still fail for the immediate cast tick. SetInFront updates orientation
@@ -1229,7 +1294,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
-    float const maxRange = spellInfo->GetMaxRange(false);
+    float const maxRange = player->GetSpellMaxRangeForTarget(target, spellInfo);
     bool const shouldUseMeleeApproachForEnemySpell =
         context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
         IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
@@ -1793,6 +1858,26 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                     }
                 }
                 IssueRangedApproachMovement(player, approachTarget, desiredRange);
+                if (approachTarget)
+                {
+                    float const postIssueDistance = player->GetDistance(approachTarget);
+                    if (!player->isMoving() && postIssueDistance > (desiredRange + 1.0f))
+                    {
+                        MotionMaster* motionMaster = player->GetMotionMaster();
+                        if (motionMaster)
+                        {
+                            Position const forcedDestination = BuildFollowDestination(player, approachTarget, std::max(1.0f, desiredRange - 2.0f));
+                            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+                            if (player->IsValidAttackTarget(approachTarget))
+                                motionMaster->MoveChase(approachTarget, std::max(1.0f, desiredRange - 2.0f));
+                            else
+                                motionMaster->MoveFollow(approachTarget, std::max(1.0f, desiredRange - 2.0f), player->GetFollowAngle());
+                            TC_LOG_DEBUG("playerbots.pvp.classspell",
+                                "ReachSpellRange post-exec forced chase/follow move: guid={} target={} desiredRange={} distance={}.",
+                                player->GetGUID().ToString(), approachTarget->GetGUID().ToString(), desiredRange, postIssueDistance);
+                        }
+                    }
+                }
             }
                 break;
             case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
@@ -1807,19 +1892,18 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                 {
                     if (!IssueStrictHumanMove(player, destination))
                     {
-                        // Strict segment pathing can fail to resolve around
-                        // battleground geometry. Fall back to a direct point
-                        // move so flee directives never devolve into idle.
+                        // If strict pathing could not issue this tick, keep
+                        // flee behavior on follow/chase generators.
                         MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
                         if (fallbackMotionMaster)
-                            fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                            fallbackMotionMaster->MoveFollow(movementTarget, fleeDistance, angleToTarget + static_cast<float>(M_PI));
                     }
                 }
                 else
                 {
                     MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
                     if (fallbackMotionMaster)
-                        fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                        fallbackMotionMaster->MoveFollow(movementTarget, fleeDistance, angleToTarget + static_cast<float>(M_PI));
                 }
                 break;
             }
@@ -1865,38 +1949,42 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         std::string const lastStatus = GetLastExecutionStatus(player);
         bool const previousLosFailure =
             lastStatus == "cast_failed_no_los" ||
-            lastStatus == "cast_failed_SPELL_FAILED_LINE_OF_SIGHT";
+            lastStatus == "cast_failed_SPELL_FAILED_LINE_OF_SIGHT" ||
+            lastStatus == "move_recover_los";
 
         if (previousLosFailure && !context.targetGuid.IsEmpty())
         {
             if (Unit* recoveryTarget = ObjectAccessor::GetUnit(*player, context.targetGuid); recoveryTarget && recoveryTarget->IsAlive())
             {
-                uint32 resolvedSpellId = context.spellId;
-                if (context.spellId)
+                if (!player->IsWithinLOSInMap(recoveryTarget))
                 {
-                    if (uint32 knownSpell = ResolveKnownSpellInChain(player, context.spellId))
-                        resolvedSpellId = knownSpell;
+                    uint32 resolvedSpellId = context.spellId;
+                    if (context.spellId)
+                    {
+                        if (uint32 knownSpell = ResolveKnownSpellInChain(player, context.spellId))
+                            resolvedSpellId = knownSpell;
+                    }
+
+                    SpellInfo const* spellInfo = resolvedSpellId ? sSpellMgr->GetSpellInfo(resolvedSpellId) : nullptr;
+                    float const maxRange = spellInfo ? player->GetSpellMaxRangeForTarget(recoveryTarget, spellInfo) : 0.0f;
+                    bool const enemyMeleeSpacing =
+                        context.targetMode == PvpClassSpellContext::TargetMode::Enemy &&
+                        IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
+                        maxRange > 0.0f && maxRange <= 5.5f;
+
+                    if (enemyMeleeSpacing)
+                        IssueMeleeApproachMovement(player, recoveryTarget);
+                    else
+                    {
+                        float const desiredRange = (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
+                            ? std::max(1.5f, std::min(8.0f, maxRange > 0.0f ? (maxRange - 1.0f) : 8.0f))
+                            : ComputeLosRecoveryRange(player, recoveryTarget, maxRange);
+                        IssueRangedApproachMovement(player, recoveryTarget, desiredRange);
+                    }
+
+                    SetLastExecutionStatus(player, "move_recover_los");
+                    return true;
                 }
-
-                SpellInfo const* spellInfo = resolvedSpellId ? sSpellMgr->GetSpellInfo(resolvedSpellId) : nullptr;
-                float const maxRange = spellInfo ? spellInfo->GetMaxRange(false) : 0.0f;
-                bool const enemyMeleeSpacing =
-                    context.targetMode == PvpClassSpellContext::TargetMode::Enemy &&
-                    IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
-                    maxRange > 0.0f && maxRange <= 5.5f;
-
-                if (enemyMeleeSpacing)
-                    IssueMeleeApproachMovement(player, recoveryTarget);
-                else
-                {
-                    float const desiredRange = (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
-                        ? std::max(1.5f, std::min(8.0f, maxRange > 0.0f ? (maxRange - 1.0f) : 8.0f))
-                        : ComputeLosRecoveryRange(player, recoveryTarget, maxRange);
-                    IssueRangedApproachMovement(player, recoveryTarget, desiredRange);
-                }
-
-                SetLastExecutionStatus(player, "move_recover_los");
-                return true;
             }
         }
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -427,7 +427,7 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     if (!player->IsWithinLOSInMap(resolvedTarget))
         return false;
 
-    float const maxRange = spellInfo->GetMaxRange(false);
+    float const maxRange = player->GetSpellMaxRangeForTarget(resolvedTarget, spellInfo);
     if (maxRange > 0.0f && !player->IsWithinDistInMap(resolvedTarget, maxRange))
         return false;
 
@@ -2780,11 +2780,11 @@ bool CanUseHealRangeSpacing(uint8 classId)
 
 float ComputeApproachFollowRange(float nominalRange)
 {
-    // Keep an extra movement buffer so ranged bots do not settle in a
-    // dead-zone where spell-selection still reports out-of-range but chase
-    // motion does not re-engage because the desired distance is too close to
-    // edge tolerances.
-    return std::max(1.0f, nominalRange - 3.0f);
+    // Keep a larger inward buffer so approach directives trigger visible
+    // displacement even when current distance is only slightly above range.
+    // A small 2-3y delta can leave chase generators stationary on tolerance
+    // edges in battleground terrain.
+    return std::max(1.0f, nominalRange - 5.0f);
 }
 
 bool IsPrimaryMeleeClassForSpacing(uint8 classId)
@@ -3282,6 +3282,30 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     if (context.spellId &&
         (context.targetMode == PvpClassSpellContext::TargetMode::Enemy || context.targetMode == PvpClassSpellContext::TargetMode::Ally))
     {
+        Unit const* losRecoveryTarget = resolveTargetByGuid(context.targetGuid);
+        if (losRecoveryTarget && !player->IsWithinLOSInMap(losRecoveryTarget))
+        {
+            SpellInfo const* recoverySpellInfo = sSpellMgr->GetSpellInfo(context.spellId);
+            float const spellMaxRange = recoverySpellInfo ? player->GetSpellMaxRangeForTarget(losRecoveryTarget, recoverySpellInfo) : 0.0f;
+            float const currentDistance = player->GetDistance(losRecoveryTarget);
+            float const maxFollowRange = spellMaxRange > 0.0f
+                ? std::max(1.5f, spellMaxRange - 1.0f)
+                : std::max(1.5f, GetConfiguredSpellRange() - 1.0f);
+            float const desiredRange = std::clamp(currentDistance - 2.0f, 1.5f, maxFollowRange);
+
+            ConsiderMovementDirective(context, PvpClassSpellContext::MovementDirective::ReachSpellRange, losRecoveryTarget->GetGUID(),
+                desiredRange, "recover los", "selected spell target out of line of sight", 86.0f);
+            context.spellId = 0;
+            context.itemEntry = 0;
+            context.targetMode = PvpClassSpellContext::TargetMode::None;
+            context.targetGuid = ObjectGuid::Empty;
+            context.selfCast = false;
+        }
+    }
+
+    if (context.spellId &&
+        (context.targetMode == PvpClassSpellContext::TargetMode::Enemy || context.targetMode == PvpClassSpellContext::TargetMode::Ally))
+    {
         Unit const* facingTarget = resolveTargetByGuid(context.targetGuid);
         if (facingTarget && !player->HasInArc(static_cast<float>(M_PI), facingTarget))
         {
@@ -3336,7 +3360,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         if (spellInfo && spacingTarget)
         {
             float const distance = player->GetDistance(spacingTarget);
-            float const maxRange = spellInfo->GetMaxRange(false);
+            float const maxRange = player->GetSpellMaxRangeForTarget(spacingTarget, spellInfo);
             float const minRange = spellInfo->GetMinRange(false);
             if (maxRange > 0.0f && distance > maxRange)
             {
@@ -3520,7 +3544,37 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    context.shouldExecute = context.shouldExecute || context.spellId != 0;
+    auto const movementDirectiveNeedsTarget = [](PvpClassSpellContext::MovementDirective directive) -> bool
+    {
+        switch (directive)
+        {
+            case PvpClassSpellContext::MovementDirective::ReachSpellRange:
+            case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
+            case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
+            case PvpClassSpellContext::MovementDirective::FaceSpellTarget:
+                return true;
+            default:
+                return false;
+        }
+    };
+
+    if (movementDirectiveNeedsTarget(context.movementDirective) && context.movementTargetGuid.IsEmpty())
+    {
+        // Defensive target backfill: stale snapshot races can occasionally
+        // leave movement directives with an empty target guid, which causes
+        // strict-path follower movement to no-op and the bot to idle in place.
+        if (Unit const* movementFallbackTarget = resolveTargetByGuid(activeTargetGuid))
+            context.movementTargetGuid = movementFallbackTarget->GetGUID();
+        else if (Unit const* movementSelectedTarget = resolveTargetByGuid(selectedTargetGuid))
+            context.movementTargetGuid = movementSelectedTarget->GetGUID();
+        else if (Unit const* movementVictim = player->GetVictim(); movementVictim && movementVictim->IsAlive())
+            context.movementTargetGuid = movementVictim->GetGUID();
+        else
+            context.movementDirective = PvpClassSpellContext::MovementDirective::None;
+    }
+
+    context.shouldExecute = context.shouldExecute || context.spellId != 0 ||
+        context.movementDirective != PvpClassSpellContext::MovementDirective::None;
 
     char const* targetModeLabel = "none";
     switch (context.targetMode)


### PR DESCRIPTION
### Motivation
- Reduce brittle point-move orders that leave bots idle or stuttering in battleground geometry and improve LOS recovery and spacing behavior for PvP bots.

### Description
- Replace direct `MovePoint` usage in strict-human pathing with a policy that avoids issuing point-moves and instead anchors movement to navmesh-aware chase/follow generators, and add defensive fallbacks when strict pathing cannot be issued.
- Add `EnsureActiveChaseTracksTarget` to re-anchor active `CHASE`/`FOLLOW` generators to the intended target and add forced chase/follow fallbacks when approach moves leave the bot idle.
- Bias LOS recovery inward in `ComputeLosRecoveryRange`, expand approach buffer in `ComputeApproachFollowRange`, and prefer `MoveFollow`/`MoveChase` for flee and retreat behaviors to keep movement continuous.
- Use per-target max-range resolution via `GetSpellMaxRangeForTarget` in place of `SpellInfo::GetMaxRange(false)` in range/LOS checks to account for dynamic target-dependent ranges (including pet casts).
- In `BuildClassSpellContext`, convert out-of-LOS spell decisions into `ReachSpellRange` movement directives and clear the spell selection to force movement execution, and defend against empty movement directive targets by backfilling from available targets.
- Add include and runtime checks for follower reanchoring via `Movement/AbstractFollower.h` and add debug logs for forced/reanchored movement paths.

### Testing
- Project compiled successfully after the changes (`build` completed without errors`).
- Existing unit tests and automated CI checks covering `playerbot/pvp` were executed and passed with no regressions detected.
- Manual/regression PvP movement scenarios were exercised to validate that bots no longer idle on stalled point-moves and that LOS recovery movement directives are issued as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7ca6c06c8327bedd3ed777be5654)