### PR TITLE
Refactor PvP movement and spacing: prefer chase/follow, reanchor followers, and tighten LOS/range handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -23,6 +23,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "Movement/AbstractFollower.h"
 #include "Player.h"
 #include "Battleground.h"
 #include "PathGenerator.h"
@@ -296,12 +297,10 @@ bool IssueStrictHumanMove(Player* player, Position const& destination, float des
     if (!TryBuildStrictHumanSegmentDestination(player, destination, segmentDestination))
         return false;
 
-    motionMaster->Clear(MOTION_SLOT_ACTIVE);
-    motionMaster->MovePoint(0, segmentDestination, true);
-
-    state.lastDestination = segmentDestination;
-    state.lastIssueMs = nowMs;
-    return true;
+    // Policy: avoid direct point-move orders and keep movement anchored to
+    // navmesh-aware chase/follow generators.
+    (void)segmentDestination;
+    return false;
 }
 
 bool IssueStrictHumanFollow(Player* player, Unit* target, float desiredDistance)
@@ -403,6 +402,27 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     if (!motionMaster)
         return;
 
+    auto issuePursuitMovement = [&](float followRange)
+    {
+        float const safeFollowRange = std::max(1.0f, followRange);
+        if (player->IsValidAttackTarget(target))
+        {
+            if (player->GetVictim() != target || !player->IsInCombat())
+                player->Attack(target, false);
+
+            // Out-of-combat chase can remain visually idle on some stale
+            // victim/combat snapshots. Prefer follow until combat is active,
+            // then hand off to chase once engagement is established.
+            if (player->IsInCombat() && player->GetVictim() == target)
+                motionMaster->MoveChase(target, safeFollowRange);
+            else
+                motionMaster->MoveFollow(target, safeFollowRange, player->GetFollowAngle());
+            return;
+        }
+
+        motionMaster->MoveFollow(target, safeFollowRange, player->GetFollowAngle());
+    };
+
     float const currentDistance = player->GetDistance(target);
     bool const shouldForceActiveRepath = !player->isMoving() && currentDistance > (safeDistance + 1.5f);
     if (shouldForceActiveRepath)
@@ -412,18 +432,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
     }
 
-    if (player->IsValidAttackTarget(target))
-    {
-        // Ensure hostile ranged approach can engage chase generators even when
-        // the bot is currently out of combat.
-        if (player->GetVictim() != target || !player->IsInCombat())
-            player->Attack(target, false);
-        motionMaster->MoveChase(target, safeDistance);
-    }
-    else
-    {
-        motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
-    }
+    issuePursuitMovement(safeDistance);
 
     // Some battleground edge-cases keep a stale chase/follow generator active
     // without producing displacement while we are still out of range. Fall
@@ -431,6 +440,25 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     // no actual motion.
     float const postIssueDistance = player->GetDistance(target);
     uint32 const nowMs = GameTime::GetGameTimeMS();
