### PR TITLE
SCM: Scale loser honor the same as winner to ensure parity

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -105,15 +105,19 @@ uint32 BattlegroundSCM::GetHonorRewardForTeam() const
     return reward;
 }
 
-void BattlegroundSCM::ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, uint32& winnerHonor, uint32& /*loserHonor*/) const
+void BattlegroundSCM::ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, uint32& winnerHonor, uint32& loserHonor) const
 {
     if (winner != ALLIANCE && winner != HORDE)
         return;
 
     if (!_humanFaceoffEverHappened)
+    {
         winnerHonor /= 2;
+        loserHonor /= 2;
+    }
 
     winnerHonor = (winnerHonor * 3.5) / 5;
+    loserHonor = (loserHonor * 3.5) / 5;
 }
 
 bool BattlegroundSCM::SetupBattleground()


### PR DESCRIPTION
### Motivation
- SCM battleground applied special scaling to the winner honor but left loser honor unmodified, producing a mismatch between win/lose honor values.
- The intent is to ensure both winner and loser honors follow the same SCM-specific adjustments so end-of-match rewards are consistent.

### Description
- Updated `BattlegroundSCM::ModifyEndOfMatchHonorRewards` to accept a `loserHonor` reference and apply the same SCM logic to it as to `winnerHonor`.
- When `_humanFaceoffEverHappened` is false, both `winnerHonor` and `loserHonor` are halved, preserving existing behavior for the winner and extending it to the loser.
- Applied the existing SCM multiplier `(3.5 / 5)` to both `winnerHonor` and `loserHonor` to keep SCM-specific tuning symmetric.
- Change implemented in `src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp` (function `ModifyEndOfMatchHonorRewards`).

### Testing
- Ran `git diff --check` to verify no whitespace/formatting issues and it succeeded.
- Ran `git status --short` to confirm staged changes and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f731ad308327aaeb1196f05947df)