### PR TITLE
Prevent BFG leave crash for offline players

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
@@ -188,8 +188,10 @@ void BattlegroundBFG::AddPlayer(Player* player)
     PlayerScores.emplace(player->GetGUID().GetCounter(), new BattlegroundBFGScore(player->GetGUID()));
 }
 
-void BattlegroundBFG::RemovePlayer(Player* player, ObjectGuid /*guid*/, uint32 /*team*/) {
-    player->SetPhaseMask(1, false);
+void BattlegroundBFG::RemovePlayer(Player* player, ObjectGuid /*guid*/, uint32 /*team*/)
+{
+    if (player)
+        player->SetPhaseMask(1, false);
 }
 
 void BattlegroundBFG::HandleAreaTrigger(Player* /* player*/, uint32 trigger)


### PR DESCRIPTION
### Motivation
- Prevent a segmentation fault that can occur when `Battleground::RemovePlayerAtLeave` invokes the BFG-specific `RemovePlayer` with an offline or unloaded `Player*` (null), which previously dereferenced the pointer to call `SetPhaseMask`.

### Description
- Add a null check in `BattlegroundBFG::RemovePlayer` so `player->SetPhaseMask(1, false)` is only called when `player` is non-null.

### Testing
- Successfully compiled the modified translation unit with `cmake --build build --target src/server/game/CMakeFiles/game.dir/Battlegrounds/Zones/BattlegroundBFG.cpp.o -j2`.
- Started a full build with `cmake --build build --target worldserver -j2`; the changed BFG source compiled, but the full build was manually interrupted while rebuilding the large project (no failure in the modified file compilation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac37ce9e88327aff582598e9c9f07)