### PR TITLE
Add Scarlet Chapel queue NPC and honor forced queue team in BattlegroundQueue

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -229,7 +229,11 @@ GroupQueueInfo* BattlegroundQueue::AddGroup(Player* leader, Group* grp, Battlegr
     // For battlegrounds we use synthetic queue sides instead of the player's real faction.
     // This keeps the first waiting team on one side and pushes the next waiting team to the
     // opposite side so cross-faction queues can always produce a match.
-    if (!ArenaType)
+    //
+    // Scarlet Chapel may explicitly request a side via Player::GetBGTeam() before queueing.
+    // If set to ALLIANCE/HORDE, honor that request and skip synthetic side assignment.
+    bool const hasForcedQueueTeam = (BgTypeId == BATTLEGROUND_SCM) && (leader->GetBGTeam() == ALLIANCE || leader->GetBGTeam() == HORDE);
+    if (!ArenaType && !hasForcedQueueTeam)
     {
         uint32 alliancePlayers = 0;
         uint32 hordePlayers = 0;
@@ -295,6 +299,10 @@ GroupQueueInfo* BattlegroundQueue::AddGroup(Player* leader, Group* grp, Battlegr
                 break;
             }
         }
+    }
+    else if (hasForcedQueueTeam)
+    {
+        ginfo->Team = leader->GetBGTeam();
     }
 
     ginfo->Players.clear();

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -29,6 +29,7 @@ void AddSC_custom_diremaul_beads();
 void AddSC_custom_gurubashi_arena();
 void AddSC_custom_depleted_mark_exchange();
 void AddSC_custom_pvpve_dungeon();
+void AddSC_npc_scarlet_chapel_queue();
 void AddSC_npc_account_banker();
 
 void AddCustomScripts()
@@ -42,5 +43,6 @@ void AddCustomScripts()
     AddSC_custom_gurubashi_arena();
     AddSC_custom_depleted_mark_exchange();
     AddSC_custom_pvpve_dungeon();
+    AddSC_npc_scarlet_chapel_queue();
     AddSC_npc_account_banker();
 }

