### PR TITLE
Use Warsong flag spells in Twin Peaks

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundTP.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundTP.h
@@ -64,10 +64,10 @@ enum BG_TP_Sound
 enum BG_TP_SpellId
 {
     BG_TP_SPELL_HORDE_FLAG              = 23333,
-    BG_TP_SPELL_HORDE_FLAG_DROPPED      = 85003,
+    BG_TP_SPELL_HORDE_FLAG_DROPPED      = 23334,
     BG_TP_SPELL_HORDE_FLAG_PICKED       = 61266,    // fake spell, does not exist but used as timer start event
     BG_TP_SPELL_ALLIANCE_FLAG           = 23335,
-    BG_TP_SPELL_ALLIANCE_FLAG_DROPPED   = 85004,
+    BG_TP_SPELL_ALLIANCE_FLAG_DROPPED   = 23336,
     BG_TP_SPELL_ALLIANCE_FLAG_PICKED    = 61265,    // fake spell, does not exist but used as timer start event
     BG_TP_SPELL_FOCUSED_ASSAULT         = 46392,
     BG_TP_SPELL_BRUTAL_ASSAULT          = 46393
@@ -119,8 +119,8 @@ enum BG_TP_ObjectEntry
     BG_OBJECT_DOOR_H_4_TP_ENTRY          = 208207,
     BG_OBJECT_A_FLAG_TP_ENTRY            = 179830,
     BG_OBJECT_H_FLAG_TP_ENTRY            = 179831,
-    BG_OBJECT_A_FLAG_GROUND_TP_ENTRY     = 208208,
-    BG_OBJECT_H_FLAG_GROUND_TP_ENTRY     = 208209
+    BG_OBJECT_A_FLAG_GROUND_TP_ENTRY     = 179785,
+    BG_OBJECT_H_FLAG_GROUND_TP_ENTRY     = 179786
 };
 
 enum BG_TP_FlagState

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2197,7 +2197,7 @@ void GameObject::Use(Unit* user)
                         break;
                 }
                 // BG flag dropped
-                // WS:
+                // WS/TP:
                 // 179785 - Silverwing Flag
                 // 179786 - Warsong Flag
                 // EotS:
@@ -2209,7 +2209,7 @@ void GameObject::Use(Unit* user)
                     {
                         case 179785:                        // Silverwing Flag
                         case 179786:                        // Warsong Flag
-                            if (bg->GetTypeID(true) == BATTLEGROUND_WS)
+                            if (bg->GetTypeID(true) == BATTLEGROUND_WS || bg->GetTypeID(true) == BATTLEGROUND_TP)
                                 bg->EventPlayerClickedOnFlag(player, this);
                             break;
                         case 184142:                        // Netherstorm Flag


### PR DESCRIPTION
### Motivation
- Twin Peaks should use the same carried/dropped flag spells and ground flag objects as Warsong Gulch so flag pickups/drops behave identically and clients receive the same spell-produced objects.

### Description
- Changed Twin Peaks flag spell IDs in `src/server/game/Battlegrounds/Zones/BattlegroundTP.h` to use Warsong IDs (`BG_TP_SPELL_HORDE_FLAG_DROPPED = 23334`, `BG_TP_SPELL_ALLIANCE_FLAG_DROPPED = 23336`).
- Updated Twin Peaks dropped-flag gameobject entries in `BattlegroundTP.h` to the Warsong ground-flag entries (`BG_OBJECT_A_FLAG_GROUND_TP_ENTRY = 179785`, `BG_OBJECT_H_FLAG_GROUND_TP_ENTRY = 179786`).
- Allowed Warsong flag gameobjects to route click handling to Twin Peaks by permitting `BATTLEGROUND_TP` in the gameobject click dispatch in `src/server/game/Entities/GameObject/GameObject.cpp` so clicks on the shared dropped-flag objects invoke `EventPlayerClickedOnFlag` for TP as well as WSG.

### Testing
- Ran `git diff --check` with no issues reported (success).
- Compiled the modified translation units with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/GameObject/GameObject.cpp.o src/server/game/CMakeFiles/game.dir/Battlegrounds/Zones/BattlegroundTP.cpp.o` (successful incremental build of those objects).
- Started a full build with `cmake --build build --target worldserver -j2`, which configured successfully but was interrupted before completing a full `worldserver` rebuild in this environment (configuration step succeeded, full rebuild not completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8db73d3c8327969b84f748ef99d0)