### PR TITLE
Grant Revenge aura-state to attackers with aura 12800 when target dodges/parries/blocks

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10509,6 +10509,13 @@ void Unit::ProcSkillsAndReactives(bool isVictim, Unit* procTarget, uint32 typeMa
             }
             else // For attacker
             {
+                // Revenge on target dodge/parry/block if Revenge trigger aura is active
+                if ((hitMask & (PROC_HIT_DODGE | PROC_HIT_PARRY | PROC_HIT_BLOCK)) && GetTypeId() == TYPEID_PLAYER && HasAura(12800))
+                {
+                    ModifyAuraState(AURA_STATE_DEFENSE, true);
+                    StartReactiveTimer(REACTIVE_DEFENSE);
+                }
+
                 // Overpower on victim dodge
                 if ((hitMask & PROC_HIT_DODGE) && GetTypeId() == TYPEID_PLAYER && GetClass() == CLASS_WARRIOR)
                 {


### PR DESCRIPTION
### Motivation
- Enable a Revenge-style reactive window for attackers that have the special trigger aura `12800` so they gain the defensive aurastate when their TARGET dodges, parries, or blocks their attack. 
- This restores/implements expected behavior where an attacker with the Revenge trigger gains the reactive `AURA_STATE_DEFENSE` and can use revenge mechanics when avoided.

### Description
- Modified `Unit::ProcSkillsAndReactives` in `src/server/game/Entities/Unit/Unit.cpp` to add an attacker-side check for `hitMask & (PROC_HIT_DODGE | PROC_HIT_PARRY | PROC_HIT_BLOCK)` combined with `GetTypeId() == TYPEID_PLAYER` and `HasAura(12800)`.
- When the condition is met the code now calls `ModifyAuraState(AURA_STATE_DEFENSE, true)` and `StartReactiveTimer(REACTIVE_DEFENSE)` to open the Revenge aurastate window, leaving existing Overpower and other reactive logic unchanged.

### Testing
- No automated tests were executed for this change since it is a logic-only core modification and no test harness was run in this task.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2726cbfa48327b9c8073d5aec2463)