### PR TITLE
Harden aura aggregation against null AuraEffect and missing SpellInfo

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5055,13 +5055,13 @@ int32 Unit::GetTotalAuraModifier(AuraType auraType, std::function<bool(AuraEffec
 
     for (AuraEffect const* aurEff : mTotalAuraList)
     {
-        if (predicate(aurEff))
-        {
-            // Check if the Aura Effect has a the Same Effect Stack Rule and if so, use the highest amount of that SpellGroup
-            // If the Aura Effect does not have this Stack Rule, it returns false so we can add to the multiplier as usual
-            if (!sSpellMgr->AddSameEffectStackRuleSpellGroups(aurEff->GetSpellInfo(), static_cast<uint32>(auraType), aurEff->GetAmount(), sameEffectSpellGroup))
-                modifier += aurEff->GetAmount();
-        }
+        if (!aurEff || !predicate(aurEff))
+            continue;
+
+        // Check if the Aura Effect has a the Same Effect Stack Rule and if so, use the highest amount of that SpellGroup
+        // If the Aura Effect does not have this Stack Rule, it returns false so we can add to the modifier as usual
+        if (!sSpellMgr->AddSameEffectStackRuleSpellGroups(aurEff->GetSpellInfo(), static_cast<uint32>(auraType), aurEff->GetAmount(), sameEffectSpellGroup))
+            modifier += aurEff->GetAmount();
     }
 
     // Add the highest of the Same Effect Stack Rule SpellGroups to the accumulator
@@ -5082,13 +5082,13 @@ float Unit::GetTotalAuraMultiplier(AuraType auraType, std::function<bool(AuraEff
 
     for (AuraEffect const* aurEff : mTotalAuraList)
     {
-        if (predicate(aurEff))
-        {
-            // Check if the Aura Effect has a the Same Effect Stack Rule and if so, use the highest amount of that SpellGroup
-            // If the Aura Effect does not have this Stack Rule, it returns false so we can add to the multiplier as usual
-            if (!sSpellMgr->AddSameEffectStackRuleSpellGroups(aurEff->GetSpellInfo(), static_cast<uint32>(auraType), aurEff->GetAmount(), sameEffectSpellGroup))
-                AddPct(multiplier, aurEff->GetAmount());
-        }
+        if (!aurEff || !predicate(aurEff))
+            continue;
+
+        // Check if the Aura Effect has a the Same Effect Stack Rule and if so, use the highest amount of that SpellGroup
+        // If the Aura Effect does not have this Stack Rule, it returns false so we can add to the multiplier as usual
+        if (!sSpellMgr->AddSameEffectStackRuleSpellGroups(aurEff->GetSpellInfo(), static_cast<uint32>(auraType), aurEff->GetAmount(), sameEffectSpellGroup))
+            AddPct(multiplier, aurEff->GetAmount());
     }
 
     // Add the highest of the Same Effect Stack Rule SpellGroups to the multiplier
@@ -5107,7 +5107,7 @@ int32 Unit::GetMaxPositiveAuraModifier(AuraType auraType, std::function<bool(Aur
     int32 modifier = 0;
     for (AuraEffect const* aurEff : mTotalAuraList)
     {
-        if (predicate(aurEff))
+        if (aurEff && predicate(aurEff))
             modifier = std::max(modifier, aurEff->GetAmount());
     }
 
@@ -5123,7 +5123,7 @@ int32 Unit::GetMaxNegativeAuraModifier(AuraType auraType, std::function<bool(Aur
     int32 modifier = 0;
     for (AuraEffect const* aurEff : mTotalAuraList)
     {
-        if (predicate(aurEff))
+        if (aurEff && predicate(aurEff))
             modifier = std::min(modifier, aurEff->GetAmount());
     }
 

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -442,7 +442,14 @@ void SpellMgr::GetSetOfSpellsInSpellGroup(SpellGroup group_id, std::set<uint32>&
 
 bool SpellMgr::AddSameEffectStackRuleSpellGroups(SpellInfo const* spellInfo, uint32 auraType, int32 amount, std::map<SpellGroup, int32>& groups) const
 {
-    uint32 spellId = spellInfo->GetFirstRankSpell()->Id;
+    if (!spellInfo)
+        return false;
+
+    SpellInfo const* firstRankSpell = spellInfo->GetFirstRankSpell();
+    if (!firstRankSpell)
+        return false;
+
+    uint32 spellId = firstRankSpell->Id;
     auto spellGroupBounds = GetSpellSpellGroupMapBounds(spellId);
     // Find group with SPELL_GROUP_STACK_RULE_EXCLUSIVE_SAME_EFFECT if it belongs to one
     for (auto itr = spellGroupBounds.first; itr != spellGroupBounds.second; ++itr)


### PR DESCRIPTION
### Motivation
- Prevent crashes when iterating aura lists by skipping null `AuraEffect*` entries before calling predicates or dereferencing members.
- Avoid dereferencing missing `SpellInfo`/first-rank data when evaluating same-effect stack rules for spells with malformed or custom data.

### Description
- Add null checks in `Unit::GetTotalAuraModifier(...)` and `Unit::GetTotalAuraMultiplier(...)` to `continue` if the `AuraEffect*` is null or the predicate returns false, and preserve existing same-effect stack handling.
- Add the same null-safe guard to `GetMaxPositiveAuraModifier(...)` and `GetMaxNegativeAuraModifier(...)` to keep max/min aggregation consistent and safe.
- Guard `SpellMgr::AddSameEffectStackRuleSpellGroups(...)` against a null `spellInfo` and a missing `GetFirstRankSpell()` by returning `false` so the caller falls back to normal handling.

### Testing
- Built the impacted translation units with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/Unit/Unit.cpp.o src/server/game/CMakeFiles/game.dir/Spells/SpellMgr.cpp.o` which completed successfully.
- Ran `git diff --check` to verify there are no whitespace/check issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa51757f9c83278e91526ccacb7447)