### PR TITLE
Fix BIH wrapper object index bookkeeping

### DIFF
--- a/src/common/Collision/BoundingIntervalHierarchyWrapper.h
+++ b/src/common/Collision/BoundingIntervalHierarchyWrapper.h
@@ -92,8 +92,14 @@ public:
         m_objects.fastClear();
         m_obj2Idx.getKeys(m_objects);
         m_objects_to_push.getMembers(m_objects);
-        //assert that m_obj2Idx has all the keys
 
+        // Rebuild index table from the currently live object list and reset the pending insert set.
+        m_obj2Idx.clear();
+        for (uint32 i = 0; i < m_objects.size(); ++i)
+            if (m_objects[i])
+                m_obj2Idx.set(m_objects[i], i);
+
+        m_objects_to_push.clear();
         m_tree.build(m_objects, BoundsFunc::getBounds2);
     }
 


### PR DESCRIPTION
### Motivation
- The server crashed inside BIH rebuilds while loading GameObjects due to inconsistent bookkeeping in the BIH wrapper during merges of existing objects and pending inserts. 
- The intent is to keep the object index mapping (`m_obj2Idx`) in sync with the merged object array and to clear pending inserts once they are folded into the balanced tree to avoid stale references.

### Description
- Reworked `BIHWrap::balance()` in `src/common/Collision/BoundingIntervalHierarchyWrapper.h` to rebuild `m_obj2Idx` from the merged `m_objects` array after calling `m_obj2Idx.getKeys(m_objects)` and `m_objects_to_push.getMembers(m_objects)`. 
- Added null filtering when rebuilding indices so only live object pointers are reinserted into `m_obj2Idx`. 
- Cleared `m_objects_to_push` after the rebuild so pending-insert state does not persist across future balances.

### Testing
- Ran an automated build with `cmake --build build --target worldserver -j2`, which started and progressed through compilation steps in the captured output without compiler errors. 
- No automated unit tests were run in this session (unit tests are not enabled by default in this build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c824088c83279c939f409a49a2dd)