### PR TITLE
Fix stationary-cast defer loop on unlaunched movement

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2081,11 +2081,17 @@ bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget
 
     uint32 const nowMs = GameTime::GetGameTimeMS();
     uint32 const orderAgeMs = order && order->lastIssueMs != 0 && nowMs >= order->lastIssueMs ? nowMs - order->lastIssueMs : 0;
+    bool const moveOrderMatchesCastTarget = moveTarget && moveTarget == castTarget;
 
-    // Defer only when a target-relative move is actually active/recent and not
-    // done. This prevents indefinite suppression if a stale order was already
-    // cleared by the movement code.
-    bool const shouldDefer = (activeTargetRelativeMotion || moveOrderStillOutside) && activeMoveOrder && orderAgeMs < 6000;
+    std::string preserveDiag;
+    bool const preservingTargetRelativeMotion = moveOrderMatchesCastTarget &&
+        ShouldPreserveTargetRelativeMovement(player, castTarget, order ? order->issuedRange : 0.0f, 1800,
+            "stationary_cast_defer_motion_preserved", &preserveDiag);
+
+    // Defer only while the active CHASE/FOLLOW order is still making progress
+    // (or inside a short launch window). This avoids repeated defer loops when
+    // a movement generator exists but never launched (moving=no/spline=no).
+    bool const shouldDefer = preservingTargetRelativeMotion || (moveOrderStillOutside && orderAgeMs < 6000);
     if (!shouldDefer)
         return false;
 
@@ -2130,11 +2136,14 @@ bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget
              << " follow_move=" << (player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ? "yes" : "no")
              << " move_signal=" << (hasMoveSignal ? "yes" : "no")
              << " order_present=" << (activeMoveOrder ? "yes" : "no")
+             << " order_matches_cast_target=" << (moveOrderMatchesCastTarget ? "yes" : "no")
              << " order_age_ms=" << orderAgeMs
              << " order_range=" << (order ? order->issuedRange : 0.0f)
              << " order_target=" << (moveTarget ? moveTarget->GetGUID().ToString() : "none")
              << " order_target_dist=" << moveTargetDistance
-             << " order_outside=" << (moveOrderStillOutside ? "yes" : "no");
+             << " order_outside=" << (moveOrderStillOutside ? "yes" : "no")
+             << " motion_preserve=" << (preservingTargetRelativeMotion ? "yes" : "no")
+             << " preserve_diag=" << (preserveDiag.empty() ? "none" : preserveDiag);
         *diagOut = diag.str();
     }
 


### PR DESCRIPTION
### Motivation

- Prevent bots from getting stuck when a CHASE/FOLLOW movement generator exists but never actually launches, which previously caused repeated stationary-cast deferral and left bots idle.
- Make stationary-cast deferral depend on the health of the target-relative movement order and require that the tracked move order matches the current cast target.

### Description

- Tighten `ShouldDeferStationaryCastForActiveMovement` so deferral only continues when the active target-relative movement order is still making progress as determined by `ShouldPreserveTargetRelativeMovement` and the move order matches the cast target (added `moveOrderMatchesCastTarget`).
- Preserve the fallback path for explicit out-of-range recovery (`moveOrderStillOutside`) but avoid deferring when a movement generator exists yet never launches (no movement signal/spline).
- Expand diagnostic output produced to include `order_matches_cast_target`, `motion_preserve`, and `preserve_diag` to aid stuck-state forensics (file: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp`, function: `ShouldDeferStationaryCastForActiveMovement`).

### Testing

- Attempted a local smoke build with `cmake --build build -j2 --target worldserver`, which started successfully in this environment but was intentionally stopped before completion due to runtime cost, so no full build artifact/result is available to report.
- No automated unit tests were available/run in this environment against the modified logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd9eadac483278ff56245aaad10d3)