### PR TITLE
Refine target-relative movement handling and shorten motion settle window

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -460,8 +460,10 @@ void RecordTargetRelativeMovementOrder(Player const* player, Unit const* target,
     state.lastY = player->GetPositionY();
     state.lastZ = player->GetPositionZ();
     state.lastIssueMs = GameTime::GetGameTimeMS();
-    state.lastProgressMs = state.lastIssueMs;
-    state.lastPositionProgressMs = state.lastIssueMs;
+    // Do not treat order issuance itself as progress. These are updated only
+    // after observed distance/position gains in ShouldPreserve... .
+    state.lastProgressMs = 0;
+    state.lastPositionProgressMs = 0;
     state.mode = mode;
 }
 
@@ -1206,9 +1208,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
                 return;
             }
 
-            // Give the queued generator a settle window after a failed prime.
-            // Only after that window do we clear/reissue.
-            if (lastIssueAgeMs < 2500)
+            // Give the queued generator a short settle window after a failed
+            // prime, then force a reissue if still unlaunched. Waiting ~2.5s
+            // here left bots visibly stuck with motion=follow/chase but
+            // moving=no, no spline, and no CHASE_MOVE/FOLLOW_MOVE state.
+            if (lastIssueAgeMs < 900)
             {
                 std::ostringstream extra;
                 extra << BuildRangedMovementDiag(player, target, "near_edge_waiting_for_motion_update",
@@ -1224,7 +1228,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             }
         }
 
-        bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 2500;
+        bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 900;
         float const forcedRange = std::max(1.0f, safeDistance - 8.0f);
 
         if (targetAttackable && (player->GetVictim() != target || !player->IsInCombat()))
@@ -2081,11 +2085,17 @@ bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget
 
     uint32 const nowMs = GameTime::GetGameTimeMS();
     uint32 const orderAgeMs = order && order->lastIssueMs != 0 && nowMs >= order->lastIssueMs ? nowMs - order->lastIssueMs : 0;
+    bool const moveOrderMatchesCastTarget = moveTarget && moveTarget == castTarget;
 
-    // Defer only when a target-relative move is actually active/recent and not
-    // done. This prevents indefinite suppression if a stale order was already
-    // cleared by the movement code.
-    bool const shouldDefer = (activeTargetRelativeMotion || moveOrderStillOutside) && activeMoveOrder && orderAgeMs < 6000;
+    std::string preserveDiag;
+    bool const preservingTargetRelativeMotion = moveOrderMatchesCastTarget &&
+        ShouldPreserveTargetRelativeMovement(player, castTarget, order ? order->issuedRange : 0.0f, 1800,
+            "stationary_cast_defer_motion_preserved", &preserveDiag);
+
+    // Defer only while the active CHASE/FOLLOW order is still making progress
+    // (or inside a short launch window). This avoids repeated defer loops when
+    // a movement generator exists but never launched (moving=no/spline=no).
+    bool const shouldDefer = preservingTargetRelativeMotion || (moveOrderStillOutside && orderAgeMs < 6000);
     if (!shouldDefer)
         return false;
 
@@ -2130,11 +2140,14 @@ bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget
              << " follow_move=" << (player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ? "yes" : "no")
              << " move_signal=" << (hasMoveSignal ? "yes" : "no")
              << " order_present=" << (activeMoveOrder ? "yes" : "no")
+             << " order_matches_cast_target=" << (moveOrderMatchesCastTarget ? "yes" : "no")
              << " order_age_ms=" << orderAgeMs
              << " order_range=" << (order ? order->issuedRange : 0.0f)
              << " order_target=" << (moveTarget ? moveTarget->GetGUID().ToString() : "none")
              << " order_target_dist=" << moveTargetDistance
-             << " order_outside=" << (moveOrderStillOutside ? "yes" : "no");
+             << " order_outside=" << (moveOrderStillOutside ? "yes" : "no")
+             << " motion_preserve=" << (preservingTargetRelativeMotion ? "yes" : "no")
+             << " preserve_diag=" << (preserveDiag.empty() ? "none" : preserveDiag);
         *diagOut = diag.str();
     }
 


### PR DESCRIPTION
### Motivation
- Prevent treating move order issuance as immediate "progress" to avoid suppressing reissues prematurely when movement doesn't actually launch. 
- Reduce the wait time for a queued CHASE/FOLLOW generator that never launches to avoid bots stuck in a non-moving state. 
- Avoid deferring stationary casts when a target-relative movement order is present but not actually making progress. 

### Description
- Initialize `lastProgressMs` and `lastPositionProgressMs` to `0` in `TargetRelativeMoveOrderState` and add a comment explaining these are only set after observed progress. 
- Shorten the settle window for a queued-but-unlaunched movement generator from `2500ms` to `900ms` and update related diagnostics and condition checks. 
- Use `ShouldPreserveTargetRelativeMovement` to detect when a target-relative order that matches the cast target is still making progress, and only defer stationary casts while that preservation is true or the order is still outside within the older age heuristic. 
- Add additional diagnostic fields (`order_matches_cast_target`, `motion_preserve`, and `preserve_diag`) to the deferral diagnostic output.

### Testing
- Performed a full build of the server with `make` and the build completed successfully. 
- Executed automated tests including movement and PvP unit tests via `ctest`, and the test suite passed.
- Verified no new compiler warnings were introduced during the build process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd9eadac483278ff56245aaad10d3)