### PR TITLE
Align Twin Peaks and Battle for Gilneas battleground rules

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
@@ -106,17 +106,17 @@ void BattlegroundBFG::PostUpdateImpl(uint32 diff)
                         break;
                     }
 
-                    // uint8 honorRewards = uint8(m_TeamScores[teamId] / _honorTics);
-                    // uint8 reputationRewards = uint8(m_TeamScores[teamId] / _reputationTics);
+                    uint8 honorRewards = uint8(m_TeamScores[teamId] / _honorTics);
+                    uint8 reputationRewards = uint8(m_TeamScores[teamId] / _reputationTics);
                     uint8 information = uint8(m_TeamScores[teamId] / GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE);
                     m_TeamScores[teamId] += GILNEAS_BG_TickPoints[controlledPoints];
                     if (m_TeamScores[teamId] > GILNEAS_BG_MAX_TEAM_SCORE)
                         m_TeamScores[teamId] = GILNEAS_BG_MAX_TEAM_SCORE;
 
-                    // if (honorRewards < uint8(m_TeamScores[teamId] / _honorTics))
-                    //     RewardHonorToTeam(GetBonusHonorFromKill(1), teamId);
-                    // if (reputationRewards < uint8(m_TeamScores[teamId] / _reputationTics))
-                    //     RewardReputationToTeam(teamId == TEAM_ALLIANCE ? 509 : 510, 10, teamId);
+                    if (honorRewards < uint8(m_TeamScores[teamId] / _honorTics))
+                        RewardHonorToTeam(GetBonusHonorFromKill(1), teamId);
+                    if (reputationRewards < uint8(m_TeamScores[teamId] / _reputationTics))
+                        RewardReputationToTeam(teamId == TEAM_ALLIANCE ? 509 : 510, 10, teamId);
 
                     if (information < uint8(m_TeamScores[teamId] / GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE))
                     {
@@ -425,8 +425,8 @@ void BattlegroundBFG::Init()
 
     _bgEvents.Reset();
 
-    // _honorTics = BattlegroundMgr::IsBGWeekend(GetTypeID()) ? BG_AB_HONOR_TICK_WEEKEND : BG_AB_HONOR_TICK_NORMAL;
-    // _reputationTics = BattlegroundMgr::IsBGWeekend(GetTypeID()) ? BG_AB_REP_TICK_WEEKEND : BG_AB_REP_TICK_NORMAL;
+    _honorTics = BattlegroundMgr::IsBGWeekend(GetTypeID()) ? GILNEAS_BG_BGWeekendHonorTicks : GILNEAS_BG_NotBGWeekendHonorTicks;
+    _reputationTics = BattlegroundMgr::IsBGWeekend(GetTypeID()) ? GILNEAS_BG_BGWeekendRepTicks : GILNEAS_BG_NotBGWeekendRepTicks;
 
     _capturePointInfo[GILNEAS_BG_NODE_LIGHTHOUSE]._iconNone    = GILNEAS_BG_OP_LIGHTHOUSE_ICON;
     _capturePointInfo[GILNEAS_BG_NODE_WATERWORKS]._iconNone    = GILNEAS_BG_OP_WATERWORKS_ICON;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
@@ -156,8 +156,8 @@ enum GILNEAS_BG_Timers
 
 enum GILNEAS_BG_Score
 {
-    GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE = 1800,
-    GILNEAS_BG_MAX_TEAM_SCORE             = 2000
+    GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE = 1400,
+    GILNEAS_BG_MAX_TEAM_SCORE             = 1600
 };
 
 enum GILNEAS_BG_BattlegroundNodes
@@ -222,8 +222,8 @@ const float GILNEAS_BG_DoorPositions[4][8] =
     { 1396.15f, 977.014f, 0.33169f, 6.27043f, 0.0f, 0.0f, 0.006378f, -0.99998f }
 };
 
-const uint32 GILNEAS_BG_TickIntervals[4] = { 0, 12000, 6000, 1000 };
-const uint32 GILNEAS_BG_TickPoints[4] = { 0, 10, 10, 30 };
+const uint32 GILNEAS_BG_TickIntervals[4] = { 0, 12000, 9000, 6000 };
+const uint32 GILNEAS_BG_TickPoints[4] = { 0, 10, 10, 10 };
 
 const uint32 GILNEAS_BG_GraveyardIds[GILNEAS_BG_ALL_NODES_COUNT] = { 1736, 1737, 1735, 1739, 1738 };
 

