### PR TITLE
Battleground: prefer human leaders over virtual playerbots

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -70,6 +70,25 @@ bool HasAnyNonVirtualHumanParticipant(Battleground const* battleground)
 
     return false;
 }
+
+ObjectGuid GetFirstNonVirtualMemberGuid(Group const* group)
+{
+    if (!group)
+        return ObjectGuid::Empty;
+
+    for (GroupReference const* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+    {
+        Player const* member = itr->GetSource();
+        if (!member)
+            continue;
+
+        WorldSession const* session = member->GetSession();
+        if (session && !session->IsVirtualSession())
+            return member->GetGUID();
+    }
+
+    return ObjectGuid::Empty;
+}
 }
 
 void BattlegroundScore::AppendToPacket(WorldPacket& data)
@@ -1246,6 +1265,7 @@ void Battleground::AddOrSetPlayerToCorrectBgGroup(Player* player, uint32 team)
 {
     ObjectGuid playerGuid = player->GetGUID();
     Group* group = GetBgRaid(team);
+    bool const joiningPlayerIsNonVirtual = player->GetSession() && !player->GetSession()->IsVirtualSession();
     if (!group)                                      // first player joined
     {
         group = new Group;
@@ -1269,6 +1289,20 @@ void Battleground::AddOrSetPlayerToCorrectBgGroup(Player* player, uint32 team)
                     group->ChangeLeader(playerGuid);
                     group->SendUpdate();
                 }
+        }
+    }
+
+    ObjectGuid const currentLeaderGuid = group->GetLeaderGUID();
+    Player const* currentLeader = ObjectAccessor::FindConnectedPlayer(currentLeaderGuid);
+    bool const currentLeaderIsNonVirtual = currentLeader && currentLeader->GetSession() && !currentLeader->GetSession()->IsVirtualSession();
+
+    if (!currentLeaderIsNonVirtual)
+    {
+        ObjectGuid const humanLeaderGuid = joiningPlayerIsNonVirtual ? playerGuid : GetFirstNonVirtualMemberGuid(group);
+        if (!humanLeaderGuid.IsEmpty() && humanLeaderGuid != currentLeaderGuid)
+        {
+            group->ChangeLeader(humanLeaderGuid);
+            group->SendUpdate();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure battleground/SCM raid leadership is held by real human players when available instead of virtual-session managed playerbots.
- Implement leadership handoff in the active server code (not in playerbot reference) to match runtime grouping behavior in battleground joins.

### Description
- Added `GetFirstNonVirtualMemberGuid(Group const*)` helper to locate the first non-virtual (human-controlled) member in a group.
- Updated `Battleground::AddOrSetPlayerToCorrectBgGroup` to detect whether the joining player is non-virtual, check the current raid leader's session type, and promote a human leader if the current leader is a virtual session by preferring the joining human or falling back to the first existing human member.
- Preserved the existing original-group leader promotion flow and perform the human-first leader correction after standard group assignment logic in `src/server/game/Battlegrounds/Battleground.cpp`.

### Testing
- Ran repository inspections and diffs (`rg` searches and `git diff`) and committed the change successfully; these commands completed without error.
- No automated unit/CI tests or build were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f6adb6a0832782b760c2a5b59b84)