### PR TITLE
Playerbot PvP: prefer chase/follow movement, add ranged approach diagnostics, and use target-aware spell ranges

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -23,6 +23,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "Movement/AbstractFollower.h"
 #include "Player.h"
 #include "Battleground.h"
 #include "PathGenerator.h"
@@ -296,12 +297,10 @@ bool IssueStrictHumanMove(Player* player, Position const& destination, float des
     if (!TryBuildStrictHumanSegmentDestination(player, destination, segmentDestination))
         return false;
 
-    motionMaster->Clear(MOTION_SLOT_ACTIVE);
-    motionMaster->MovePoint(0, segmentDestination, true);
-
-    state.lastDestination = segmentDestination;
-    state.lastIssueMs = nowMs;
-    return true;
+    // Policy: avoid direct point-move orders and keep movement anchored to
+    // navmesh-aware chase/follow generators.
+    (void)segmentDestination;
+    return false;
 }
 
 bool IssueStrictHumanFollow(Player* player, Unit* target, float desiredDistance)
@@ -367,7 +366,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     };
 
     static std::unordered_map<uint64, RangedApproachStallState> stallStateByGuid;
-    RangedApproachStallState& stallState = stallStateByGuid[player->GetGUID().GetRawValue()];
+    uint64 const botGuidRaw = player->GetGUID().GetRawValue();
+    RangedApproachStallState& stallState = stallStateByGuid[botGuidRaw];
+    playerbot::PvpClassActions::RangedApproachDiagnostic& approachDiag = g_RangedApproachDiagnosticByGuid[botGuidRaw];
+    approachDiag.valid = true;
+    approachDiag.targetGuid = target->GetGUID();
 
     float const safeDistance = std::max(1.0f, desiredDistance);
     if (RequiresStrictHumanPathing(player) && IssueStrictHumanFollow(player, target, safeDistance))
@@ -403,6 +406,27 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     if (!motionMaster)
         return;
 
+    auto issuePursuitMovement = [&](float followRange)
+    {
+        float const safeFollowRange = std::max(1.0f, followRange);
+        if (player->IsValidAttackTarget(target))
+        {
+            if (player->GetVictim() != target || !player->IsInCombat())
+                player->Attack(target, false);
+
+            // Out-of-combat chase can remain visually idle on some stale
+            // victim/combat snapshots. Prefer follow until combat is active,
+            // then hand off to chase once engagement is established.
+            if (player->IsInCombat() && player->GetVictim() == target)
+                motionMaster->MoveChase(target, safeFollowRange);
+            else
+                motionMaster->MoveFollow(target, safeFollowRange, player->GetFollowAngle());
+            return;
+        }
+
+        motionMaster->MoveFollow(target, safeFollowRange, player->GetFollowAngle());
+    };
+
     float const currentDistance = player->GetDistance(target);
     bool const shouldForceActiveRepath = !player->isMoving() && currentDistance > (safeDistance + 1.5f);
     if (shouldForceActiveRepath)
@@ -412,18 +436,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
     }
 
-    if (player->IsValidAttackTarget(target))
-    {
-        // Ensure hostile ranged approach can engage chase generators even when
-        // the bot is currently out of combat.
-        if (player->GetVictim() != target || !player->IsInCombat())
-            player->Attack(target, false);
-        motionMaster->MoveChase(target, safeDistance);
-    }
-    else
-    {
-        motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
-    }
+    issuePursuitMovement(safeDistance);
 
     // Some battleground edge-cases keep a stale chase/follow generator active
     // without producing displacement while we are still out of range. Fall
@@ -431,6 +444,25 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     // no actual motion.
     float const postIssueDistance = player->GetDistance(target);
     uint32 const nowMs = GameTime::GetGameTimeMS();
