### PR TITLE
Cancel fleeing on AttackMe+Fear taunt so victims immediately chase attacker

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12047,6 +12047,8 @@ void Unit::SetTaunted(bool apply)
         }
         if (caster)
         {
+            // AttackMe fear should force immediate chase/attack behavior instead of continuing to flee.
+            GetMotionMaster()->Remove(FLEEING_MOTION_TYPE);
             GetMotionMaster()->MoveChase(caster);
             CastStop();
             Attack(caster, true);


### PR DESCRIPTION
### Motivation
- AttackMe+Fear (taunt) effects did not force victims to attack immediately because the active fleeing motion was not cancelled when taunt was applied.

### Description
- Add `GetMotionMaster()->Remove(FLEEING_MOTION_TYPE);` immediately before `MoveChase(caster)` in `Unit::SetTaunted(bool apply)` in `src/server/game/Entities/Unit/Unit.cpp` so taunted units stop fleeing and start chasing the caster right away.

### Testing
- No automated test suite was executed for this small change; only repository validation and commit commands were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f530139a908327866e224a40818198)