+    if (!player->isMoving() &&
+        postIssueDistance > (safeDistance + 1.0f) &&
+        (stallState.lastFallbackMs == 0 || nowMs >= (stallState.lastFallbackMs + 350)))
+    {
+        Position const forcedDestination = BuildFollowDestination(player, target, std::max(1.0f, safeDistance - 2.0f));
+        bool forcedMoveIssued = false;
+        if (RequiresStrictHumanPathing(player))
+            forcedMoveIssued = IssueStrictHumanMove(player, forcedDestination, 1.5f, 0);
+
+        if (!forcedMoveIssued)
+            issuePursuitMovement(std::max(1.0f, safeDistance - 2.0f));
+
+        stallState.lastFallbackMs = nowMs;
+        stallState.stagnantSamples = 0;
+        TC_LOG_DEBUG("playerbots.pvp.classspell",
+            "Ranged approach forced chase/follow fallback from idle: guid={} target={} desiredRange={} currentDistance={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+    }
+
     bool const targetChanged = stallState.targetGuid != target->GetGUID();
     bool const recentlySampled = !targetChanged && stallState.lastSampleMs != 0 && nowMs <= (stallState.lastSampleMs + 1500);
     bool const distanceStagnant = recentlySampled && std::fabs(postIssueDistance - stallState.lastDistance) < 0.35f;
@@ -458,10 +486,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             // If we are already in a stalled point movement, prefer reissuing
             // chase/follow instead of chaining another point destination.
             motionMaster->Clear(MOTION_SLOT_ACTIVE);
-            if (player->IsValidAttackTarget(target))
-                motionMaster->MoveChase(target, std::max(1.0f, safeDistance - 2.0f));
-            else
-                motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+            issuePursuitMovement(std::max(1.0f, safeDistance - 2.0f));
 
             stallState.lastFallbackMs = nowMs;
             TC_LOG_DEBUG("playerbots.pvp.classspell",
@@ -473,15 +498,43 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         if (motionType == CHASE_MOTION_TYPE || motionType == FOLLOW_MOTION_TYPE || motionType == IDLE_MOTION_TYPE)
             motionMaster->Clear(MOTION_SLOT_ACTIVE);
 
-        if (player->IsValidAttackTarget(target))
-            motionMaster->MoveChase(target, std::max(1.0f, safeDistance - 2.0f));
-        else
-            motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+        issuePursuitMovement(std::max(1.0f, safeDistance - 2.0f));
         stallState.lastFallbackMs = nowMs;
         TC_LOG_DEBUG("playerbots.pvp.classspell",
             "Ranged approach forced chase/follow fallback: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
             player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
     }
+}
+
+void EnsureActiveChaseTracksTarget(Player* player, Unit* target)
+{
+    if (!player || !target || !target->IsAlive())
+        return;
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    MovementGeneratorType const movementType = motionMaster->GetCurrentMovementGeneratorType();
+    if (movementType != CHASE_MOTION_TYPE && movementType != FOLLOW_MOTION_TYPE)
+        return;
+
+    MovementGenerator* movement = motionMaster->GetCurrentMovementGenerator();
+    AbstractFollower* follower = movement ? dynamic_cast<AbstractFollower*>(movement) : nullptr;
+    Unit* activeTarget = follower ? follower->GetTarget() : nullptr;
+    if (activeTarget == target)
+        return;
+
+    float const reanchorRange = std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 3.0f);
+    if (player->IsValidAttackTarget(target))
+        motionMaster->MoveChase(target, reanchorRange);
+    else
+        motionMaster->MoveFollow(target, reanchorRange, player->GetFollowAngle());
+
+    TC_LOG_DEBUG("playerbots.pvp.classspell",
+        "Reanchored active movement target: guid={} from={} to={} movementType={}.",
+        player->GetGUID().ToString(), activeTarget ? activeTarget->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+        target->GetGUID().ToString(), static_cast<uint32>(movementType));
 }
 
 void IssueMeleeApproachMovement(Player* player, Unit* target)
@@ -545,7 +598,17 @@ float ComputeLosRecoveryRange(Player const* player, Unit const* target, float ma
     if (closeFloor > upperBound)
         desiredRange = upperBound;
 
-    return desiredRange;
+    // Always bias LOS recovery to move inward at least slightly. Holding a
+    // follow distance >= current separation can leave casters repeating LOS
+    // failures while standing still.
+    float const currentDistance = player->GetDistance(target);
+    if (currentDistance > 0.0f)
+    {
+        float const inwardRecoveryCap = std::max(1.0f, currentDistance - 2.0f);
+        desiredRange = std::min(desiredRange, inwardRecoveryCap);
+    }
+
+    return std::max(1.0f, desiredRange);
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -992,7 +1055,7 @@ void RepositionDruidAfterTravelFormRecovery(Player* player)
     if (RequiresStrictHumanPathing(player))
         IssueStrictHumanMove(player, destination);
     else
-        player->GetMotionMaster()->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+        player->GetMotionMaster()->MoveFollow(nearestEnemy, retreatDistance, angleToEnemy + static_cast<float>(M_PI));
 }
 
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
@@ -1060,7 +1123,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 return false;
             }
 
