### PR TITLE
Improve target-relative movement preservation, add contact-rescue escalation and stealth chase fixes

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -520,8 +520,15 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
     float const positionDelta2D = std::sqrt(dx * dx + dy * dy);
     float const positionDelta3D = std::sqrt(dx * dx + dy * dy + dz * dz);
 
-    bool const madeDistanceProgress = state.lastDistance > 0.0f && currentDistance + 0.20f < state.lastDistance;
     bool const madePositionProgress = positionDelta2D >= 0.35f || positionDelta3D >= 0.50f;
+    bool const splineInitialized = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
+    bool const splineStarted = splineInitialized && player->movespline->HasStarted();
+    bool const hasMovementSignal = player->isMoving() ||
+        player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
+        player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
+        splineInitialized;
+    bool const rawDistanceProgress = state.lastDistance > 0.0f && currentDistance + 0.20f < state.lastDistance;
+    bool const madeDistanceProgress = rawDistanceProgress && (hasMovementSignal || madePositionProgress);
 
     if (madeDistanceProgress)
     {
@@ -541,24 +548,28 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
     uint32 const positionProgressAgeMs = state.lastPositionProgressMs != 0 && nowMs >= state.lastPositionProgressMs ? nowMs - state.lastPositionProgressMs : 0;
     uint32 const launchAgeMs = state.lastLaunchMs != 0 && nowMs >= state.lastLaunchMs ? nowMs - state.lastLaunchMs : 0;
 
-    bool const splineInitialized = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
-    bool const splineStarted = splineInitialized && player->movespline->HasStarted();
-    bool const hasMovementSignal = player->isMoving() ||
-        player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
-        player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
-        splineInitialized;
-
     // Do not keep a dead CHASE/FOLLOW generator alive for the whole normal
     // settle window. The bad screenshots show motion=CHASE/FOLLOW with
     // moving=no, chase_move=no, follow_move=no, and spline_started=no. In that
     // state the order has not actually launched; preserving it for 1.5-3s
     // pins rogues/casters at spawn or makes ranged bots appear stuck.
     uint32 const effectiveSettleMs = hasMovementSignal ? minRunMs : std::min<uint32>(minRunMs, 350);
-    bool const inSettleWindow = ageMs < effectiveSettleMs;
+    bool inSettleWindow = ageMs < effectiveSettleMs;
     bool const recentLaunch = state.lastLaunchMs != 0 && launchAgeMs < 1200;
+    bool const credibleRecentLaunch = recentLaunch && (hasMovementSignal || splineStarted);
     bool const recentDistanceProgress = state.lastProgressMs != 0 && distanceProgressAgeMs < minRunMs;
     bool const recentPositionProgress = state.lastPositionProgressMs != 0 && positionProgressAgeMs < minRunMs;
-    bool const preserve = inSettleWindow || recentLaunch || madeDistanceProgress || madePositionProgress || recentDistanceProgress || recentPositionProgress;
+    bool const credibleRecentDistanceProgress = recentDistanceProgress && (hasMovementSignal || recentPositionProgress || madePositionProgress);
+    bool const farFromDesiredRange = desiredRange > 0.0f && currentDistance > (desiredRange + 4.0f);
+
+    // Elegant fail-safe for the "stuck but preserved" state:
+    // if we are still significantly outside desired range and have neither
+    // recent launch nor distance progress, stop preserving and reissue a fresh
+    // target-relative order immediately.
+    if (inSettleWindow && farFromDesiredRange && ageMs > 900 && !credibleRecentLaunch && !madeDistanceProgress && !credibleRecentDistanceProgress)
+        inSettleWindow = false;
+
+    bool const preserve = inSettleWindow || credibleRecentLaunch || madeDistanceProgress || madePositionProgress || credibleRecentDistanceProgress || recentPositionProgress;
 
     if (!preserve)
     {
@@ -570,6 +581,7 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
                  << " mode=" << uint32(state.mode)
                  << " age_ms=" << ageMs
                  << " launch_age_ms=" << launchAgeMs
+                 << " launch_credible=" << (credibleRecentLaunch ? "yes" : "no")
                  << " distance_progress_age_ms=" << distanceProgressAgeMs
                  << " position_progress_age_ms=" << positionProgressAgeMs
                  << " desired_range=" << desiredRange
@@ -584,7 +596,9 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
                  << " spline_init=" << (splineInitialized ? "yes" : "no")
                  << " spline_started=" << (splineStarted ? "yes" : "no")
                  << " movement_signal=" << (hasMovementSignal ? "yes" : "no")
+                 << " raw_dist_progress=" << (rawDistanceProgress ? "yes" : "no")
                  << " effective_settle_ms=" << effectiveSettleMs
+                 << " far_desired=" << (farFromDesiredRange ? "yes" : "no")
                  << " not_move=" << (player->HasUnitState(UNIT_STATE_NOT_MOVE) ? "yes" : "no")
                  << " casting_prevent=" << (player->IsMovementPreventedByCasting() ? "yes" : "no")
                  << " reason=" << (!hasMovementSignal && ageMs >= effectiveSettleMs ? "unlaunched_settle_expired" : "no_position_or_distance_progress");
@@ -601,6 +615,7 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
              << " mode=" << uint32(state.mode)
              << " age_ms=" << ageMs
              << " launch_age_ms=" << launchAgeMs
+             << " launch_credible=" << (credibleRecentLaunch ? "yes" : "no")
              << " distance_progress_age_ms=" << distanceProgressAgeMs
              << " position_progress_age_ms=" << positionProgressAgeMs
              << " desired_range=" << desiredRange
@@ -615,12 +630,14 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
              << " spline_init=" << (splineInitialized ? "yes" : "no")
              << " spline_started=" << (splineStarted ? "yes" : "no")
              << " movement_signal=" << (hasMovementSignal ? "yes" : "no")
+             << " raw_dist_progress=" << (rawDistanceProgress ? "yes" : "no")
              << " effective_settle_ms=" << effectiveSettleMs
+             << " far_desired=" << (farFromDesiredRange ? "yes" : "no")
              << " not_move=" << (player->HasUnitState(UNIT_STATE_NOT_MOVE) ? "yes" : "no")
              << " casting_prevent=" << (player->IsMovementPreventedByCasting() ? "yes" : "no")
              << " reason=" << (inSettleWindow
                     ? (hasMovementSignal ? "settle_window" : "unlaunched_short_settle")
-                    : (recentLaunch ? "recent_launch" : (madePositionProgress || recentPositionProgress ? "position_progress" : "distance_progress")));
+                    : (credibleRecentLaunch ? "recent_launch" : (madePositionProgress || recentPositionProgress ? "position_progress" : "distance_progress")));
         *reasonOut = diag.str();
     }
 
