### PR TITLE
Guard against null ItemTemplate in Player::GetWeaponForAttack and GetShield

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10360,7 +10360,8 @@ Item* Player::GetWeaponForAttack(WeaponAttackType attackType, bool useable /*= f
         item = GetUseableItemByPos(INVENTORY_SLOT_BAG_0, slot);
     else
         item = GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
-    if (!item || item->GetTemplate()->Class != ITEM_CLASS_WEAPON)
+    ItemTemplate const* itemTemplate = item ? item->GetTemplate() : nullptr;
+    if (!itemTemplate || itemTemplate->Class != ITEM_CLASS_WEAPON)
         return nullptr;
 
     if (!useable)
@@ -10379,7 +10380,8 @@ Item* Player::GetShield(bool useable) const
         item = GetUseableItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
     else
         item = GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    if (!item || item->GetTemplate()->Class != ITEM_CLASS_ARMOR)
+    ItemTemplate const* itemTemplate = item ? item->GetTemplate() : nullptr;
+    if (!itemTemplate || itemTemplate->Class != ITEM_CLASS_ARMOR)
         return nullptr;
 
     if (!useable)


### PR DESCRIPTION
### Motivation
- Prevent a crash observed during aura cleanup/logout where `Player::GetWeaponForAttack` dereferenced `item->GetTemplate()` when the item template pointer was null, causing SIGSEGV.

### Description
- Add defensive checks in `Player::GetWeaponForAttack` and `Player::GetShield` by fetching `ItemTemplate const* itemTemplate = item ? item->GetTemplate() : nullptr;` and returning `nullptr` when the template is missing or the item class doesn't match.

### Testing
- Ran code inspections and searches (`rg "GetWeaponForAttack|CheckAttackFitToAuraRequirement|UpdateWeaponDependentCritAuras"`) and inspected the updated file ranges with `sed`/`nl`, and those checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36da957bc8327bfee6727b4f0184f)