### PR TITLE
Guard Player cinematic manager access during Update

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -498,6 +498,7 @@ Player::~Player()
     delete m_achievementMgr;
     delete m_reputationMgr;
     delete _cinematicMgr;
+    _cinematicMgr = nullptr;
 
     sWorld->DecreasePlayerCount();
 }
@@ -1093,11 +1094,14 @@ void Player::Update(uint32 p_time)
     }
 
     // Update cinematic location, if 500ms have passed and we're doing a cinematic now.
-    _cinematicMgr->m_cinematicDiff += p_time;
-    if (_cinematicMgr->m_cinematicCamera && _cinematicMgr->m_activeCinematicCameraId && GetMSTimeDiffToNow(_cinematicMgr->m_lastCinematicCheck) > CINEMATIC_UPDATEDIFF)
+    if (_cinematicMgr)
     {
-        _cinematicMgr->m_lastCinematicCheck = GameTime::GetGameTimeMS();
-        _cinematicMgr->UpdateCinematicLocation(p_time);
+        _cinematicMgr->m_cinematicDiff += p_time;
+        if (_cinematicMgr->m_cinematicCamera && _cinematicMgr->m_activeCinematicCameraId && GetMSTimeDiffToNow(_cinematicMgr->m_lastCinematicCheck) > CINEMATIC_UPDATEDIFF)
+        {
+            _cinematicMgr->m_lastCinematicCheck = GameTime::GetGameTimeMS();
+            _cinematicMgr->UpdateCinematicLocation(p_time);
+        }
     }
 
     //used to implement delayed far teleports


### PR DESCRIPTION
### Motivation
- Prevent a potential segmentation fault in `Player::Update` caused by dereferencing a deleted or null `_cinematicMgr` by making cinematic access explicit and safe.

### Description
- Added a null check around `_cinematicMgr` usage in `Player::Update` and moved the `m_cinematicDiff` increment inside the guarded block to avoid dereferencing a removed manager while keeping existing cinematic update behavior intact.
- Set `_cinematicMgr` to `nullptr` immediately after `delete` in `Player::~Player` to make teardown semantics explicit and reduce race/window-of-use hazards.
- All changes are in `src/server/game/Entities/Player/Player.cpp`.

### Testing
- Ran `git diff --check` to validate patch formatting and it completed without errors.
- Performed file content verification to confirm the null-guard and nulling change were applied; no automated build or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f945d399148327a0ee45d7fe695b3a)