### PR TITLE
Preserve forced Scarlet Chapel queue side

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -76,6 +76,19 @@ bool HasVirtualPlayerOnTeam(Battleground* battleground, uint32 team)
     return false;
 }
 
+bool AddForcedGroupToSelectionPool(BattlegroundQueue::SelectionPool selectionPools[PVP_TEAMS_COUNT], GroupQueueInfo* ginfo,
+    Battleground* bg, int32 hordeFree, int32 allianceFree)
+{
+    TeamId const forcedTeamIndex = ginfo->Team == HORDE ? TEAM_HORDE : TEAM_ALLIANCE;
+    int32 const freeSlots = ginfo->Team == HORDE ? hordeFree : allianceFree;
+    uint32 desiredCount = freeSlots > 0 ? uint32(freeSlots) : 0u;
+
+    if (!desiredCount && GroupHasRealPlayerInvitee(ginfo) && HasVirtualPlayerOnTeam(bg, ginfo->Team))
+        desiredCount = 1;
+
+    return selectionPools[forcedTeamIndex].AddGroup(ginfo, desiredCount, forcedTeamIndex);
+}
+
 bool RemoveOneVirtualPlayerFromTeam(Battleground* battleground, uint32 team)
 {
     if (!battleground)
@@ -220,6 +233,7 @@ GroupQueueInfo* BattlegroundQueue::AddGroup(Player* leader, Group* grp, Battlegr
     ginfo->JoinTime = GameTime::GetGameTimeMS();
     ginfo->RemoveInviteTime = 0;
     ginfo->Team = leader->GetTeam();
+    ginfo->IsForcedTeam = false;
     ginfo->ArenaTeamRating = ArenaRating;
     ginfo->ArenaMatchmakerRating = MatchmakerRating;
     ginfo->PreviousOpponentsTeamId = PreviousOpponentsArenaTeamId;
@@ -305,6 +319,7 @@ GroupQueueInfo* BattlegroundQueue::AddGroup(Player* leader, Group* grp, Battlegr
     else if (hasForcedQueueTeam)
     {
         ginfo->Team = explicitBgTeam;
+        ginfo->IsForcedTeam = true;
     }
 
     ginfo->Players.clear();
@@ -694,26 +709,34 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
 
         uint32 aliCount = m_QueuedGroups[bracket_id][BG_QUEUE_NORMAL_ALLIANCE].size();
         uint32 hordeCount = m_QueuedGroups[bracket_id][BG_QUEUE_NORMAL_HORDE].size();
-        bool addToHorde = (projectedHordeInGame < projectedAliInGame) ||
-            (projectedHordeInGame == projectedAliInGame && roll_chance_i(50));
-
-        if (addToHorde)
+        if ((*Ali_itr)->IsForcedTeam)
         {
-            uint32 hordeDesired = hordeFree > 0 ? uint32(hordeFree) : 0u;
-            if (!hordeDesired && GroupHasRealPlayerInvitee(*Ali_itr) && HasVirtualPlayerOnTeam(bg, HORDE))
-                hordeDesired = 1;
-
-            if (!m_SelectionPools[TEAM_HORDE].AddGroup((*Ali_itr), hordeDesired, TEAM_HORDE))
+            if (!AddForcedGroupToSelectionPool(m_SelectionPools, *Ali_itr, bg, hordeFree, aliFree))
                 break;
         }
         else
         {
-            uint32 allianceDesired = aliFree > 0 ? uint32(aliFree) : 0u;
-            if (!allianceDesired && GroupHasRealPlayerInvitee(*Ali_itr) && HasVirtualPlayerOnTeam(bg, ALLIANCE))
-                allianceDesired = 1;
+            bool addToHorde = (projectedHordeInGame < projectedAliInGame) ||
+                (projectedHordeInGame == projectedAliInGame && roll_chance_i(50));
 
-            if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Ali_itr), allianceDesired, TEAM_ALLIANCE))
-                break;
+            if (addToHorde)
+            {
+                uint32 hordeDesired = hordeFree > 0 ? uint32(hordeFree) : 0u;
+                if (!hordeDesired && GroupHasRealPlayerInvitee(*Ali_itr) && HasVirtualPlayerOnTeam(bg, HORDE))
+                    hordeDesired = 1;
+
+                if (!m_SelectionPools[TEAM_HORDE].AddGroup((*Ali_itr), hordeDesired, TEAM_HORDE))
+                    break;
+            }
+            else
+            {
+                uint32 allianceDesired = aliFree > 0 ? uint32(aliFree) : 0u;
+                if (!allianceDesired && GroupHasRealPlayerInvitee(*Ali_itr) && HasVirtualPlayerOnTeam(bg, ALLIANCE))
+                    allianceDesired = 1;
+
+                if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Ali_itr), allianceDesired, TEAM_ALLIANCE))
+                    break;
+            }
         }
         ++Ali_itr;
     }
