### PR TITLE
Playerbot: avoid restarting active wand auto-repeat casts

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2632,6 +2632,17 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             return false;
         }
 
+    // Auto-repeat spells (wand Shoot / Auto Shot) should not be re-cast every
+    // AI tick when already channeling on the same target. Reissuing the spell
+    // repeatedly restarts the opener and causes "startup only" behavior where
+    // bots appear to idle after the start sound.
+    if (spellInfo->IsAutoRepeatRangedSpell())
+        if (Spell const* autoRepeat = player->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL))
+            if (SpellInfo const* activeAutoRepeatInfo = autoRepeat->GetSpellInfo())
+                if (activeAutoRepeatInfo->Id == resolvedSpellId &&
+                    autoRepeat->m_targets.GetUnitTargetGUID() == target->GetGUID())
+                    return true;
+
     // Cast-time spells like Frostbolt fail while moving. Since playerbots do
     // not have client-side stop-cast behavior, explicitly stop movement before
     // attempting non-instant casts.


### PR DESCRIPTION
### Motivation
- Fix bots that play wand startup but then idle by preventing the AI from reissuing auto-repeat ranged spells (wand Shoot / Auto Shot) every tick when an identical auto-repeat is already active on the same target.

### Description
- In `CastDirectSpell` added an early-return guard that, when `spellInfo->IsAutoRepeatRangedSpell()` and `player->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL)` is active with the same `SpellInfo->Id` and the same target GUID (`m_targets.GetUnitTargetGUID()`), returns early to avoid restarting the auto-repeat.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f92e22011c8327a28ca38c542b0c37)