### PR TITLE
Guard CombatManager::SetInCombatWith against null/self targets

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -218,6 +218,9 @@ bool ShouldPropagateCombatToOwner(Unit* owner, Unit* controlled)
 
 bool CombatManager::SetInCombatWith(Unit* who, bool addSecondUnitSuppressed)
 {
+    if (!who || who == _owner)
+        return false;
+
     // Are we already in combat? If yes, refresh pvp combat
     if (PvPCombatReference* existingPvpRef = Trinity::Containers::MapGetValuePtr(_pvpRefs, who->GetGUID()))
     {


### PR DESCRIPTION
### Motivation
- Prevent crashes and duplicate-insert assertions observed when the combat system attempts to create a combat reference for a null or the same unit (stack trace pointed at `CombatManager::PutReference` and the duplicate state assert). 

### Description
- Add an early-return check in `src/server/game/Combat/CombatManager.cpp` in `CombatManager::SetInCombatWith` that returns `false` when `who` is `nullptr` or `who == _owner` to avoid creating self-combat references. 

### Testing
- Ran `git diff --check -- src/server/game/Combat/CombatManager.cpp` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef73640abc8327ab6aba515df465c7)