### PR TITLE
Fix extractor MPQ patch discovery

### DIFF
--- a/src/tools/map_extractor/System.cpp
+++ b/src/tools/map_extractor/System.cpp
@@ -36,6 +36,9 @@
 
 #include <G3D/Plane.h>
 #include <boost/filesystem.hpp>
+#include <algorithm>
+#include <cctype>
+#include <vector>
 
 extern ArchiveSet gOpenArchives;
 
@@ -79,23 +82,61 @@ float CONF_float_to_int16_limit = 2048.0f;   // Max accuracy = val/65536
 float CONF_flat_height_delta_limit = 0.005f; // If max - min less this value - surface is flat
 float CONF_flat_liquid_delta_limit = 0.001f; // If max - min less this value - liquid surface is flat
 
-// List MPQ for extract from
-const char *CONF_mpq_list[]={
-    "common.MPQ",
-    "common-2.MPQ",
-    "lichking.MPQ",
-    "expansion.MPQ",
-    "patch.MPQ",
-    "patch-2.MPQ",
-    "patch-3.MPQ",
-    "patch-4.MPQ",
-    "patch-5.MPQ",
-    "patch-6.MPQ",
-    "patch-Z.MPQ",
-};
-
 static char const* const langs[] = {"enGB", "enUS", "deDE", "esES", "frFR", "koKR", "zhCN", "zhTW", "enCN", "enTW", "esMX", "ruRU" };
 #define LANG_COUNT 12
+
+namespace
+{
+    std::string ToLower(std::string value)
+    {
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return char(std::tolower(c)); });
+        return value;
+    }
+
+    boost::filesystem::path ResolveExistingPath(boost::filesystem::path const& path)
+    {
+        namespace fs = boost::filesystem;
+
+        if (fs::exists(path))
+            return path;
+
+        fs::path parent = path.parent_path();
+        if (parent.empty())
+            parent = ".";
+
+        if (!fs::exists(parent) || !fs::is_directory(parent))
+            return path;
+
+        std::string target = ToLower(path.filename().string());
+        for (fs::directory_iterator itr(parent), end; itr != end; ++itr)
+            if (ToLower(itr->path().filename().string()) == target)
+                return itr->path();
+
+        return path;
+    }
+
+    bool OpenArchiveIfExists(boost::filesystem::path const& path)
+    {
+        boost::filesystem::path resolved = ResolveExistingPath(path);
+        if (!boost::filesystem::exists(resolved))
+            return false;
+
+        new MPQArchive(resolved.string().c_str());
+        return true;
+    }
+
+    void AddPatchArchiveNames(std::vector<std::string>& names, std::string const& prefix)
+    {
+        names.emplace_back(prefix + ".MPQ");
+
+        for (int i = 2; i <= 99; ++i)
+            names.emplace_back(Trinity::StringFormat("{}-{}.MPQ", prefix, i));
+
+        for (char suffix = 'A'; suffix <= 'Z'; ++suffix)
+            names.emplace_back(Trinity::StringFormat("{}-{}.MPQ", prefix, suffix));
+    }
+}
+
 
 void CreateDir(boost::filesystem::path const& path)
 {
@@ -1088,32 +1129,33 @@ void ExtractCameraFiles(int locale, bool basicLocale)
 
 void LoadLocaleMPQFiles(int const locale)
 {
-    std::string fileName = Trinity::StringFormat("{}/Data/{}/locale-{}.MPQ", input_path, langs[locale], langs[locale]);
+    OpenArchiveIfExists(Trinity::StringFormat("{}/Data/{}/locale-{}.MPQ", input_path, langs[locale], langs[locale]));
 
-    new MPQArchive(fileName.c_str());
+    std::vector<std::string> localePatchNames;
+    AddPatchArchiveNames(localePatchNames, Trinity::StringFormat("patch-{}", langs[locale]));
 
-    for(int i = 1; i < 20; ++i)
-    {
-        std::string ext;
-        if (i > 1)
-            ext = Trinity::StringFormat("-{}", i);
-
-        fileName = Trinity::StringFormat("{}/Data/{}/patch-{}{}.MPQ", input_path, langs[locale], langs[locale], ext);
-        if (boost::filesystem::exists(fileName))
-            new MPQArchive(fileName.c_str());
-    }
+    for (std::string const& patchName : localePatchNames)
+        OpenArchiveIfExists(Trinity::StringFormat("{}/Data/{}/{}", input_path, langs[locale], patchName));
 }
 
 void LoadCommonMPQFiles()
 {
-    std::string fileName;
-    int count = sizeof(CONF_mpq_list)/sizeof(char*);
-    for(int i = 0; i < count; ++i)
+    static char const* const baseArchiveNames[] =
     {
-        fileName = Trinity::StringFormat("{}/Data/{}", input_path, CONF_mpq_list[i]);
-        if (boost::filesystem::exists(fileName))
-            new MPQArchive(fileName.c_str());
-    }
+        "common.MPQ",
+        "common-2.MPQ",
+        "lichking.MPQ",
+        "expansion.MPQ"
+    };
+
+    for (char const* archiveName : baseArchiveNames)
+        OpenArchiveIfExists(Trinity::StringFormat("{}/Data/{}", input_path, archiveName));
+
+    std::vector<std::string> patchNames;
+    AddPatchArchiveNames(patchNames, "patch");
+
+    for (std::string const& patchName : patchNames)
+        OpenArchiveIfExists(Trinity::StringFormat("{}/Data/{}", input_path, patchName));
 }
 
 inline void CloseMPQFiles()