--- a/src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp
+++ b/src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp
@@ -1,0 +1,154 @@
+#include "Battleground.h"
+#include "BattlegroundMgr.h"
+#include "BattlegroundQueue.h"
+#include "Group.h"
+#include "GroupReference.h"
+#include "Player.h"
+#include "ScriptMgr.h"
+#include "ScriptedCreature.h"
+#include "ScriptedGossip.h"
+#include "SharedDefines.h"
+#include "WorldSession.h"
+
+namespace
+{
+constexpr uint32 ACTION_QUEUE_REGULAR = GOSSIP_ACTION_INFO_DEF + 1;
+constexpr uint32 ACTION_QUEUE_ALLIANCE = GOSSIP_ACTION_INFO_DEF + 2;
+constexpr uint32 ACTION_QUEUE_HORDE = GOSSIP_ACTION_INFO_DEF + 3;
+constexpr uint32 ACTION_CLOSE = GOSSIP_ACTION_INFO_DEF + 4;
+
+void SendQueueError(Player* player, char const* text)
+{
+    CloseGossipMenuFor(player);
+    if (WorldSession* session = player ? player->GetSession() : nullptr)
+        session->SendNotification("%s", text);
+}
+
+bool QueueSinglePlayer(Player* player, uint32 forcedTeam)
+{
+    if (!player || !player->GetBGAccessByLevel(BATTLEGROUND_SCM) || !player->HasFreeBattlegroundQueueId())
+        return false;
+
+    Battleground* bgTemplate = sBattlegroundMgr->GetBattlegroundTemplate(BATTLEGROUND_SCM);
+    if (!bgTemplate)
+        return false;
+
+    BattlegroundQueueTypeId const queueTypeId = BattlegroundMgr::BGQueueTypeId(BATTLEGROUND_SCM, 0);
+    if (queueTypeId == BATTLEGROUND_QUEUE_NONE)
+        return false;
+
+    if (player->GetBattlegroundQueueIndex(queueTypeId) < PLAYER_MAX_BATTLEGROUND_QUEUES)
+        return false;
+
+    PvPDifficultyEntry const* bracketEntry = GetBattlegroundBracketByLevel(bgTemplate->GetMapId(), player->GetLevel());
+    if (!bracketEntry)
+        return false;
+
+    uint32 const previousBgTeam = player->GetBGTeam();
+    if (forcedTeam == TEAM_ALLIANCE)
+        player->SetBGTeam(ALLIANCE);
+    else if (forcedTeam == TEAM_HORDE)
+        player->SetBGTeam(HORDE);
+
+    BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(queueTypeId);
+    GroupQueueInfo* ginfo = bgQueue.AddGroup(player, nullptr, BATTLEGROUND_SCM, bracketEntry, 0, false, false, 0, 0);
+
+    player->SetBGTeam(previousBgTeam);
+
+    if (!ginfo)
+        return false;
+
+    player->AddBattlegroundQueueId(queueTypeId);
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, queueTypeId, BATTLEGROUND_SCM, bracketEntry->GetBracketId());
+    return true;
+}
+}
+
+class npc_scarlet_chapel_queue : public CreatureScript
+{
+public:
+    npc_scarlet_chapel_queue() : CreatureScript("npc_scarlet_chapel_queue") { }
+
+    struct npc_scarlet_chapel_queueAI : public ScriptedAI
+    {
+        npc_scarlet_chapel_queueAI(Creature* creature) : ScriptedAI(creature) { }
+
+        bool OnGossipHello(Player* player) override
+        {
+            ClearGossipMenuFor(player);
+            AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Queue for Scarlet Chapel", GOSSIP_SENDER_MAIN, ACTION_QUEUE_REGULAR);
+            AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Queue for Scarlet Chapel (Force Alliance side)", GOSSIP_SENDER_MAIN, ACTION_QUEUE_ALLIANCE);
+            AddGossipItemFor(player, GOSSIP_ICON_BATTLE, "Queue for Scarlet Chapel (Force Horde side)", GOSSIP_SENDER_MAIN, ACTION_QUEUE_HORDE);
+            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Maybe later", GOSSIP_SENDER_MAIN, ACTION_CLOSE);
+            SendGossipMenuFor(player, player->GetGossipTextId(me), me);
+            return true;
+        }
+
+        bool OnGossipSelect(Player* player, uint32, uint32 gossipListId) override
+        {
+            uint32 const action = player->PlayerTalkClass->GetGossipOptionAction(gossipListId);
+            switch (action)
+            {
+                case ACTION_QUEUE_REGULAR: return HandleQueue(player, TEAM_NEUTRAL);
+                case ACTION_QUEUE_ALLIANCE: return HandleQueue(player, TEAM_ALLIANCE);
+                case ACTION_QUEUE_HORDE: return HandleQueue(player, TEAM_HORDE);
+                case ACTION_CLOSE: CloseGossipMenuFor(player); return true;
+                default: return false;
+            }
+        }
+
+        bool HandleQueue(Player* player, uint32 forcedTeam)
+        {
+            Group* group = player->GetGroup();
+            if (group && !group->IsLeader(player->GetGUID()))
+            {
+                SendQueueError(player, "Only the party leader can queue your group.");
+                return true;
+            }
+
+            if (!group)
+            {
+                if (!QueueSinglePlayer(player, forcedTeam))
+                    SendQueueError(player, "Unable to queue for Scarlet Chapel right now.");
+                else
+                    CloseGossipMenuFor(player);
+                return true;
+            }
+
+            for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+            {
+                Player* member = ref->GetSource();
+                if (!member)
+                {
+                    SendQueueError(player, "All party members must be online.");
+                    return true;
+                }
+            }
+
+            bool anyFailed = false;
+            for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+            {
+                Player* member = ref->GetSource();
+                if (!QueueSinglePlayer(member, forcedTeam))
+                    anyFailed = true;
+            }
+
+            if (anyFailed)
+                SendQueueError(player, "One or more party members could not be queued.");
+            else
+                CloseGossipMenuFor(player);
+
+            return true;
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_scarlet_chapel_queueAI(creature);
+    }
+};
+
+void AddSC_npc_scarlet_chapel_queue()
+{
+    new npc_scarlet_chapel_queue();
+}


### PR DESCRIPTION
### Motivation
- Allow Scarlet Chapel to request an explicit battleground side so NPCs or scripts can force Alliance/Horde when queuing.
- Provide an NPC to let players or party leaders queue for Scarlet Chapel with options to force a side or queue normally.

### Description
- In `BattlegroundQueue::AddGroup` added `hasForcedQueueTeam` detection for `BATTLEGROUND_SCM` that honors `Player::GetBGTeam()` when set to `ALLIANCE` or `HORDE`, skipping synthetic side assignment and applying the forced team to `ginfo->Team`.
- Added new script `src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp` implementing a gossip NPC with options: regular queue, force Alliance, and force Horde; it temporarily sets the player's BG team, calls `AddGroup`, restores the previous team, and schedules the queue update.
- Registered the new script by declaring and calling `AddSC_npc_scarlet_chapel_queue()` in `src/server/scripts/Custom/custom_script_loader.cpp`.

### Testing
- Built the project with `make`, and the build completed successfully.
- Executed the automated test suite via `make test`/`ctest`, and all tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d798a14483279907ef127210f4c6)