### PR TITLE
Fix spellcasting while under Attack Me fear/taunt

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6576,7 +6576,7 @@ SpellCastResult Spell::CheckCasterAuras(uint32* param1) const
         result = SPELL_FAILED_CHARMED;
 
     bool hasAttackMeFear = unitCaster->HasAttackMeFearAura();
-    if (result == SPELL_CAST_OK && hasAttackMeFear && !CheckSpellCancelsCharm(param1))
+    if (result == SPELL_CAST_OK && hasAttackMeFear && !CheckSpellCancelsTaunt(param1))
         result = SPELL_FAILED_CHARMED;
 
     // spell has attribute usable while having a cc state, check if caster has allowed mechanic auras, another mechanic types must prevent cast spell
@@ -6650,7 +6650,7 @@ SpellCastResult Spell::CheckCasterAuras(uint32* param1) const
             result = SPELL_FAILED_STUNNED;
     }
 
-    if (result == SPELL_CAST_OK && unitCaster->IsTaunted() && !CheckSpellCancelsCharm(param1))
+    if (result == SPELL_CAST_OK && unitCaster->IsTaunted() && !CheckSpellCancelsTaunt(param1))
         result = SPELL_FAILED_CHARMED;
     if (result == SPELL_CAST_OK && unitflag & UNIT_FLAG_SILENCED && m_spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE && !CheckSpellCancelsSilence(param1))
         result = SPELL_FAILED_SILENCED;


### PR DESCRIPTION
### Motivation
- Prevent players from retaining control to cast spells while affected by "Attack Me" fear or taunt effects by using the proper taunt-cancellation checks instead of charm checks.

### Description
- Replaced two incorrect calls to `CheckSpellCancelsCharm(param1)` with `CheckSpellCancelsTaunt(param1)` in `Spell::CheckCasterAuras` (`src/server/game/Spells/Spell.cpp`), so both the `hasAttackMeFear` branch and the `IsTaunted()` branch validate using taunt-specific logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64c5a8e4083279459b6515df5ca01)