### PR TITLE
Hunter: apply Gurubashi teleport visual to Outmaneuver

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -92,6 +92,7 @@ enum HunterSpells
     SPELL_HUNTER_ROUGH_PLAY_BUFF_R1 = 81294,
     SPELL_HUNTER_ROUGH_PLAY_BUFF_R2 = 81295,
     SPELL_HUNTER_OUTMANEUVER = 81297,
+    SPELL_TELEPORT_VISUAL_GURUBASHI = 64446,
     SPELL_HUNTER_WEAVING_R1 = 81288,
     SPELL_HUNTER_WEAVING_R2 = 81289,
     SPELL_HUNTER_WEAVING_AUTOSHOT_R1 = 81290,
@@ -1666,9 +1667,9 @@ class spell_hun_outmaneuver : public SpellScript
         pet->GetCharmInfo()->SetIsCommandAttack(false);
         pet->GetCharmInfo()->SetIsCommandFollow(false);
 
-        //blink graphic
-        player->CastSpell(player, 81358);
-        pet->CastSpell(pet, 81358);
+        // Gurubashi chest teleport visual
+        player->CastSpell(player, SPELL_TELEPORT_VISUAL_GURUBASHI, TRIGGERED_FULL_MASK);
+        pet->CastSpell(pet, SPELL_TELEPORT_VISUAL_GURUBASHI, TRIGGERED_FULL_MASK);
     }
 
     void Register() override


### PR DESCRIPTION
### Motivation
- Make `Outmaneuver` (spell `81297`) show the same teleport animation used for the Gurubashi chest teleport for visual consistency when hunter and pet swap positions.

### Description
- Added `SPELL_TELEPORT_VISUAL_GURUBASHI = 64446` to the `HunterSpells` enum and replaced the previous blink visual with `player->CastSpell(player, SPELL_TELEPORT_VISUAL_GURUBASHI, TRIGGERED_FULL_MASK)` and `pet->CastSpell(pet, SPELL_TELEPORT_VISUAL_GURUBASHI, TRIGGERED_FULL_MASK)` in `spell_hun_outmaneuver::HandleDummy` in `src/server/scripts/Spells/spell_hunter.cpp`.

### Testing
- Verified the local change with `git diff` and `git status` and committed the patch, and no build/runtime tests were executed for this script-level change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22f752b84832791dacd158057daf4)