### PR TITLE
Migrate battleground code to DBC stores, Duration API and ObjectAccessor (BFG, SV, TP)

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
@@ -10,19 +10,30 @@
 #include "WorldPacket.h"
 #include "ObjectMgr.h"
 #include "BattlegroundMgr.h"
+#include "DBCStores.h"
+#include "Duration.h"
+#include "Map.h"
 #include "Creature.h"
+#include "GameObject.h"
 #include "Language.h"
 #include "Object.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "Util.h"
 #include "WorldSession.h"
 
-#include "GameGraveyard.h"
 #include <unordered_map>
 
 #include "ScriptMgr.h"
 #include "Config.h"
 
+namespace
+{
+    TeamId GetOtherGilneasTeamId(TeamId teamId)
+    {
+        return teamId == TEAM_ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE;
+    }
+}
 
 void BattlegroundBFGScore::BuildObjectivesBlock(WorldPacket& data)
 {
@@ -91,7 +102,7 @@ void BattlegroundBFG::PostUpdateImpl(uint32 diff)
                     uint8 controlledPoints = _controlledPoints[teamId];
                     if (controlledPoints == 0)
                     {
-                        _bgEvents.ScheduleEvent(eventId, 3000);
+                        _bgEvents.ScheduleEvent(eventId, 3s);
                         break;
                     }
 
@@ -114,12 +125,12 @@ void BattlegroundBFG::PostUpdateImpl(uint32 diff)
                     }
 
                     UpdateWorldState(teamId == TEAM_ALLIANCE ? GILNEAS_BG_OP_RESOURCES_ALLY : GILNEAS_BG_OP_RESOURCES_HORDE, m_TeamScores[teamId]);
-                    if (m_TeamScores[teamId] > m_TeamScores[GetOtherTeamId(teamId)] + 500)
-                        _teamScores500Disadvantage[GetOtherTeamId(teamId)] = true;
+                    if (m_TeamScores[teamId] > m_TeamScores[GetOtherGilneasTeamId(teamId)] + 500)
+                        _teamScores500Disadvantage[GetOtherGilneasTeamId(teamId)] = true;
                     if (m_TeamScores[teamId] >= GILNEAS_BG_MAX_TEAM_SCORE)
                         EndBattleground(teamId);
 
-                    _bgEvents.ScheduleEvent(eventId, GILNEAS_BG_TickIntervals[controlledPoints]);
+                    _bgEvents.ScheduleEvent(eventId, Milliseconds(GILNEAS_BG_TickIntervals[controlledPoints]));
                     break;
                 }
             }
@@ -166,8 +177,8 @@ void BattlegroundBFG::StartingEventOpenDoors()
     // Achievement: Let's Get This Done
     StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, BG_BFG_EVENT_START_BATTLE);
 
-    _bgEvents.ScheduleEvent(BG_BFG_EVENT_ALLIANCE_TICK, 3000);
-    _bgEvents.ScheduleEvent(BG_BFG_EVENT_HORDE_TICK, 3000);
+    _bgEvents.ScheduleEvent(BG_BFG_EVENT_ALLIANCE_TICK, 3s);
+    _bgEvents.ScheduleEvent(BG_BFG_EVENT_HORDE_TICK, 3s);
 }
 
 
@@ -213,7 +224,7 @@ void BattlegroundBFG::CreateBanner(uint8 node, bool delay)
     // Just put it into the queue
     if (delay)
     {
-        _bgEvents.RescheduleEvent(BG_BFG_EVENT_UPDATE_BANNER_LIGHTHOUSE+node, BG_BFG_BANNER_UPDATE_TIME);
+        _bgEvents.RescheduleEvent(BG_BFG_EVENT_UPDATE_BANNER_LIGHTHOUSE + node, Milliseconds(BG_BFG_BANNER_UPDATE_TIME));
         return;
     }
 
@@ -321,7 +332,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
         UpdatePlayerScore(player, SCORE_BASES_ASSAULTED, 1);
         _capturePointInfo[node]._state = static_cast<uint8>(GILNEAS_BG_NODE_STATUS_ALLY_CONTESTED) + player->GetTeamId();
         _capturePointInfo[node]._ownerTeamId = TEAM_NEUTRAL;
-        _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, GILNEAS_BG_FLAG_CAPTURING_TIME);
+        _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
         sound = GILNEAS_BG_SOUND_NODE_CLAIMED;
         // message = LANG_BG_BFG_NODE_CLAIMED;
         // message2 = player->GetTeamId() == TEAM_ALLIANCE ? LANG_BG_BFG_ALLY : LANG_BG_BFG_HORDE;
@@ -333,7 +344,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
             UpdatePlayerScore(player, SCORE_BASES_ASSAULTED, 1);
             _capturePointInfo[node]._state = static_cast<uint8>(GILNEAS_BG_NODE_STATUS_ALLY_CONTESTED) + player->GetTeamId();
             _capturePointInfo[node]._ownerTeamId = TEAM_NEUTRAL;
-            _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, GILNEAS_BG_FLAG_CAPTURING_TIME);
+            _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
             // message = LANG_BG_BFG_NODE_ASSAULTED;
         }
         else
@@ -355,7 +366,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
         _capturePointInfo[node]._state = static_cast<uint8>(GILNEAS_BG_NODE_STATUS_ALLY_CONTESTED) + player->GetTeamId();
 
         ApplyPhaseMask();
-        _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, GILNEAS_BG_FLAG_CAPTURING_TIME);
+        _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
         // message = LANG_BG_BFG_NODE_ASSAULTED;
         sound = player->GetTeamId() == TEAM_ALLIANCE ? GILNEAS_BG_SOUND_NODE_ASSAULTED_ALLIANCE : GILNEAS_BG_SOUND_NODE_ASSAULTED_HORDE;
     }
@@ -412,8 +423,8 @@ void BattlegroundBFG::Init()
 
     _bgEvents.Reset();
 
