### PR TITLE
Fix ATTACK_ME fear control state after stun

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11776,7 +11776,10 @@ void Unit::SetControlled(bool apply, UnitState state)
                     ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
                     SendMeleeAttackStop();
                     // SendAutoRepeatCancel ?
-                    SetFeared(true);
+                    if (HasAttackMeFearAura())
+                        SetTaunted(true);
+                    else
+                        SetFeared(true);
                 }
                 break;
             case UNIT_STATE_TAUNTED:
@@ -11849,7 +11852,12 @@ void Unit::ApplyControlStatesIfNeeded()
         SetConfused(true);
 
     if (HasUnitState(UNIT_STATE_FLEEING) || HasAuraType(SPELL_AURA_MOD_FEAR))
-        SetFeared(true);
+    {
+        if (HasAttackMeFearAura())
+            SetTaunted(true);
+        else
+            SetFeared(true);
+    }
 
     if (HasUnitState(UNIT_STATE_TAUNTED) || HasAttackMeFearAura())
         SetTaunted(true);


### PR DESCRIPTION
### Motivation

- When a unit had a combined `ATTACK_ME` + fear aura and was stunned, control-state reapplication could treat it as a normal fear and cause the unit to flee instead of chase the taunter after the stun expired.

### Description

- Update `Unit::SetControlled` to route `UNIT_STATE_FLEEING` to `SetTaunted(true)` when `HasAttackMeFearAura()` is true and otherwise call `SetFeared(true)` in `src/server/game/Entities/Unit/Unit.cpp`.
- Update `Unit::ApplyControlStatesIfNeeded` to prefer taunt semantics when an `ATTACK_ME`-style fear aura is present instead of unconditionally calling `SetFeared(true)`.
- This keeps taunt/chase behavior consistent during control-state transitions such as when stun/root/fear states are reapplied or cleared.

### Testing

- Applied the source patch via an automated script (`python` patch) and it completed successfully.
- Verified the diff with `git diff -- src/server/game/Entities/Unit/Unit.cpp` and committed the change with `git commit -m "Fix ATTACK_ME fear control state after stun"`, both commands succeeded.
- Inspected modified lines with `nl -ba src/server/game/Entities/Unit/Unit.cpp | sed -n '11760,11870p'` to confirm the runtime logic was updated, and the command succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f373f66a788327b4c00ded0b8be944)