### PR TITLE
Allow gear and talent changes in Scarlet Chapel (SCM) battleground

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -136,8 +136,12 @@ namespace HiddenSets
 
 namespace
 {
-    bool IsBattlegroundEquipChangeAllowed(uint8 slot)
+    bool IsBattlegroundEquipChangeAllowed(Player const* player, uint8 slot)
     {
+        if (Battleground const* battleground = player->GetBattleground())
+            if (battleground->GetTypeID(true) == BATTLEGROUND_SCM)
+                return true;
+
         switch (slot)
         {
         case EQUIPMENT_SLOT_TRINKET1:
@@ -11781,7 +11785,7 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16& dest, Item* pItem, bool
             if (not_loading)
             {
                 if (Battleground* battleground = GetBattleground())
-                    if (!IsBattlegroundEquipChangeAllowed(eslot))
+                    if (!IsBattlegroundEquipChangeAllowed(this, eslot))
                         return EQUIP_ERR_CANT_DO_RIGHT_NOW;
             }
 
@@ -11936,7 +11940,7 @@ InventoryResult Player::CanUnequipItem(uint16 pos, bool swap) const
     uint8 slot = pos & 255;
     if (bag == INVENTORY_SLOT_BAG_0 && slot < EQUIPMENT_SLOT_END)
         if (Battleground* battleground = GetBattleground())
-            if (!IsBattlegroundEquipChangeAllowed(slot))
+            if (!IsBattlegroundEquipChangeAllowed(this, slot))
                 return EQUIP_ERR_CANT_DO_RIGHT_NOW;
 
     return EQUIP_ERR_OK;
@@ -26154,9 +26158,14 @@ void Player::LearnTalent(uint32 talentId, uint32 talentRank)
 {
     uint32 CurTalentPoints = GetFreeTalentPoints();
 
-    if (InBattleground() || InArena())
-    {
+    if (InArena())
         return;
+
+    if (InBattleground())
+    {
+        Battleground const* battleground = GetBattleground();
+        if (!battleground || battleground->GetTypeID(true) != BATTLEGROUND_SCM)
+            return;
     }
 
     if (CurTalentPoints == 0)


### PR DESCRIPTION
### Motivation
- Players should be allowed to swap full equipment and change talents while inside the Scarlet Chapel battleground (`BATTLEGROUND_SCM`) to match its intended behavior.
- Existing restrictions for arenas and other battlegrounds should remain unchanged to avoid altering PvP rules elsewhere.

### Description
- Updated the helper `IsBattlegroundEquipChangeAllowed` to accept a `Player const*` and to return `true` for any slot when the player's battleground type is `BATTLEGROUND_SCM`.
- Wired the new helper into equip/unequip checks in `CanEquipItem` and `CanUnequipItem` so SCM players can change any equipment slot while other battlegrounds remain restricted.
- Modified `Player::LearnTalent` to keep talent changes blocked in arenas but allow learning/unlearning while in SCM (talent changes remain blocked in non-SCM battlegrounds).

### Testing
- No automated unit or integration tests were executed for this change in this environment.
- Code-level validation performed by updating the affected `Player.cpp` checks and running repository search/inspection to ensure call sites were adjusted to the new helper signature and logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30e45799c8327a9dd5dc6bd1a55fa)