### PR TITLE
Add Twin Peaks (TP) support for flag objects and spells

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundTP.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundTP.h
@@ -64,10 +64,10 @@ enum BG_TP_Sound
 enum BG_TP_SpellId
 {
     BG_TP_SPELL_HORDE_FLAG              = 23333,
-    BG_TP_SPELL_HORDE_FLAG_DROPPED      = 85003,
+    BG_TP_SPELL_HORDE_FLAG_DROPPED      = 23334,
     BG_TP_SPELL_HORDE_FLAG_PICKED       = 61266,    // fake spell, does not exist but used as timer start event
     BG_TP_SPELL_ALLIANCE_FLAG           = 23335,
-    BG_TP_SPELL_ALLIANCE_FLAG_DROPPED   = 85004,
+    BG_TP_SPELL_ALLIANCE_FLAG_DROPPED   = 23336,
     BG_TP_SPELL_ALLIANCE_FLAG_PICKED    = 61265,    // fake spell, does not exist but used as timer start event
     BG_TP_SPELL_FOCUSED_ASSAULT         = 46392,
     BG_TP_SPELL_BRUTAL_ASSAULT          = 46393
@@ -119,8 +119,8 @@ enum BG_TP_ObjectEntry
     BG_OBJECT_DOOR_H_4_TP_ENTRY          = 208207,
     BG_OBJECT_A_FLAG_TP_ENTRY            = 179830,
     BG_OBJECT_H_FLAG_TP_ENTRY            = 179831,
-    BG_OBJECT_A_FLAG_GROUND_TP_ENTRY     = 208208,
-    BG_OBJECT_H_FLAG_GROUND_TP_ENTRY     = 208209
+    BG_OBJECT_A_FLAG_GROUND_TP_ENTRY     = 179785,
+    BG_OBJECT_H_FLAG_GROUND_TP_ENTRY     = 179786
 };
 
 enum BG_TP_FlagState

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2197,7 +2197,7 @@ void GameObject::Use(Unit* user)
                         break;
                 }
                 // BG flag dropped
-                // WS:
+                // WS/TP:
                 // 179785 - Silverwing Flag
                 // 179786 - Warsong Flag
                 // EotS:
@@ -2209,7 +2209,7 @@ void GameObject::Use(Unit* user)
                     {
                         case 179785:                        // Silverwing Flag
                         case 179786:                        // Warsong Flag
-                            if (bg->GetTypeID(true) == BATTLEGROUND_WS)
+                            if (bg->GetTypeID(true) == BATTLEGROUND_WS || bg->GetTypeID(true) == BATTLEGROUND_TP)
                                 bg->EventPlayerClickedOnFlag(player, this);
                             break;
                         case 184142:                        // Netherstorm Flag

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1607,7 +1607,13 @@ SpellCastResult SpellInfo::CheckLocation(uint32 map_id, uint32 zone_id, uint32 a
     {
         case 23333:                                         // Warsong Flag
         case 23335:                                         // Silverwing Flag
-            return map_id == 489 && player && player->InBattleground() ? SPELL_CAST_OK : SPELL_FAILED_REQUIRES_AREA;
+            if (player && player->InBattleground())
+            {
+                if (Battleground const* battleground = player->GetBattleground())
+                    if (battleground->GetTypeID(true) == BATTLEGROUND_WS || battleground->GetTypeID(true) == BATTLEGROUND_TP)
+                        return SPELL_CAST_OK;
+            }
+            return SPELL_FAILED_REQUIRES_AREA;
         case 34976:                                         // Netherstorm Flag
             return map_id == 566 && player && player->InBattleground() ? SPELL_CAST_OK : SPELL_FAILED_REQUIRES_AREA;
         case 2584:                                          // Waiting to Resurrect


### PR DESCRIPTION
### Motivation

- Ensure Twin Peaks battleground uses correct flag spell and object IDs and supports the same flag interaction and spell-cast rules as Warsong Gulch.

### Description

- Updated dropped flag spell IDs in `BG_TP_SpellId` from `85003`/`85004` to `23334`/`23336` to match expected values. 
- Fixed ground flag gameobject entries in `BG_TP_ObjectEntry` to `179785` and `179786` for Alliance and Horde respectively. 
- Extended `GameObject::Use` flag handling to treat entries `179785`/`179786` as valid for `BATTLEGROUND_TP` in addition to `BATTLEGROUND_WS`. 
- Modified `SpellInfo::CheckLocation` to allow flag spells `23333` and `23335` in Twin Peaks by checking `battleground->GetTypeID(true)` for `BATTLEGROUND_TP` as well as `BATTLEGROUND_WS`.

### Testing

- Performed a full project build and server smoke startup to validate no compile/runtime errors, which succeeded. 
- Executed battleground-related unit/integration tests for flag pickup/cast behavior in WS and TP, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8db73d3c8327969b84f748ef99d0)