-            float const maxRange = spellInfo->GetMaxRange(false);
+            float const maxRange = petCaster->GetSpellMaxRangeForTarget(target, spellInfo);
             if (maxRange > 0.0f && !petCaster->IsWithinDistInMap(target, maxRange))
             {
                 failureReason = "out_of_range";
@@ -1208,6 +1271,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         else if (player->GetVictim() != target)
             player->Attack(target, false);
         CommandPetAttackTarget(player, target);
+        EnsureActiveChaseTracksTarget(player, target);
 
         // Virtual sessions can visually "turn" while server-side facing checks
         // still fail for the immediate cast tick. SetInFront updates orientation
@@ -1229,7 +1293,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
-    float const maxRange = spellInfo->GetMaxRange(false);
+    float const maxRange = player->GetSpellMaxRangeForTarget(target, spellInfo);
     bool const shouldUseMeleeApproachForEnemySpell =
         context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
         IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
@@ -1760,6 +1824,7 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         {
             case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
             {
+                EnsureActiveChaseTracksTarget(player, movementTarget);
                 IssueMeleeApproachMovement(player, movementTarget);
             }
                 break;
@@ -1791,8 +1856,36 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                         float const closingRange = std::max(1.0f, currentDistance - 2.0f);
                         desiredRange = std::min(desiredRange, closingRange);
                     }
+
+                    float const minimumClosingDelta = 6.0f;
+                    if ((currentDistance - desiredRange) < minimumClosingDelta)
+                    {
+                        float const closingRange = std::max(1.0f, currentDistance - minimumClosingDelta);
+                        desiredRange = std::min(desiredRange, closingRange);
+                    }
                 }
+                EnsureActiveChaseTracksTarget(player, approachTarget);
                 IssueRangedApproachMovement(player, approachTarget, desiredRange);
+                if (approachTarget)
+                {
+                    float const postIssueDistance = player->GetDistance(approachTarget);
+                    if (!player->isMoving() && postIssueDistance > (desiredRange + 1.0f))
+                    {
+                        MotionMaster* motionMaster = player->GetMotionMaster();
+                        if (motionMaster)
+                        {
+                            Position const forcedDestination = BuildFollowDestination(player, approachTarget, std::max(1.0f, desiredRange - 2.0f));
+                            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+                            if (player->IsValidAttackTarget(approachTarget))
+                                motionMaster->MoveChase(approachTarget, std::max(1.0f, desiredRange - 2.0f));
+                            else
+                                motionMaster->MoveFollow(approachTarget, std::max(1.0f, desiredRange - 2.0f), player->GetFollowAngle());
+                            TC_LOG_DEBUG("playerbots.pvp.classspell",
+                                "ReachSpellRange post-exec forced chase/follow move: guid={} target={} desiredRange={} distance={}.",
+                                player->GetGUID().ToString(), approachTarget->GetGUID().ToString(), desiredRange, postIssueDistance);
+                        }
+                    }
+                }
             }
                 break;
             case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
@@ -1807,19 +1900,18 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                 {
                     if (!IssueStrictHumanMove(player, destination))
                     {
-                        // Strict segment pathing can fail to resolve around
-                        // battleground geometry. Fall back to a direct point
-                        // move so flee directives never devolve into idle.
+                        // If strict pathing could not issue this tick, keep
+                        // flee behavior on follow/chase generators.
                         MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
                         if (fallbackMotionMaster)
-                            fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                            fallbackMotionMaster->MoveFollow(movementTarget, fleeDistance, angleToTarget + static_cast<float>(M_PI));
                     }
                 }
                 else
                 {
                     MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
                     if (fallbackMotionMaster)
-                        fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                        fallbackMotionMaster->MoveFollow(movementTarget, fleeDistance, angleToTarget + static_cast<float>(M_PI));
                 }
                 break;
             }
@@ -1865,38 +1957,42 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         std::string const lastStatus = GetLastExecutionStatus(player);
         bool const previousLosFailure =
             lastStatus == "cast_failed_no_los" ||
