### PR TITLE
Simplify WSG pursuit logic and add pathfinding fallback to avoid spawn-berm blocking

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -423,95 +423,32 @@ bool TryPursueNearestEnemyInWarsong(Player* player)
     if (!player || !IsWarsongGulch(player))
         return false;
 
-    static std::unordered_map<uint64, ObjectGuid> chaseTargetByBotGuid;
-    static std::unordered_map<uint64, uint32> chaseTargetSetMsByBotGuid;
-
-    auto const isValidChaseTarget = [player](Player* candidate) -> bool
-    {
-        if (!candidate || candidate == player)
-            return false;
-        if (!candidate->IsAlive() || !candidate->IsInWorld())
-            return false;
-        if (candidate->GetMapId() != player->GetMapId())
-            return false;
-        if (candidate->GetBattlegroundId() != player->GetBattlegroundId())
-            return false;
-        return player->IsValidAttackTarget(candidate);
-    };
-
-    uint32 scannedPlayers = 0;
-    uint32 attackableEnemies = 0;
-    Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), &scannedPlayers, &attackableEnemies);
-    uint64 const botGuid = player->GetGUID().GetRawValue();
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-    Player* selectedEnemy = nearestEnemy;
-    bool stickyTargetHeld = false;
-
-    std::unordered_map<uint64, ObjectGuid>::const_iterator stickyItr = chaseTargetByBotGuid.find(botGuid);
-    if (stickyItr != chaseTargetByBotGuid.end() && !stickyItr->second.IsEmpty())
-    {
-        Player* stickyEnemy = ObjectAccessor::FindConnectedPlayer(stickyItr->second);
-        if (isValidChaseTarget(stickyEnemy))
-        {
-            uint32 const setMs = chaseTargetSetMsByBotGuid[botGuid];
-            uint32 const stickyAgeMs = nowMs - setMs;
-            float const stickyDist = player->GetDistance(stickyEnemy);
-            float const nearestDist = nearestEnemy ? player->GetDistance(nearestEnemy) : std::numeric_limits<float>::max();
-            bool const withinStickyWindow = stickyAgeMs < 6000;
-            bool const nearestNotMeaningfullyBetter = nearestDist + 12.0f >= stickyDist;
-
-            if (withinStickyWindow && nearestNotMeaningfullyBetter)
-            {
-                selectedEnemy = stickyEnemy;
-                stickyTargetHeld = true;
-            }
-        }
-    }
-
-    if (!selectedEnemy)
-    {
-        chaseTargetByBotGuid.erase(botGuid);
-        chaseTargetSetMsByBotGuid.erase(botGuid);
-        EmitBattlegroundGmDebug(player,
-            "wsg-pursuit=no-enemy scanned=" + std::to_string(scannedPlayers) +
-            " attackable=" + std::to_string(attackableEnemies), 1500);
-        return false;
-    }
-
-    if (!stickyTargetHeld || chaseTargetByBotGuid[botGuid] != selectedEnemy->GetGUID())
-    {
-        chaseTargetByBotGuid[botGuid] = selectedEnemy->GetGUID();
-        chaseTargetSetMsByBotGuid[botGuid] = nowMs;
-    }
-
-    float const distanceToEnemy = player->GetDistance(selectedEnemy);
     float const combatEngageDistance = std::clamp(GetAggressiveCombatScanDistance(player, 100.0f), 25.0f, 60.0f);
-    if (distanceToEnemy <= combatEngageDistance)
-    {
-        EmitBattlegroundGmDebug(player,
-            "wsg-pursuit=engage target=" + selectedEnemy->GetName() +
-            " dist=" + std::to_string(int32(distanceToEnemy)) +
-            " scan=" + std::to_string(scannedPlayers) +
-            " attackable=" + std::to_string(attackableEnemies) +
-            " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0), 1200);
-        return playerbot::EngageNearestEnemyPlayer(player, combatEngageDistance);
-    }
+    if (playerbot::EngageNearestEnemyPlayer(player, combatEngageDistance))
+        return true;
 
-    bool chaseIssued = MoveTowardUnit(player, selectedEnemy, 20.0f);
+    Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr);
+    if (!nearestEnemy)
+        return false;
+
+    bool chaseIssued = MoveTowardUnit(player, nearestEnemy, combatEngageDistance);
     if (!chaseIssued && CanIssueBotMovement(player))
     {
-        // Last-resort kick in case pursuit helper declines movement while the
-        // bot is otherwise free to move.
-        chaseIssued = IssueMovePointThrottled(player, selectedEnemy->GetPosition(), 30.0f, 2000) || player->isMoving();
-    }
+        PathGenerator path(player);
+        bool const hasPath = path.CalculatePath(
+            nearestEnemy->GetPositionX(), nearestEnemy->GetPositionY(), nearestEnemy->GetPositionZ(), false);
 
-    EmitBattlegroundGmDebug(player,
-        "wsg-pursuit=chase target=" + selectedEnemy->GetName() +
-        " dist=" + std::to_string(int32(distanceToEnemy)) +
-        " scan=" + std::to_string(scannedPlayers) +
-        " attackable=" + std::to_string(attackableEnemies) +
-        " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0) +
-        " issued=" + std::to_string(chaseIssued ? 1 : 0), 1200);
+        if (!hasPath || (path.GetPathType() & PATHFIND_NOPATH))
+        {
+            // Gate/fence geometry can block direct first-segment pursuit from
+            // the spawn berm. Nudge toward midfield, then resume enemy pursuit.
+            static Position const midPoint(1258.810181f, 1463.801758f, 312.229401f, 0.0f);
+            chaseIssued = IssueMovePointThrottled(player, midPoint, 8.0f, 700) || player->isMoving();
+        }
+
+        if (!chaseIssued)
+            chaseIssued = IssueMovePointThrottled(player, nearestEnemy->GetPosition(), 30.0f, 2000) || player->isMoving();
+    }
     return chaseIssued;
 }
 


### PR DESCRIPTION
### Motivation

- Reduce fragile per-bot sticky-target state and simplify enemy pursuit logic in Warsong Gulch. 
- Avoid bots getting stuck behind gates/fences at the spawn berm by adding a pathfinding-aware fallback to nudge them midfield before resuming pursuit.

### Description

- Removed sticky target tracking maps and associated heuristics from `TryPursueNearestEnemyInWarsong` and replaced with a unified engagement helper call to `playerbot::EngageNearestEnemyPlayer`.
- Use a clamped `combatEngageDistance` from `GetAggressiveCombatScanDistance` and short-circuit when `EngageNearestEnemyPlayer` succeeds.
- Attempt `MoveTowardUnit` to the nearest enemy and, if movement is not issued and bot movement is allowed, run `PathGenerator::CalculatePath` and detect `PATHFIND_NOPATH` to handle blocked direct routes.
- When no path to the enemy exists, issue a throttled move toward a midfield `Position` to unstick bots, and otherwise fall back to `IssueMovePointThrottled` toward the enemy position; removed several battleground debug emits.

### Testing

- Built the project (`make`/project build) on the modified sources and the build completed successfully. 
- Ran automated unit/CI tests for playerbot and core server subsystems and they passed.
- Executed automated pathfinding checks for the modified `TryPursueNearestEnemyInWarsong` behavior and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f510b88cec8327b026c1069addad71)