### PR TITLE
Simplify Warsong Gulch pursuit logic and remove sticky-target tracking

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -423,95 +423,17 @@ bool TryPursueNearestEnemyInWarsong(Player* player)
     if (!player || !IsWarsongGulch(player))
         return false;
 
-    static std::unordered_map<uint64, ObjectGuid> chaseTargetByBotGuid;
-    static std::unordered_map<uint64, uint32> chaseTargetSetMsByBotGuid;
-
-    auto const isValidChaseTarget = [player](Player* candidate) -> bool
-    {
-        if (!candidate || candidate == player)
-            return false;
-        if (!candidate->IsAlive() || !candidate->IsInWorld())
-            return false;
-        if (candidate->GetMapId() != player->GetMapId())
-            return false;
-        if (candidate->GetBattlegroundId() != player->GetBattlegroundId())
-            return false;
-        return player->IsValidAttackTarget(candidate);
-    };
-
-    uint32 scannedPlayers = 0;
-    uint32 attackableEnemies = 0;
-    Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), &scannedPlayers, &attackableEnemies);
-    uint64 const botGuid = player->GetGUID().GetRawValue();
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-    Player* selectedEnemy = nearestEnemy;
-    bool stickyTargetHeld = false;
-
-    std::unordered_map<uint64, ObjectGuid>::const_iterator stickyItr = chaseTargetByBotGuid.find(botGuid);
-    if (stickyItr != chaseTargetByBotGuid.end() && !stickyItr->second.IsEmpty())
-    {
-        Player* stickyEnemy = ObjectAccessor::FindConnectedPlayer(stickyItr->second);
-        if (isValidChaseTarget(stickyEnemy))
-        {
-            uint32 const setMs = chaseTargetSetMsByBotGuid[botGuid];
-            uint32 const stickyAgeMs = nowMs - setMs;
-            float const stickyDist = player->GetDistance(stickyEnemy);
-            float const nearestDist = nearestEnemy ? player->GetDistance(nearestEnemy) : std::numeric_limits<float>::max();
-            bool const withinStickyWindow = stickyAgeMs < 6000;
-            bool const nearestNotMeaningfullyBetter = nearestDist + 12.0f >= stickyDist;
-
-            if (withinStickyWindow && nearestNotMeaningfullyBetter)
-            {
-                selectedEnemy = stickyEnemy;
-                stickyTargetHeld = true;
-            }
-        }
-    }
-
-    if (!selectedEnemy)
-    {
-        chaseTargetByBotGuid.erase(botGuid);
-        chaseTargetSetMsByBotGuid.erase(botGuid);
-        EmitBattlegroundGmDebug(player,
-            "wsg-pursuit=no-enemy scanned=" + std::to_string(scannedPlayers) +
-            " attackable=" + std::to_string(attackableEnemies), 1500);
-        return false;
-    }
-
-    if (!stickyTargetHeld || chaseTargetByBotGuid[botGuid] != selectedEnemy->GetGUID())
-    {
-        chaseTargetByBotGuid[botGuid] = selectedEnemy->GetGUID();
-        chaseTargetSetMsByBotGuid[botGuid] = nowMs;
-    }
-
-    float const distanceToEnemy = player->GetDistance(selectedEnemy);
     float const combatEngageDistance = std::clamp(GetAggressiveCombatScanDistance(player, 100.0f), 25.0f, 60.0f);
-    if (distanceToEnemy <= combatEngageDistance)
-    {
-        EmitBattlegroundGmDebug(player,
-            "wsg-pursuit=engage target=" + selectedEnemy->GetName() +
-            " dist=" + std::to_string(int32(distanceToEnemy)) +
-            " scan=" + std::to_string(scannedPlayers) +
-            " attackable=" + std::to_string(attackableEnemies) +
-            " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0), 1200);
-        return playerbot::EngageNearestEnemyPlayer(player, combatEngageDistance);
-    }
+    if (playerbot::EngageNearestEnemyPlayer(player, combatEngageDistance))
+        return true;
 
-    bool chaseIssued = MoveTowardUnit(player, selectedEnemy, 20.0f);
+    Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr);
+    if (!nearestEnemy)
+        return false;
+
+    bool chaseIssued = MoveTowardUnit(player, nearestEnemy, combatEngageDistance);
     if (!chaseIssued && CanIssueBotMovement(player))
-    {
-        // Last-resort kick in case pursuit helper declines movement while the
-        // bot is otherwise free to move.
-        chaseIssued = IssueMovePointThrottled(player, selectedEnemy->GetPosition(), 30.0f, 2000) || player->isMoving();
-    }
-
-    EmitBattlegroundGmDebug(player,
-        "wsg-pursuit=chase target=" + selectedEnemy->GetName() +
-        " dist=" + std::to_string(int32(distanceToEnemy)) +
-        " scan=" + std::to_string(scannedPlayers) +
-        " attackable=" + std::to_string(attackableEnemies) +
-        " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0) +
-        " issued=" + std::to_string(chaseIssued ? 1 : 0), 1200);
+        chaseIssued = IssueMovePointThrottled(player, nearestEnemy->GetPosition(), 30.0f, 2000) || player->isMoving();
     return chaseIssued;
 }
 


### PR DESCRIPTION
### Motivation
- Reduce complexity and duplicated pursuit logic in `TryPursueNearestEnemyInWarsong` by relying on existing engagement helper behavior and removing fragile sticky-target state. 
- Make chase distance calculation explicit and bounded using `GetAggressiveCombatScanDistance` and `std::clamp` for predictable engagement range.

### Description
- Rewrote `TryPursueNearestEnemyInWarsong` to call `playerbot::EngageNearestEnemyPlayer` first with a clamped `combatEngageDistance` and return on success. 
- Removed per-bot sticky target state maps and the `isValidChaseTarget` lambda plus scanned/attackable counters, simplifying selection to a single nearest enemy lookup via `FindNearestEnemyBattlegroundPlayer`. 
- Simplified movement logic to call `MoveTowardUnit` and fall back to `IssueMovePointThrottled` using the computed `combatEngageDistance`, and removed several battleground debug emits. 
- Preserved existing safety checks for map/battleground presence and teleport/in-flight guards.

### Testing
- Built the project with the updated code using the normal build system (`make`) and the build completed successfully. 
- Executed the existing automated unit/integration test suite (`ctest`) and all tests completed without failures. 
- Ran the existing automated PvP bot integration tests to validate pursuit behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f510b88cec8327b026c1069addad71)