### PR TITLE
Guard GameObjectModel collision calls against invalid state

### DIFF
--- a/src/common/Collision/Models/GameObjectModel.cpp
+++ b/src/common/Collision/Models/GameObjectModel.cpp
@@ -124,6 +124,12 @@ bool GameObjectModel::initialize(std::unique_ptr<GameObjectModelOwnerBase> model
     iPos = modelOwner->GetPosition();
     phasemask = modelOwner->GetPhaseMask();
     iScale = modelOwner->GetScale();
+    if (iScale == 0.0f)
+    {
+        TC_LOG_ERROR("misc", "GameObject model {} has zero scale, loading skipped", it->second.name);
+        return false;
+    }
+
     iInvScale = 1.f / iScale;
 
     G3D::Matrix3 iRotation = G3D::Matrix3::fromEulerAnglesZYX(modelOwner->GetOrientation(), 0, 0);
@@ -163,7 +169,7 @@ GameObjectModel* GameObjectModel::Create(std::unique_ptr<GameObjectModelOwnerBas
 
 bool GameObjectModel::intersectRay(const G3D::Ray& ray, float& MaxDist, bool StopAtFirstHit, uint32 ph_mask, VMAP::ModelIgnoreFlags ignoreFlags) const
 {
-    if (!(phasemask & ph_mask) || !owner->IsSpawned())
+    if (!iModel || !owner || !(phasemask & ph_mask) || !owner->IsSpawned())
         return false;
 
     float time = ray.intersectionTime(iBound);
@@ -185,7 +191,7 @@ bool GameObjectModel::intersectRay(const G3D::Ray& ray, float& MaxDist, bool Sto
 
 void GameObjectModel::intersectPoint(G3D::Vector3 const& point, VMAP::AreaInfo& info, uint32 ph_mask) const
 {
-    if (!(phasemask & ph_mask) || !owner->IsSpawned() || !isMapObject())
+    if (!iModel || !owner || !(phasemask & ph_mask) || !owner->IsSpawned() || !isMapObject())
         return;
 
     if (!iBound.contains(point))
@@ -206,7 +212,7 @@ void GameObjectModel::intersectPoint(G3D::Vector3 const& point, VMAP::AreaInfo& 
 
 bool GameObjectModel::GetLocationInfo(G3D::Vector3 const& point, VMAP::LocationInfo& info, uint32 ph_mask) const
 {
-    if (!(phasemask & ph_mask) || !owner->IsSpawned() || !isMapObject())
+    if (!iModel || !owner || !(phasemask & ph_mask) || !owner->IsSpawned() || !isMapObject())
         return false;
 
     if (!iBound.contains(point))


### PR DESCRIPTION
### Motivation
- Prevent crashes observed in `GameObjectModel::intersectPoint` during object/grid load caused by invalid model state (null `iModel`, null `owner`, or zero `iScale`).
- Add defensive checks to avoid dereferencing invalid pointers and performing `1.f / iScale` when `iScale` is zero.

### Description
- Add a zero-scale guard in `GameObjectModel::initialize` that logs an error and returns `false` when `iScale == 0.0f` to avoid invalid inverse-scale math used later.
- Add early-return guards in `GameObjectModel::intersectRay` to check `iModel` and `owner` before using them.
- Add the same `iModel`/`owner` guards to `GameObjectModel::intersectPoint` and `GameObjectModel::GetLocationInfo` to harden collision/location code paths.

### Testing
- Ran `git diff -- src/common/Collision/Models/GameObjectModel.cpp` to verify the intended changes and the diff output matched expectations (succeeded).
- Committed the change with `git commit -m "Guard GameObjectModel collision calls against invalid state"` (succeeded); no build or runtime test was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30a539b5c832790c355823ac4b2a4)