### PR TITLE
Prevent worldserver abort when aura application is missing during unapply

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -586,8 +586,8 @@ void Aura::_ApplyForTarget(Unit* target, Unit* caster, AuraApplication* auraApp)
 void Aura::_UnapplyForTarget(Unit* target, Unit* caster, AuraApplication* auraApp)
 {
     ASSERT(target);
-    ASSERT(auraApp->GetRemoveMode());
     ASSERT(auraApp);
+    ASSERT(auraApp->GetRemoveMode());
 
     ApplicationMap::iterator itr = m_applications.find(target->GetGUID());
 
@@ -595,8 +595,8 @@ void Aura::_UnapplyForTarget(Unit* target, Unit* caster, AuraApplication* auraAp
     if (itr == m_applications.end())
     {
         TC_LOG_ERROR("spells", "Aura::_UnapplyForTarget, target: {}, caster: {}, spell:{} was not found in owners application map!",
-        target->GetGUID().ToString(), caster ? caster->GetGUID().ToString() : "0", auraApp->GetBase()->GetSpellInfo()->Id);
-        ABORT();
+            target->GetGUID().ToString(), caster ? caster->GetGUID().ToString() : "0", auraApp->GetBase()->GetSpellInfo()->Id);
+        return;
     }
 
     // aura has to be already applied


### PR DESCRIPTION
### Motivation
- Prevent the server abort/crash triggered during logout/cleanup when an `AuraApplication` is missing from an aura's `m_applications` map, which previously led to an `ABORT()` and terminated `worldserver`.

### Description
- In `src/server/game/Spells/Auras/SpellAuras.cpp` updated `Aura::_UnapplyForTarget` to assert `auraApp` before dereferencing it and to log the desync case and `return` early instead of calling `ABORT()`, preserving existing behavior for the normal path.

### Testing
- Verified the change with `git diff` and committed the patch with `git commit`, and inspected the modified lines with `nl`; these commands completed successfully and show the intended guard change; no build or unit tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8054153488327b29b8413a76e91cb)