### PR TITLE
Detect and preserve actual launch of target-relative movement to avoid stuck CHASE/FOLLOW generators

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -67,6 +67,7 @@ bool IsFriendlySupportTarget(Player const* player, Unit const* target, SpellInfo
 void SetLastExecutionStatus(Player const* player, std::string const& status);
 void SetLastMovementDebugStatus(Player const* player, std::string const& status);
 void RecordTargetRelativeMovementOrder(Player const* player, Unit const* target, float issuedRange, uint8 mode);
+void MarkTargetRelativeMovementLaunch(Player const* player);
 bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* target, float desiredRange, uint32 minRunMs, char const* label, std::string* reasonOut);
 
 struct LastLosCastFailureState
@@ -440,6 +441,7 @@ struct TargetRelativeMoveOrderState
     float lastY = 0.0f;
     float lastZ = 0.0f;
     uint32 lastIssueMs = 0;
+    uint32 lastLaunchMs = 0;
     uint32 lastProgressMs = 0;
     uint32 lastPositionProgressMs = 0;
     uint8 mode = 0; // 1=chase, 2=follow
@@ -460,9 +462,32 @@ void RecordTargetRelativeMovementOrder(Player const* player, Unit const* target,
     state.lastY = player->GetPositionY();
     state.lastZ = player->GetPositionZ();
     state.lastIssueMs = GameTime::GetGameTimeMS();
-    state.lastProgressMs = state.lastIssueMs;
-    state.lastPositionProgressMs = state.lastIssueMs;
+    state.lastLaunchMs = 0;
+    // Do not treat order issuance itself as progress. These are updated only
+    // after observed distance/position gains in ShouldPreserve... .
+    state.lastProgressMs = 0;
+    state.lastPositionProgressMs = 0;
     state.mode = mode;
+}
+
+void MarkTargetRelativeMovementLaunch(Player const* player)
+{
+    if (!player)
+        return;
+
+    auto itr = g_TargetRelativeMoveOrderByGuid.find(player->GetGUID().GetRawValue());
+    if (itr == g_TargetRelativeMoveOrderByGuid.end())
+        return;
+
+    bool const hasActiveSpline = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
+    bool const launched = player->isMoving() ||
+        player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
+        player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
+        hasActiveSpline;
+    if (!launched)
+        return;
+
+    itr->second.lastLaunchMs = GameTime::GetGameTimeMS();
 }
 
 bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* target, float desiredRange, uint32 minRunMs,
@@ -514,13 +539,14 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
 
     uint32 const distanceProgressAgeMs = state.lastProgressMs != 0 && nowMs >= state.lastProgressMs ? nowMs - state.lastProgressMs : 0;
     uint32 const positionProgressAgeMs = state.lastPositionProgressMs != 0 && nowMs >= state.lastPositionProgressMs ? nowMs - state.lastPositionProgressMs : 0;
+    uint32 const launchAgeMs = state.lastLaunchMs != 0 && nowMs >= state.lastLaunchMs ? nowMs - state.lastLaunchMs : 0;
 
     bool const splineInitialized = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
     bool const splineStarted = splineInitialized && player->movespline->HasStarted();
     bool const hasMovementSignal = player->isMoving() ||
         player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
         player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
-        splineStarted;
+        splineInitialized;
 
     // Do not keep a dead CHASE/FOLLOW generator alive for the whole normal
     // settle window. The bad screenshots show motion=CHASE/FOLLOW with
@@ -529,9 +555,10 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
     // pins rogues/casters at spawn or makes ranged bots appear stuck.
     uint32 const effectiveSettleMs = hasMovementSignal ? minRunMs : std::min<uint32>(minRunMs, 350);
     bool const inSettleWindow = ageMs < effectiveSettleMs;
+    bool const recentLaunch = state.lastLaunchMs != 0 && launchAgeMs < 1200;
     bool const recentDistanceProgress = state.lastProgressMs != 0 && distanceProgressAgeMs < minRunMs;
     bool const recentPositionProgress = state.lastPositionProgressMs != 0 && positionProgressAgeMs < minRunMs;
