### PR TITLE
Delay bot Attack() during active Charge and use gapCloseTarget for warrior gap-close logic

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2812,18 +2812,39 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         }
     }
 
-    // Charge/Intercept target switching: when bots are already attacking one
-    // unit and gap-close a different unit, preserve the charge destination by
-    // immediately promoting the spell target to combat/selection context.
-    // Otherwise downstream pursuit logic can snap movement back to the old
-    // victim in the same tick, which looks like "stun/sound with no charge".
+    // Charge/Intercept target switching: preserve the intended enemy target in
+    // selection/combat context, but do not immediately override an active
+    // charge movement generator. For playerbot sessions an eager Attack() call
+    // can replace the charge spline with chase in the same tick, which looks
+    // like "charge debuff landed but the warrior never moved".
     if (hasChargeEffect &&
         context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
         target && target->IsAlive())
     {
         player->SetSelection(target->GetGUID());
         if (player->GetVictim() != target || !player->HasUnitState(UNIT_STATE_MELEE_ATTACKING))
-            player->Attack(target, true);
+        {
+            if (player->HasUnitState(UNIT_STATE_CHARGING))
+            {
+                ObjectGuid const playerGuid = player->GetGUID();
+                ObjectGuid const targetGuid = target->GetGUID();
+                player->m_Events.AddEventAtOffset([playerGuid, targetGuid]()
+                {
+                    Player* delayedAttacker = ObjectAccessor::FindConnectedPlayer(playerGuid);
+                    if (!delayedAttacker || !delayedAttacker->IsInWorld() || !delayedAttacker->IsAlive())
+                        return;
+
+                    Unit* delayedTarget = ObjectAccessor::GetUnit(*delayedAttacker, targetGuid);
+                    if (!delayedTarget || !delayedTarget->IsAlive())
+                        return;
+
+                    if (delayedAttacker->GetVictim() != delayedTarget || !delayedAttacker->HasUnitState(UNIT_STATE_MELEE_ATTACKING))
+                        delayedAttacker->Attack(delayedTarget, true);
+                }, std::chrono::milliseconds(250));
+            }
+            else
+                player->Attack(target, true);
+        }
     }
 
     // Avoid immediate reapplication loops after quick dispels by imposing

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2507,12 +2507,13 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
     bool const inBattleStance = player->HasAura(2457);
     bool const inDefensiveStance = player->HasAura(71);
     bool const inBerserkerStance = player->HasAura(2458);
+    Unit const* gapCloseTarget = HasHostileTarget(player, target) ? target : activeTarget;
     SpellInfo const* chargeInfo = sSpellMgr->GetSpellInfo(11578);
     SpellInfo const* interceptInfo = sSpellMgr->GetSpellInfo(20617);
     float const chargeMinRange = chargeInfo ? chargeInfo->GetMinRange(false) : 8.0f;
     float const interceptMinRange = interceptInfo ? interceptInfo->GetMinRange(false) : 8.0f;
-    bool const canChargeByRange = !player->IsWithinDistInMap(activeTarget, chargeMinRange);
-    bool const canInterceptByRange = !player->IsWithinDistInMap(activeTarget, interceptMinRange);
+    bool const canChargeByRange = !player->IsWithinDistInMap(gapCloseTarget, chargeMinRange);
+    bool const canInterceptByRange = !player->IsWithinDistInMap(gapCloseTarget, interceptMinRange);
     Unit const* nearbyMeleeTarget = SelectNearbyMeleeTarget(player, activeTarget, 8.0f);
     Unit const* nearbyCastingTarget = SelectEnemyCastingTarget(player, 8.0f, activeTarget);
     bool const hasNearbyMeleeThreat = HasHostileTarget(player, nearbyMeleeTarget);
@@ -2541,14 +2542,14 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
         { "warrior bloodrage", "generate rage to unlock rotational abilities", 2687, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, inDefensiveStance && (!IsSpellReady(player, 676) || !hasNearbyMeleeThreat) && IsSpellReady(player, 2458), 53.0f,
         { "warrior berserker stance", "leave defensive stance when disarm is unavailable or no melee threat is nearby", 2458, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && !player->IsInCombat() && !inBattleStance && IsSpellReady(player, 2457), 52.5f,
+    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(gapCloseTarget) && !player->IsInCombat() && !inBattleStance && IsSpellReady(player, 2457), 52.5f,
         { "warrior battle stance", "switch to battle stance before out-of-combat charge", 2457, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && !player->IsInCombat() && canChargeByRange && IsSpellReady(player, 11578), 52.0f,
-        { "warrior charge", "close gap to target from out of combat", 11578, playerbot::PvpClassSpellContext::TargetMode::Enemy, activeTarget ? activeTarget->GetGUID() : ObjectGuid::Empty });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && player->IsInCombat() && !inBerserkerStance && IsSpellReady(player, 2458), 51.5f,
+    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(gapCloseTarget) && !player->IsInCombat() && canChargeByRange && IsSpellReady(player, 11578), 52.0f,
+        { "warrior charge", "close gap to target from out of combat", 11578, playerbot::PvpClassSpellContext::TargetMode::Enemy, gapCloseTarget ? gapCloseTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(gapCloseTarget) && player->IsInCombat() && !inBerserkerStance && IsSpellReady(player, 2458), 51.5f,
         { "warrior berserker stance", "switch to berserker stance before intercept gap close", 2458, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(activeTarget) && player->IsInCombat() && canInterceptByRange && IsSpellReady(player, 20617), 51.0f,
-        { "warrior intercept", "close gap to target while in combat", 20617, playerbot::PvpClassSpellContext::TargetMode::Enemy, activeTarget ? activeTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(gapCloseTarget) && player->IsInCombat() && canInterceptByRange && IsSpellReady(player, 20617), 51.0f,
+        { "warrior intercept", "close gap to target while in combat", 20617, playerbot::PvpClassSpellContext::TargetMode::Enemy, gapCloseTarget ? gapCloseTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, player->IsWithinMeleeRange(activeTarget) && !inBerserkerStance &&
             IsSpellReady(player, 1680) && IsSpellReady(player, 2458), 50.4f,
         { "warrior berserker stance", "switch to berserker stance to enable whirlwind in melee", 2458, playerbot::PvpClassSpellContext::TargetMode::Self });


### PR DESCRIPTION
### Motivation

- Prevent playerbot virtual sessions from prematurely cancelling an active charge spline by an immediate `Attack()` call, which made charge appear to fail to move the warrior.
- Improve warrior gap-closing decision logic so range checks and spell targets for `Charge`/`Intercept` use the actual gap-close candidate instead of the current active target.

### Description

- Change PvP cast handling to preserve selection/combat context for charge/intercept but defer invoking `Attack()` if the player currently has `UNIT_STATE_CHARGING`, scheduling a delayed `Attack()` via `m_Events.AddEventAtOffset` (250ms) that re-resolves attacker/target and calls `Attack()` only if still valid.
- Update related comment to clarify intent: do not override an active charge movement generator immediately for playerbot sessions.
- Add `gapCloseTarget` in warrior spell selection logic and switch range checks and decision candidates for stance/charge/intercept to use `gapCloseTarget` instead of `activeTarget`, and pass `gapCloseTarget` GUIDs for charge/intercept decisions.

### Testing

- Project compiled successfully after changes with no compile errors in modified files.
- Ran automated unit tests for the playerbot PvP/warrior decision code; tests passed without regressions.
- Ran automated integration checks exercising charge/intercept decision paths; observed expected delayed-attack behavior and unchanged decision priorities.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11b3354648327ba1cf717afa3ad9c)