### PR TITLE
Fix pet owner cleanup during world unload

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -92,6 +92,14 @@ void Pet::RemoveFromWorld()
     ///- Remove the pet from the accessor
     if (IsInWorld())
     {
+        // Pets bypass Minion::RemoveFromWorld because they are stored in the pet
+        // accessor rather than the creature accessor. Keep the minion ownership
+        // cleanup here so direct map/world unloads do not leave this pet in its
+        // owner's controlled list before Unit::RemoveFromWorld validates it.
+        if (Unit* owner = WorldObject::GetOwner())
+            if (GetOwnerGUID() == owner->GetGUID())
+                owner->SetMinion(this, false);
+
         ///- Don't call the function for Creature, normal mobs + totems go in a different storage
         Unit::RemoveFromWorld();
         GetMap()->GetObjectsStore().Remove<Pet>(GetGUID());


### PR DESCRIPTION
### Motivation
- Prevent a crash during shutdown/map-unload where `Unit::RemoveFromWorld()` aborts because a pet remained in its owner’s `m_Controlled` list while the pet is stored in the pet accessor (bypassing `Minion::RemoveFromWorld()` cleanup).

### Description
- In `src/server/game/Entities/Pet/Pet.cpp` updated `Pet::RemoveFromWorld()` to detach the pet from its owner by calling `owner->SetMinion(this, false)` when the owner exists and matches `GetOwnerGUID()`, performed before calling `Unit::RemoveFromWorld()`.
- The change preserves the pet-specific object store removal (`GetMap()->GetObjectsStore().Remove<Pet>(GetGUID())`) and does not alter `Unit::RemoveFromWorld()` behavior.
- This mirrors the ownership cleanup normally performed by `Minion::RemoveFromWorld()` for creatures that use the creature accessor.

### Testing
- Built the modified translation unit with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/Pet/Pet.cpp.o`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe55a921c88327a0cb1c3ee955a659)