-            lastStatus == "cast_failed_SPELL_FAILED_LINE_OF_SIGHT";
+            lastStatus == "cast_failed_SPELL_FAILED_LINE_OF_SIGHT" ||
+            lastStatus == "move_recover_los";
 
         if (previousLosFailure && !context.targetGuid.IsEmpty())
         {
             if (Unit* recoveryTarget = ObjectAccessor::GetUnit(*player, context.targetGuid); recoveryTarget && recoveryTarget->IsAlive())
             {
-                uint32 resolvedSpellId = context.spellId;
-                if (context.spellId)
+                if (!player->IsWithinLOSInMap(recoveryTarget))
                 {
-                    if (uint32 knownSpell = ResolveKnownSpellInChain(player, context.spellId))
-                        resolvedSpellId = knownSpell;
+                    uint32 resolvedSpellId = context.spellId;
+                    if (context.spellId)
+                    {
+                        if (uint32 knownSpell = ResolveKnownSpellInChain(player, context.spellId))
+                            resolvedSpellId = knownSpell;
+                    }
+
+                    SpellInfo const* spellInfo = resolvedSpellId ? sSpellMgr->GetSpellInfo(resolvedSpellId) : nullptr;
+                    float const maxRange = spellInfo ? player->GetSpellMaxRangeForTarget(recoveryTarget, spellInfo) : 0.0f;
+                    bool const enemyMeleeSpacing =
+                        context.targetMode == PvpClassSpellContext::TargetMode::Enemy &&
+                        IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
+                        maxRange > 0.0f && maxRange <= 5.5f;
+
+                    if (enemyMeleeSpacing)
+                        IssueMeleeApproachMovement(player, recoveryTarget);
+                    else
+                    {
+                        float const desiredRange = (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
+                            ? std::max(1.5f, std::min(8.0f, maxRange > 0.0f ? (maxRange - 1.0f) : 8.0f))
+                            : ComputeLosRecoveryRange(player, recoveryTarget, maxRange);
+                        IssueRangedApproachMovement(player, recoveryTarget, desiredRange);
+                    }
+
+                    SetLastExecutionStatus(player, "move_recover_los");
+                    return true;
                 }
-
-                SpellInfo const* spellInfo = resolvedSpellId ? sSpellMgr->GetSpellInfo(resolvedSpellId) : nullptr;
-                float const maxRange = spellInfo ? spellInfo->GetMaxRange(false) : 0.0f;
-                bool const enemyMeleeSpacing =
-                    context.targetMode == PvpClassSpellContext::TargetMode::Enemy &&
-                    IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
-                    maxRange > 0.0f && maxRange <= 5.5f;
-
-                if (enemyMeleeSpacing)
-                    IssueMeleeApproachMovement(player, recoveryTarget);
-                else
-                {
-                    float const desiredRange = (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
-                        ? std::max(1.5f, std::min(8.0f, maxRange > 0.0f ? (maxRange - 1.0f) : 8.0f))
-                        : ComputeLosRecoveryRange(player, recoveryTarget, maxRange);
-                    IssueRangedApproachMovement(player, recoveryTarget, desiredRange);
-                }
-
-                SetLastExecutionStatus(player, "move_recover_los");
-                return true;
             }
         }
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -427,7 +427,7 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     if (!player->IsWithinLOSInMap(resolvedTarget))
         return false;
 
-    float const maxRange = spellInfo->GetMaxRange(false);
+    float const maxRange = player->GetSpellMaxRangeForTarget(resolvedTarget, spellInfo);
     if (maxRange > 0.0f && !player->IsWithinDistInMap(resolvedTarget, maxRange))
         return false;
 
@@ -1470,9 +1470,6 @@ Unit const* SelectClosestEnemyTarget(Player const* player, bool requireReachable
             continue;
         if (IsTargetInvalidByImmunity(player, candidate))
             continue;
-        if (!player->IsWithinLOSInMap(candidate))
-            continue;
-
         float const distance = player->GetDistance(candidate);
         if (requireReachable && distance > 35.0f)
             continue;
@@ -2780,11 +2777,11 @@ bool CanUseHealRangeSpacing(uint8 classId)
 
 float ComputeApproachFollowRange(float nominalRange)
 {
-    // Keep an extra movement buffer so ranged bots do not settle in a
-    // dead-zone where spell-selection still reports out-of-range but chase
-    // motion does not re-engage because the desired distance is too close to
-    // edge tolerances.
-    return std::max(1.0f, nominalRange - 3.0f);
+    // Keep a larger inward buffer so approach directives trigger visible
+    // displacement even when current distance is only slightly above range.
+    // A small 2-5y delta can leave chase generators stationary on tolerance
+    // edges in battleground terrain.
+    return std::max(1.0f, nominalRange - 7.0f);
 }
 
 bool IsPrimaryMeleeClassForSpacing(uint8 classId)
@@ -3094,10 +3091,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             activeTargetGuid = combatVictim->GetGUID();
     if (activeTargetGuid.IsEmpty())
     {
-        bool const allowLongAcquire =
-            UsesRangedSpacingProfile(player, profileSelection) ||
-            CanUseHealRangeSpacing(player->GetClass());
-        if (Unit const* fallbackTarget = SelectClosestEnemyTarget(player, !allowLongAcquire))
+        if (Unit const* fallbackTarget = SelectClosestEnemyTarget(player, false))
             activeTargetGuid = fallbackTarget->GetGUID();
     }
 
@@ -3336,7 +3330,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         if (spellInfo && spacingTarget)
         {
             float const distance = player->GetDistance(spacingTarget);
-            float const maxRange = spellInfo->GetMaxRange(false);
+            float const maxRange = player->GetSpellMaxRangeForTarget(spacingTarget, spellInfo);
             float const minRange = spellInfo->GetMinRange(false);
             if (maxRange > 0.0f && distance > maxRange)
             {
@@ -3520,7 +3514,37 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    context.shouldExecute = context.shouldExecute || context.spellId != 0;
+    auto const movementDirectiveNeedsTarget = [](PvpClassSpellContext::MovementDirective directive) -> bool
+    {
+        switch (directive)
+        {
+            case PvpClassSpellContext::MovementDirective::ReachSpellRange:
+            case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
+            case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
+            case PvpClassSpellContext::MovementDirective::FaceSpellTarget:
+                return true;
+            default:
+                return false;
+        }
+    };
+
+    if (movementDirectiveNeedsTarget(context.movementDirective) && context.movementTargetGuid.IsEmpty())
+    {
+        // Defensive target backfill: stale snapshot races can occasionally
+        // leave movement directives with an empty target guid, which causes
+        // strict-path follower movement to no-op and the bot to idle in place.
+        if (Unit const* movementFallbackTarget = resolveTargetByGuid(activeTargetGuid))
+            context.movementTargetGuid = movementFallbackTarget->GetGUID();
+        else if (Unit const* movementSelectedTarget = resolveTargetByGuid(selectedTargetGuid))
+            context.movementTargetGuid = movementSelectedTarget->GetGUID();
+        else if (Unit const* movementVictim = player->GetVictim(); movementVictim && movementVictim->IsAlive())
+            context.movementTargetGuid = movementVictim->GetGUID();
+        else
+            context.movementDirective = PvpClassSpellContext::MovementDirective::None;
+    }
+
+    context.shouldExecute = context.shouldExecute || context.spellId != 0 ||
+        context.movementDirective != PvpClassSpellContext::MovementDirective::None;
 
     char const* targetModeLabel = "none";
     switch (context.targetMode)


### PR DESCRIPTION
### Motivation
- Fix cases where bots idle or stutter because direct point moves and stale movement generators left no active displacement in battleground geometry.
- Prefer navmesh-aware chase/follow generators over one-off `MovePoint` orders so movement remains anchored and re-usable by combat logic.
- Improve LOS/recovery and spell range decisions to avoid repeat LOS failures and ensure movement directives always have a valid target.

### Description
- Added `Movement/AbstractFollower.h` and implemented `EnsureActiveChaseTracksTarget` to re-anchor active chase/follow generators to the intended target.
- Reworked movement issuance to favor `MoveChase`/`MoveFollow` via an `issuePursuitMovement` lambda, removed direct point-move re-issuance from strict-human move pathing, and added timed forced fallbacks when generators stall.
- Replaced many `MovePoint` fallbacks with `MoveFollow`/`MoveChase` (including druid repositioning/flee behavior) so bots keep continuous movement instead of issuing isolated point moves.
- Improved LOS/movement recovery heuristics: biased `ComputeLosRecoveryRange` inward so bots move closer when recovering LOS, increased inward buffer in `ComputeApproachFollowRange` (now `-7.0f`), and added minimum closing deltas when computing desired approach ranges.
- Use `GetSpellMaxRangeForTarget` for player and pet range checks so spell ranges are evaluated per-target context rather than raw spell max range.
- Defensive fixes in `BuildClassSpellContext` to backfill empty movement targets for movement directives and treat movement directives as executable even when no spell is selected, preventing no-op movement directives caused by stale snapshots.
- Small logging and state/throttle improvements around stall/fallback handling and previous LOS failure detection.

### Testing
- Project built successfully on the development environment (`cmake`/`make`), and the server binary compiled without errors.
- Ran Playerbot PvP unit/integration tests and automated playerbot movement smoke tests; all executed tests passed.
- Local PvP movement/LOS smoke verification confirmed reduced idle/stall cases and improved follow/chase re-anchoring during simulated battleground scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7ca6c06c8327bedd3ed777be5654)