--- a/src/server/game/Battlegrounds/Zones/BattlegroundTP.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundTP.cpp
@@ -92,14 +92,7 @@ void BattlegroundTP::PostUpdateImpl(uint32 diff)
         switch (_bgEvents.ExecuteEvent())
         {
             case BG_TP_EVENT_UPDATE_GAME_TIME:
-                UpdateWorldState(BG_TP_STATE_TIMER, GetMatchTime());
-                _bgEvents.ScheduleEvent(BG_TP_EVENT_UPDATE_GAME_TIME, Milliseconds(((BG_TP_TOTAL_GAME_TIME - GetStartTime()) % (MINUTE * IN_MILLISECONDS)) + 1));
-                break;
             case BG_TP_EVENT_NO_TIME_LEFT:
-                if (GetTeamScore(TEAM_ALLIANCE) == GetTeamScore(TEAM_HORDE))
-                    EndBattleground(_lastFlagCaptureTeam);
-                else
-                    EndBattleground(GetTeamScore(TEAM_HORDE) > GetTeamScore(TEAM_ALLIANCE) ? TEAM_HORDE : TEAM_ALLIANCE);
                 break;
             case BG_TP_EVENT_RESPAWN_BOTH_FLAGS:
                 SpawnBGObject(BG_TP_OBJECT_H_FLAG, RESPAWN_IMMEDIATELY);
@@ -161,9 +154,7 @@ void BattlegroundTP::StartingEventOpenDoors()
 
     // players joining later are not egible
     //StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, TP_EVENT_START_BATTLE);
-    UpdateWorldState(BG_TP_STATE_TIMER_ACTIVE, 1);
-    _bgEvents.ScheduleEvent(BG_TP_EVENT_UPDATE_GAME_TIME, 0ms);
-    _bgEvents.ScheduleEvent(BG_TP_EVENT_NO_TIME_LEFT, Milliseconds(BG_TP_TOTAL_GAME_TIME - 2 * MINUTE * IN_MILLISECONDS)); // 27 - 2 = 25 minutes
+    UpdateWorldState(BG_TP_STATE_TIMER_ACTIVE, 0);
 }
 
 void BattlegroundTP::AddPlayer(Player* player)
@@ -189,6 +180,7 @@ void BattlegroundTP::RespawnFlagAfterDrop(TeamId teamId)
     _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT10);
     _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15);
     RemoveAssaultAuras();
+    HandleFlagRoomCapturePoint(GetOtherTwinPeaksTeamId(teamId));
 }
 
 void BattlegroundTP::EventPlayerCapturedFlag(Player* player)
@@ -236,6 +228,14 @@ void BattlegroundTP::EventPlayerCapturedFlag(Player* player)
     _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15);
 }
 
+void BattlegroundTP::HandleFlagRoomCapturePoint(TeamId teamId)
+{
+    Player* flagCarrier = ObjectAccessor::GetPlayer(GetBgMap(), GetFlagPickerGUID(teamId));
+    uint32 areaTrigger = teamId == TEAM_ALLIANCE ? 5905 : 5904;
+    if (flagCarrier && flagCarrier->IsInAreaTriggerRadius(sAreaTriggerStore.LookupEntry(areaTrigger)))
+        EventPlayerCapturedFlag(flagCarrier);
+}
+
 void BattlegroundTP::EventPlayerDroppedFlag(Player* player)
 {
     if (GetFlagPickerGUID(TEAM_HORDE) != player->GetGUID() && GetFlagPickerGUID(TEAM_ALLIANCE) != player->GetGUID())
@@ -243,13 +243,13 @@ void BattlegroundTP::EventPlayerDroppedFlag(Player* player)
 
     SetFlagPicker(ObjectGuid::Empty, GetOtherTwinPeaksTeamId(player->GetTeamId()));
     player->RemoveAurasDueToSpell(BG_TP_SPELL_HORDE_FLAG);
+    player->RemoveAurasDueToSpell(BG_TP_SPELL_ALLIANCE_FLAG);
     player->RemoveAurasDueToSpell(BG_TP_SPELL_FOCUSED_ASSAULT);
     player->RemoveAurasDueToSpell(BG_TP_SPELL_BRUTAL_ASSAULT);
 
     if (GetStatus() != STATUS_IN_PROGRESS)
         return;
 
-    player->CastSpell(player, SPELL_RECENTLY_DROPPED_FLAG, true);
     if (player->GetTeamId() == TEAM_ALLIANCE)
     {
         UpdateFlagState(TEAM_HORDE, BG_TP_FLAG_STATE_ON_GROUND);
@@ -332,6 +332,7 @@ void BattlegroundTP::EventPlayerClickedOnFlag(Player* player, GameObject* gameOb
             _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT10);
             _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15);
             RemoveAssaultAuras();
+            HandleFlagRoomCapturePoint(TEAM_HORDE);
             return;
         }
         else
@@ -363,6 +364,7 @@ void BattlegroundTP::EventPlayerClickedOnFlag(Player* player, GameObject* gameOb
             _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT10);
             _bgEvents.CancelEvent(BG_TP_EVENT_BOTH_FLAGS_KEPT15);
             RemoveAssaultAuras();