@@ -736,26 +759,34 @@ void BattlegroundQueue::FillPlayersToBG(Battleground* bg, BattlegroundBracketId 
 
         uint32 aliCount = m_QueuedGroups[bracket_id][BG_QUEUE_NORMAL_ALLIANCE].size();
         uint32 hordeCount = m_QueuedGroups[bracket_id][BG_QUEUE_NORMAL_HORDE].size();
-        bool addToHorde = (projectedHordeInGame < projectedAliInGame) ||
-            (projectedHordeInGame == projectedAliInGame && roll_chance_i(50));
-
-        if (addToHorde)
+        if ((*Horde_itr)->IsForcedTeam)
         {
-            uint32 hordeDesired = hordeFree > 0 ? uint32(hordeFree) : 0u;
-            if (!hordeDesired && GroupHasRealPlayerInvitee(*Horde_itr) && HasVirtualPlayerOnTeam(bg, HORDE))
-                hordeDesired = 1;
-
-            if (!m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeDesired, TEAM_HORDE))
+            if (!AddForcedGroupToSelectionPool(m_SelectionPools, *Horde_itr, bg, hordeFree, aliFree))
                 break;
         }
         else
         {
-            uint32 allianceDesired = aliFree > 0 ? uint32(aliFree) : 0u;
-            if (!allianceDesired && GroupHasRealPlayerInvitee(*Horde_itr) && HasVirtualPlayerOnTeam(bg, ALLIANCE))
-                allianceDesired = 1;
+            bool addToHorde = (projectedHordeInGame < projectedAliInGame) ||
+                (projectedHordeInGame == projectedAliInGame && roll_chance_i(50));
 
-            if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Horde_itr), allianceDesired, TEAM_ALLIANCE))
-                break;
+            if (addToHorde)
+            {
+                uint32 hordeDesired = hordeFree > 0 ? uint32(hordeFree) : 0u;
+                if (!hordeDesired && GroupHasRealPlayerInvitee(*Horde_itr) && HasVirtualPlayerOnTeam(bg, HORDE))
+                    hordeDesired = 1;
+
+                if (!m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeDesired, TEAM_HORDE))
+                    break;
+            }
+            else
+            {
+                uint32 allianceDesired = aliFree > 0 ? uint32(aliFree) : 0u;
+                if (!allianceDesired && GroupHasRealPlayerInvitee(*Horde_itr) && HasVirtualPlayerOnTeam(bg, ALLIANCE))
+                    allianceDesired = 1;
+
+                if (!m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Horde_itr), allianceDesired, TEAM_ALLIANCE))
+                    break;
+            }
         }
         ++Horde_itr;
     }

--- a/src/server/game/Battlegrounds/BattlegroundQueue.h
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.h
@@ -41,6 +41,7 @@ struct GroupQueueInfo                                       // stores informatio
 {
     std::map<ObjectGuid, PlayerQueueInfo*> Players;         // player queue info map
     uint32  Team;                                           // Player team (ALLIANCE/HORDE)
+    bool    IsForcedTeam;                                   // True when a queue entry must stay on Team instead of being rebalanced
     BattlegroundTypeId BgTypeId;                            // battleground type id
     bool    IsRated;                                        // rated
     uint8   ArenaType;                                      // 2v2, 3v3, 4v4, 5v5 or 0 when BG

--- a/tests/game/ScarletChapelQueue.cpp
+++ b/tests/game/ScarletChapelQueue.cpp
@@ -1,0 +1,28 @@
+#include "../tc_catch2.h"
+
+#include <fstream>
+#include <string>
+
+namespace
+{
+std::string ReadFile(std::string const& path)
+{
+    std::ifstream in(path);
+    REQUIRE(in.good());
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+}
+
+TEST_CASE("Scarlet Chapel forced queue side is preserved during active battleground refill", "[scarlet][queue]")
+{
+    std::string const queueSource = ReadFile("src/server/game/Battlegrounds/BattlegroundQueue.cpp");
+    std::string const queueHeader = ReadFile("src/server/game/Battlegrounds/BattlegroundQueue.h");
+    std::string const npcSource = ReadFile("src/server/scripts/Custom/npc_scarlet_chapel_queue.cpp");
+
+    CHECK(queueHeader.find("IsForcedTeam") != std::string::npos);
+    CHECK(queueSource.find("ginfo->IsForcedTeam = true") != std::string::npos);
+    CHECK(queueSource.find("if ((*Ali_itr)->IsForcedTeam)") != std::string::npos);
+    CHECK(queueSource.find("if ((*Horde_itr)->IsForcedTeam)") != std::string::npos);
+    CHECK(npcSource.find("ACTION_QUEUE_ALLIANCE") != std::string::npos);
+    CHECK(npcSource.find("ACTION_QUEUE_HORDE") != std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Allow players to explicitly force Alliance/Horde when queuing via the Scarlet Chapel NPC so human requests are honored instead of being auto-rebalanced by the SCM queue refill logic.

### Description
- Add `IsForcedTeam` to `GroupQueueInfo` to mark queue entries that must remain on the requested side (`src/server/game/Battlegrounds/BattlegroundQueue.h`).
- Set `ginfo->IsForcedTeam = true` when a Scarlet Chapel queue entry uses an explicit BG team override, and initialize it to `false` for normal entries (`BattlegroundQueue::AddGroup` in `BattlegroundQueue.cpp`).
- Add helper `AddForcedGroupToSelectionPool(...)` and update `FillPlayersToBG` selection logic to place forced entries on their requested side instead of reassigning them during active battleground refill (`src/server/game/Battlegrounds/BattlegroundQueue.cpp`).
- Add a small regression test that checks the new wiring and NPC actions remain present (`tests/game/ScarletChapelQueue.cpp`).

### Testing
- Static source assertions (`python3` checks for symbols/strings) passed.
- Incremental compile of the modified translation unit succeeded via `ninja -C build src/server/game/CMakeFiles/game.dir/Battlegrounds/BattlegroundQueue.cpp.o` (compiler warnings from third-party code observed but unrelated).
- Full `tests` target could not be executed because the current build directory was configured with `BUILD_TESTING=0`, so the `tests` target is not available; no runtime test failures were produced by the automated steps that were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe83ece4748327bd603edf71ee989c)