### PR TITLE
Rogue: Apply Improved Garrote poisons from both weapons

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -154,34 +154,39 @@ class spell_rog_garrote : public SpellScript
         if (!player->HasAura(SPELL_ROGUE_GARROTE_POISON))
             return;
 
-        Item* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-        if (!item)
-            return;
-
-        for (uint8 slot = 0; slot < MAX_ENCHANTMENT_SLOT; ++slot)
+        auto applyWeaponPoisons = [player, target](Item* weapon) -> void
         {
-            SpellItemEnchantmentEntry const* enchant = sSpellItemEnchantmentStore.LookupEntry(item->GetEnchantmentId(EnchantmentSlot(slot)));
-            if (!enchant)
-                continue;
+            if (!weapon)
+                return;
 
-            for (uint8 s = 0; s < 3; ++s)
+            for (uint8 slot = 0; slot < MAX_ENCHANTMENT_SLOT; ++slot)
             {
-                if (enchant->Effect[s] != ITEM_ENCHANTMENT_TYPE_COMBAT_SPELL)
+                SpellItemEnchantmentEntry const* enchant = sSpellItemEnchantmentStore.LookupEntry(weapon->GetEnchantmentId(EnchantmentSlot(slot)));
+                if (!enchant)
                     continue;
 
-                SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(enchant->EffectArg[s]);
-                if (!spellInfo)
+                for (uint8 s = 0; s < 3; ++s)
                 {
-                    TC_LOG_ERROR("spells", "Player::CastItemCombatSpell Enchant {}, player (Name: {}, {}) cast unknown spell {}", enchant->ID, player->GetName(), player->GetGUID().ToString(), enchant->EffectArg[s]);
-                    continue;
+                    if (enchant->Effect[s] != ITEM_ENCHANTMENT_TYPE_COMBAT_SPELL)
+                        continue;
+
+                    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(enchant->EffectArg[s]);
+                    if (!spellInfo)
+                    {
+                        TC_LOG_ERROR("spells", "Player::CastItemCombatSpell Enchant {}, player (Name: {}, {}) cast unknown spell {}", enchant->ID, player->GetName(), player->GetGUID().ToString(), enchant->EffectArg[s]);
+                        continue;
+                    }
+
+                    if (spellInfo->SpellFamilyName != SPELLFAMILY_ROGUE || spellInfo->Dispel != DISPEL_POISON)
+                        continue;
+
+                    player->CastSpell(target, enchant->EffectArg[s], weapon);
                 }
-
-                if (spellInfo->SpellFamilyName != SPELLFAMILY_ROGUE || spellInfo->Dispel != DISPEL_POISON)
-                    continue;
-
-                player->CastSpell(target, enchant->EffectArg[s], item);
             }
-        }
+        };
+
+        applyWeaponPoisons(player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND));
+        applyWeaponPoisons(player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND));
     }
 
     void Register() override


### PR DESCRIPTION
### Motivation
- Ensure `Improved Garrote` triggers eligible rogue poison enchants from both main-hand and off-hand weapons when the garrote poison effect is applied.

### Description
- Refactored the enchantment scan/cast logic into a local lambda `applyWeaponPoisons` inside `spell_rog_garrote` and call it for both `EQUIPMENT_SLOT_MAINHAND` and `EQUIPMENT_SLOT_OFFHAND`.
- Preserved existing filtering so only combat-spell enchants with `SPELLFAMILY_ROGUE` and `DISPEL_POISON` are applied.
- The change is implemented in `src/server/scripts/Spells/spell_rogue.cpp`.

### Testing
- Verified repository diff and status to confirm only `src/server/scripts/Spells/spell_rogue.cpp` was modified and the patch matches the intended edits (succeeded).
- Inspected the updated function lines to ensure `applyWeaponPoisons` is invoked for both weapons (succeeded).
- No automated unit tests or CI/build were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2302e9d3483279e63ff56b8e7cd1d)