### PR TITLE
Improve WSG pursuit: remove sticky targets, add pathcheck and midpoint fallback

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -423,95 +423,36 @@ bool TryPursueNearestEnemyInWarsong(Player* player)
     if (!player || !IsWarsongGulch(player))
         return false;
 
-    static std::unordered_map<uint64, ObjectGuid> chaseTargetByBotGuid;
-    static std::unordered_map<uint64, uint32> chaseTargetSetMsByBotGuid;
-
-    auto const isValidChaseTarget = [player](Player* candidate) -> bool
-    {
-        if (!candidate || candidate == player)
-            return false;
-        if (!candidate->IsAlive() || !candidate->IsInWorld())
-            return false;
-        if (candidate->GetMapId() != player->GetMapId())
-            return false;
-        if (candidate->GetBattlegroundId() != player->GetBattlegroundId())
-            return false;
-        return player->IsValidAttackTarget(candidate);
-    };
-
-    uint32 scannedPlayers = 0;
-    uint32 attackableEnemies = 0;
-    Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), &scannedPlayers, &attackableEnemies);
-    uint64 const botGuid = player->GetGUID().GetRawValue();
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-    Player* selectedEnemy = nearestEnemy;
-    bool stickyTargetHeld = false;
-
-    std::unordered_map<uint64, ObjectGuid>::const_iterator stickyItr = chaseTargetByBotGuid.find(botGuid);
-    if (stickyItr != chaseTargetByBotGuid.end() && !stickyItr->second.IsEmpty())
-    {
-        Player* stickyEnemy = ObjectAccessor::FindConnectedPlayer(stickyItr->second);
-        if (isValidChaseTarget(stickyEnemy))
-        {
-            uint32 const setMs = chaseTargetSetMsByBotGuid[botGuid];
-            uint32 const stickyAgeMs = nowMs - setMs;
-            float const stickyDist = player->GetDistance(stickyEnemy);
-            float const nearestDist = nearestEnemy ? player->GetDistance(nearestEnemy) : std::numeric_limits<float>::max();
-            bool const withinStickyWindow = stickyAgeMs < 6000;
-            bool const nearestNotMeaningfullyBetter = nearestDist + 12.0f >= stickyDist;
-
-            if (withinStickyWindow && nearestNotMeaningfullyBetter)
-            {
-                selectedEnemy = stickyEnemy;
-                stickyTargetHeld = true;
-            }
-        }
-    }
-
-    if (!selectedEnemy)
-    {
-        chaseTargetByBotGuid.erase(botGuid);
-        chaseTargetSetMsByBotGuid.erase(botGuid);
-        EmitBattlegroundGmDebug(player,
-            "wsg-pursuit=no-enemy scanned=" + std::to_string(scannedPlayers) +
-            " attackable=" + std::to_string(attackableEnemies), 1500);
-        return false;
-    }
-
-    if (!stickyTargetHeld || chaseTargetByBotGuid[botGuid] != selectedEnemy->GetGUID())
-    {
-        chaseTargetByBotGuid[botGuid] = selectedEnemy->GetGUID();
-        chaseTargetSetMsByBotGuid[botGuid] = nowMs;
-    }
-
-    float const distanceToEnemy = player->GetDistance(selectedEnemy);
     float const combatEngageDistance = std::clamp(GetAggressiveCombatScanDistance(player, 100.0f), 25.0f, 60.0f);
-    if (distanceToEnemy <= combatEngageDistance)
-    {
-        EmitBattlegroundGmDebug(player,
-            "wsg-pursuit=engage target=" + selectedEnemy->GetName() +
-            " dist=" + std::to_string(int32(distanceToEnemy)) +
-            " scan=" + std::to_string(scannedPlayers) +
-            " attackable=" + std::to_string(attackableEnemies) +
-            " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0), 1200);
-        return playerbot::EngageNearestEnemyPlayer(player, combatEngageDistance);
-    }
+    if (playerbot::EngageNearestEnemyPlayer(player, combatEngageDistance))
+        return true;
 
-    bool chaseIssued = MoveTowardUnit(player, selectedEnemy, 20.0f);
-    if (!chaseIssued && CanIssueBotMovement(player))
-    {
-        // Last-resort kick in case pursuit helper declines movement while the
-        // bot is otherwise free to move.
-        chaseIssued = IssueMovePointThrottled(player, selectedEnemy->GetPosition(), 30.0f, 2000) || player->isMoving();
-    }
+    Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr);
+    if (!nearestEnemy)
+        return false;
 
-    EmitBattlegroundGmDebug(player,
-        "wsg-pursuit=chase target=" + selectedEnemy->GetName() +
-        " dist=" + std::to_string(int32(distanceToEnemy)) +
-        " scan=" + std::to_string(scannedPlayers) +
-        " attackable=" + std::to_string(attackableEnemies) +
-        " sticky=" + std::to_string(stickyTargetHeld ? 1 : 0) +
-        " issued=" + std::to_string(chaseIssued ? 1 : 0), 1200);
+    bool chaseIssued = MoveTowardUnit(player, nearestEnemy, combatEngageDistance);
+    if (!chaseIssued)
+    {
+        // If direct pursuit did not issue movement, clear stale motion so a new
+        // path request can be accepted even when the bot is parked at gate edge.
+        player->GetMotionMaster()->Clear();
+
+        PathGenerator path(player);
+        bool const hasPath = path.CalculatePath(
+            nearestEnemy->GetPositionX(), nearestEnemy->GetPositionY(), nearestEnemy->GetPositionZ(), false);
+
+        if (!hasPath || (path.GetPathType() & PATHFIND_NOPATH))
+        {
+            // Gate/fence geometry can block direct first-segment pursuit from
+            // the spawn berm. Nudge toward midfield, then resume enemy pursuit.
+            static Position const midPoint(1258.810181f, 1463.801758f, 312.229401f, 0.0f);
+            chaseIssued = IssueMovePointThrottled(player, midPoint, 8.0f, 700) || player->isMoving();
+        }
+
+        if (!chaseIssued)
+            chaseIssued = IssueMovePointThrottled(player, nearestEnemy->GetPosition(), 30.0f, 2000) || player->isMoving();
+    }
     return chaseIssued;
 }
 


### PR DESCRIPTION
### Motivation

- Prevent bots from getting stuck at spawn gates or relying on stale "sticky" chase targets in Warsong Gulch. 
- Simplify pursuit logic to prefer immediate engagement and to rely on pathfinding checks instead of per-bot sticky state. 
- Improve chase reliability by nudging bots to a safe midfield point when direct paths are blocked by map geometry.

### Description

- Replaced per-bot sticky maps with a simpler flow that first tries to `EngageNearestEnemyPlayer` using a clamped `combatEngageDistance`.
- Use `FindNearestEnemyBattlegroundPlayer` to pick a pursuit target and attempt `MoveTowardUnit`; if movement is not issued, clear the bot motion with `GetMotionMaster()->Clear()` to allow a fresh path request.
- Run a `PathGenerator` calculation to the enemy and, if no path or `PATHFIND_NOPATH` is returned, issue a throttled move to a hardcoded midfield `Position` as a fallback; otherwise throttle a move directly to the enemy position.
- Removed sticky-target tracking maps, associated heuristics, and verbose battleground debug emissions, simplifying decision state and timing logic.

### Testing

- Project build completed successfully after the change (compilation step executed). 
- Ran the automated test suite for playerbot/battleground components via the project's test runner; related tests passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f510b88cec8327b026c1069addad71)