### PR TITLE
Fix missing battleground bracket include in Scarlet Chapel queue script

### DIFF
--- a/src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp
+++ b/src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp
@@ -3,6 +3,7 @@
 #include "BattlegroundQueue.h"
 #include "Group.h"
 #include "GroupReference.h"
+#include "DBCStores.h"
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"


### PR DESCRIPTION
### Motivation
- Fix compile errors in `src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp` caused by a missing declaration for `GetBattlegroundBracketByLevel` and an incomplete `PvPDifficultyEntry` type.

### Description
- Add `#include "DBCStores.h"` to `npc_scarlet_chapel_queue.cpp` so `GetBattlegroundBracketByLevel` and `PvPDifficultyEntry` are available at the use site.

### Testing
- Verified the source change with `git diff` and created a commit for the updated `npc_scarlet_chapel_queue.cpp`; no full build or automated test suite was run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e38be1c88327b3d3d81672274629)