-    // _honorTics = BattlegroundMgr::IsBGWeekend(GetBgTypeID()) ? BG_AB_HONOR_TICK_WEEKEND : BG_AB_HONOR_TICK_NORMAL;
-    // _reputationTics = BattlegroundMgr::IsBGWeekend(GetBgTypeID()) ? BG_AB_REP_TICK_WEEKEND : BG_AB_REP_TICK_NORMAL;
+    // _honorTics = BattlegroundMgr::IsBGWeekend(GetTypeID()) ? BG_AB_HONOR_TICK_WEEKEND : BG_AB_HONOR_TICK_NORMAL;
+    // _reputationTics = BattlegroundMgr::IsBGWeekend(GetTypeID()) ? BG_AB_REP_TICK_WEEKEND : BG_AB_REP_TICK_NORMAL;
 
     _capturePointInfo[GILNEAS_BG_NODE_LIGHTHOUSE]._iconNone    = GILNEAS_BG_OP_LIGHTHOUSE_ICON;
     _capturePointInfo[GILNEAS_BG_NODE_WATERWORKS]._iconNone    = GILNEAS_BG_OP_WATERWORKS_ICON;
@@ -432,21 +443,21 @@ void BattlegroundBFG::EndBattleground(uint32 winnerTeamId)
     _bgEvents.Reset();
 }
 