-    bool const preserve = inSettleWindow || madeDistanceProgress || madePositionProgress || recentDistanceProgress || recentPositionProgress;
+    bool const preserve = inSettleWindow || recentLaunch || madeDistanceProgress || madePositionProgress || recentDistanceProgress || recentPositionProgress;
 
     if (!preserve)
     {
@@ -542,6 +569,7 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
                  << " motion=" << uint32(motionType)
                  << " mode=" << uint32(state.mode)
                  << " age_ms=" << ageMs
+                 << " launch_age_ms=" << launchAgeMs
                  << " distance_progress_age_ms=" << distanceProgressAgeMs
                  << " position_progress_age_ms=" << positionProgressAgeMs
                  << " desired_range=" << desiredRange
@@ -572,6 +600,7 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
              << " motion=" << uint32(motionType)
              << " mode=" << uint32(state.mode)
              << " age_ms=" << ageMs
+             << " launch_age_ms=" << launchAgeMs
              << " distance_progress_age_ms=" << distanceProgressAgeMs
              << " position_progress_age_ms=" << positionProgressAgeMs
              << " desired_range=" << desiredRange
@@ -589,7 +618,9 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
              << " effective_settle_ms=" << effectiveSettleMs
              << " not_move=" << (player->HasUnitState(UNIT_STATE_NOT_MOVE) ? "yes" : "no")
              << " casting_prevent=" << (player->IsMovementPreventedByCasting() ? "yes" : "no")
-             << " reason=" << (inSettleWindow ? (hasMovementSignal ? "settle_window" : "unlaunched_short_settle") : (madePositionProgress || recentPositionProgress ? "position_progress" : "distance_progress"));
+             << " reason=" << (inSettleWindow
+                    ? (hasMovementSignal ? "settle_window" : "unlaunched_short_settle")
+                    : (recentLaunch ? "recent_launch" : (madePositionProgress || recentPositionProgress ? "position_progress" : "distance_progress")));
         *reasonOut = diag.str();
     }
 
