### PR TITLE
Prevent null deref in facing logic when applying taunt

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12042,7 +12042,8 @@ void Unit::SetTaunted(bool apply)
         {
             ToPlayer()->Dismount();
             ToPlayer()->RemoveAurasByType(SPELL_AURA_MOUNTED);
-            ToPlayer()->SetFacingToObject(caster, true);
+            if (caster)
+                ToPlayer()->SetFacingToObject(caster, true);
         }
         if (caster)
         {
@@ -13890,6 +13891,9 @@ void Unit::SetFacingTo(float ori, bool force)
 
 void Unit::SetFacingToObject(WorldObject const* object, bool force)
 {
+    if (!object)
+        return;
+
     // do not face when already moving
     if (!force && (!IsStopped() || !movespline->Finalized()))
         return;


### PR DESCRIPTION
### Motivation
- A crash trace showed `Position::GetAbsoluteAngle` being invoked through `Unit::SetFacingToObject` during taunt handling when the resolved taunt caster could be null, leading to a segmentation fault.

### Description
- Guard `Unit::SetTaunted(true)` so `ToPlayer()->SetFacingToObject(caster, true)` is only called when `caster` is non-null in `src/server/game/Entities/Unit/Unit.cpp`.
- Add a defensive null check at the start of `Unit::SetFacingToObject(WorldObject const* object, bool force)` to early-return when `object` is null and avoid calling `GetAbsoluteAngle(object)`.

### Testing
- No automated unit tests were run for this change; basic repository checks (`git diff`, `git status`, and `git commit`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40e581148832797ed3b358b142044)