### PR TITLE
Fix battleground corpse loot flag cleanup

### DIFF
--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -93,8 +93,9 @@ void WorldSession::HandleAutostoreLootItemOpcode(WorldPacket& recvData)
 
     player->StoreLootItem(lootSlot, loot);
 
-    // If player is removing the last LootItem, delete the empty container.
-    if (loot->isLooted() && lguid.IsItem())
+    // If player is removing the last LootItem, delete the empty container or
+    // clear the completed player-corpse loot state immediately.
+    if (loot->isLooted() && (lguid.IsItem() || lguid.IsCorpse()))
         player->GetSession()->DoLootRelease(lguid);
 }
 
@@ -210,8 +211,8 @@ void WorldSession::HandleLootMoneyOpcode(WorldPacket& /*recvData*/)
         if (loot->containerID > 0)
             sLootItemStorage->RemoveStoredMoneyForContainer(loot->containerID);
 
-        // Delete container if empty
-        if (loot->isLooted() && guid.IsItem())
+        // Delete container if empty, or clear completed player-corpse loot state.
+        if (loot->isLooted() && (guid.IsItem() || guid.IsCorpse()))
             player->GetSession()->DoLootRelease(guid);
     }
 }
@@ -306,7 +307,7 @@ void WorldSession::DoLootRelease(ObjectGuid lguid)
     else if (lguid.IsCorpse())        // ONLY remove insignia at BG
     {
         Corpse* corpse = ObjectAccessor::GetCorpse(*player, lguid);
-        if (!corpse || !corpse->IsWithinDistInMap(_player, INTERACTION_DISTANCE))
+        if (!corpse)
             return;
 
         loot = &corpse->loot;
@@ -315,6 +316,7 @@ void WorldSession::DoLootRelease(ObjectGuid lguid)
         {
             loot->clear();
             corpse->RemoveFlag(CORPSE_FIELD_DYNAMIC_FLAGS, CORPSE_DYNFLAG_LOOTABLE);
+            corpse->lootRecipient = nullptr;
         }
     }
     else if (lguid.IsItem())


### PR DESCRIPTION
### Motivation
- Player corpse loot flags in battlegrounds could remain set after the last corpse loot item or money was taken, leaving the corpse appearing lootable when it should not be.
- The corpse `lootRecipient` was not always cleared and the corpse release path depended on proximity checks that prevented immediate cleanup in some cases.

### Description
- Update `src/server/game/Handlers/LootHandler.cpp` so that when `Loot::isLooted()` becomes true for a corpse the session release path runs immediately by treating `lguid.IsCorpse()` similarly to `IsItem()` in the autostore/money handlers.
- Relax the proximity check in `WorldSession::DoLootRelease` for corpse GUIDs so the cleanup code can run even if the looter moved out of interaction range.
- Clear the corpse `lootRecipient` when a corpse loot is fully consumed and the dynamic lootable flag is removed.
- These changes ensure battleground corpse dynamic flags (`CORPSE_FIELD_DYNAMIC_FLAGS`) and recipient state are cleared as soon as the last item/money is removed.

### Testing
- Ran `git diff --check` to validate no whitespace or obvious diff issues and it passed.
- Performed a single-file syntax-only compile of `src/server/game/Handlers/LootHandler.cpp` using the project's `compile_commands.json` invocation and it completed successfully.
- Started a full build with `cmake --build build --target worldserver -j2` but did not complete the entire 1110-step rebuild in this environment; no compilation errors were observed during the targeted syntax check above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9ce4d2e88327b914991595d4146b)