### PR TITLE
Stabilize world socket packet queue

### DIFF
--- a/src/server/game/Server/WorldSocket.h
+++ b/src/server/game/Server/WorldSocket.h
@@ -32,14 +32,9 @@ using boost::asio::ip::tcp;
 class EncryptablePacket : public WorldPacket
 {
 public:
-    EncryptablePacket(WorldPacket const& packet, bool encrypt) : WorldPacket(packet), _encrypt(encrypt)
-    {
-        SocketQueueLink.store(nullptr, std::memory_order_relaxed);
-    }
+    EncryptablePacket(WorldPacket const& packet, bool encrypt) : WorldPacket(packet), _encrypt(encrypt) { }
 
     bool NeedsEncryption() const { return _encrypt; }
-
-    std::atomic<EncryptablePacket*> SocketQueueLink;
 
 private:
     bool _encrypt;
@@ -124,7 +119,7 @@ private:
 
     MessageBuffer _headerBuffer;
     MessageBuffer _packetBuffer;
-    MPSCQueue<EncryptablePacket, &EncryptablePacket::SocketQueueLink> _bufferQueue;
+    MPSCQueue<EncryptablePacket> _bufferQueue;
     std::size_t _sendBufferSize;
 
     QueryCallbackProcessor _queryProcessor;


### PR DESCRIPTION
### Motivation
- Crash evidence showed a `SIGSEGV` during `WorldSocket::Update()` while deleting outgoing `EncryptablePacket` objects, consistent with corruption or misuse of the intrusive MPSC queue link inside packets. 
- The intent is to avoid the intrusive queue path and its dummy-node/link edge cases by using the non-intrusive MPSC queue implementation for outgoing packets.

### Description
- Replace the intrusive queue usage in `WorldSocket` by switching `_bufferQueue` from `MPSCQueue<EncryptablePacket, &EncryptablePacket::SocketQueueLink>` to the non-intrusive `MPSCQueue<EncryptablePacket>` in `src/server/game/Server/WorldSocket.h`.
- Remove the intrusive `SocketQueueLink` member and its initialization from the `EncryptablePacket` class and simplify the constructor to a plain wrapper that only stores the `encrypt` flag.
- Preserve existing ownership and deletion behavior in `WorldSocket::Update()` so packet lifetime semantics remain unchanged while avoiding embedded-link handling.

### Testing
- Built the relevant translation unit with `ninja -C build src/server/game/CMakeFiles/game.dir/Server/WorldSocket.cpp.o -j2`, and the compilation completed successfully.
- Started a full build with `cmake --build build --target worldserver -j2` but it was not completed because a large cold rebuild was initiated and then halted; no full binary/runtime tests were run yet.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbdc9d52b083278838ade3242b1963)