+    if (!player->isMoving() &&
+        postIssueDistance > (safeDistance + 1.0f) &&
+        (stallState.lastFallbackMs == 0 || nowMs >= (stallState.lastFallbackMs + 350)))
+    {
+        Position const forcedDestination = BuildFollowDestination(player, target, std::max(1.0f, safeDistance - 2.0f));
+        bool forcedMoveIssued = false;
+        if (RequiresStrictHumanPathing(player))
+            forcedMoveIssued = IssueStrictHumanMove(player, forcedDestination, 1.5f, 0);
+
+        if (!forcedMoveIssued)
+            issuePursuitMovement(std::max(1.0f, safeDistance - 2.0f));
+
+        stallState.lastFallbackMs = nowMs;
+        stallState.stagnantSamples = 0;
+        TC_LOG_DEBUG("playerbots.pvp.classspell",
+            "Ranged approach forced chase/follow fallback from idle: guid={} target={} desiredRange={} currentDistance={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance);
+    }
+
     bool const targetChanged = stallState.targetGuid != target->GetGUID();
     bool const recentlySampled = !targetChanged && stallState.lastSampleMs != 0 && nowMs <= (stallState.lastSampleMs + 1500);
     bool const distanceStagnant = recentlySampled && std::fabs(postIssueDistance - stallState.lastDistance) < 0.35f;
@@ -444,6 +476,13 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     stallState.targetGuid = target->GetGUID();
     stallState.lastDistance = postIssueDistance;
     stallState.lastSampleMs = nowMs;
+    approachDiag.desiredRange = safeDistance;
+    approachDiag.currentDistance = postIssueDistance;
+    approachDiag.stagnantSamples = stallState.stagnantSamples;
+    approachDiag.lastSampleMs = stallState.lastSampleMs;
+    approachDiag.lastFallbackMs = stallState.lastFallbackMs;
+    approachDiag.motionType = motionMaster->GetCurrentMovementGeneratorType();
+    approachDiag.moving = player->isMoving();
 
     // Avoid clearing active movement every tick; only recover when we have
     // repeated stagnant samples and throttle the fallback issue rate.
@@ -458,10 +497,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             // If we are already in a stalled point movement, prefer reissuing
             // chase/follow instead of chaining another point destination.
             motionMaster->Clear(MOTION_SLOT_ACTIVE);
-            if (player->IsValidAttackTarget(target))
-                motionMaster->MoveChase(target, std::max(1.0f, safeDistance - 2.0f));
-            else
-                motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+            issuePursuitMovement(std::max(1.0f, safeDistance - 2.0f));
 
             stallState.lastFallbackMs = nowMs;
             TC_LOG_DEBUG("playerbots.pvp.classspell",
@@ -473,15 +509,46 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         if (motionType == CHASE_MOTION_TYPE || motionType == FOLLOW_MOTION_TYPE || motionType == IDLE_MOTION_TYPE)
             motionMaster->Clear(MOTION_SLOT_ACTIVE);
 
-        if (player->IsValidAttackTarget(target))
-            motionMaster->MoveChase(target, std::max(1.0f, safeDistance - 2.0f));
-        else
-            motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
+        issuePursuitMovement(std::max(1.0f, safeDistance - 2.0f));
         stallState.lastFallbackMs = nowMs;
+        approachDiag.lastFallbackMs = stallState.lastFallbackMs;
+        approachDiag.motionType = motionMaster->GetCurrentMovementGeneratorType();
+        approachDiag.moving = player->isMoving();
         TC_LOG_DEBUG("playerbots.pvp.classspell",
             "Ranged approach forced chase/follow fallback: guid={} target={} desiredRange={} currentDistance={} motionType={}.",
             player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, postIssueDistance, static_cast<uint32>(motionType));
     }
+}
+
+void EnsureActiveChaseTracksTarget(Player* player, Unit* target)
+{
+    if (!player || !target || !target->IsAlive())
+        return;
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    MovementGeneratorType const movementType = motionMaster->GetCurrentMovementGeneratorType();
+    if (movementType != CHASE_MOTION_TYPE && movementType != FOLLOW_MOTION_TYPE)
+        return;
+
+    MovementGenerator* movement = motionMaster->GetCurrentMovementGenerator();
+    AbstractFollower* follower = movement ? dynamic_cast<AbstractFollower*>(movement) : nullptr;
+    Unit* activeTarget = follower ? follower->GetTarget() : nullptr;
+    if (activeTarget == target)
+        return;
+
+    float const reanchorRange = std::max(1.0f, playerbot::PvpCore::GetConfig().spellRange - 3.0f);
+    if (player->IsValidAttackTarget(target))
+        motionMaster->MoveChase(target, reanchorRange);
+    else
+        motionMaster->MoveFollow(target, reanchorRange, player->GetFollowAngle());
+
+    TC_LOG_DEBUG("playerbots.pvp.classspell",
+        "Reanchored active movement target: guid={} from={} to={} movementType={}.",
+        player->GetGUID().ToString(), activeTarget ? activeTarget->GetGUID().ToString() : ObjectGuid::Empty.ToString(),
+        target->GetGUID().ToString(), static_cast<uint32>(movementType));
 }
 
 void IssueMeleeApproachMovement(Player* player, Unit* target)
@@ -545,7 +612,17 @@ float ComputeLosRecoveryRange(Player const* player, Unit const* target, float ma
     if (closeFloor > upperBound)
         desiredRange = upperBound;
 
-    return desiredRange;
+    // Always bias LOS recovery to move inward at least slightly. Holding a
+    // follow distance >= current separation can leave casters repeating LOS
+    // failures while standing still.
+    float const currentDistance = player->GetDistance(target);
+    if (currentDistance > 0.0f)
+    {
+        float const inwardRecoveryCap = std::max(1.0f, currentDistance - 2.0f);
+        desiredRange = std::min(desiredRange, inwardRecoveryCap);
+    }
+
+    return std::max(1.0f, desiredRange);
 }
 
 bool IsCrowdControlledForAction(Player const* player)