@@ -1137,7 +1179,7 @@ int main(int argc, char * arg[])
 
     for (int i = 0; i < LANG_COUNT; i++)
     {
-        std::string filename = Trinity::StringFormat("{}/Data/{}/locale-{}.MPQ", input_path, langs[i], langs[i]);
+        boost::filesystem::path filename = ResolveExistingPath(Trinity::StringFormat("{}/Data/{}/locale-{}.MPQ", input_path, langs[i], langs[i]));
         if (boost::filesystem::exists(filename))
         {
             printf("Detected locale: %s\n", langs[i]);

--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -34,6 +34,8 @@
 #include <vector>
 #include <cstdio>
 #include <cerrno>
+#include <algorithm>
+#include <cctype>
 #include <sys/stat.h>
 
 #ifdef _WIN32
@@ -69,6 +71,44 @@ std::unordered_map<std::string, WMODoodadData> WmoDoodads;
 char const* szWorkDirWmo = "./Buildings";
 
 std::map<std::pair<uint32, uint16>, uint32> uniqueObjectIds;
+
+namespace
+{
+    std::string ToLower(std::string value)
+    {
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return char(std::tolower(c)); });
+        return value;
+    }
+
+    std::string ResolveExistingPath(std::string const& path)
+    {
+        boost::filesystem::path requested(path);
+        if (boost::filesystem::exists(requested))
+            return requested.string();
+
+        boost::filesystem::path parent = requested.parent_path();
+        if (parent.empty())
+            parent = ".";
+
+        if (!boost::filesystem::exists(parent) || !boost::filesystem::is_directory(parent))
+            return path;
+
+        std::string target = ToLower(requested.filename().string());
+        for (boost::filesystem::directory_iterator itr(parent), end; itr != end; ++itr)
+            if (ToLower(itr->path().filename().string()) == target)
+                return itr->path().string();
+
+        return path;
+    }
+
+    void AddArchiveIfExists(std::vector<std::string>& archiveNames, std::string const& path)
+    {
+        std::string resolvedPath = ResolveExistingPath(path);
+        if (boost::filesystem::exists(resolvedPath))
+            archiveNames.push_back(resolvedPath);
+    }
+}
+
 
 uint32 GenerateUniqueObjectId(uint32 clientId, uint16 clientDoodadId)
 {
@@ -236,32 +276,20 @@ void getGamePath()
 
 bool scan_patches(char const* scanmatch, std::vector<std::string>& pArchiveNames)
 {
-    int i;
-    char path[512];
-
-    for (i = 1; i <= 99; i++)
+    auto addIfExists = [&](std::string const& path)
     {
-        if (i != 1)
-        {
-            sprintf(path, "%s-%d.MPQ", scanmatch, i);
-        }
-        else
-        {
-            sprintf(path, "%s.MPQ", scanmatch);
-        }
-#ifdef __linux__
-        if(FILE* h = fopen64(path, "rb"))
-#else
-        if(FILE* h = fopen(path, "rb"))
-#endif
-        {
-            fclose(h);
-            //matches.push_back(path);
-            pArchiveNames.push_back(path);
-        }
-    }
+        AddArchiveIfExists(pArchiveNames, path);
+    };
 
-    return(true);
+    addIfExists(Trinity::StringFormat("{}.MPQ", scanmatch));
+
+    for (int i = 2; i <= 99; ++i)
+        addIfExists(Trinity::StringFormat("{}-{}.MPQ", scanmatch, i));
+
+    for (char suffix = 'A'; suffix <= 'Z'; ++suffix)
+        addIfExists(Trinity::StringFormat("{}-{}.MPQ", scanmatch, suffix));
+
+    return true;
 }
 
 bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
