### PR TITLE
Handle Scarlet Chapel group bot replacement

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -31,6 +31,8 @@
 #include "WorldSession.h"
 #include "World.h"
 
+#include <vector>
+
 namespace
 {
 bool GroupHasRealPlayerInvitee(GroupQueueInfo const* ginfo)
@@ -52,11 +54,12 @@ bool GroupHasRealPlayerInvitee(GroupQueueInfo const* ginfo)
     return false;
 }
 
-bool HasVirtualPlayerOnTeam(Battleground* battleground, uint32 team)
+uint32 CountVirtualPlayersOnTeam(Battleground* battleground, uint32 team)
 {
     if (!battleground)
-        return false;
+        return 0;
 
+    uint32 count = 0;
     for (auto const& [memberGuid, bgPlayer] : battleground->GetPlayers())
     {
         if (bgPlayer.Team != team)
@@ -70,19 +73,25 @@ bool HasVirtualPlayerOnTeam(Battleground* battleground, uint32 team)
         if (!session || !session->IsVirtualSession())
             continue;
 
-        return true;
+        ++count;
     }
 
-    return false;
+    return count;
 }
 
-bool RemoveOneVirtualPlayerFromTeam(Battleground* battleground, uint32 team)
+uint32 RemoveVirtualPlayersFromTeam(Battleground* battleground, uint32 team, uint32 count)
 {
-    if (!battleground)
-        return false;
+    if (!battleground || !count)
+        return 0;
+
+    std::vector<ObjectGuid> removalGuids;
+    removalGuids.reserve(count);
 
     for (auto const& [memberGuid, bgPlayer] : battleground->GetPlayers())
     {
+        if (removalGuids.size() >= count)
+            break;
+
         if (bgPlayer.Team != team)
             continue;
 
@@ -94,11 +103,13 @@ bool RemoveOneVirtualPlayerFromTeam(Battleground* battleground, uint32 team)
         if (!session || !session->IsVirtualSession())
             continue;
 
-        battleground->RemovePlayerAtLeave(memberGuid, true, true);
-        return true;
+        removalGuids.push_back(memberGuid);
     }
 
-    return false;
+    for (ObjectGuid const& guid : removalGuids)
+        battleground->RemovePlayerAtLeave(guid, true, true);
+
+    return removalGuids.size();
 }
 }
 
@@ -592,12 +603,19 @@ bool BattlegroundQueue::InviteGroupToBG(GroupQueueInfo* ginfo, Battleground* bg,
     if (side)
         ginfo->Team = side;
 
-    // Let bots fully populate battlegrounds, but if a real player is now being invited
-    // and the target team is full, free exactly one slot by dropping a virtual-session actor.
-    if (bg && bg->isBattleground() && GroupHasRealPlayerInvitee(ginfo) && !bg->GetFreeSlotsForTeam(ginfo->Team))
+    // Let bots fully populate battlegrounds, but if a real player group is now being
+    // invited and the target team does not have enough room, free one virtual-session
+    // actor per incoming group member so the entire group can zone in together.
+    if (bg && bg->isBattleground() && GroupHasRealPlayerInvitee(ginfo))
     {
-        if (!RemoveOneVirtualPlayerFromTeam(bg, ginfo->Team))
-            return false;
+        uint32 const freeSlots = bg->GetFreeSlotsForTeam(ginfo->Team);
+        uint32 const playerCount = ginfo->Players.size();
+        if (freeSlots < playerCount)
+        {
+            uint32 const removed = RemoveVirtualPlayersFromTeam(bg, ginfo->Team, playerCount - freeSlots);
+            if (removed < playerCount - freeSlots)
+                return false;
+        }
     }
 
     if (!ginfo->IsInvitedToBGInstanceGUID)
@@ -700,8 +718,8 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
         if (addToHorde)
         {
             uint32 hordeDesired = hordeFree > 0 ? uint32(hordeFree) : 0u;
-            if (!hordeDesired && GroupHasRealPlayerInvitee(*Ali_itr) && HasVirtualPlayerOnTeam(bg, HORDE))
-                hordeDesired = 1;
+            if (GroupHasRealPlayerInvitee(*Ali_itr))
+                hordeDesired += CountVirtualPlayersOnTeam(bg, HORDE);
 
             if (!m_SelectionPools[TEAM_HORDE].AddGroup((*Ali_itr), hordeDesired, TEAM_HORDE))
                 break;
@@ -709,8 +727,8 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
         else
         {
             uint32 allianceDesired = aliFree > 0 ? uint32(aliFree) : 0u;
-            if (!allianceDesired && GroupHasRealPlayerInvitee(*Ali_itr) && HasVirtualPlayerOnTeam(bg, ALLIANCE))
-                allianceDesired = 1;
+            if (GroupHasRealPlayerInvitee(*Ali_itr))
+                allianceDesired += CountVirtualPlayersOnTeam(bg, ALLIANCE);
 
             if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Ali_itr), allianceDesired, TEAM_ALLIANCE))
                 break;