@@ -831,6 +862,7 @@ TargetRelativeRangedMoveResult IssuePathProbedFollow(Player* player, Unit* targe
     motionMaster->MoveFollow(target, safeRange, ChaseAngle(angle, float(M_PI_4)));
     RecordTargetRelativeMovementOrder(player, target, safeRange, 2);
     MotionPrimeResult prime = PrimeTargetRelativeMotion(player);
+    MarkTargetRelativeMovementLaunch(player);
     prime.addToWorldCalled = preparedMotionMaster;
     if (primeOut)
         *primeOut = prime;
@@ -869,6 +901,7 @@ TargetRelativeRangedMoveResult IssueTargetRelativeRangedMovement(Player* player,
         motionMaster->MoveChase(target, BuildEdgeDistanceChaseRange(safeDistance));
         RecordTargetRelativeMovementOrder(player, target, safeDistance, 1);
         MotionPrimeResult prime = PrimeTargetRelativeMotion(player);
+        MarkTargetRelativeMovementLaunch(player);
         prime.addToWorldCalled = preparedMotionMaster;
         if (primeOut)
             *primeOut = prime;
@@ -878,6 +911,7 @@ TargetRelativeRangedMoveResult IssueTargetRelativeRangedMovement(Player* player,
     motionMaster->MoveFollow(target, safeDistance, player->GetFollowAngle());
     RecordTargetRelativeMovementOrder(player, target, safeDistance, 2);
     MotionPrimeResult prime = PrimeTargetRelativeMotion(player);
+    MarkTargetRelativeMovementLaunch(player);
     prime.addToWorldCalled = preparedMotionMaster;
     if (primeOut)
         *primeOut = prime;
@@ -900,6 +934,7 @@ TargetRelativeRangedMoveResult IssueContactChaseRescue(Player* player, Unit* tar
         motionMaster->MoveFollow(target, 1.0f, player->GetFollowAngle());
         RecordTargetRelativeMovementOrder(player, target, 1.0f, 2);
         MotionPrimeResult prime = PrimeTargetRelativeMotion(player);
+        MarkTargetRelativeMovementLaunch(player);
         prime.addToWorldCalled = preparedMotionMaster;
         return TargetRelativeRangedMoveResult::FollowIssued;
     }
@@ -914,6 +949,7 @@ TargetRelativeRangedMoveResult IssueContactChaseRescue(Player* player, Unit* tar
     motionMaster->MoveChase(target);
     RecordTargetRelativeMovementOrder(player, target, 0.5f, 1);
     MotionPrimeResult prime = PrimeTargetRelativeMotion(player);
+    MarkTargetRelativeMovementLaunch(player);
     prime.addToWorldCalled = preparedMotionMaster;
     return TargetRelativeRangedMoveResult::ChaseIssued;
 }
@@ -993,10 +1029,12 @@ bool IsStaleTargetRelativeMotion(Player const* player)
 
     MotionMaster const* motionMaster = player->GetMotionMaster();
     MovementGeneratorType const motionType = motionMaster ? motionMaster->GetCurrentMovementGeneratorType() : IDLE_MOTION_TYPE;
+    bool const hasActiveSpline = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
     return (motionType == CHASE_MOTION_TYPE || motionType == FOLLOW_MOTION_TYPE) &&
         !player->isMoving() &&
         !player->HasUnitState(UNIT_STATE_CHASE_MOVE) &&
         !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) &&
+        !hasActiveSpline &&
         !player->HasUnitState(UNIT_STATE_NOT_MOVE) &&
         !player->IsMovementPreventedByCasting();
 }
@@ -1132,7 +1170,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     uint32 const nowMs = GameTime::GetGameTimeMS();
     bool const sameStallTarget = stallState.targetGuid == target->GetGUID();
     bool const activeTargetRelativeMotion = initialMotionType == CHASE_MOTION_TYPE || initialMotionType == FOLLOW_MOTION_TYPE;
-    bool const movementGeneratorHasNotLaunched = !player->isMoving() && !player->HasUnitState(UNIT_STATE_CHASE_MOVE) && !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE);
+    bool const hasActiveSpline = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
+    bool const movementGeneratorHasNotLaunched = !player->isMoving() &&
+        !player->HasUnitState(UNIT_STATE_CHASE_MOVE) &&
+        !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) &&
+        !hasActiveSpline;
     uint32 const lastIssueAgeMs = sameStallTarget && stallState.lastIssueMs != 0 && nowMs >= stallState.lastIssueMs ? nowMs - stallState.lastIssueMs : 0;
 
     if (!forceMovementWhenAlreadyInRange && activeTargetRelativeMotion && currentDistance > (safeDistance + 0.75f))
@@ -1206,9 +1248,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
                 return;
             }
 
-            // Give the queued generator a settle window after a failed prime.
-            // Only after that window do we clear/reissue.
-            if (lastIssueAgeMs < 2500)
+            // Give the queued generator a short settle window after a failed
+            // prime, then force a reissue if still unlaunched. Waiting ~2.5s
+            // here left bots visibly stuck with motion=follow/chase but
+            // moving=no, no spline, and no CHASE_MOVE/FOLLOW_MOVE state.
+            if (lastIssueAgeMs < 900)
             {
                 std::ostringstream extra;
                 extra << BuildRangedMovementDiag(player, target, "near_edge_waiting_for_motion_update",
@@ -1224,7 +1268,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             }
         }
 
-        bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 2500;
+        bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 900;
         float const forcedRange = std::max(1.0f, safeDistance - 8.0f);
 
         if (targetAttackable && (player->GetVictim() != target || !player->IsInCombat()))
@@ -2081,11 +2125,17 @@ bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget
 
     uint32 const nowMs = GameTime::GetGameTimeMS();
     uint32 const orderAgeMs = order && order->lastIssueMs != 0 && nowMs >= order->lastIssueMs ? nowMs - order->lastIssueMs : 0;
+    bool const moveOrderMatchesCastTarget = moveTarget && moveTarget == castTarget;
 
