### PR TITLE
Suppress /kneel and /lie emote chat messages

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -836,11 +836,15 @@ void WorldSession::HandleTextEmoteOpcode(WorldPacket& recvData)
 
     Emote emote = static_cast<Emote>(em->EmoteID);
 
+    bool sendTextEmote = true;
+
     switch (emote)
     {
         case EMOTE_STATE_SLEEP:
         case EMOTE_STATE_SIT:
         case EMOTE_STATE_KNEEL:
+            sendTextEmote = false;
+            break;
         case EMOTE_ONESHOT_NONE:
             break;
         default:
@@ -853,16 +857,19 @@ void WorldSession::HandleTextEmoteOpcode(WorldPacket& recvData)
 
     Unit* unit = ObjectAccessor::GetUnit(*_player, guid);
 
-    CellCoord p = Trinity::ComputeCellCoord(GetPlayer()->GetPositionX(), GetPlayer()->GetPositionY());
+    if (sendTextEmote)
+    {
+        CellCoord p = Trinity::ComputeCellCoord(GetPlayer()->GetPositionX(), GetPlayer()->GetPositionY());
 
-    Cell cell(p);
-    cell.SetNoCreate();
+        Cell cell(p);
+        cell.SetNoCreate();
 
-    Trinity::EmoteChatBuilder emote_builder(*GetPlayer(), text_emote, emoteNum, unit);
-    Trinity::LocalizedPacketDo<Trinity::EmoteChatBuilder > emote_do(emote_builder);
-    Trinity::PlayerDistWorker<Trinity::LocalizedPacketDo<Trinity::EmoteChatBuilder > > emote_worker(GetPlayer(), sWorld->getFloatConfig(CONFIG_LISTEN_RANGE_TEXTEMOTE), emote_do);
-    TypeContainerVisitor<Trinity::PlayerDistWorker<Trinity::LocalizedPacketDo<Trinity::EmoteChatBuilder> >, WorldTypeMapContainer> message(emote_worker);
-    cell.Visit(p, message, *GetPlayer()->GetMap(), *GetPlayer(), sWorld->getFloatConfig(CONFIG_LISTEN_RANGE_TEXTEMOTE));
+        Trinity::EmoteChatBuilder emote_builder(*GetPlayer(), text_emote, emoteNum, unit);
+        Trinity::LocalizedPacketDo<Trinity::EmoteChatBuilder > emote_do(emote_builder);
+        Trinity::PlayerDistWorker<Trinity::LocalizedPacketDo<Trinity::EmoteChatBuilder > > emote_worker(GetPlayer(), sWorld->getFloatConfig(CONFIG_LISTEN_RANGE_TEXTEMOTE), emote_do);
+        TypeContainerVisitor<Trinity::PlayerDistWorker<Trinity::LocalizedPacketDo<Trinity::EmoteChatBuilder> >, WorldTypeMapContainer> message(emote_worker);
+        cell.Visit(p, message, *GetPlayer()->GetMap(), *GetPlayer(), sWorld->getFloatConfig(CONFIG_LISTEN_RANGE_TEXTEMOTE));
+    }
 
     GetPlayer()->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_DO_EMOTE, text_emote, 0, unit);
 


### PR DESCRIPTION
### Motivation
- Users should be able to use `/kneel` and `/lie` without generating a visible text-emote chat line in chat logs while keeping the actual animation/state changes.

### Description
- Added a `bool sendTextEmote` guard in `WorldSession::HandleTextEmoteOpcode` to control whether the `SMSG_TEXT_EMOTE` broadcast is sent. 
- Suppressed text-emote broadcasts for `EMOTE_STATE_SLEEP`, `EMOTE_STATE_SIT`, and `EMOTE_STATE_KNEEL` by setting `sendTextEmote = false` for those cases. 
- Wrapped the existing localized broadcast code in a `if (sendTextEmote)` block so the emote animation/state still applies via `HandleEmoteCommand` when appropriate. 
- Left achievement updates (`UpdateAchievementCriteria`) and scripted `ReceiveEmote` callbacks intact so behavior and server-side tracking remain unchanged.

### Testing
- Inspected `src/server/game/Handlers/ChatHandler.cpp` to confirm the new `sendTextEmote` guard correctly prevents constructing/sending the localized `SMSG_TEXT_EMOTE` packet for the targeted state emotes. 
- No automated unit tests were executed as part of this change; verification was performed via source inspection and control-flow review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91d5c892c8327953dc46c7a18fec8)