### PR TITLE
Add Improved Revenge (12800) armor bypass for Revenge

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1738,6 +1738,27 @@ void Unit::HandleEmoteCommand(Emote emoteId)
             }
         }
 
+        // Custom: Improved Revenge (12800) makes Revenge bypass all armor.
+        if (spellInfo && attacker->GetTypeId() == TYPEID_PLAYER && attacker->HasAura(12800))
+        {
+            switch (spellInfo->Id)
+            {
+                case 6572:   // Revenge (Rank 1)
+                case 6574:   // Revenge (Rank 2)
+                case 7379:   // Revenge (Rank 3)
+                case 11600:  // Revenge (Rank 4)
+                case 11601:  // Revenge (Rank 5)
+                case 25288:  // Revenge (Rank 6)
+                case 25269:  // Revenge (Rank 7)
+                case 30357:  // Revenge (Rank 8)
+                case 57823:  // Revenge (Rank 9)
+                    armor = 0.0f;
+                    break;
+                default:
+                    break;
+            }
+        }
+
         // Apply Player CR_ARMOR_PENETRATION rating and buffs from stances\specializations etc.
         if (attacker->GetTypeId() == TYPEID_PLAYER)
         {


### PR DESCRIPTION
### Motivation
- Implement Improved Revenge behavior so that when a player has aura `12800`, their Revenge spell bypasses all target armor as intended.

### Description
- Added a custom armor-bypass check in `Unit::CalcArmorReducedDamage` to set `armor = 0.0f` when the attacker is a player with aura `12800` and the spell ID matches Revenge ranks.
- The bypass covers Revenge spell IDs `6572`, `6574`, `7379`, `11600`, `11601`, `25288`, `25269`, `30357`, and `57823` and is placed before armor-penetration calculations.
- Change is implemented in `src/server/game/Entities/Unit/Unit.cpp` within `Unit::CalcArmorReducedDamage`.

### Testing
- No automated tests were executed for this change; the modification is a logic-only addition to the damage mitigation path and requires runtime/build verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f370cfbd8c8327b94087de8651618a)