@@ -742,8 +760,8 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
         if (addToHorde)
         {
             uint32 hordeDesired = hordeFree > 0 ? uint32(hordeFree) : 0u;
-            if (!hordeDesired && GroupHasRealPlayerInvitee(*Horde_itr) && HasVirtualPlayerOnTeam(bg, HORDE))
-                hordeDesired = 1;
+            if (GroupHasRealPlayerInvitee(*Horde_itr))
+                hordeDesired += CountVirtualPlayersOnTeam(bg, HORDE);
 
             if (!m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeDesired, TEAM_HORDE))
                 break;
@@ -751,8 +769,8 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
         else
         {
             uint32 allianceDesired = aliFree > 0 ? uint32(aliFree) : 0u;
-            if (!allianceDesired && GroupHasRealPlayerInvitee(*Horde_itr) && HasVirtualPlayerOnTeam(bg, ALLIANCE))
-                allianceDesired = 1;
+            if (GroupHasRealPlayerInvitee(*Horde_itr))
+                allianceDesired += CountVirtualPlayersOnTeam(bg, ALLIANCE);
 
             if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Horde_itr), allianceDesired, TEAM_ALLIANCE))
                 break;

--- a/src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp
+++ b/src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp
@@ -25,6 +25,64 @@ void SendQueueError(Player* player, char const* text)
         session->SendNotification("%s", text);
 }
 
+bool CanQueuePlayerForScm(Player* player, BattlegroundQueueTypeId queueTypeId)
+{
+    return player && player->GetBGAccessByLevel(BATTLEGROUND_SCM) && player->HasFreeBattlegroundQueueId() &&
+        player->GetBattlegroundQueueIndex(queueTypeId) >= PLAYER_MAX_BATTLEGROUND_QUEUES;
+}
+
+bool QueueGroup(Player* leader, Group* group, uint32 forcedTeam)
+{
+    if (!leader || !group)
+        return false;
+
+    Battleground* bgTemplate = sBattlegroundMgr->GetBattlegroundTemplate(BATTLEGROUND_SCM);
+    if (!bgTemplate)
+        return false;
+
+    BattlegroundQueueTypeId const queueTypeId = BattlegroundMgr::BGQueueTypeId(BATTLEGROUND_SCM, 0);
+    if (queueTypeId == BATTLEGROUND_QUEUE_NONE)
+        return false;
+
+    PvPDifficultyEntry const* bracketEntry = GetBattlegroundBracketByLevel(bgTemplate->GetMapId(), leader->GetLevel());
+    if (!bracketEntry)
+        return false;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!CanQueuePlayerForScm(member, queueTypeId))
+            return false;
+
+        PvPDifficultyEntry const* memberBracket = GetBattlegroundBracketByLevel(bgTemplate->GetMapId(), member->GetLevel());
+        if (!memberBracket || memberBracket->GetBracketId() != bracketEntry->GetBracketId())
+            return false;
+    }
+
+    uint32 const previousBgTeam = leader->GetBGTeamOverride();
+    if (forcedTeam == TEAM_ALLIANCE)
+        leader->SetBGTeam(ALLIANCE);
+    else if (forcedTeam == TEAM_HORDE)
+        leader->SetBGTeam(HORDE);
+    else
+        leader->SetBGTeam(0);
+
+    BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(queueTypeId);
+    GroupQueueInfo* ginfo = bgQueue.AddGroup(leader, group, BATTLEGROUND_SCM, bracketEntry, 0, false, false, 0, 0);
+
+    leader->SetBGTeam(previousBgTeam);
+
+    if (!ginfo)
+        return false;
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        if (Player* member = ref->GetSource())
+            member->AddBattlegroundQueueId(queueTypeId);
+
+    sBattlegroundMgr->ScheduleQueueUpdate(ginfo->ArenaMatchmakerRating, ginfo->ArenaType, queueTypeId, BATTLEGROUND_SCM, bracketEntry->GetBracketId());
+    return true;
+}
+
 bool QueueSinglePlayer(Player* player, uint32 forcedTeam)
 {
     if (!player || !player->GetBGAccessByLevel(BATTLEGROUND_SCM) || !player->HasFreeBattlegroundQueueId())
@@ -128,15 +186,7 @@ public:
                 }
             }
 
-            bool anyFailed = false;
-            for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-            {
-                Player* member = ref->GetSource();
-                if (!QueueSinglePlayer(member, forcedTeam))
-                    anyFailed = true;
-            }
-
-            if (anyFailed)
+            if (!QueueGroup(player, group, forcedTeam))
                 SendQueueError(player, "One or more party members could not be queued.");
             else
                 CloseGossipMenuFor(player);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -95,6 +95,7 @@ std::unordered_map<uint64, uint32> g_BattlegroundQueuedNoInviteSinceMsByGuid;
 uint32 g_LastHumanInterestPopulationRebalanceAttemptMs = 0;
 uint32 g_LastScmSlotRefillAttemptMs = 0;
 bool BattlegroundHasAnyRealHumanPlayers(Player const* player);
