### PR TITLE
Refine target-relative movement preservation and reissue timing to avoid stuck bots

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -460,8 +460,10 @@ void RecordTargetRelativeMovementOrder(Player const* player, Unit const* target,
     state.lastY = player->GetPositionY();
     state.lastZ = player->GetPositionZ();
     state.lastIssueMs = GameTime::GetGameTimeMS();
-    state.lastProgressMs = state.lastIssueMs;
-    state.lastPositionProgressMs = state.lastIssueMs;
+    // Do not treat order issuance itself as progress. These are updated only
+    // after observed distance/position gains in ShouldPreserve... .
+    state.lastProgressMs = 0;
+    state.lastPositionProgressMs = 0;
     state.mode = mode;
 }
 
@@ -520,7 +522,7 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
     bool const hasMovementSignal = player->isMoving() ||
         player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
         player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
-        splineStarted;
+        splineInitialized;
 
     // Do not keep a dead CHASE/FOLLOW generator alive for the whole normal
     // settle window. The bad screenshots show motion=CHASE/FOLLOW with
@@ -1132,7 +1134,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     uint32 const nowMs = GameTime::GetGameTimeMS();
     bool const sameStallTarget = stallState.targetGuid == target->GetGUID();
     bool const activeTargetRelativeMotion = initialMotionType == CHASE_MOTION_TYPE || initialMotionType == FOLLOW_MOTION_TYPE;
-    bool const movementGeneratorHasNotLaunched = !player->isMoving() && !player->HasUnitState(UNIT_STATE_CHASE_MOVE) && !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE);
+    bool const hasActiveSpline = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
+    bool const movementGeneratorHasNotLaunched = !player->isMoving() &&
+        !player->HasUnitState(UNIT_STATE_CHASE_MOVE) &&
+        !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) &&
+        !hasActiveSpline;
     uint32 const lastIssueAgeMs = sameStallTarget && stallState.lastIssueMs != 0 && nowMs >= stallState.lastIssueMs ? nowMs - stallState.lastIssueMs : 0;
 
     if (!forceMovementWhenAlreadyInRange && activeTargetRelativeMotion && currentDistance > (safeDistance + 0.75f))
@@ -1206,9 +1212,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
                 return;
             }
 
-            // Give the queued generator a settle window after a failed prime.
-            // Only after that window do we clear/reissue.
-            if (lastIssueAgeMs < 2500)
+            // Give the queued generator a short settle window after a failed
+            // prime, then force a reissue if still unlaunched. Waiting ~2.5s
+            // here left bots visibly stuck with motion=follow/chase but
+            // moving=no, no spline, and no CHASE_MOVE/FOLLOW_MOVE state.
+            if (lastIssueAgeMs < 900)
             {
                 std::ostringstream extra;
                 extra << BuildRangedMovementDiag(player, target, "near_edge_waiting_for_motion_update",
@@ -1224,7 +1232,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             }
         }
 
-        bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 2500;
+        bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 900;
         float const forcedRange = std::max(1.0f, safeDistance - 8.0f);
 
         if (targetAttackable && (player->GetVictim() != target || !player->IsInCombat()))
@@ -2081,11 +2089,17 @@ bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget
 
     uint32 const nowMs = GameTime::GetGameTimeMS();
     uint32 const orderAgeMs = order && order->lastIssueMs != 0 && nowMs >= order->lastIssueMs ? nowMs - order->lastIssueMs : 0;
+    bool const moveOrderMatchesCastTarget = moveTarget && moveTarget == castTarget;
 
-    // Defer only when a target-relative move is actually active/recent and not
-    // done. This prevents indefinite suppression if a stale order was already
-    // cleared by the movement code.
-    bool const shouldDefer = (activeTargetRelativeMotion || moveOrderStillOutside) && activeMoveOrder && orderAgeMs < 6000;
+    std::string preserveDiag;
+    bool const preservingTargetRelativeMotion = moveOrderMatchesCastTarget &&
+        ShouldPreserveTargetRelativeMovement(player, castTarget, order ? order->issuedRange : 0.0f, 1800,
+            "stationary_cast_defer_motion_preserved", &preserveDiag);
+
+    // Defer only while the active CHASE/FOLLOW order is still making progress
+    // (or inside a short launch window). This avoids repeated defer loops when
+    // a movement generator exists but never launched (moving=no/spline=no).
+    bool const shouldDefer = preservingTargetRelativeMotion || (moveOrderStillOutside && orderAgeMs < 6000);
     if (!shouldDefer)
         return false;
 
@@ -2130,11 +2144,14 @@ bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget
              << " follow_move=" << (player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ? "yes" : "no")
              << " move_signal=" << (hasMoveSignal ? "yes" : "no")
              << " order_present=" << (activeMoveOrder ? "yes" : "no")
+             << " order_matches_cast_target=" << (moveOrderMatchesCastTarget ? "yes" : "no")
              << " order_age_ms=" << orderAgeMs
              << " order_range=" << (order ? order->issuedRange : 0.0f)
              << " order_target=" << (moveTarget ? moveTarget->GetGUID().ToString() : "none")
              << " order_target_dist=" << moveTargetDistance
-             << " order_outside=" << (moveOrderStillOutside ? "yes" : "no");
+             << " order_outside=" << (moveOrderStillOutside ? "yes" : "no")
+             << " motion_preserve=" << (preservingTargetRelativeMotion ? "yes" : "no")
+             << " preserve_diag=" << (preserveDiag.empty() ? "none" : preserveDiag);
         *diagOut = diag.str();
     }
 


### PR DESCRIPTION
### Motivation
- Prevent CHASE/FOLLOW orders from being treated as already-progressed on issuance and avoid long stalls where bots show a chase/follow generator but never actually move.
- Make detection of an active movement generator more robust by accounting for active splines and reduce the wait time before reissuing stale target-relative moves.
- Avoid deferring stationary casts unless the target-relative order actually matches and is being preserved for the cast target.

### Description
- Initialize `lastProgressMs` and `lastPositionProgressMs` to `0` in `RecordTargetRelativeMovementOrder` so issuance doesn't count as observed progress.
- Change movement-spline checks: use `movespline->Initialized()` as a movement signal in `ShouldPreserveTargetRelativeMovement` and treat an active spline as launched in `IssueRangedApproachMovement` via a new `hasActiveSpline` variable.
- Shorten the settle/reissue window for unlaunched target-relative generators from ~2500ms to 900ms and update the corresponding stale detection threshold accordingly.
- Tighten stationary-cast deferral so it only defers when the saved move order matches the cast target and `ShouldPreserveTargetRelativeMovement` indicates the order should be preserved, and add additional diagnostic fields (`order_matches_cast_target`, `motion_preserve`, `preserve_diag`) to the debug output.
- Add clarifying comments and adjust diagnostic labels around motion priming and reissue logic.

### Testing
- Project builds successfully (`make`/CMake build completed) after the changes. 
- Automated unit/integration tests exercising movement and playerbot/PvP behavior were run and passed, including tests covering target-relative motion preservation and reissue timing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd9eadac483278ff56245aaad10d3)