-GraveyardStruct const* BattlegroundBFG::GetClosestGraveyard(Player* player)
+WorldSafeLocsEntry const* BattlegroundBFG::GetClosestGraveyard(Player* player)
 {
-    GraveyardStruct const* entry = sGraveyard->GetGraveyard(GILNEAS_BG_GraveyardIds[static_cast<uint8>(GILNEAS_BG_SPIRIT_ALLIANCE) + player->GetTeamId()]);
-    GraveyardStruct const* nearestEntry = entry;
+    WorldSafeLocsEntry const* entry = sWorldSafeLocsStore.LookupEntry(GILNEAS_BG_GraveyardIds[static_cast<uint8>(GILNEAS_BG_SPIRIT_ALLIANCE) + player->GetTeamId()]);
+    WorldSafeLocsEntry const* nearestEntry = entry;
 
     float pX = player->GetPositionX();
     float pY = player->GetPositionY();
-    float dist = (entry->x - pX)*(entry->x - pX)+(entry->y - pY)*(entry->y - pY);
+    float dist = (entry->Loc.X - pX)*(entry->Loc.X - pX)+(entry->Loc.Y - pY)*(entry->Loc.Y - pY);
     float minDist = dist;
 
     for (uint8 i = GILNEAS_BG_NODE_LIGHTHOUSE; i < GILNEAS_BG_DYNAMIC_NODES_COUNT; ++i)
         if (_capturePointInfo[i]._ownerTeamId == player->GetTeamId())
         {
-            entry = sGraveyard->GetGraveyard(GILNEAS_BG_GraveyardIds[i]);
-            dist = (entry->x - pX)*(entry->x - pX) + (entry->y - pY)*(entry->y - pY);
+            entry = sWorldSafeLocsStore.LookupEntry(GILNEAS_BG_GraveyardIds[i]);
+            dist = (entry->Loc.X - pX)*(entry->Loc.X - pX) + (entry->Loc.Y - pY)*(entry->Loc.Y - pY);
             if (dist < minDist)
             {
                 minDist = dist;
@@ -501,11 +512,14 @@ void BattlegroundBFG::ApplyPhaseMask()
         if (_capturePointInfo[i]._ownerTeamId != TEAM_NEUTRAL)
             phaseMask |= 1 << (i*2+1 + _capturePointInfo[i]._ownerTeamId);
 
-    const BattlegroundPlayerMap& bgPlayerMap = GetPlayers();
+    BattlegroundPlayerMap const& bgPlayerMap = GetPlayers();
     for (BattlegroundPlayerMap::const_iterator itr = bgPlayerMap.begin(); itr != bgPlayerMap.end(); ++itr)
     {
-        itr->second->SetPhaseMask(phaseMask, false);
-        itr->second->UpdateObjectVisibility(true, false);
+        if (Player* player = ObjectAccessor::FindPlayer(itr->first))
+        {
+            player->SetPhaseMask(phaseMask, false);
+            player->UpdateObjectVisibility(true);
+        }
     }
 }
 

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSV.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSV.cpp
@@ -1,10 +1,12 @@
 #include "BattlegroundSV.h"
 #include "Battleground.h"
 #include "BattlegroundMgr.h"
-#include "GameGraveyard.h"
+#include "DBCStores.h"
 #include "GameObject.h"
 #include "Language.h"
+#include "Log.h"
 #include "ObjectMgr.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "Transport.h"
@@ -14,6 +16,12 @@
 
 #include "Config.h"
 #include "ScriptMgr.h"
+
+void BattlegroundSVScore::BuildObjectivesBlock(WorldPacket& data)
+{
+    data << uint32(1);
+    data << uint32(KillingPoints);
+}
 
 BattlegroundSV::BattlegroundSV()
 {
@@ -31,7 +39,7 @@ BattlegroundSV::BattlegroundSV()
 
 	//	Set score
 	for (uint8 i = 0; i < 2; ++i)
-		TeamScore[i] = sConfigMgr->GetOption<uint32>("InitialPoints", 80);
+		TeamScore[i] = uint32(sConfigMgr->GetIntDefault("InitialPoints", 80));
 
 	// Set timer
 	ReloadTimer = BG_SV_RELOAD_TIME;
@@ -105,7 +113,7 @@ void BattlegroundSV::PostUpdateImpl(uint32 diff)
 						BG_SV_UpdateNodeWorldState(&nodePoint[i]);
 						BG_SV_HandleCapturedNodes(&nodePoint[i], false);
 
-						SendMessage2ToAll(LANG_BG_SV_TAKEN, nodePoint[i].faction == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, NULL, (nodePoint[i].faction == TEAM_ALLIANCE ? LANG_BG_SV_ALLY : LANG_BG_SV_HORDE), nodePoint[i].string);
+						PSendMessageToAll(LANG_BG_SV_TAKEN, nodePoint[i].faction == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, nullptr, (nodePoint[i].faction == TEAM_ALLIANCE ? LANG_BG_SV_ALLY : LANG_BG_SV_HORDE), nodePoint[i].string);
 						PlaySoundToAll(nodePoint[i].faction == TEAM_ALLIANCE ? BG_SV_SOUND_NODE_CAPTURED_ALLIANCE : BG_SV_SOUND_NODE_CAPTURED_HORDE);
 
 						nodePoint[i].needChange = false;
@@ -132,7 +140,7 @@ void BattlegroundSV::PostUpdateImpl(uint32 diff)
 			if (BossSpawnTimer <= diff)
 			{
 				SpawnBoss();
-				SendMessage2ToAll(LANG_BG_SV_BOSS_INC_NOW, CHAT_MSG_BG_SYSTEM_NEUTRAL, NULL);
+				SendMessageToAll(LANG_BG_SV_BOSS_INC_NOW, CHAT_MSG_BG_SYSTEM_NEUTRAL, nullptr);
 				PlaySoundToAll(BG_SV_SOUND_BOSS_INC);
 				BossSpawnTimer = BG_SV_BOSS_SPAWN_TIMER;
 				BossSpawnAllowed = false;
@@ -142,7 +150,7 @@ void BattlegroundSV::PostUpdateImpl(uint32 diff)
 
 			if (BossWarningTimer <= diff)
 			{
-				SendMessage2ToAll(LANG_BG_SV_BOSS_INC_1MIN, CHAT_MSG_BG_SYSTEM_NEUTRAL, NULL);
+				SendMessageToAll(LANG_BG_SV_BOSS_INC_1MIN, CHAT_MSG_BG_SYSTEM_NEUTRAL, nullptr);
 				BossWarningTimer = BG_SV_BOSS_SPAWN_TIMER;
 			}
 			else
@@ -269,7 +277,7 @@ bool BattlegroundSV::SetupBattleground()
 
 	for (uint8 i = 0; i < 1; ++i)
 	{
-		if (!AddCreature(BG_SV_BossSpawnlocs[i].entry, BG_SV_BossSpawnlocs[i].type, BG_SV_BossSpawnlocs[i].x, BG_SV_BossSpawnlocs[i].y, BG_SV_BossSpawnlocs[i].z, BG_SV_BossSpawnlocs[i].o, /*BG_SV_BossSpawnlocs[i].team,*/ RESPAWN_ONE_DAY))
+		if (!AddCreature(BG_SV_BossSpawnlocs[i].entry, BG_SV_BossSpawnlocs[i].type, BG_SV_BossSpawnlocs[i].x, BG_SV_BossSpawnlocs[i].y, BG_SV_BossSpawnlocs[i].z, BG_SV_BossSpawnlocs[i].o, BG_SV_BossSpawnlocs[i].team, RESPAWN_ONE_DAY))
 		{
 			TC_LOG_INFO("module", "Slavery Valley: There was an error spawning creature {}", BG_SV_BossSpawnlocs[i].entry);
 			return false;
@@ -278,14 +286,14 @@ bool BattlegroundSV::SetupBattleground()
 
 	for (uint8 i = 0; i < BG_SV_MAX_BUFF_SPAWNS; ++i)
 	{
-		if (!AddObject(BG_SV_BuffSpawnlocs[i].type, BG_SV_BuffSpawnlocs[i].entry, BG_SV_BuffSpawnlocs[i].x, BG_SV_BuffSpawnlocs[i].y, BG_SV_BuffSpawnlocs[i].z, BG_SV_BuffSpawnlocs[i].o, 0, 0, 0, 0, SPEED_BUFF_RESPAWN_TIME))
+		if (!AddObject(BG_SV_BuffSpawnlocs[i].type, BG_SV_BuffSpawnlocs[i].entry, BG_SV_BuffSpawnlocs[i].x, BG_SV_BuffSpawnlocs[i].y, BG_SV_BuffSpawnlocs[i].z, BG_SV_BuffSpawnlocs[i].o, 0, 0, 0, 0, BUFF_RESPAWN_TIME))
 		{
 			TC_LOG_INFO("module", "Slavery Valley: There was an error spawning buff {}", BG_SV_BuffSpawnlocs[i].entry);
 			return false;
 		}
 	}
 
-	if (!AddSpiritGuide(BG_SV_NPC_SPIRIT_GUIDE_1 + 2, BG_SV_SpiritGuidePos[4].m_positionX, BG_SV_SpiritGuidePos[4].m_positionY, BG_SV_SpiritGuidePos[4].m_positionZ, BG_SV_SpiritGuidePos[4].m_orientation, TEAM_ALLIANCE) || !AddSpiritGuide(BG_SV_NPC_SPIRIT_GUIDE_1 + 3, BG_SV_SpiritGuidePos[5].m_positionX, BG_SV_SpiritGuidePos[5].m_positionY, BG_SV_SpiritGuidePos[5].m_positionZ, BG_SV_SpiritGuidePos[5].m_orientation, TEAM_HORDE))
+	if (!AddSpiritGuide(BG_SV_NPC_SPIRIT_GUIDE_1 + 2, BG_SV_SpiritGuidePos[4].m_positionX, BG_SV_SpiritGuidePos[4].m_positionY, BG_SV_SpiritGuidePos[4].m_positionZ, BG_SV_SpiritGuidePos[4].GetOrientation(), TEAM_ALLIANCE) || !AddSpiritGuide(BG_SV_NPC_SPIRIT_GUIDE_1 + 3, BG_SV_SpiritGuidePos[5].m_positionX, BG_SV_SpiritGuidePos[5].m_positionY, BG_SV_SpiritGuidePos[5].m_positionZ, BG_SV_SpiritGuidePos[5].GetOrientation(), TEAM_HORDE))
 	{
 		TC_LOG_INFO("module", "Slavery Valley: Failed to spawn initial spirit guide!");
 		return false;
@@ -304,7 +312,7 @@ void BattlegroundSV::SpawnBoss()
 
 	for (uint8 i = 1; i < BG_SV_MAX_CREATURE_SPAWNS; ++i)
 	{
-		if (!AddCreature(BG_SV_BossSpawnlocs[i].entry, BG_SV_BossSpawnlocs[i].type, BG_SV_BossSpawnlocs[i].x, BG_SV_BossSpawnlocs[i].y, BG_SV_BossSpawnlocs[i].z, BG_SV_BossSpawnlocs[i].o, /*BG_SV_BossSpawnlocs[i].team,*/ RESPAWN_ONE_DAY))
+		if (!AddCreature(BG_SV_BossSpawnlocs[i].entry, BG_SV_BossSpawnlocs[i].type, BG_SV_BossSpawnlocs[i].x, BG_SV_BossSpawnlocs[i].y, BG_SV_BossSpawnlocs[i].z, BG_SV_BossSpawnlocs[i].o, BG_SV_BossSpawnlocs[i].team, RESPAWN_ONE_DAY))
 		{
 			TC_LOG_INFO("module", "Slavery Valley: There was an error spawning creature {}", BG_SV_BossSpawnlocs[i].entry);
 		}
@@ -483,7 +491,7 @@ void BattlegroundSV::EventPlayerClickedOnFlag(Player *player, GameObject *target
 					if (BgCreatures[BG_SV_NPC_SPIRIT_GUIDE_1 + (nodePoint[i].nodeType) - 2])
 						DelCreature(BG_SV_NPC_SPIRIT_GUIDE_1 + (nodePoint[i].nodeType) - 2);
 
-				SendMessage2ToAll(LANG_BG_SV_ASSAULTED, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, player, nodePoint[i].string);
+				PSendMessageToAll(LANG_BG_SV_ASSAULTED, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, player, nodePoint[i].string);
 				PlaySoundToAll(nodePoint[i].faction == TEAM_ALLIANCE ? BG_SV_SOUND_NODE_ASSAULTED_ALLIANCE : BG_SV_SOUND_NODE_ASSAULTED_HORDE);
 				BG_SV_HandleContestedNodes(&nodePoint[i]);
 			}
@@ -491,7 +499,7 @@ void BattlegroundSV::EventPlayerClickedOnFlag(Player *player, GameObject *target
 			{
 				nodePoint[i].timer = BG_SV_BANNER_STATE_CHANGE_TIME;
 				nodePoint[i].needChange = false;
-				SendMessage2ToAll(LANG_BG_SV_DEFENDED, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, player, nodePoint[i].string);
+				PSendMessageToAll(LANG_BG_SV_DEFENDED, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, player, nodePoint[i].string);
 				PlaySoundToAll(nodePoint[i].faction == TEAM_ALLIANCE ? BG_SV_SOUND_NODE_CAPTURED_ALLIANCE : BG_SV_SOUND_NODE_CAPTURED_HORDE);
 				BG_SV_HandleCapturedNodes(&nodePoint[i], true);
 			}
@@ -597,7 +605,7 @@ void BattlegroundSV::BG_SV_HandleCapturedNodes(BG_SV_NodePoint *node, bool /* re
 {
 	if (node->nodeType != NODE_TYPE_FIX && node->nodeType != NODE_TYPE_PRISON)
 	{
-		if (!AddSpiritGuide(BG_SV_NPC_SPIRIT_GUIDE_1 + node->nodeType - 2, BG_SV_SpiritGuidePos[node->nodeType].m_positionX, BG_SV_SpiritGuidePos[node->nodeType].m_positionY, BG_SV_SpiritGuidePos[node->nodeType].m_positionZ, BG_SV_SpiritGuidePos[node->nodeType].m_orientation, node->faction))
+		if (!AddSpiritGuide(BG_SV_NPC_SPIRIT_GUIDE_1 + node->nodeType - 2, BG_SV_SpiritGuidePos[node->nodeType].m_positionX, BG_SV_SpiritGuidePos[node->nodeType].m_positionY, BG_SV_SpiritGuidePos[node->nodeType].m_positionZ, BG_SV_SpiritGuidePos[node->nodeType].GetOrientation(), node->faction))
 			TC_LOG_INFO("module", "Slavery Valley Failed to spawn spirit guide! point: {}, team: {}, ", node->nodeType, node->faction);
 	}
 

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSV.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSV.h
@@ -291,7 +291,7 @@ struct BattlegroundSVScore final : public BattlegroundScore
     friend class BattlegroundSV;
 
     protected:
-        explicit BattlegroundSVScore(ObjectGuid playerGuid) : BattlegroundScore(playerGuid) { }
+        explicit BattlegroundSVScore(ObjectGuid playerGuid) : BattlegroundScore(playerGuid), KillingPoints(0) { }
 
         void UpdateScore(uint32 type, uint32 value) override
         {
@@ -301,12 +301,12 @@ struct BattlegroundSVScore final : public BattlegroundScore
                 KillingPoints += value;
                 break;
             default:
-                UpdateScore(type, value);
+                BattlegroundScore::UpdateScore(type, value);
                 break;
             }
         }
 
-        void BuildObjectivesBlock(WorldPacket& data) final;
+        void BuildObjectivesBlock(WorldPacket& data) final override;
 
         uint32 GetAttr1() const final override { return KillingPoints; }
 

--- a/src/server/game/Battlegrounds/Zones/BattlegroundTP.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundTP.cpp
@@ -7,18 +7,32 @@
 #include "Creature.h"
 #include "GameObject.h"
 #include "Language.h"
+#include "Log.h"
 #include "Object.h"
 #include "ObjectMgr.h"
+#include "ObjectAccessor.h"
 #include "BattlegroundMgr.h"
+#include "DBCStores.h"
+#include "Duration.h"
+#include "Map.h"
 #include "Player.h"
 #include "World.h"
 #include "WorldPacket.h"
 #include "Battleground.h"
-#include "GameGraveyard.h"
 #include <unordered_map>
 
 #include "ScriptMgr.h"
 #include "Config.h"
+
+namespace
+{
+    constexpr uint32 BG_TP_BUFF_RESPAWN_TIME = 150;
+
+    TeamId GetOtherTwinPeaksTeamId(TeamId teamId)
+    {
+        return teamId == TEAM_ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE;
+    }
+}
 
 // these variables aren't used outside of this file, so declare them only here
 enum BG_TP_Rewards
@@ -79,7 +93,7 @@ void BattlegroundTP::PostUpdateImpl(uint32 diff)
         {
             case BG_TP_EVENT_UPDATE_GAME_TIME:
                 UpdateWorldState(BG_TP_STATE_TIMER, GetMatchTime());
-                _bgEvents.ScheduleEvent(BG_TP_EVENT_UPDATE_GAME_TIME, ((BG_TP_TOTAL_GAME_TIME - GetStartTime()) % (MINUTE*IN_MILLISECONDS)) + 1);
+                _bgEvents.ScheduleEvent(BG_TP_EVENT_UPDATE_GAME_TIME, Milliseconds(((BG_TP_TOTAL_GAME_TIME - GetStartTime()) % (MINUTE * IN_MILLISECONDS)) + 1));
                 break;
             case BG_TP_EVENT_NO_TIME_LEFT:
                 if (GetTeamScore(TEAM_ALLIANCE) == GetTeamScore(TEAM_HORDE))
@@ -148,8 +162,8 @@ void BattlegroundTP::StartingEventOpenDoors()
     // players joining later are not egible
     //StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, TP_EVENT_START_BATTLE);
     UpdateWorldState(BG_TP_STATE_TIMER_ACTIVE, 1);
-    _bgEvents.ScheduleEvent(BG_TP_EVENT_UPDATE_GAME_TIME, 0);
-    _bgEvents.ScheduleEvent(BG_TP_EVENT_NO_TIME_LEFT, BG_TP_TOTAL_GAME_TIME - 2*MINUTE*IN_MILLISECONDS); // 27 - 2 = 25 minutes
+    _bgEvents.ScheduleEvent(BG_TP_EVENT_UPDATE_GAME_TIME, 0ms);
+    _bgEvents.ScheduleEvent(BG_TP_EVENT_NO_TIME_LEFT, Milliseconds(BG_TP_TOTAL_GAME_TIME - 2 * MINUTE * IN_MILLISECONDS)); // 27 - 2 = 25 minutes
 }
 
 void BattlegroundTP::AddPlayer(Player* player)
@@ -186,8 +200,8 @@ void BattlegroundTP::EventPlayerCapturedFlag(Player* player)
     RemoveAssaultAuras();
 
     AddPoints(player->GetTeamId(), 1);
-    SetFlagPicker(ObjectGuid::Empty, GetOtherTeamId(player->GetTeamId()));
-    UpdateFlagState(GetOtherTeamId(player->GetTeamId()), BG_TP_FLAG_STATE_ON_BASE);
+    SetFlagPicker(ObjectGuid::Empty, GetOtherTwinPeaksTeamId(player->GetTeamId()));
+    UpdateFlagState(GetOtherTwinPeaksTeamId(player->GetTeamId()), BG_TP_FLAG_STATE_ON_BASE);
     if (player->GetTeamId() == TEAM_ALLIANCE)
     {
         player->RemoveAurasDueToSpell(BG_TP_SPELL_HORDE_FLAG);
@@ -216,7 +230,7 @@ void BattlegroundTP::EventPlayerCapturedFlag(Player* player)
         EndBattleground(GetTeamScore(TEAM_HORDE) == BG_TP_MAX_TEAM_SCORE ? TEAM_HORDE : TEAM_ALLIANCE);
     }
     else
-        _bgEvents.ScheduleEvent(BG_TP_EVENT_RESPAWN_BOTH_FLAGS, BG_TP_FLAG_RESPAWN_TIME);
+        _bgEvents.ScheduleEvent(BG_TP_EVENT_RESPAWN_BOTH_FLAGS, Milliseconds(BG_TP_FLAG_RESPAWN_TIME));
 
     _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT10);
     _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15);
@@ -227,7 +241,7 @@ void BattlegroundTP::EventPlayerDroppedFlag(Player* player)
     if (GetFlagPickerGUID(TEAM_HORDE) != player->GetGUID() && GetFlagPickerGUID(TEAM_ALLIANCE) != player->GetGUID())
         return;
 
-    SetFlagPicker(ObjectGuid::Empty, GetOtherTeamId(player->GetTeamId()));
+    SetFlagPicker(ObjectGuid::Empty, GetOtherTwinPeaksTeamId(player->GetTeamId()));
     player->RemoveAurasDueToSpell(BG_TP_SPELL_HORDE_FLAG);
     player->RemoveAurasDueToSpell(BG_TP_SPELL_FOCUSED_ASSAULT);
     player->RemoveAurasDueToSpell(BG_TP_SPELL_BRUTAL_ASSAULT);
@@ -241,14 +255,14 @@ void BattlegroundTP::EventPlayerDroppedFlag(Player* player)
         UpdateFlagState(TEAM_HORDE, BG_TP_FLAG_STATE_ON_GROUND);
         player->CastSpell(player, BG_TP_SPELL_HORDE_FLAG_DROPPED, true);
         SendBroadcastText(LANG_BG_TP_DROPPED_HF, CHAT_MSG_BG_SYSTEM_HORDE, player);
-        _bgEvents.RescheduleEvent(BG_TP_EVENT_HORDE_DROP_FLAG, BG_TP_FLAG_DROP_TIME);
+        _bgEvents.RescheduleEvent(BG_TP_EVENT_HORDE_DROP_FLAG, Milliseconds(BG_TP_FLAG_DROP_TIME));
     }
     else
     {
         UpdateFlagState(TEAM_ALLIANCE, BG_TP_FLAG_STATE_ON_GROUND);
         player->CastSpell(player, BG_TP_SPELL_ALLIANCE_FLAG_DROPPED, true);
         SendBroadcastText(LANG_BG_TP_DROPPED_AF, CHAT_MSG_BG_SYSTEM_ALLIANCE, player);
-        _bgEvents.RescheduleEvent(BG_TP_EVENT_ALLIANCE_DROP_FLAG, BG_TP_FLAG_DROP_TIME);
+        _bgEvents.RescheduleEvent(BG_TP_EVENT_ALLIANCE_DROP_FLAG, Milliseconds(BG_TP_FLAG_DROP_TIME));
     }
 }
 
@@ -265,7 +279,7 @@ void BattlegroundTP::EventPlayerClickedOnFlag(Player* player, GameObject* gameOb
         SpawnBGObject(BG_TP_OBJECT_A_FLAG, RESPAWN_ONE_DAY);
         SetFlagPicker(player->GetGUID(), TEAM_ALLIANCE);
         UpdateFlagState(TEAM_ALLIANCE, BG_TP_FLAG_STATE_ON_PLAYER);
-        Aura::TryRefreshStackOrCreate(sSpellMgr->GetSpellInfo(BG_TP_SPELL_ALLIANCE_FLAG), MAX_EFFECT_MASK, player, player);
+        player->CastSpell(player, BG_TP_SPELL_ALLIANCE_FLAG, true);
         player->StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_SPELL_TARGET, BG_TP_SPELL_ALLIANCE_FLAG_PICKED);
 
         PlaySoundToAll(BG_TP_SOUND_ALLIANCE_FLAG_PICKED_UP);
@@ -273,8 +287,8 @@ void BattlegroundTP::EventPlayerClickedOnFlag(Player* player, GameObject* gameOb
 
         if (GetFlagState(TEAM_HORDE) != BG_TP_FLAG_STATE_ON_BASE)
         {
-            _bgEvents.RescheduleEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT10, BG_TP_SPELL_FORCE_TIME);
-            _bgEvents.RescheduleEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15, BG_TP_SPELL_BRUTAL_TIME);
+            _bgEvents.RescheduleEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT10, Milliseconds(BG_TP_SPELL_FORCE_TIME));
+            _bgEvents.RescheduleEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15, Milliseconds(BG_TP_SPELL_BRUTAL_TIME));
         }
         return;
     }
@@ -285,7 +299,7 @@ void BattlegroundTP::EventPlayerClickedOnFlag(Player* player, GameObject* gameOb
         SpawnBGObject(BG_TP_OBJECT_H_FLAG, RESPAWN_ONE_DAY);
         SetFlagPicker(player->GetGUID(), TEAM_HORDE);
         UpdateFlagState(TEAM_HORDE, BG_TP_FLAG_STATE_ON_PLAYER);
-        Aura::TryRefreshStackOrCreate(sSpellMgr->GetSpellInfo(BG_TP_SPELL_HORDE_FLAG), MAX_EFFECT_MASK, player, player);
+        player->CastSpell(player, BG_TP_SPELL_HORDE_FLAG, true);
         player->StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_SPELL_TARGET, BG_TP_SPELL_HORDE_FLAG_PICKED);
 
         PlaySoundToAll(BG_TP_SOUND_HORDE_FLAG_PICKED_UP);
@@ -293,8 +307,8 @@ void BattlegroundTP::EventPlayerClickedOnFlag(Player* player, GameObject* gameOb
 
         if (GetFlagState(TEAM_ALLIANCE) != BG_TP_FLAG_STATE_ON_BASE)
         {
-            _bgEvents.RescheduleEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT10, BG_TP_SPELL_FORCE_TIME);
-            _bgEvents.RescheduleEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15, BG_TP_SPELL_BRUTAL_TIME);
+            _bgEvents.RescheduleEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT10, Milliseconds(BG_TP_SPELL_FORCE_TIME));
+            _bgEvents.RescheduleEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15, Milliseconds(BG_TP_SPELL_BRUTAL_TIME));
         }
         return;
     }
@@ -324,7 +338,7 @@ void BattlegroundTP::EventPlayerClickedOnFlag(Player* player, GameObject* gameOb
         {
             SetFlagPicker(player->GetGUID(), TEAM_ALLIANCE);
             UpdateFlagState(TEAM_ALLIANCE, BG_TP_FLAG_STATE_ON_PLAYER);
-            Aura::TryRefreshStackOrCreate(sSpellMgr->GetSpellInfo(BG_TP_SPELL_ALLIANCE_FLAG), MAX_EFFECT_MASK, player, player);
+            player->CastSpell(player, BG_TP_SPELL_ALLIANCE_FLAG, true);
             if (uint32 assaultSpellId = GetAssaultSpellId())
               player->CastSpell(player, assaultSpellId, true);
 
@@ -355,7 +369,7 @@ void BattlegroundTP::EventPlayerClickedOnFlag(Player* player, GameObject* gameOb
         {
             SetFlagPicker(player->GetGUID(), TEAM_HORDE);
             UpdateFlagState(TEAM_HORDE, BG_TP_FLAG_STATE_ON_PLAYER);
-            Aura::TryRefreshStackOrCreate(sSpellMgr->GetSpellInfo(BG_TP_SPELL_HORDE_FLAG), MAX_EFFECT_MASK, player, player);
+            player->CastSpell(player, BG_TP_SPELL_HORDE_FLAG, true);
             if (uint32 assaultSpellId = GetAssaultSpellId())
               player->CastSpell(player, assaultSpellId, true);
 
@@ -416,12 +430,12 @@ bool BattlegroundTP::SetupBattleground()
     AddObject(BG_TP_OBJECT_A_FLAG, BG_OBJECT_A_FLAG_TP_ENTRY, 2118.210f, 191.621f, 44.052f, 5.741259f, 0, 0, 0.9996573f, 0.02617699f, BG_TP_FLAG_RESPAWN_TIME/1000);
     AddObject(BG_TP_OBJECT_H_FLAG, BG_OBJECT_H_FLAG_TP_ENTRY, 1578.380f, 344.037f, 2.419f, 3.055978f, 0, 0, 0.008726535f, 0.9999619f, BG_TP_FLAG_RESPAWN_TIME/1000);
         // buffs
-    AddObject(BG_TP_OBJECT_SPEEDBUFF_1, BG_OBJECTID_SPEEDBUFF_ENTRY, 1545.402f, 304.028f, 0.5923f, -1.64061f, 0, 0, 0.7313537f, -0.6819983f, SPEED_BUFF_RESPAWN_TIME);
-    AddObject(BG_TP_OBJECT_SPEEDBUFF_2, BG_OBJECTID_SPEEDBUFF_ENTRY, 2171.279f, 222.334f, 43.8001f, 2.663309f, 0, 0, 0.7313537f, 0.6819984f, SPEED_BUFF_RESPAWN_TIME);
-    AddObject(BG_TP_OBJECT_REGENBUFF_1, BG_OBJECTID_REGENBUFF_ENTRY, 1753.957f, 242.092f, -14.1170f, 1.105848f, 0, 0, 0.1305263f, -0.9914448f, SPEED_BUFF_RESPAWN_TIME);
-    AddObject(BG_TP_OBJECT_REGENBUFF_2, BG_OBJECTID_REGENBUFF_ENTRY, 1952.121f, 383.857f, -10.2870f, 4.192612f, 0, 0, 0.333807f, -0.9426414f, SPEED_BUFF_RESPAWN_TIME);
-    AddObject(BG_TP_OBJECT_BERSERKBUFF_1, BG_OBJECTID_BERSERKERBUFF_ENTRY, 1934.369f, 226.064f, -17.0441f, 2.499154f, 0, 0, 0.5591929f, 0.8290376f, SPEED_BUFF_RESPAWN_TIME);
-    AddObject(BG_TP_OBJECT_BERSERKBUFF_2, BG_OBJECTID_BERSERKERBUFF_ENTRY, 1725.240f, 446.431f, -7.8327f, 5.709677f, 0, 0, 0.9396926f, -0.3420201f, SPEED_BUFF_RESPAWN_TIME);
+    AddObject(BG_TP_OBJECT_SPEEDBUFF_1, BG_OBJECTID_SPEEDBUFF_ENTRY, 1545.402f, 304.028f, 0.5923f, -1.64061f, 0, 0, 0.7313537f, -0.6819983f, BG_TP_BUFF_RESPAWN_TIME);
+    AddObject(BG_TP_OBJECT_SPEEDBUFF_2, BG_OBJECTID_SPEEDBUFF_ENTRY, 2171.279f, 222.334f, 43.8001f, 2.663309f, 0, 0, 0.7313537f, 0.6819984f, BG_TP_BUFF_RESPAWN_TIME);
+    AddObject(BG_TP_OBJECT_REGENBUFF_1, BG_OBJECTID_REGENBUFF_ENTRY, 1753.957f, 242.092f, -14.1170f, 1.105848f, 0, 0, 0.1305263f, -0.9914448f, BG_TP_BUFF_RESPAWN_TIME);
+    AddObject(BG_TP_OBJECT_REGENBUFF_2, BG_OBJECTID_REGENBUFF_ENTRY, 1952.121f, 383.857f, -10.2870f, 4.192612f, 0, 0, 0.333807f, -0.9426414f, BG_TP_BUFF_RESPAWN_TIME);
+    AddObject(BG_TP_OBJECT_BERSERKBUFF_1, BG_OBJECTID_BERSERKERBUFF_ENTRY, 1934.369f, 226.064f, -17.0441f, 2.499154f, 0, 0, 0.5591929f, 0.8290376f, BG_TP_BUFF_RESPAWN_TIME);
+    AddObject(BG_TP_OBJECT_BERSERKBUFF_2, BG_OBJECTID_BERSERKERBUFF_ENTRY, 1725.240f, 446.431f, -7.8327f, 5.709677f, 0, 0, 0.9396926f, -0.3420201f, BG_TP_BUFF_RESPAWN_TIME);
         // alliance gates
     AddObject(BG_TP_OBJECT_DOOR_A_1, BG_OBJECT_DOOR_A_1_TP_ENTRY, 2115.399f, 150.175f, 43.526f, 2.544690f, 0, 0, 0, 0, RESPAWN_IMMEDIATELY);
     AddObject(BG_TP_OBJECT_DOOR_A_2, BG_OBJECT_DOOR_A_2_TP_ENTRY, 2156.803f, 220.331f, 43.482f, 2.544690f, 0, 0, 0, 0, RESPAWN_IMMEDIATELY);
@@ -433,29 +447,29 @@ bool BattlegroundTP::SetupBattleground()
     AddObject(BG_TP_OBJECT_DOOR_H_3, BG_OBJECT_DOOR_H_3_TP_ENTRY, 1591.463f, 365.732f, 13.494f, 6.179126f, 0, 0, 0, 0, RESPAWN_IMMEDIATELY);
     AddObject(BG_TP_OBJECT_DOOR_H_4, BG_OBJECT_DOOR_H_4_TP_ENTRY, 1558.315f, 372.709f, 1.4840f, 6.179126f, 0, 0, 0, 0, RESPAWN_IMMEDIATELY);
 
-    GraveyardStruct const* sg = sGraveyard->GetGraveyard(TP_GRAVEYARD_MIDDLE_ALLIANCE);
-    AddSpiritGuide(TP_SPIRIT_ALLIANCE, sg->x, sg->y, sg->z, 3.641396f, TEAM_ALLIANCE);
+    WorldSafeLocsEntry const* sg = sWorldSafeLocsStore.LookupEntry(TP_GRAVEYARD_MIDDLE_ALLIANCE);
+    AddSpiritGuide(TP_SPIRIT_ALLIANCE, sg->Loc.X, sg->Loc.Y, sg->Loc.Z, 3.641396f, TEAM_ALLIANCE);
 
-    sg = sGraveyard->GetGraveyard(TP_GRAVEYARD_START_ALLIANCE);
-    AddSpiritGuide(TP_SPIRIT_ALLIANCE, sg->x, sg->y, sg->z, 3.641396f, TEAM_ALLIANCE);
+    sg = sWorldSafeLocsStore.LookupEntry(TP_GRAVEYARD_START_ALLIANCE);
+    AddSpiritGuide(TP_SPIRIT_ALLIANCE, sg->Loc.X, sg->Loc.Y, sg->Loc.Z, 3.641396f, TEAM_ALLIANCE);
 
-    sg = sGraveyard->GetGraveyard(TP_GRAVEYARD_MIDDLE_HORDE);
-    AddSpiritGuide(TP_SPIRIT_HORDE, sg->x, sg->y, sg->z, 3.641396f, TEAM_HORDE);
+    sg = sWorldSafeLocsStore.LookupEntry(TP_GRAVEYARD_MIDDLE_HORDE);
+    AddSpiritGuide(TP_SPIRIT_HORDE, sg->Loc.X, sg->Loc.Y, sg->Loc.Z, 3.641396f, TEAM_HORDE);
 
-    sg = sGraveyard->GetGraveyard(TP_GRAVEYARD_START_HORDE);
-    AddSpiritGuide(TP_SPIRIT_ALLIANCE, sg->x, sg->y, sg->z, 3.641396f, TEAM_HORDE);
+    sg = sWorldSafeLocsStore.LookupEntry(TP_GRAVEYARD_START_HORDE);
+    AddSpiritGuide(TP_SPIRIT_ALLIANCE, sg->Loc.X, sg->Loc.Y, sg->Loc.Z, 3.641396f, TEAM_HORDE);
 
     for (uint32 i = BG_TP_OBJECT_DOOR_A_1; i < BG_TP_OBJECT_MAX; ++i)
         if (!BgObjects[i])
         {
-            LOG_ERROR("sql.sql", "BatteGroundTP: Failed to spawn some object Battleground not created!");
+            TC_LOG_ERROR("sql.sql", "BatteGroundTP: Failed to spawn some object Battleground not created!");
             return false;
         }
 
     for (uint32 i = TP_SPIRIT_ALLIANCE; i < BG_CREATURES_MAX_TP; ++i)
         if (!BgCreatures[i])
         {
-            LOG_ERROR("sql.sql", "BatteGroundTP: Failed to spawn spirit guides Battleground not created!");
+            TC_LOG_ERROR("sql.sql", "BatteGroundTP: Failed to spawn spirit guides Battleground not created!");
             return false;
         }
 
@@ -475,7 +489,7 @@ void BattlegroundTP::Init()
     _flagState[TEAM_HORDE]          = BG_TP_FLAG_STATE_ON_BASE;
     _lastFlagCaptureTeam            = TEAM_NEUTRAL;
 
-    if (sBattlegroundMgr->IsBGWeekend(GetBgTypeID()))
+    if (sBattlegroundMgr->IsBGWeekend(GetTypeID()))
     {
         _reputationCapture = 45;
         _honorWinKills = 3;
@@ -530,12 +544,12 @@ bool BattlegroundTP::UpdatePlayerScore(Player* player, uint32 type, uint32 value
     return true;
 }
 
-GraveyardStruct const* BattlegroundTP::GetClosestGraveyard(Player* player)
+WorldSafeLocsEntry const* BattlegroundTP::GetClosestGraveyard(Player* player)
 {
     if (GetStatus() == STATUS_IN_PROGRESS)
-      return sGraveyard->GetGraveyard(player->GetTeamId() == TEAM_ALLIANCE ? TP_GRAVEYARD_MIDDLE_ALLIANCE : TP_GRAVEYARD_MIDDLE_HORDE);
-    else
-      return sGraveyard->GetGraveyard(player->GetTeamId() == TEAM_ALLIANCE ? TP_GRAVEYARD_FLAGROOM_ALLIANCE : TP_GRAVEYARD_FLAGROOM_HORDE);
+        return sWorldSafeLocsStore.LookupEntry(player->GetTeamId() == TEAM_ALLIANCE ? TP_GRAVEYARD_MIDDLE_ALLIANCE : TP_GRAVEYARD_MIDDLE_HORDE);
+
+    return sWorldSafeLocsStore.LookupEntry(player->GetTeamId() == TEAM_ALLIANCE ? TP_GRAVEYARD_FLAGROOM_ALLIANCE : TP_GRAVEYARD_FLAGROOM_HORDE);
 }
 
 void BattlegroundTP::FillInitialWorldStates(WorldPackets::WorldState::InitWorldStates& packet)
@@ -565,10 +579,10 @@ uint32 BattlegroundTP::GetAssaultSpellId() const
 {
     if ((!GetFlagPickerGUID(TEAM_ALLIANCE) && GetFlagState(TEAM_ALLIANCE) != BG_TP_FLAG_STATE_ON_GROUND) ||
         (!GetFlagPickerGUID(TEAM_HORDE) && GetFlagState(TEAM_HORDE) != BG_TP_FLAG_STATE_ON_GROUND) ||
-        _bgEvents.GetNextEventTime(BG_TP_EVENT_BOTH_FLAGS_KEPT10) > 0)
+        _bgEvents.HasEventScheduled(BG_TP_EVENT_BOTH_FLAGS_KEPT10))
     return 0;
 
-    return _bgEvents.GetNextEventTime(BG_TP_EVENT_BOTH_FLAGS_KEPT15) > 0 ? BG_TP_SPELL_FOCUSED_ASSAULT : BG_TP_SPELL_BRUTAL_ASSAULT;
+    return _bgEvents.HasEventScheduled(BG_TP_EVENT_BOTH_FLAGS_KEPT15) ? BG_TP_SPELL_FOCUSED_ASSAULT : BG_TP_SPELL_BRUTAL_ASSAULT;
 }
 
 void BattlegroundTP::RemoveAssaultAuras()


### PR DESCRIPTION
### Motivation

- Replace deprecated graveyard API and raw coordinates with DBC `WorldSafeLocs` entries to centralize spawn locations.
- Modernize event timing and scheduling by using `Duration`/`Milliseconds` and chrono literals instead of raw millisecond integers.
- Fix player/object access and API mismatches (phase updates, object/player lookups, spell/aura application) and clean up several battleground-specific issues.

### Description

- Added `DBCStores`, `Duration`, and `ObjectAccessor` includes and small helper `GetOther...TeamId` functions where needed.`
- Replaced `sGraveyard->GetGraveyard(...)` with `sWorldSafeLocsStore.LookupEntry(...)` and switched coordinate access to `entry->Loc.X/Y/Z` and updated `GetClosestGraveyard` return types to `WorldSafeLocsEntry const*`.
- Converted event scheduling/rescheduling calls to use `Milliseconds(...)` or chrono literals (e.g. `3s`, `0ms`) instead of raw integers and adapted related `_bgEvents` checks to `HasEventScheduled(...)`.
- Updated `ApplyPhaseMask` to locate actual `Player*` via `ObjectAccessor::FindPlayer` before calling `SetPhaseMask` and `UpdateObjectVisibility` with the updated signature.
- Twin Peaks: introduced `BG_TP_BUFF_RESPAWN_TIME` constant and replaced legacy buff respawn constants; switched flag aura application to `player->CastSpell(...)`; replaced `GetBgTypeID()` with `GetTypeID()` for weekend checks; improved event timing usage.
- Slavery Valley: added/implemented `BattlegroundSVScore::BuildObjectivesBlock`, initialize `KillingPoints` properly, changed `TeamScore` config access to `GetIntDefault`, added `AddCreature` calls to pass `team` parameter, replaced `m_orientation` with `GetOrientation()`, replaced legacy send message calls with new `PSendMessageToAll`/`SendMessageToAll` usage, and updated logging to `TC_LOG_*`.
- Gilneas (BFG): updated banner/event scheduling to `Milliseconds(...)`, replaced team comparisons with the new helper `GetOtherGilneasTeamId`, replaced graveyard usage, and adjusted player visibility updates.
- Misc: fixed several API and override declarations, adjusted score/objective packet builders, and cleaned up unused includes.

### Testing

- Ran a full project build (CI/build) which completed successfully with no compile errors after the changes.
- Executed battleground-related automated checks and available unit tests (build-time and battleground modules); all automated tests targeting the modified code passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa85f9471483278d61c3d55bb3b9ec)