@@ -647,6 +724,7 @@ struct CasterSpellCooldownKeyHash
 
 std::unordered_map<CasterSpellCooldownKey, std::chrono::steady_clock::time_point, CasterSpellCooldownKeyHash> g_CasterSpellCooldowns;
 std::unordered_map<uint64, std::string> g_LastClassExecutionStatusByGuid;
+std::unordered_map<uint64, playerbot::PvpClassActions::RangedApproachDiagnostic> g_RangedApproachDiagnosticByGuid;
 struct LastDirectiveState
 {
     playerbot::PvpClassSpellContext::MovementDirective directive = playerbot::PvpClassSpellContext::MovementDirective::None;
@@ -992,7 +1070,7 @@ void RepositionDruidAfterTravelFormRecovery(Player* player)
     if (RequiresStrictHumanPathing(player))
         IssueStrictHumanMove(player, destination);
     else
-        player->GetMotionMaster()->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+        player->GetMotionMaster()->MoveFollow(nearestEnemy, retreatDistance, angleToEnemy + static_cast<float>(M_PI));
 }
 
 bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& context, std::string& failureReason)
@@ -1060,7 +1138,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 return false;
             }
 
-            float const maxRange = spellInfo->GetMaxRange(false);
+            float const maxRange = petCaster->GetSpellMaxRangeForTarget(target, spellInfo);
             if (maxRange > 0.0f && !petCaster->IsWithinDistInMap(target, maxRange))
             {
                 failureReason = "out_of_range";
@@ -1208,6 +1286,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         else if (player->GetVictim() != target)
             player->Attack(target, false);
         CommandPetAttackTarget(player, target);
+        EnsureActiveChaseTracksTarget(player, target);
 
         // Virtual sessions can visually "turn" while server-side facing checks
         // still fail for the immediate cast tick. SetInFront updates orientation
@@ -1229,7 +1308,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         return false;
     }
 
-    float const maxRange = spellInfo->GetMaxRange(false);
+    float const maxRange = player->GetSpellMaxRangeForTarget(target, spellInfo);
     bool const shouldUseMeleeApproachForEnemySpell =
         context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
         IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
@@ -1692,6 +1771,19 @@ std::string PvpClassActions::GetLastExecutionStatus(Player const* player)
     return itr->second;
 }
 
+PvpClassActions::RangedApproachDiagnostic PvpClassActions::GetRangedApproachDiagnostic(Player const* player)
+{
+    RangedApproachDiagnostic diagnostic;
+    if (!player)
+        return diagnostic;
+
+    auto const itr = g_RangedApproachDiagnosticByGuid.find(player->GetGUID().GetRawValue());
+    if (itr == g_RangedApproachDiagnosticByGuid.end())
+        return diagnostic;
+
+    return itr->second;
+}
+
 bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& context)
 {
     if (!player || !context.classSpellsEnabled || !context.shouldExecute)
@@ -1760,6 +1852,7 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         {
             case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
             {
+                EnsureActiveChaseTracksTarget(player, movementTarget);
                 IssueMeleeApproachMovement(player, movementTarget);
             }
                 break;
@@ -1791,8 +1884,36 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                         float const closingRange = std::max(1.0f, currentDistance - 2.0f);
                         desiredRange = std::min(desiredRange, closingRange);
                     }
+
+                    float const minimumClosingDelta = 6.0f;
+                    if ((currentDistance - desiredRange) < minimumClosingDelta)
+                    {
+                        float const closingRange = std::max(1.0f, currentDistance - minimumClosingDelta);
+                        desiredRange = std::min(desiredRange, closingRange);
+                    }
                 }
+                EnsureActiveChaseTracksTarget(player, approachTarget);
                 IssueRangedApproachMovement(player, approachTarget, desiredRange);
+                if (approachTarget)
+                {
+                    float const postIssueDistance = player->GetDistance(approachTarget);
+                    if (!player->isMoving() && postIssueDistance > (desiredRange + 1.0f))
+                    {
+                        MotionMaster* motionMaster = player->GetMotionMaster();
+                        if (motionMaster)
+                        {
+                            Position const forcedDestination = BuildFollowDestination(player, approachTarget, std::max(1.0f, desiredRange - 2.0f));
+                            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+                            if (player->IsValidAttackTarget(approachTarget))
+                                motionMaster->MoveChase(approachTarget, std::max(1.0f, desiredRange - 2.0f));
+                            else
+                                motionMaster->MoveFollow(approachTarget, std::max(1.0f, desiredRange - 2.0f), player->GetFollowAngle());
+                            TC_LOG_DEBUG("playerbots.pvp.classspell",
+                                "ReachSpellRange post-exec forced chase/follow move: guid={} target={} desiredRange={} distance={}.",
+                                player->GetGUID().ToString(), approachTarget->GetGUID().ToString(), desiredRange, postIssueDistance);
+                        }
+                    }
+                }
             }
                 break;
             case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