+            HandleFlagRoomCapturePoint(TEAM_ALLIANCE);
             return;
         }
         else
@@ -558,8 +560,7 @@ void BattlegroundTP::FillInitialWorldStates(WorldPackets::WorldState::InitWorldS
   packet.Worldstates.emplace_back(BG_TP_FLAG_CAPTURES_HORDE, GetTeamScore(TEAM_HORDE));
   packet.Worldstates.emplace_back(BG_TP_FLAG_CAPTURES_MAX, BG_TP_MAX_TEAM_SCORE);
 
-  packet.Worldstates.emplace_back(BG_TP_STATE_TIMER_ACTIVE, uint32(GetStatus() == STATUS_IN_PROGRESS));
-  packet.Worldstates.emplace_back(BG_TP_STATE_TIMER, GetMatchTime());
+  packet.Worldstates.emplace_back(BG_TP_STATE_TIMER_ACTIVE, 0);
 
   packet.Worldstates.emplace_back(BG_TP_FLAG_STATE_HORDE, GetFlagState(TEAM_HORDE));
   packet.Worldstates.emplace_back(BG_TP_FLAG_STATE_ALLIANCE, GetFlagState(TEAM_ALLIANCE));

--- a/src/server/game/Battlegrounds/Zones/BattlegroundTP.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundTP.h
@@ -235,6 +235,7 @@ class BattlegroundTP : public Battleground
         uint32 GetMatchTime() const { return 1 + (BG_TP_TOTAL_GAME_TIME - GetStartTime()) / (MINUTE*IN_MILLISECONDS); }
         uint32 GetAssaultSpellId() const;
         void RemoveAssaultAuras();
+        void HandleFlagRoomCapturePoint(TeamId teamId);
 
         /* Achievements*/
         bool CheckAchievementCriteriaMeet(uint32 criteriaId, Player const* source, Unit const* target = nullptr, uint32 miscvalue1 = 0) override;


### PR DESCRIPTION
### Motivation
- Make Twin Peaks (TP) flag behavior match Warsong Gulch (no recently-dropped debuff, no active match timer, correct flag return/capture handling).
- Bring Battle for Gilneas (BFG) scoring and tick cadence into parity with Arathi Basin (AB) as the authoritative reference for objective tick behavior and rewards.

### Description
- TP: stop scheduling/updating the match timer and send an inactive timer worldstate in `BattlegroundTP::StartingEventOpenDoors` and `FillInitialWorldStates`, and make `BG_TP_EVENT_UPDATE_GAME_TIME`/`BG_TP_EVENT_NO_TIME_LEFT` no-ops to remove the time-limit behavior (`src/server/game/Battlegrounds/Zones/BattlegroundTP.cpp` and `.h`).
- TP: remove application of the `SPELL_RECENTLY_DROPPED_FLAG`, ensure both flag aura cleanups (`BG_TP_SPELL_HORDE_FLAG`/`BG_TP_SPELL_ALLIANCE_FLAG`) are performed on drop, and add `HandleFlagRoomCapturePoint` to check opposing flag capture after respawn/return (`src/server/game/Battlegrounds/Zones/BattlegroundTP.cpp` and `.h`).
- BFG: change resource/warning thresholds and tick pacing to match AB-like values by updating `GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE`, `GILNEAS_BG_MAX_TEAM_SCORE`, `GILNEAS_BG_TickIntervals` and `GILNEAS_BG_TickPoints` in the header, re-enable periodic honor/reputation rewards and use weekend/non-weekend tick settings in `Init` so rewards are given as scores progress (`src/server/game/Battlegrounds/Zones/BattlegroundBFG.h` and `.cpp`).
- Minor housekeeping: update score/honor reward logic to use computed tick counters and cancel/reschedule capture events consistently after flag returns/respawns.

### Testing
- Ran `git diff --check` and found no whitespace/patch issues, which passed.
- Compiled the modified translation units with `ninja -C build src/server/game/CMakeFiles/game.dir/Battlegrounds/Zones/BattlegroundTP.cpp.o src/server/game/CMakeFiles/game.dir/Battlegrounds/Zones/BattlegroundBFG.cpp.o` which succeeded for the changed objects.
- Started a full build with `cmake --build build --target game -- -j2`; it began configuring and compiling but was interrupted due to the long-running rebuild (targeted object compilation already verified the local changes compiled).
- No automated unit tests were present for these BG changes; functional verification should be performed in a server instance to confirm in-game behavior (TP no timer, no recently-dropped debuff, correct capture on returns; BFG tick/reward/score behavior matches AB expectations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6a57a4608327a058514247a1d069)