@@ -896,7 +913,14 @@ TargetRelativeRangedMoveResult IssueTargetRelativeRangedMovement(Player* player,
     }
 
     bool const preparedMotionMaster = PrepareMotionMasterForExplicitBotMovement(player);
-    if (targetAttackable && !forceFollow)
+    bool canUseHostileChase = targetAttackable && !forceFollow;
+    if (canUseHostileChase && player->GetVictim() != target)
+    {
+        player->Attack(target, false);
+        canUseHostileChase = player->GetVictim() == target;
+    }
+
+    if (canUseHostileChase)
     {
         motionMaster->MoveChase(target, BuildEdgeDistanceChaseRange(safeDistance));
         RecordTargetRelativeMovementOrder(player, target, safeDistance, 1);
@@ -918,7 +942,7 @@ TargetRelativeRangedMoveResult IssueTargetRelativeRangedMovement(Player* player,
     return TargetRelativeRangedMoveResult::FollowIssued;
 }
 
-TargetRelativeRangedMoveResult IssueContactChaseRescue(Player* player, Unit* target)
+TargetRelativeRangedMoveResult IssueContactChaseRescue(Player* player, Unit* target, MotionPrimeResult* primeOut = nullptr)
 {
     if (!player || !target)
         return TargetRelativeRangedMoveResult::None;
@@ -936,6 +960,8 @@ TargetRelativeRangedMoveResult IssueContactChaseRescue(Player* player, Unit* tar
         MotionPrimeResult prime = PrimeTargetRelativeMotion(player);
         MarkTargetRelativeMovementLaunch(player);
         prime.addToWorldCalled = preparedMotionMaster;
+        if (primeOut)
+            *primeOut = prime;
         return TargetRelativeRangedMoveResult::FollowIssued;
     }
 
@@ -951,6 +977,8 @@ TargetRelativeRangedMoveResult IssueContactChaseRescue(Player* player, Unit* tar
     MotionPrimeResult prime = PrimeTargetRelativeMotion(player);
     MarkTargetRelativeMovementLaunch(player);
     prime.addToWorldCalled = preparedMotionMaster;
+    if (primeOut)
+        *primeOut = prime;
     return TargetRelativeRangedMoveResult::ChaseIssued;
 }
 
@@ -1137,7 +1165,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         uint32 lastFallbackMs = 0;
         uint32 lastIssueMs = 0;
         uint8 stagnantSamples = 0;
-        uint8 lastIssuedMode = 0; // 1=chase, 2=follow
+        uint8 lastIssuedMode = 0; // 1=chase, 2=follow, 3=contact_rescue
     };
 
     static std::unordered_map<uint64, RangedApproachStallState> stallStateByGuid;
@@ -1270,19 +1298,29 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
 
         bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 900;
         float const forcedRange = std::max(1.0f, safeDistance - 8.0f);
+        bool const prefersContactRescue = requestedSafeDistance <= 8.0f;
+        bool const shouldEscalateContactRescue = targetAttackable && staleQueuedGenerator && lastIssueAgeMs >= 1400 && prefersContactRescue;
+        uint8 const prevIssuedMode = stallState.lastIssuedMode;
+        uint32 const mmSizeBeforeIssue = motionMaster->Size();
+        MovementGeneratorType const mmMotionBeforeIssue = motionMaster->GetCurrentMovementGeneratorType();
 
         if (targetAttackable && (player->GetVictim() != target || !player->IsInCombat()))
             player->Attack(target, false);
 
         RangedPathProbeResult const chaseProbe = ProbeChasePath(player, target);
-        RangedPathProbeResult const followProbe = FindBestFollowProbe(player, target, forcedRange);
+        RangedPathProbeResult const followProbe = targetAttackable ? RangedPathProbeResult() : FindBestFollowProbe(player, target, forcedRange);
 
-        if (!(activeTargetRelativeMotion && (player->isMoving() || player->HasUnitState(UNIT_STATE_CHASE_MOVE) || player->HasUnitState(UNIT_STATE_FOLLOW_MOVE))))
+        bool const shouldClearBeforeIssue = initialMotionType == POINT_MOTION_TYPE;
+        if (shouldClearBeforeIssue)
             motionMaster->Clear(MOTION_SLOT_ACTIVE);
         MotionPrimeResult primeResult;
-        TargetRelativeRangedMoveResult const moveResult = staleQueuedGenerator && IsUsableProbePath(followProbe)
+        TargetRelativeRangedMoveResult const moveResult = shouldEscalateContactRescue
+            ? IssueContactChaseRescue(player, target, &primeResult)
+            : ((!targetAttackable && staleQueuedGenerator && IsUsableProbePath(followProbe))
             ? IssuePathProbedFollow(player, target, followProbe, forcedRange, &primeResult)
-            : IssueTargetRelativeRangedMovement(player, target, forcedRange, targetAttackable, false, &primeResult);
+            : IssueTargetRelativeRangedMovement(player, target, forcedRange, targetAttackable, false, &primeResult));
+        uint32 const mmSizeAfterIssue = motionMaster->Size();
+        MovementGeneratorType const mmMotionAfterIssue = motionMaster->GetCurrentMovementGeneratorType();
 
         stallState.targetGuid = target->GetGUID();
         stallState.lastDistance = currentDistance;
@@ -1290,12 +1328,19 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         stallState.lastFallbackMs = nowMs;
         stallState.lastIssueMs = nowMs;
         stallState.lastIssuedRange = forcedRange;
-        stallState.lastIssuedMode = moveResult == TargetRelativeRangedMoveResult::FollowIssued ? 2 : 1;
+        stallState.lastIssuedMode = shouldEscalateContactRescue ? 3 : (moveResult == TargetRelativeRangedMoveResult::FollowIssued ? 2 : 1);
         stallState.stagnantSamples = staleQueuedGenerator ? 1 : 0;
 
-        char const* label = staleQueuedGenerator
-            ? (IsUsableProbePath(followProbe) ? "near_edge_stale_pathprobed_follow" : "near_edge_stale_reissued_chase_no_follow_path")
-            : "near_edge_chase_follow_nudge";
+        char const* label = "near_edge_chase_nudge";
+        if (staleQueuedGenerator)
+        {
+            if (shouldEscalateContactRescue)
+                label = "near_edge_stale_contact_rescue";
+            else if (!targetAttackable && IsUsableProbePath(followProbe))
+                label = "near_edge_stale_pathprobed_follow";
+            else
+                label = "near_edge_stale_reissued_chase";
+        }
 
         std::string diag = BuildRangedMovementDiag(player, target, label,
             safeDistance, forcedRange, targetLos, targetAttackable, true, initialMotionType,
@@ -1304,6 +1349,13 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         extra << diag
               << " stale=" << (staleQueuedGenerator ? "yes" : "no")
               << " issue_age_ms=" << lastIssueAgeMs
+              << " cleared_before_issue=" << (shouldClearBeforeIssue ? "yes" : "no")
+              << " contact_rescue_allowed=" << (prefersContactRescue ? "yes" : "no")
+              << " rescue_prev_mode=" << uint32(prevIssuedMode)
+              << " mm_size_before_issue=" << mmSizeBeforeIssue
+              << " mm_size_after_issue=" << mmSizeAfterIssue
+              << " mm_motion_before_issue=" << uint32(mmMotionBeforeIssue)
+              << " mm_motion_after_issue=" << uint32(mmMotionAfterIssue)
               << " force_in_range=" << (forceMovementWhenAlreadyInRange ? "yes" : "no")
               << " forced_reason=" << (forcedReason ? forcedReason : "none")
               << " requested_edge=" << requestedSafeDistance;
@@ -1473,15 +1525,15 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         bool const hostileTarget = player->IsValidAttackTarget(target);
         float const fallbackRange = std::max(1.0f, safeDistance - 2.0f);
         RangedPathProbeResult const chaseProbe = ProbeChasePath(player, target);
-        RangedPathProbeResult const followProbe = FindBestFollowProbe(player, target, fallbackRange);
+        RangedPathProbeResult const followProbe = hostileTarget ? RangedPathProbeResult() : FindBestFollowProbe(player, target, fallbackRange);
         MotionPrimeResult fallbackPrimeResult;
-        TargetRelativeRangedMoveResult const fallbackMoveResult = IsUsableProbePath(followProbe)
+        TargetRelativeRangedMoveResult const fallbackMoveResult = (!hostileTarget && IsUsableProbePath(followProbe))
             ? IssuePathProbedFollow(player, target, followProbe, fallbackRange, &fallbackPrimeResult)
-            : IssueTargetRelativeRangedMovement(player, target, fallbackRange, hostileTarget, !hostileTarget, &fallbackPrimeResult);
+            : IssueTargetRelativeRangedMovement(player, target, fallbackRange, hostileTarget, false, &fallbackPrimeResult);
         stallState.lastFallbackMs = nowMs;
         {
             std::ostringstream diag;
-            diag << (IsUsableProbePath(followProbe) ? "stagnant_pathprobed_follow" : "stagnant_reissued_target_relative_no_follow_path")
+            diag << (!hostileTarget && IsUsableProbePath(followProbe) ? "stagnant_pathprobed_follow" : "stagnant_reissued_target_relative_chase")
                  << " dist=" << postIssueDistance
                  << " desired=" << safeDistance
                  << " issued_range=" << fallbackRange
@@ -1513,11 +1565,9 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
 
     if (player->HasStealthAura())
     {
-        // For hostile stealth openers, use default MoveChase instead of
-        // MoveFollow. FollowMovementGenerator can choose a behind/angle point
-        // that never launches on some BG/mmaps, leaving rogues stealthed at
-        // their base. Default MoveChase is still target-relative and pathing-
-        // aware, but it does not depend on a fragile follow angle point.
+        // For hostile stealth openers, always use default MoveChase.
+        // This keeps the behavior deterministic and avoids fragile
+        // angle/near-point follow probes that can stall in BGs.
         if (player->IsValidAttackTarget(target))
         {
             if (player->GetVictim() != target || !player->IsInCombat())
@@ -1530,28 +1580,21 @@ void IssueMeleeApproachMovement(Player* player, Unit* target)
                 return;
             }
 
-            RangedPathProbeResult const followProbe = FindBestFollowProbe(player, target, 1.5f);
-            MotionPrimeResult stealthPrimeResult;
-            if (IsUsableProbePath(followProbe))
-                IssuePathProbedFollow(player, target, followProbe, 1.5f, &stealthPrimeResult);
-            else
-            {
-                bool const preparedMotionMaster = PrepareMotionMasterForExplicitBotMovement(player);
-                motionMaster->MoveChase(target);
-                RecordTargetRelativeMovementOrder(player, target, 0.5f, 1);
-                stealthPrimeResult = PrimeTargetRelativeMotion(player);
-                stealthPrimeResult.addToWorldCalled = preparedMotionMaster;
-            }
+            bool const preparedMotionMaster = PrepareMotionMasterForExplicitBotMovement(player);
+            motionMaster->MoveChase(target);
+            RecordTargetRelativeMovementOrder(player, target, 0.5f, 1);
+            MotionPrimeResult stealthPrimeResult = PrimeTargetRelativeMotion(player);
+            MarkTargetRelativeMovementLaunch(player);
+            stealthPrimeResult.addToWorldCalled = preparedMotionMaster;
 
             std::ostringstream diag;
-            diag << (IsUsableProbePath(followProbe) ? "stealth_melee_pathprobed_follow" : "stealth_melee_chase_no_follow_path")
-                 << " issued_mode=" << (IsUsableProbePath(followProbe) ? "follow" : "chase")
+            diag << "stealth_melee_chase"
+                 << " issued_mode=chase"
                  << " motion_after=" << uint32(motionMaster->GetCurrentMovementGeneratorType())
                  << " moving_after=" << (player->isMoving() ? "yes" : "no")
                  << " chase_move=" << (player->HasUnitState(UNIT_STATE_CHASE_MOVE) ? "yes" : "no")
                  << " follow_move=" << (player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ? "yes" : "no");
             AppendMotionPrimeDiag(diag, stealthPrimeResult);
-            AppendProbeDiag(diag, "follow_probe", followProbe);
             SetLastMovementDebugStatus(player, diag.str());
             return;
         }
@@ -2907,6 +2950,24 @@ std::string PvpClassActions::GetLastMovementDebugStatus(Player const* player)
     return itr->second;
 }
 
+bool PvpClassActions::HasRecentTargetRelativeMovementOrder(Player const* player, Unit const* target, uint32 maxAgeMs)
+{
+    if (!player)
+        return false;
+
+    auto orderItr = g_TargetRelativeMoveOrderByGuid.find(player->GetGUID().GetRawValue());
+    if (orderItr == g_TargetRelativeMoveOrderByGuid.end())
+        return false;
+
+    TargetRelativeMoveOrderState const& order = orderItr->second;
+    if (target && order.targetGuid != target->GetGUID())
+        return false;
+
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint32 const ageMs = order.lastIssueMs != 0 && nowMs >= order.lastIssueMs ? nowMs - order.lastIssueMs : std::numeric_limits<uint32>::max();
+    return ageMs <= maxAgeMs;
+}
+
 bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& context)
 {
     if (!player || !context.classSpellsEnabled || !context.shouldExecute)
@@ -2989,6 +3050,18 @@ bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& contex
                 break;
             case PvpClassSpellContext::MovementDirective::ReachSpellRange:
             {
+                // Root-cause fix for rogue opener stalls:
+                // LOS recovery can emit ReachSpellRange with a tiny range (e.g. 4y)
+                // while stealthed, but stealth opener movement should use the
+                // deterministic melee chase path. Routing this through ranged
+                // approach caused repeated slow/stale reissues in BG starts.
+                if (player->GetClass() == CLASS_ROGUE && player->HasStealthAura() &&
+                    movementTarget && player->IsValidAttackTarget(movementTarget))
+                {
+                    IssueMeleeApproachMovement(player, movementTarget);
+                    break;
+                }
+
                 float desiredRange = std::max(1.0f,
                     context.movementFollowRange > 0.0f ? context.movementFollowRange : (PvpCore::GetConfig().spellRange - 1.0f));
                 Unit* approachTarget = movementTarget;

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
@@ -38,6 +38,7 @@ public:
     static void RegisterCasterSpellCooldown(Player const* player, uint32 spellId, std::chrono::seconds cooldown);
     static std::string GetLastExecutionStatus(Player const* player);
     static std::string GetLastMovementDebugStatus(Player const* player);
+    static bool HasRecentTargetRelativeMovementOrder(Player const* player, Unit const* target, uint32 maxAgeMs = 1500);
 };
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "PlayerbotPvpLifecycleActions.h"
+#include "PlayerbotPvpClassActions.h"
 #include "PlayerbotRandomBotParticipation.h"
 #include "SpellHistory.h"
 #include "BattlegroundMgr.h"
@@ -2228,6 +2229,12 @@ bool DriveCombatPositioning(Player* player, Unit* target, CombatPositioningProfi
 {
     if (!player || !target || !target->IsAlive() || !CanIssueBotMovement(player))
         return false;
+
+    // Class spell actions can issue target-relative chase/follow in the same
+    // scheduler frame. Do not immediately override those orders from lifecycle
+    // distance-band helpers (follow/stop), or bots can visibly inch/stop.
+    if (playerbot::PvpClassActions::HasRecentTargetRelativeMovementOrder(player, target, 1500))
+        return true;
 
     float const distance = player->GetDistance(target);
     bool const hasLos = player->IsWithinLOSInMap(target);


### PR DESCRIPTION
### Motivation
- Reduce bot stalls and visible inching when target-relative chase/follow orders are preserved despite no credible launch or progress.
- Provide a reliable fallback (contact rescue) for near-edge stale ranged approach cases and make stealth openers deterministic for rogues.
- Avoid lifecycle code immediately overriding recently-issued class movement orders.

### Description
- Enhance `ShouldPreserveTargetRelativeMovement` to consider spline state, explicit movement signals, a `rawDistanceProgress` metric, and a credibility check for recent launches, and add an elegant fail-safe to reissue when far from the desired range.
- Add more diagnostic fields to preservation logging (e.g. `raw_dist_progress`, `far_desired`, `launch_credible`) for easier debugging.
- In `IssueTargetRelativeRangedMovement`, ensure hostile chase is only used after setting the victim via `player->Attack(target, false)` so `MoveChase` can use combat context reliably.
- Add optional `primeOut` handling to `IssueContactChaseRescue` and ensure `MarkTargetRelativeMovementLaunch` is called for issued chases/follows where appropriate.
- Introduce a contact-rescue escalation path in `IssueRangedApproachMovement` that uses `IssueContactChaseRescue` when a stale queued generator persists near-edge and contact rescue is preferred; adjust follow-probe usage for hostile targets to avoid inappropriate follow attempts.
- Simplify stealth melee opener logic to always use `MoveChase` for hostile stealth openers (rogues and others) to avoid fragile follow probes stalling on some maps.
- Track and log `MotionMaster` size/motion-type before/after issuing movement to aid diagnostics and adjust issued-mode bookkeeping (add mode `3` = contact_rescue).
- Add `PvpClassActions::HasRecentTargetRelativeMovementOrder` API and use it in `DriveCombatPositioning` to prevent lifecycle distance-band helpers from immediately overriding class-issued target-relative movement orders.
- Expose `HasRecentTargetRelativeMovementOrder` in the header with a default `maxAgeMs` of `1500` ms.

### Testing
- Project built successfully using the normal build (`cmake`/`make`) with the changes compiled into the server binary with debug logging enabled.
- Ran the test-suite and playerbot movement-related unit/integration tests; no regressions observed and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09c98052083278bec326a4fb93362)