### PR TITLE
Prevent mounted playerbots from casting while traveling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -173,6 +173,14 @@ float GetConfiguredMeleeRange() { return g_PvpCoreConfig.meleeRange; }
 float GetConfiguredCloseRange() { return g_PvpCoreConfig.closeRange; }
 float GetConfiguredLongRange() { return g_PvpCoreConfig.longRange; }
 
+float GetConfiguredCombatRange()
+{
+    float range = std::max(GetConfiguredLongRange(), GetConfiguredSpellRange());
+    range = std::max(range, GetConfiguredCloseRange());
+    range = std::max(range, GetConfiguredMeleeRange());
+    return std::max(range, 0.0f);
+}
+
 bool IsLifecycleGateEnabled(playerbot::PvpCoreConfig const& config)
 {
     return config.moduleEnabled && config.pvpCoreEnabled && config.pvpLifecycleEnabled;
@@ -3203,6 +3211,38 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         (!selectedTargetByGuid || !HasHostileTarget(player, selectedTargetByGuid));
     ObjectGuid const selectedAllyGuid = SelectAllyTargetGuid(player);
     bool const hasValidAllyTarget = resolveTargetByGuid(selectedAllyGuid) != nullptr;
+
+    // Reference parity guard: never allow mounted state indoors. In addition,
+    // while in combat always force mount-state correction immediately. When a
+    // mounted bot is simply traveling, do not let class spell selection break
+    // the mount unless an enemy has actually entered the combat envelope.
+    bool const outdoors = IsEffectivelyOutdoors(player);
+    bool const sustainedIndoorMounted = player->IsMounted() && ShouldForceIndoorDismount(player, outdoors);
+    if (player->IsMounted())
+    {
+        if (sustainedIndoorMounted || player->IsInCombat())
+        {
+            context.movementDirective = PvpClassSpellContext::MovementDirective::CheckMountState;
+            context.actionName = "check mount state";
+            context.reason = player->IsInCombat() ? "mounted in combat" : "mounted indoors";
+            context.shouldExecute = true;
+            return context;
+        }
+
+        if (hasInvalidSelectedTarget)
+        {
+            context.movementDirective = PvpClassSpellContext::MovementDirective::DropInvalidTarget;
+            context.actionName = "drop target";
+            context.reason = "invalid target";
+            context.shouldExecute = true;
+            context.movementTargetGuid = selectedTargetGuid;
+            return context;
+        }
+
+        if (!HasNearbyAttackableEnemyPlayer(player, GetConfiguredCombatRange()))
+            return context;
+    }
+
     bool const criticalLowMana = player->GetMaxPower(POWER_MANA) > 0 && player->GetPowerPct(POWER_MANA) < 10.0f;
 
     // Hard-priority mana preservation policy: below 10% mana, disengage from
@@ -3260,19 +3300,6 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
     else
     {
         ResetCombatNoTargetTicks(player);
-    }
-
-    // Reference parity guard: never allow mounted state indoors. In addition,
-    // while in combat always force mount-state correction immediately.
-    bool const outdoors = IsEffectivelyOutdoors(player);
-    bool const sustainedIndoorMounted = player->IsMounted() && ShouldForceIndoorDismount(player, outdoors);
-    if (player->IsMounted() && (sustainedIndoorMounted || player->IsInCombat()))
-    {
-        context.movementDirective = PvpClassSpellContext::MovementDirective::CheckMountState;
-        context.actionName = "check mount state";
-        context.reason = player->IsInCombat() ? "mounted in combat" : "mounted indoors";
-        context.shouldExecute = true;
-        return context;
     }
 
     if (hasInvalidSelectedTarget)


### PR DESCRIPTION
### Motivation
- Playerbots were selecting class/utility spells while mounted and simply traveling, causing unwanted cast attempts when no enemies were in combat range.
- The intent is to keep existing forced mount-state correction for indoor/combat cases and still allow invalid-target cleanup while suppressing spell decisions during harmless mounted travel.

### Description
- Added a helper `GetConfiguredCombatRange()` that returns the largest configured PvP engagement distance used by playerbot logic.
- In `PvpCore::BuildClassSpellContext` (in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`) short-circuit class-spell selection when `player->IsMounted()` unless one of the following holds: the mount is indoors and must be checked/dismounted, the bot is in combat (existing forced mount correction), or an attackable enemy player is detected within `GetConfiguredCombatRange()`; the function still preserves the invalid-target `DropInvalidTarget` movement directive.
- No other gameplay changes were introduced beyond refining when class/utility spell selection runs while mounted.

### Testing
- Ran `git diff --check` to validate formatting and whitespace issues, which reported no problems.
- Reconfigured a PLAYERBOT-enabled build with CMake using `cmake -S . -B build-playerbot-ninja -DPLAYERBOT=ON -DSCRIPTS=static -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, which completed successfully.
- Performed a syntax-only compilation of the modified translation unit via the generated compile command (executed `bash /tmp/playerbot_compile.sh`), which completed and produced only a benign compiler warning; this validated the change compiles for the edited file.
- Attempted a full `scripts` build; a full parallel build was started but was interrupted/failed in-flight (build system activity showed compilation started but was terminated), so a full integration build was not fully completed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff940af67c8327b0cf47cd76afbb69)