### PR TITLE
Fix null AI dereference in GameEventMgr SmartAI hooks

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1705,16 +1705,18 @@ public:
 
     void Visit(std::unordered_map<ObjectGuid, Creature*>& creatureMap)
     {
-        for (auto const& p : creatureMap)
-            if (p.second->IsInWorld() && p.second->IsAIEnabled())
-                p.second->AI()->OnGameEvent(_activate, _eventId);
+        for (auto const& pair : creatureMap)
+            if (Creature* creature = pair.second; creature && creature->IsInWorld() && creature->IsAIEnabled())
+                if (CreatureAI* ai = creature->AI())
+                    ai->OnGameEvent(_activate, _eventId);
     }
 
     void Visit(std::unordered_map<ObjectGuid, GameObject*>& gameObjectMap)
     {
-        for (auto const& p : gameObjectMap)
-            if (p.second->IsInWorld())
-                p.second->AI()->OnGameEvent(_activate, _eventId);
+        for (auto const& pair : gameObjectMap)
+            if (GameObject* gameObject = pair.second; gameObject && gameObject->IsInWorld())
+                if (GameObjectAI* ai = gameObject->AI())
+                    ai->OnGameEvent(_activate, _eventId);
     }
 
     template<class T>


### PR DESCRIPTION
### Motivation
- Prevent a SIGSEGV occurring in `GameEventMgr::RunSmartAIScripts` when visited creatures or gameobjects have missing/null `AI()` pointers during event activation/deactivation.

### Description
- Add defensive null checks in `GameEventAIHookWorker::Visit` for both `Creature` and `GameObject` stores so `OnGameEvent` is only invoked when the object exists, is in-world, and `AI()` returns a valid pointer (file changed: `src/server/game/Events/GameEventMgr.cpp`).

### Testing
- No automated tests were executed in this rollout; changes were inspected with `git diff` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa09a3d394832783de449a49772114)