### PR TITLE
Buff Shield Slam block value scaling by 50%

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -401,7 +401,8 @@ void Spell::EffectSchoolDMG()
                 {
                     uint8 level = unitCaster->GetLevel();
                     uint32 block_value = unitCaster->GetShieldBlockValue(uint32(float(level) * 50), uint32(float(level) * 50));
-                    damage += int32(unitCaster->ApplyEffectModifiers(m_spellInfo, effectInfo->EffectIndex, float(block_value)));
+                    int32 blockScaling = int32(unitCaster->ApplyEffectModifiers(m_spellInfo, effectInfo->EffectIndex, float(block_value)));
+                    damage += blockScaling + blockScaling / 2;
                 }
                 // Victory Rush
                 else if (m_spellInfo->SpellFamilyFlags[1] & 0x100)


### PR DESCRIPTION
### Motivation
- Increase Shield Slam's damage contribution from shield block value so the ability scales 50% harder off the shield block calculation in spell damage handling.

### Description
- In `src/server/game/Spells/SpellEffects.cpp` replace the direct addition of the block-value contribution with a `blockScaling` local and apply an extra 50% by using `damage += blockScaling + blockScaling / 2;` for the Shield Slam spell family handling.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f233e0fbf88327bf583a82721cd276)