### PR TITLE
SCM: alternate resurrection graveyards by wave

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -5,7 +5,6 @@
 #include "GameObject.h"
 #include "Log.h"
 #include "Player.h"
-#include "Random.h"
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
@@ -25,6 +24,8 @@ BattlegroundSCM::BattlegroundSCM()
     _allianceHumanParticipants = 0;
     _hordeHumanParticipants = 0;
     _humanFaceoffEverHappened = false;
+    _usePrimaryGraveyard = true;
+    _graveyardSwapTimer = 0;
     m_BuffChange = true;
 }
 
@@ -55,6 +56,21 @@ void BattlegroundSCM::Reset()
     _allianceHumanParticipants = 0;
     _hordeHumanParticipants = 0;
     _humanFaceoffEverHappened = false;
+    _usePrimaryGraveyard = true;
+    _graveyardSwapTimer = 0;
+}
+
+void BattlegroundSCM::PostUpdateImpl(uint32 diff)
+{
+    if (GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    _graveyardSwapTimer += diff;
+    if (_graveyardSwapTimer >= GetResurrectionInterval())
+    {
+        _graveyardSwapTimer = 0;
+        _usePrimaryGraveyard = !_usePrimaryGraveyard;
+    }
 }
 
 void BattlegroundSCM::TrackHumanParticipantAdded(Player const* player, bool isInBattleground)
@@ -251,14 +267,14 @@ void BattlegroundSCM::StartingEventOpenDoors()
     ApplyNonInteractableObjectFlags();
 }
 
-WorldSafeLocsEntry const* BattlegroundSCM::GetRandomTeamGraveyard(TeamId teamId) const
+WorldSafeLocsEntry const* BattlegroundSCM::GetCurrentTeamGraveyard(TeamId teamId) const
 {
     if (teamId == TEAM_ALLIANCE)
-        return urand(0, 1) == 0 ? sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_ALLIANCE_A)
-                                 : sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_ALLIANCE_B);
+        return _usePrimaryGraveyard ? sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_ALLIANCE_A)
+                                    : sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_ALLIANCE_B);
 
-    return urand(0, 1) == 0 ? sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_HORDE_A)
-                             : sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_HORDE_B);
+    return _usePrimaryGraveyard ? sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_HORDE_A)
+                                : sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_HORDE_B);
 }
 
 WorldSafeLocsEntry const* BattlegroundSCM::GetClosestGraveyard(Player* player)
@@ -269,13 +285,13 @@ WorldSafeLocsEntry const* BattlegroundSCM::GetClosestGraveyard(Player* player)
     if (player->GetTeam() == ALLIANCE)
     {
         if (GetStatus() == STATUS_IN_PROGRESS)
-            return GetRandomTeamGraveyard(TEAM_ALLIANCE);
+            return GetCurrentTeamGraveyard(TEAM_ALLIANCE);
 
         return sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_ALLIANCE_START);
     }
 
     if (GetStatus() == STATUS_IN_PROGRESS)
-        return GetRandomTeamGraveyard(TEAM_HORDE);
+        return GetCurrentTeamGraveyard(TEAM_HORDE);
 
     return sWorldSafeLocsStore.LookupEntry(BG_SCM_GY_HORDE_START);
 }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
@@ -98,6 +98,7 @@ public:
     void RemovePlayer(Player* player, ObjectGuid guid, uint32 team) override;
     void Reset() override;
     bool SetupBattleground() override;
+    void PostUpdateImpl(uint32 diff) override;
 
     void StartingEventCloseDoors() override;
     void StartingEventOpenDoors() override;
@@ -110,7 +111,7 @@ public:
     uint32 GetBuffRespawnTime(uint32 type) const override;
 
 private:
-    WorldSafeLocsEntry const* GetRandomTeamGraveyard(TeamId teamId) const;
+    WorldSafeLocsEntry const* GetCurrentTeamGraveyard(TeamId teamId) const;
     void UpdateTeamScoreWorldStates();
     void ApplyNonInteractableObjectFlags();
     void SpawnRandomBuffSet(uint32 speedTypeIndex);
@@ -125,6 +126,8 @@ private:
     uint32 _allianceHumanParticipants;
     uint32 _hordeHumanParticipants;
     bool _humanFaceoffEverHappened;
+    bool _usePrimaryGraveyard;
+    uint32 _graveyardSwapTimer;
 };
 
 #endif


### PR DESCRIPTION
### Motivation
- Replace per-player random resurrection selection in the Scarlet Chapel (SCM) battleground with a wave-synchronized graveyard selection so everyone resurrects together at the same graveyard.

### Description
- Added `PostUpdateImpl(uint32 diff)` to `BattlegroundSCM` to track time and flip the active graveyard every resurrection interval using `GetResurrectionInterval()`.
- Introduced persistent state members `bool _usePrimaryGraveyard` and `uint32 _graveyardSwapTimer` and initialized them in the constructor and `Reset()` so each match starts deterministically.
- Replaced the random-per-call graveyard function with `GetCurrentTeamGraveyard(TeamId)` which returns either `BG_SCM_GY_*_A` or `BG_SCM_GY_*_B` based on `_usePrimaryGraveyard`, and wired `GetClosestGraveyard` to use it.
- Files changed: `src/server/game/Battlegrounds/Zones/BattlegroundSCM.h` and `src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp`.

### Testing
- Applied the patch and verified the updated source files contain the new members and `PostUpdateImpl` implementation (file diffs show the changes successfully applied). 
- No automated unit or integration tests were executed in this rollout; runtime verification (build/run) was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d592c38083278281f8027e0f73ef)