### PR TITLE
Fix heartbeat resist setup for reflected spells

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2298,7 +2298,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
         {
             unitCaster = ASSERT_NOTNULL(m_caster->ToUnit());
         }
-        targetInfo.ReflectResult = unitCaster->SpellHitResult(unitCaster, m_spellInfo, false); // can't reflect twice
+        targetInfo.ReflectResult = unitCaster->SpellHitResult(unitCaster, m_spellInfo, false, &targetInfo.heartbeatResistChance); // can't reflect twice
 
         // Proc spell reflect aura when missile hits the original target
         target->m_Events.AddEvent(new ProcReflectDelayed(target, m_originalCasterGUID), target->m_Events.CalculateTime(Milliseconds(targetInfo.TimeDelay)));


### PR DESCRIPTION
### Motivation
- Ensure reflected crowd-control auras have their heartbeat-resist state initialized the same way as non-reflected hits so heartbeat duration/resist mechanics apply correctly.

### Description
- Pass `&targetInfo.heartbeatResistChance` into the reflected `SpellHitResult` call in `Spell::AddUnitTarget` (file `src/server/game/Spells/Spell.cpp`) so the reflected hit computes and stores heartbeat resist chance.

### Testing
- No automated tests were run for this change (code-level one-line fix only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa234a1fcc83278620e771edf1cb5c)