@@ -305,16 +333,16 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
     printf("Adding data files from locale directories.\n");
     for (std::vector<std::string>::iterator i = locales.begin(); i != locales.end(); ++i)
     {
-        pArchiveNames.push_back(in_path + *i + "/locale-" + *i + ".MPQ");
-        pArchiveNames.push_back(in_path + *i + "/expansion-locale-" + *i + ".MPQ");
-        pArchiveNames.push_back(in_path + *i + "/lichking-locale-" + *i + ".MPQ");
+        AddArchiveIfExists(pArchiveNames, in_path + *i + "/locale-" + *i + ".MPQ");
+        AddArchiveIfExists(pArchiveNames, in_path + *i + "/expansion-locale-" + *i + ".MPQ");
+        AddArchiveIfExists(pArchiveNames, in_path + *i + "/lichking-locale-" + *i + ".MPQ");
     }
 
     // open expansion and common files
-    pArchiveNames.push_back(input_path + std::string("common.MPQ"));
-    pArchiveNames.push_back(input_path + std::string("common-2.MPQ"));
-    pArchiveNames.push_back(input_path + std::string("expansion.MPQ"));
-    pArchiveNames.push_back(input_path + std::string("lichking.MPQ"));
+    AddArchiveIfExists(pArchiveNames, input_path + std::string("common.MPQ"));
+    AddArchiveIfExists(pArchiveNames, input_path + std::string("common-2.MPQ"));
+    AddArchiveIfExists(pArchiveNames, input_path + std::string("expansion.MPQ"));
+    AddArchiveIfExists(pArchiveNames, input_path + std::string("lichking.MPQ"));
 
     // now, scan for the patch levels in the core dir
     printf("Scanning patch levels from data directory.\n");


### PR DESCRIPTION
### Motivation
- Ensure map/vmap extractors find MPQ archives on case-sensitive filesystems (e.g. `patch-Z.mpq` / `patch-enUS-8.mpq`) so VMAP/VMAPS/MMAPS data present in such archives are picked up. 
- Expand patch discovery to include numeric and alphabetic variant names so common Blizzard patch naming patterns are covered.
- Verify MMAP generation will then discover maps like `801`, `726`, `761` once the extractors produce their `maps`/`vmaps` files.

### Description
- Added case-insensitive MPQ path resolution helpers (`ToLower`, `ResolveExistingPath`, `OpenArchiveIfExists`) and a patch-name generator (`AddPatchArchiveNames`) to `src/tools/map_extractor/System.cpp` and `src/tools/vmap4_extractor/vmapexport.cpp`.
- Reworked locale and common MPQ loading to use `OpenArchiveIfExists` instead of unguarded `new MPQArchive(...)` so files with differing case are resolved and missing archives are skipped safely.
- Expanded patch scanning to generate `patch.MPQ`, `patch-2.MPQ`..`patch-99.MPQ` and `patch-A.MPQ`..`patch-Z.MPQ` variants and to only enqueue archives that actually exist; updated `scan_patches` and archive collection logic accordingly.
- Left `mmaps_generator` discovery logic unchanged after validating it discovers maps and vmaps from the `maps`/`vmaps` directories (no hard-coded skips for maps 801/726/761 in discovery).

### Testing
- Ran `git diff --check` with no problems reported.
- Built the tools successfully with `cmake --build build --target mapextractor vmap4extractor mmaps_generator -- -j2` and the three tooling binaries compiled and linked successfully.
- Note: an earlier build attempt using an incorrect target `mmap` failed because that target does not exist; the correct target is `mmaps_generator` (this is not a code error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7ad0dc8483278394f71e1c9b1d55)