### PR TITLE
Fix Battle for Gilneas tick initialization crash

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
@@ -106,16 +106,16 @@ void BattlegroundBFG::PostUpdateImpl(uint32 diff)
                         break;
                     }
 
-                    uint8 honorRewards = uint8(m_TeamScores[teamId] / _honorTics);
-                    uint8 reputationRewards = uint8(m_TeamScores[teamId] / _reputationTics);
+                    uint8 honorRewards = _honorTics ? uint8(m_TeamScores[teamId] / _honorTics) : 0;
+                    uint8 reputationRewards = _reputationTics ? uint8(m_TeamScores[teamId] / _reputationTics) : 0;
                     uint8 information = uint8(m_TeamScores[teamId] / GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE);
                     m_TeamScores[teamId] += GILNEAS_BG_TickPoints[controlledPoints];
                     if (m_TeamScores[teamId] > GILNEAS_BG_MAX_TEAM_SCORE)
                         m_TeamScores[teamId] = GILNEAS_BG_MAX_TEAM_SCORE;
 
-                    if (honorRewards < uint8(m_TeamScores[teamId] / _honorTics))
+                    if (_honorTics && honorRewards < uint8(m_TeamScores[teamId] / _honorTics))
                         RewardHonorToTeam(GetBonusHonorFromKill(1), teamId);
-                    if (reputationRewards < uint8(m_TeamScores[teamId] / _reputationTics))
+                    if (_reputationTics && reputationRewards < uint8(m_TeamScores[teamId] / _reputationTics))
                         RewardReputationToTeam(teamId == TEAM_ALLIANCE ? 509 : 510, 10, teamId);
 
                     if (information < uint8(m_TeamScores[teamId] / GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE))
@@ -418,12 +418,30 @@ bool BattlegroundBFG::SetupBattleground() {
     return true;
 }
 
+void BattlegroundBFG::Reset()
+{
+    Battleground::Reset();
+
+    Init();
+}
+
 void BattlegroundBFG::Init()
 {
-
-      //call parent's class reset
-
     _bgEvents.Reset();
+
+    m_TeamScores[TEAM_ALLIANCE] = 0;
+    m_TeamScores[TEAM_HORDE] = 0;
+    _controlledPoints[TEAM_ALLIANCE] = 0;
+    _controlledPoints[TEAM_HORDE] = 0;
+    _teamScores500Disadvantage[TEAM_ALLIANCE] = false;
+    _teamScores500Disadvantage[TEAM_HORDE] = false;
+
+    for (uint8 node = 0; node < GILNEAS_BG_DYNAMIC_NODES_COUNT; ++node)
+    {
+        _capturePointInfo[node]._ownerTeamId = TEAM_NEUTRAL;
+        _capturePointInfo[node]._state = GILNEAS_BG_NODE_TYPE_NEUTRAL;
+        _capturePointInfo[node]._captured = false;
+    }
 
     _honorTics = BattlegroundMgr::IsBGWeekend(GetTypeID()) ? GILNEAS_BG_BGWeekendHonorTicks : GILNEAS_BG_NotBGWeekendHonorTicks;
     _reputationTics = BattlegroundMgr::IsBGWeekend(GetTypeID()) ? GILNEAS_BG_BGWeekendRepTicks : GILNEAS_BG_NotBGWeekendRepTicks;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
@@ -296,6 +296,7 @@ public:
     void RemovePlayer(Player* player, ObjectGuid guid, uint32 team) override;
     void HandleAreaTrigger(Player* player, uint32 trigger) override;
     bool SetupBattleground() override;
+    void Reset() override;
     void Init();
     void EndBattleground(uint32 winnerTeamId) override;
     WorldSafeLocsEntry const* GetClosestGraveyard(Player* player) override;


### PR DESCRIPTION
### Motivation
- Prevent a SIGFPE observed when capping a flag in Battle for Gilneas caused by divisions using uninitialized/zero tick counters during the BG tick handler.

### Description
- Guard the honor and reputation reward calculations in `BattlegroundBFG::PostUpdateImpl` so divisions by `_honorTics` and `_reputationTics` are only performed when those values are non-zero.  (change in `src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp`).
- Add a `Reset()` override to `BattlegroundBFG` and implement a proper `Init()` that initializes team scores, controlled-node counters, `_teamScores500Disadvantage`, capture point state, and resets `_bgEvents` so a new BFG instance starts with deterministic state. (changes in `src/server/game/Battlegrounds/Zones/BattlegroundBFG.h` and `.cpp`).
- Keep existing worldstate/icon initialization and tick scheduling logic intact while ensuring reward tick thresholds are set before any tick occurs.

### Testing
- Ran `git diff --check` to verify no whitespace/errors reported and it passed.
- Compiled the modified translation unit using the `compile_commands.json` entry for `BattlegroundBFG.cpp`, and the TU built successfully.
- Triggered a partial project build (`cmake --build build --target worldserver`), which was started and then interrupted; the targeted TU compile completed successfully before interruption.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8ab5f41083279299ae13f01fd930)