+bool HasPendingRealHumanInviteForBattleground(Battleground const* battleground);
 bool RemoveMatchingQueues(Player* player, bool arenaOnly, bool invitedOnly, bool scheduleNonArenaUpdate);
 
 bool IsScmManagedBotCandidate(Player const* player)
@@ -122,6 +123,9 @@ uint32 ComputeOverstackDepartureJitterMs(Player const* player, Battleground cons
 bool ShouldManagedBotLeaveForOverstack(Player* player, Battleground* battleground)
 {
     if (!player || !battleground || !IsScmManagedBotCandidate(player))
+        return false;
+
+    if (HasPendingRealHumanInviteForBattleground(battleground))
         return false;
 
     uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
@@ -219,6 +223,9 @@ bool ShouldManagedBotLeaveForQueuedHuman(Player* player, Battleground* battlegro
 bool TryRefillManagedScmSlots(Player* player, Battleground* battleground)
 {
     if (!player || !battleground || battleground->GetTypeID() != BATTLEGROUND_SCM)
+        return false;
+
+    if (HasPendingRealHumanInviteForBattleground(battleground))
         return false;
 
     uint32 const maxPlayers = battleground->GetMaxPlayers();
@@ -1776,6 +1783,39 @@ bool BattlegroundHasAnyRealHumanPlayers(Player const* player)
         WorldSession const* session = participant->GetSession();
         bool const isVirtualSession = session && session->IsVirtualSession();
         if (!isVirtualSession && !playerbot::IsManagedRandomBot(participant))
+            return true;
+    }
+
+    return false;
+}
+
+
+bool HasPendingRealHumanInviteForBattleground(Battleground const* battleground)
+{
+    if (!battleground || battleground->GetTypeID() != BATTLEGROUND_SCM)
+        return false;
+
+    BattlegroundQueueTypeId const queueTypeId = BattlegroundMgr::BGQueueTypeId(battleground->GetTypeID(), battleground->GetArenaType());
+    if (queueTypeId == BATTLEGROUND_QUEUE_NONE)
+        return false;
+
+    BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(queueTypeId);
+    for (auto const& [queuedGuid, queueInfo] : bgQueue.m_QueuedPlayers)
+    {
+        GroupQueueInfo const* groupInfo = queueInfo.GroupInfo;
+        if (!groupInfo || groupInfo->IsInvitedToBGInstanceGUID != battleground->GetInstanceID())
+            continue;
+
+        Player* participant = ObjectAccessor::FindConnectedPlayer(queuedGuid);
+        if (!participant)
+            continue;
+
+        WorldSession const* session = participant->GetSession();
+        bool const isVirtualSession = session && session->IsVirtualSession();
+        if (isVirtualSession || playerbot::IsManagedRandomBot(participant))
+            continue;
+
+        if (!participant->InBattleground() || participant->GetBattlegroundId() != battleground->GetInstanceID())
             return true;
     }
 


### PR DESCRIPTION
### Motivation

- Ensure when a real player group queues for Scarlet Chapel the server makes room so the entire group can zone in together by removing an equal number of virtual playerbots from the chosen side.
- Prevent automated population rebalance/overstack logic from interfering while invited real players are still pending join so the group flow is stable.

### Description

- Queue NPC: `npc_scarlet_chapel_queue.cpp` now enqueues a party as a single `GroupQueueInfo` after validating every member's bracket/eligibility and preserves any forced-side choice for the whole group.  
- Battleground queue: added `CountVirtualPlayersOnTeam` and `RemoveVirtualPlayersFromTeam` helpers and updated `InviteGroupToBG` to remove virtual-session bots equal to the incoming group shortfall so the full real group can be accommodated.  
- Selection/fill logic: `FillPlayersToBG` was adjusted to account for replaceable virtual players when computing desired invite counts so a queued real group can take over a side even if free slots are scarce.  
- Playerbot lifecycle: added `HasPendingRealHumanInviteForBattleground` and used it to temporarily suspend SCM slot-refill and overstack departure triggers while real human invitees are still expected to zone in.  
- Minor: added necessary include (`<vector>`) and small helper `QueueGroup`/`CanQueuePlayerForScm` to centralize party-queueing logic in the custom NPC script.

### Testing

- Built modified files: `ninja -C build src/server/game/CMakeFiles/game.dir/Battlegrounds/BattlegroundQueue.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Custom/npc_scarlet_chapel_queue.cpp.o` and `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o` which completed (compile warnings from third-party libs observed but unrelated).  
- Re-configured scripts with `cmake -S . -B build -DPLAYERBOT=ON -DSCRIPTS_PLAYERBOT=static` which completed successfully.  
- Verified per-file compilation of the updated script/object translation units and ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb79deb224832795fbf1c82b4bc6a7)