### PR TITLE
Clear fleeing state for `SPELL_EFFECT_ATTACK_ME` taunts so unit chases immediately

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12047,6 +12047,9 @@ void Unit::SetTaunted(bool apply)
         }
         if (caster)
         {
+            // AttackMe fear should force immediate chase/attack behavior instead of continuing to flee.
+            ClearUnitState(UNIT_STATE_FLEEING);
+            GetMotionMaster()->Remove(FLEEING_MOTION_TYPE);
             GetMotionMaster()->MoveChase(caster);
             CastStop();
             Attack(caster, true);


### PR DESCRIPTION
### Motivation
- Ensure units affected by `SPELL_EFFECT_ATTACK_ME` (AttackMe fear/taunt) stop fleeing and immediately begin chasing/attacking the caster instead of continuing to flee.

### Description
- When applying the taunt for `AttackMe` effects, clear `UNIT_STATE_FLEEING` and remove `FLEEING_MOTION_TYPE` before calling `GetMotionMaster()->MoveChase`, then call `CastStop()` and `Attack(caster, true)`.

### Testing
- No automated tests were added or executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f530139a908327866e224a40818198)