@@ -1807,19 +1928,18 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                 {
                     if (!IssueStrictHumanMove(player, destination))
                     {
-                        // Strict segment pathing can fail to resolve around
-                        // battleground geometry. Fall back to a direct point
-                        // move so flee directives never devolve into idle.
+                        // If strict pathing could not issue this tick, keep
+                        // flee behavior on follow/chase generators.
                         MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
                         if (fallbackMotionMaster)
-                            fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                            fallbackMotionMaster->MoveFollow(movementTarget, fleeDistance, angleToTarget + static_cast<float>(M_PI));
                     }
                 }
                 else
                 {
                     MotionMaster* fallbackMotionMaster = player->GetMotionMaster();
                     if (fallbackMotionMaster)
-                        fallbackMotionMaster->MovePoint(0, BuildCollisionSafeDestination(player, destination), true);
+                        fallbackMotionMaster->MoveFollow(movementTarget, fleeDistance, angleToTarget + static_cast<float>(M_PI));
                 }
                 break;
             }
@@ -1865,38 +1985,42 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
         std::string const lastStatus = GetLastExecutionStatus(player);
         bool const previousLosFailure =
             lastStatus == "cast_failed_no_los" ||
-            lastStatus == "cast_failed_SPELL_FAILED_LINE_OF_SIGHT";
+            lastStatus == "cast_failed_SPELL_FAILED_LINE_OF_SIGHT" ||
+            lastStatus == "move_recover_los";
 
         if (previousLosFailure && !context.targetGuid.IsEmpty())
         {
             if (Unit* recoveryTarget = ObjectAccessor::GetUnit(*player, context.targetGuid); recoveryTarget && recoveryTarget->IsAlive())
             {
-                uint32 resolvedSpellId = context.spellId;
-                if (context.spellId)
+                if (!player->IsWithinLOSInMap(recoveryTarget))
                 {
-                    if (uint32 knownSpell = ResolveKnownSpellInChain(player, context.spellId))
-                        resolvedSpellId = knownSpell;
+                    uint32 resolvedSpellId = context.spellId;
+                    if (context.spellId)
+                    {
+                        if (uint32 knownSpell = ResolveKnownSpellInChain(player, context.spellId))
+                            resolvedSpellId = knownSpell;
+                    }
+
+                    SpellInfo const* spellInfo = resolvedSpellId ? sSpellMgr->GetSpellInfo(resolvedSpellId) : nullptr;
+                    float const maxRange = spellInfo ? player->GetSpellMaxRangeForTarget(recoveryTarget, spellInfo) : 0.0f;
+                    bool const enemyMeleeSpacing =
+                        context.targetMode == PvpClassSpellContext::TargetMode::Enemy &&
+                        IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
+                        maxRange > 0.0f && maxRange <= 5.5f;
+
+                    if (enemyMeleeSpacing)
+                        IssueMeleeApproachMovement(player, recoveryTarget);
+                    else
+                    {
+                        float const desiredRange = (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
+                            ? std::max(1.5f, std::min(8.0f, maxRange > 0.0f ? (maxRange - 1.0f) : 8.0f))
+                            : ComputeLosRecoveryRange(player, recoveryTarget, maxRange);
+                        IssueRangedApproachMovement(player, recoveryTarget, desiredRange);
+                    }
+
+                    SetLastExecutionStatus(player, "move_recover_los");
+                    return true;
                 }
-
-                SpellInfo const* spellInfo = resolvedSpellId ? sSpellMgr->GetSpellInfo(resolvedSpellId) : nullptr;
-                float const maxRange = spellInfo ? spellInfo->GetMaxRange(false) : 0.0f;
-                bool const enemyMeleeSpacing =
-                    context.targetMode == PvpClassSpellContext::TargetMode::Enemy &&
-                    IsPrimaryMeleeClassForSpacing(player->GetClass()) &&
-                    maxRange > 0.0f && maxRange <= 5.5f;
-
-                if (enemyMeleeSpacing)
-                    IssueMeleeApproachMovement(player, recoveryTarget);
-                else
-                {
-                    float const desiredRange = (context.targetMode == PvpClassSpellContext::TargetMode::Ally)
-                        ? std::max(1.5f, std::min(8.0f, maxRange > 0.0f ? (maxRange - 1.0f) : 8.0f))
-                        : ComputeLosRecoveryRange(player, recoveryTarget, maxRange);
-                    IssueRangedApproachMovement(player, recoveryTarget, desiredRange);
-                }
-
-                SetLastExecutionStatus(player, "move_recover_los");
-                return true;
             }
         }
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
@@ -31,12 +31,26 @@ namespace playerbot
 class PvpClassActions
 {
 public:
+    struct RangedApproachDiagnostic
+    {
+        bool valid = false;
+        ObjectGuid targetGuid = ObjectGuid::Empty;
+        float desiredRange = 0.0f;
+        float currentDistance = 0.0f;
+        uint8 stagnantSamples = 0;
+        uint32 lastSampleMs = 0;
+        uint32 lastFallbackMs = 0;
+        MovementGeneratorType motionType = IDLE_MOTION_TYPE;
+        bool moving = false;
+    };
+
     static bool Execute(Player* player, PvpClassSpellContext const& context);
     static bool IsWarlockCurseTargetCooldownActive(Player const* player, Unit const* target, uint32 spellId);
     static void RegisterWarlockCurseTargetCooldown(Player const* player, Unit const* target, uint32 spellId, std::chrono::seconds cooldown);
     static bool IsCasterSpellCooldownActive(Player const* player, uint32 spellId);
     static void RegisterCasterSpellCooldown(Player const* player, uint32 spellId, std::chrono::seconds cooldown);
     static std::string GetLastExecutionStatus(Player const* player);
+    static RangedApproachDiagnostic GetRangedApproachDiagnostic(Player const* player);
 };
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -427,7 +427,7 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     if (!player->IsWithinLOSInMap(resolvedTarget))
         return false;
 
-    float const maxRange = spellInfo->GetMaxRange(false);
+    float const maxRange = player->GetSpellMaxRangeForTarget(resolvedTarget, spellInfo);
     if (maxRange > 0.0f && !player->IsWithinDistInMap(resolvedTarget, maxRange))
         return false;
 
@@ -1470,9 +1470,6 @@ Unit const* SelectClosestEnemyTarget(Player const* player, bool requireReachable
             continue;
         if (IsTargetInvalidByImmunity(player, candidate))
             continue;
-        if (!player->IsWithinLOSInMap(candidate))
-            continue;
-
         float const distance = player->GetDistance(candidate);
         if (requireReachable && distance > 35.0f)
             continue;
@@ -2780,11 +2777,11 @@ bool CanUseHealRangeSpacing(uint8 classId)
 
 float ComputeApproachFollowRange(float nominalRange)
 {
-    // Keep an extra movement buffer so ranged bots do not settle in a
-    // dead-zone where spell-selection still reports out-of-range but chase
-    // motion does not re-engage because the desired distance is too close to
-    // edge tolerances.
-    return std::max(1.0f, nominalRange - 3.0f);
+    // Keep a larger inward buffer so approach directives trigger visible
+    // displacement even when current distance is only slightly above range.
+    // A small 2-5y delta can leave chase generators stationary on tolerance
+    // edges in battleground terrain.
+    return std::max(1.0f, nominalRange - 7.0f);
 }
 
 bool IsPrimaryMeleeClassForSpacing(uint8 classId)
@@ -3094,10 +3091,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
             activeTargetGuid = combatVictim->GetGUID();
     if (activeTargetGuid.IsEmpty())
     {
-        bool const allowLongAcquire =
-            UsesRangedSpacingProfile(player, profileSelection) ||
-            CanUseHealRangeSpacing(player->GetClass());
-        if (Unit const* fallbackTarget = SelectClosestEnemyTarget(player, !allowLongAcquire))
+        if (Unit const* fallbackTarget = SelectClosestEnemyTarget(player, false))
             activeTargetGuid = fallbackTarget->GetGUID();
     }
 
@@ -3336,7 +3330,7 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         if (spellInfo && spacingTarget)
         {
             float const distance = player->GetDistance(spacingTarget);
-            float const maxRange = spellInfo->GetMaxRange(false);
+            float const maxRange = player->GetSpellMaxRangeForTarget(spacingTarget, spellInfo);
             float const minRange = spellInfo->GetMinRange(false);
             if (maxRange > 0.0f && distance > maxRange)
             {
@@ -3520,7 +3514,37 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    context.shouldExecute = context.shouldExecute || context.spellId != 0;
+    auto const movementDirectiveNeedsTarget = [](PvpClassSpellContext::MovementDirective directive) -> bool
+    {
+        switch (directive)
+        {
+            case PvpClassSpellContext::MovementDirective::ReachSpellRange:
+            case PvpClassSpellContext::MovementDirective::ReachMeleeRange:
+            case PvpClassSpellContext::MovementDirective::FleeTooCloseForSpell:
+            case PvpClassSpellContext::MovementDirective::FaceSpellTarget:
+                return true;
+            default:
+                return false;
+        }
+    };
+
+    if (movementDirectiveNeedsTarget(context.movementDirective) && context.movementTargetGuid.IsEmpty())
+    {
+        // Defensive target backfill: stale snapshot races can occasionally
+        // leave movement directives with an empty target guid, which causes
+        // strict-path follower movement to no-op and the bot to idle in place.
+        if (Unit const* movementFallbackTarget = resolveTargetByGuid(activeTargetGuid))
+            context.movementTargetGuid = movementFallbackTarget->GetGUID();
+        else if (Unit const* movementSelectedTarget = resolveTargetByGuid(selectedTargetGuid))
+            context.movementTargetGuid = movementSelectedTarget->GetGUID();
+        else if (Unit const* movementVictim = player->GetVictim(); movementVictim && movementVictim->IsAlive())
+            context.movementTargetGuid = movementVictim->GetGUID();
+        else
+            context.movementDirective = PvpClassSpellContext::MovementDirective::None;
+    }
+
+    context.shouldExecute = context.shouldExecute || context.spellId != 0 ||
+        context.movementDirective != PvpClassSpellContext::MovementDirective::None;
 
     char const* targetModeLabel = "none";
     switch (context.targetMode)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -59,6 +59,14 @@ namespace
 {
 bool IsManagedRandomBotImpl(Player const* player, std::unordered_set<uint32> const& botAccounts);
 
+bool HasClassMovementIntent(playerbot::PvpClassSpellContext const& context)
+{
+    if (!context.classSpellsEnabled || !context.shouldExecute)
+        return false;
+
+    return context.movementDirective != playerbot::PvpClassSpellContext::MovementDirective::None;
+}
+
 bool IsCrowdControlledForLifecyclePause(Player const* player)
 {
     if (!player)
@@ -381,29 +389,31 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     }
 
     playerbot::PvpValues const values = playerbot::PvpCore::CollectValues(player);
-    playerbot::BattlegroundTacticalContext const tacticalContext = playerbot::PvpCore::BuildBattlegroundTacticalContext(player, values);
-    bool const didExecuteTactical = playerbot::BattlegroundTacticalActions::Execute(player, tacticalContext);
     playerbot::PvpClassSpellContext const classContext = playerbot::PvpCore::BuildClassSpellContext(player, values);
+    bool const classOwnsMovement = HasClassMovementIntent(classContext);
+    playerbot::BattlegroundTacticalContext const tacticalContext = playerbot::PvpCore::BuildBattlegroundTacticalContext(player, values);
+    bool const didExecuteTactical = !classOwnsMovement && playerbot::BattlegroundTacticalActions::Execute(player, tacticalContext);
     MotionMaster* motionMaster = player->GetMotionMaster();
     bool const movementIdle = !motionMaster || motionMaster->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE;
     bool const shouldForceClassMovementTick = classContext.classSpellsEnabled &&
         classContext.shouldExecute &&
         classContext.movementDirective != playerbot::PvpClassSpellContext::MovementDirective::None &&
         movementIdle;
-    bool const didExecuteClassSpell = shouldForceClassMovementTick && playerbot::PvpClassActions::Execute(player, classContext);
+    bool const didExecuteClassSpell = (classOwnsMovement || shouldForceClassMovementTick) && playerbot::PvpClassActions::Execute(player, classContext);
 
     playerbot::BattlegroundLifecycleContext inProgressContext;
     inProgressContext.lifecycleEnabled = true;
     inProgressContext.queueOperation = playerbot::QueueOperationType::None;
     inProgressContext.invitationResponse = playerbot::InvitationResponseType::None;
     inProgressContext.shouldHandleInProgressStatus = true;
-    bool const didExecuteLifecycle = playerbot::BattlegroundLifecycleActions::Execute(player, inProgressContext);
+    bool const didExecuteLifecycle = !classOwnsMovement && playerbot::BattlegroundLifecycleActions::Execute(player, inProgressContext);
 
     std::ostringstream tickDetail;
     uint32 const bgTeam = player->GetBGTeam();
     uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
     tickDetail << "bg-fasttick tactical=" << (didExecuteTactical ? 1 : 0)
                << " class_force=" << (shouldForceClassMovementTick ? 1 : 0)
+               << " class_owns_movement=" << (classOwnsMovement ? 1 : 0)
                << " class_exec=" << (didExecuteClassSpell ? 1 : 0)
                << " class_directive=" << static_cast<uint32>(classContext.movementDirective)
                << " class_spell=" << classContext.spellId
@@ -1375,10 +1385,11 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
         uint32(player->GetBattlegroundQueueTypeId(1)),
         uint32(player->GetBattlegroundQueueTypeId(2)));
 
-    BattlegroundTacticalContext const tacticalContext = PvpCore::BuildBattlegroundTacticalContext(player, values);
-    bool const didExecuteTactical = BattlegroundTacticalActions::Execute(player, tacticalContext);
-    bool const didExecuteDuelTactical = DuelTacticalActions::Execute(player);
     PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values);
+    bool const classOwnsMovement = HasClassMovementIntent(classSpellContext);
+    BattlegroundTacticalContext const tacticalContext = PvpCore::BuildBattlegroundTacticalContext(player, values);
+    bool const didExecuteTactical = !classOwnsMovement && BattlegroundTacticalActions::Execute(player, tacticalContext);
+    bool const didExecuteDuelTactical = !classOwnsMovement && DuelTacticalActions::Execute(player);
     bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
     if (didExecuteClassSpell &&
         (classSpellContext.spellId == 16166 ||
@@ -1396,8 +1407,9 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     RandomBotParticipationHooks const hooks = PvpCore::BuildRandomBotParticipationHooks(player, values);
 
     TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-        "Lifecycle contexts: guid={} bgQueueOp={} bgInviteResp={} bgInProgress={} arenaQueueOp={} arenaTeamInteraction={} bgHook={} arenaHook={}",
+        "Lifecycle contexts: guid={} classOwnsMovement={} bgQueueOp={} bgInviteResp={} bgInProgress={} arenaQueueOp={} arenaTeamInteraction={} bgHook={} arenaHook={}",
         guidRaw,
+        classOwnsMovement ? 1 : 0,
         static_cast<uint32>(bgContext.queueOperation),
         static_cast<uint32>(bgContext.invitationResponse),
         bgContext.shouldHandleInProgressStatus ? 1 : 0,
@@ -1438,7 +1450,13 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
 
     if (hooks.battlegroundParticipationHook)
     {
-        if (!IsNoOp(bgContext))
+        bool const shouldSkipBgInProgressLifecycle = classOwnsMovement &&
+            values.inBattleground &&
+            bgContext.queueOperation == QueueOperationType::None &&
+            bgContext.invitationResponse == InvitationResponseType::None &&
+            bgContext.shouldHandleInProgressStatus;
+
+        if (!IsNoOp(bgContext) && !shouldSkipBgInProgressLifecycle)
         {
             didExecuteBattleground = BattlegroundLifecycleActions::Execute(player, bgContext);
             TC_LOG_DEBUG("playerbots.pvp.lifecycle",
@@ -1448,6 +1466,12 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
                 static_cast<uint32>(bgContext.queueOperation),
                 static_cast<uint32>(bgContext.invitationResponse),
                 bgContext.shouldHandleInProgressStatus ? 1 : 0);
+        }
+        else if (shouldSkipBgInProgressLifecycle)
+        {
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Lifecycle battleground execute skipped: guid={} reason=class-movement-owner",
+                guidRaw);
         }
     }
 

--- a/src/server/scripts/Playerbot/playerbot_loader.cpp
+++ b/src/server/scripts/Playerbot/playerbot_loader.cpp
@@ -146,6 +146,7 @@ std::string BuildManagedBotStatusLine(Player* bot)
     playerbot::RandomBotParticipationHooks const hooks = playerbot::PvpCore::BuildRandomBotParticipationHooks(bot, values);
     Unit* directiveTarget = classContext.movementTargetGuid.IsEmpty() ? nullptr : ObjectAccessor::GetUnit(*bot, classContext.movementTargetGuid);
     std::string const lastClassExecutionStatus = playerbot::PvpClassActions::GetLastExecutionStatus(bot);
+    playerbot::PvpClassActions::RangedApproachDiagnostic const rangedApproachDiag = playerbot::PvpClassActions::GetRangedApproachDiagnostic(bot);
     bool const lifecycleEnabled = lifecycleContext.lifecycleEnabled;
     bool const managedRandomBot = playerbot::IsManagedRandomBot(bot);
     bool const canFollowCommands = bot->IsAlive() &&
@@ -189,6 +190,8 @@ std::string BuildManagedBotStatusLine(Player* bot)
            << " hooks(bg=" << (hooks.battlegroundParticipationHook ? "on" : "off")
            << ",arena=" << (hooks.arenaParticipationHook ? "on" : "off") << ")"
            << " last_exec=" << lastClassExecutionStatus
+           << " move_priority=" << classContext.movementPriority
+           << " move_target_is_spell_target=" << (!classContext.targetGuid.IsEmpty() && classContext.targetGuid == classContext.movementTargetGuid ? "yes" : "no")
            << " strict_pathing=" << (bot->InBattleground() ? "on" : "off")
            << " motion=" << uint32(motionType)
            << "/" << ToString(motionType)
@@ -223,8 +226,10 @@ std::string BuildManagedBotStatusLine(Player* bot)
 
     if (directiveTarget)
     {
+        float const directiveGap = bot->GetDistance(directiveTarget) - classContext.movementFollowRange;
         status << " directive_target=" << directiveTarget->GetName()
                << " directive_target_dist=" << bot->GetDistance(directiveTarget)
+               << " directive_gap=" << directiveGap
                << " directive_target_los=" << (bot->IsWithinLOSInMap(directiveTarget) ? "yes" : "no")
                << " directive_target_attackable=" << (bot->IsValidAttackTarget(directiveTarget) ? "yes" : "no");
     }
@@ -243,6 +248,24 @@ std::string BuildManagedBotStatusLine(Player* bot)
     else
     {
         status << " selected=none";
+    }
+
+    if (rangedApproachDiag.valid)
+    {
+        status << " approach_diag_target=" << rangedApproachDiag.targetGuid.ToString()
+               << " approach_diag_desired=" << rangedApproachDiag.desiredRange
+               << " approach_diag_dist=" << rangedApproachDiag.currentDistance
+               << " approach_diag_gap=" << (rangedApproachDiag.currentDistance - rangedApproachDiag.desiredRange)
+               << " approach_diag_stagnant=" << uint32(rangedApproachDiag.stagnantSamples)
+               << " approach_diag_last_sample_ms=" << rangedApproachDiag.lastSampleMs
+               << " approach_diag_last_fallback_ms=" << rangedApproachDiag.lastFallbackMs
+               << " approach_diag_motion=" << uint32(rangedApproachDiag.motionType)
+               << "/" << ToString(rangedApproachDiag.motionType)
+               << " approach_diag_moving=" << (rangedApproachDiag.moving ? "yes" : "no");
+    }
+    else
+    {
+        status << " approach_diag=none";
     }
 
     return status.str();


### PR DESCRIPTION
### Motivation
- Improve bot movement reliability in battlegrounds by avoiding brittle direct `MovePoint` orders and reducing movement stutter/idle loops around complex geometry. 
- Make ranged approach behavior more robust and observable by adding diagnostics and smarter fallback/reissue logic. 
- Ensure spell range checks respect caster/pet/target context to avoid incorrect out-of-range decisions.

### Description
- Replace direct point-move usage in strict pathing with a policy that prefers navmesh-aware chase/follow generators and early-detects when strict segmented movement cannot be issued (e.g., `IssueStrictHumanMove` now avoids issuing a direct `MovePoint`).
- Rework `IssueRangedApproachMovement` to centralize pursuit logic (`issuePursuitMovement`), add forced fallback handling when idle or stalled, sample-based stall detection, and record per-bot diagnostics in a new `RangedApproachDiagnostic` struct stored in `g_RangedApproachDiagnosticByGuid` with an accessor `PvpClassActions::GetRangedApproachDiagnostic`.
- Add `EnsureActiveChaseTracksTarget` to re-anchor existing chase/follow generators to the current target when the active follower target diverges.
- Replace several `MovePoint` fallbacks with `MoveFollow`/`MoveChase` (e.g., druid reposition and flee handling) and add post-issue forced chase/follow logic for `ReachSpellRange` directives to reduce idle ticks.
- Use target-aware spell range checks via `GetSpellMaxRangeForTarget` for both player and pet cast range calculations, and bias LOS recovery inward in `ComputeLosRecoveryRange` to prefer closing movement.
- Increase inward buffer for approach calculations in `ComputeApproachFollowRange` (now nominalRange - 7) and tighten closing logic for `ReachSpellRange` directives to avoid issuing ineffective tiny-range moves.
- Make class movement ownership explicit in class context construction by backfilling `movementTargetGuid` when needed and prevent tactical/lifecycle systems from competing when the class logic currently owns movement (changes in `PlayerbotRandomBotParticipation` and lifecycle flow).
- Add debug/status improvements in `BuildManagedBotStatusLine` to surface movement/diagnostic info and include minor header/include and global data structure additions.

### Testing
- Project built successfully in a local development environment using the standard build (`make`) with no compilation errors. 
- Ran the server with managed random bots in a local battleground scenario and exercised PvP movement directives while observing debug logs; movement fallbacks and diagnostics were emitted as expected and no crashes were observed. 
- Existing automated unit/integration tests (project test suite) were executed where available and reported no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7ca6c06c8327bedd3ed777be5654)