-    // Defer only when a target-relative move is actually active/recent and not
-    // done. This prevents indefinite suppression if a stale order was already
-    // cleared by the movement code.
-    bool const shouldDefer = (activeTargetRelativeMotion || moveOrderStillOutside) && activeMoveOrder && orderAgeMs < 6000;
+    std::string preserveDiag;
+    bool const preservingTargetRelativeMotion = moveOrderMatchesCastTarget &&
+        ShouldPreserveTargetRelativeMovement(player, castTarget, order ? order->issuedRange : 0.0f, 1800,
+            "stationary_cast_defer_motion_preserved", &preserveDiag);
+
+    // Defer only while the active CHASE/FOLLOW order is still making progress
+    // (or inside a short launch window). This avoids repeated defer loops when
+    // a movement generator exists but never launched (moving=no/spline=no).
+    bool const shouldDefer = preservingTargetRelativeMotion || (moveOrderStillOutside && orderAgeMs < 6000);
     if (!shouldDefer)
         return false;
 
@@ -2130,11 +2180,14 @@ bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget
              << " follow_move=" << (player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ? "yes" : "no")
              << " move_signal=" << (hasMoveSignal ? "yes" : "no")
              << " order_present=" << (activeMoveOrder ? "yes" : "no")
+             << " order_matches_cast_target=" << (moveOrderMatchesCastTarget ? "yes" : "no")
              << " order_age_ms=" << orderAgeMs
              << " order_range=" << (order ? order->issuedRange : 0.0f)
              << " order_target=" << (moveTarget ? moveTarget->GetGUID().ToString() : "none")
              << " order_target_dist=" << moveTargetDistance
-             << " order_outside=" << (moveOrderStillOutside ? "yes" : "no");
+             << " order_outside=" << (moveOrderStillOutside ? "yes" : "no")
+             << " motion_preserve=" << (preservingTargetRelativeMotion ? "yes" : "no")
+             << " preserve_diag=" << (preserveDiag.empty() ? "none" : preserveDiag);
         *diagOut = diag.str();
     }
 


### PR DESCRIPTION
### Motivation

- Fix cases where bots appear stuck with `CHASE`/`FOLLOW` motion queued but never actually launched, causing frozen or pinned movement behavior.
- Prevent treating the act of issuing a movement order as equivalent to progress, which could mask unlaunched generators.
- Shorten settle/reissue windows to avoid long delays when a queued generator never starts and improve diagnostics for debugging movement state.

### Description

- Add `lastLaunchMs` to `TargetRelativeMoveOrderState` and introduce `MarkTargetRelativeMovementLaunch()` to record when movement actually starts. 
- Change `RecordTargetRelativeMovementOrder()` to avoid treating order issuance as progress by zeroing progress timestamps and clearing `lastLaunchMs`.
- Update `ShouldPreserveTargetRelativeMovement()` to incorporate a recent-launch window (`recentLaunch`) and use spline initialization state when determining movement signals and preservation; expand logging to include launch ages.
- Call `MarkTargetRelativeMovementLaunch()` after priming/issuing `MoveChase`/`MoveFollow` in `IssuePathProbedFollow()`, `IssueTargetRelativeRangedMovement()`, `IssueContactChaseRescue()` so launches are recorded when movement actually begins.
- Consider active splines in `IsStaleTargetRelativeMotion()` and in logic that decides whether a movement generator has not launched, and reduce the settle/retry thresholds (previous ~2500ms windows shortened to ~900ms/1200ms in key places) to force earlier reissue of truly-unlaunched orders.
- Refine stationary-cast defer logic to consult `ShouldPreserveTargetRelativeMovement()` for the cast target and add diagnostic fields like `order_matches_cast_target` and `preserve_diag` to help trace decision-making.

### Testing

- Project was compiled after changes and the build completed without errors. 
- Existing automated unit tests were executed and passed. 
- Movement-related integration scenarios were exercised by automated tests targeting target-relative motion handling and returned expected results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd9eadac483278ff56245aaad10d3)