### PR TITLE
Improve battleground navmesh movement and add fall-shortcut; remove WSG graveyard jump logic

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -35,6 +35,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "MoveSplineInit.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
 #include "Item.h"
@@ -490,120 +491,6 @@ bool MoveToClosestBattlegroundGraveyard(Player* player)
     return false;
 }
 
-bool TryJumpOffWarsongGraveyard(Player* player)
-{
-    if (!player || !IsWarsongGulch(player))
-        return false;
-
-    struct PostResurrectRouteState
-    {
-        uint32 battlegroundInstanceId = 0;
-        bool wasAlive = true;
-        bool active = false;
-        uint8 phase = 0; // 0 = move to tip, 1 = run forward burst, 2 = move to mid
-        uint32 forwardBurstEndMs = 0;
-    };
-
-    static std::unordered_map<uint64, PostResurrectRouteState> stateByGuid;
-    PostResurrectRouteState& state = stateByGuid[player->GetGUID().GetRawValue()];
-
-    Battleground* battleground = player->GetBattleground();
-    if (!battleground)
-        return false;
-
-    if (state.battlegroundInstanceId != battleground->GetInstanceID())
-    {
-        state = {};
-        state.battlegroundInstanceId = battleground->GetInstanceID();
-        state.wasAlive = player->IsAlive();
-    }
-
-    if (!player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
-    {
-        state.wasAlive = false;
-        state.active = false;
-        return false;
-    }
-
-    bool const justResurrected = !state.wasAlive;
-    state.wasAlive = true;
-    if (justResurrected)
-    {
-        state.active = true;
-        state.phase = 0;
-        state.forwardBurstEndMs = 0;
-    }
-
-    if (!state.active)
-        return false;
-
-    static Position const midPoint(1258.810181f, 1463.801758f, 312.229401f, 0.0f);
-    uint32 const nowMs = GameTime::GetGameTimeMS();
-
-    // Replace rigid graveyard jump anchors with navmesh-driven pursuit:
-    // build movement toward the nearest enemy immediately after resurrection
-    // and keep issuing path segments for a short bootstrap window so bots do
-    // not tunnel through floor/wall geometry while leaving spawn platforms.
-    if (state.phase == 0)
-    {
-        if (!state.forwardBurstEndMs)
-            state.forwardBurstEndMs = nowMs + 7000;
-        state.phase = 1;
-    }
-
-    if (state.phase == 1)
-    {
-        bool issuedMovement = false;
-        TeamId const teamId = ResolveBotTeamId(player);
-        Position const gateStagingPoint = (teamId == TEAM_HORDE)
-            ? Position(1066.0946404f, 1380.843994f, 340.612305f, 0.0f)
-            : Position(1406.597412f, 1553.099121f, 343.533295f, 0.0f);
-        Position const gateExitPoint = (teamId == TEAM_HORDE)
-            ? Position(978.20f, 1427.10f, 335.20f, 0.0f)
-            : Position(1498.60f, 1484.30f, 340.20f, 0.0f);
-
-        // Explicit egress routing near the spawn gate. This keeps bots from
-        // parking against the fence/gate line when direct nearest-enemy
-        // pathing fails to build a viable first segment from spawn.
-        if (!player->IsWithinDist3d(gateStagingPoint.GetPositionX(), gateStagingPoint.GetPositionY(), gateStagingPoint.GetPositionZ(), 5.0f))
-        {
-            issuedMovement = IssueMovePointThrottled(player, gateStagingPoint, 2.0f, 400);
-            if (issuedMovement)
-                return true;
-        }
-
-        if (!player->IsWithinDist3d(gateExitPoint.GetPositionX(), gateExitPoint.GetPositionY(), gateExitPoint.GetPositionZ(), 8.0f))
-        {
-            issuedMovement = IssueMovePointThrottled(player, gateExitPoint, 2.0f, 400);
-            if (issuedMovement)
-                return true;
-        }
-
-        if (Player* nearestEnemy = playerbot::FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
-        {
-            issuedMovement = MoveTowardUnit(player, nearestEnemy, 20.0f) ||
-                IssueMovePointThrottled(player, nearestEnemy->GetPosition(), 12.0f, 500);
-            if (issuedMovement)
-                return true;
-        }
-
-        issuedMovement = IssueMovePointThrottled(player, midPoint, 4.0f, 500);
-        if (nowMs >= state.forwardBurstEndMs)
-            state.phase = 2;
-        return issuedMovement;
-    }
-
-    if (state.phase == 2)
-    {
-        state.active = false;
-        state.phase = 0;
-        state.forwardBurstEndMs = 0;
-        return false;
-    }
-
-    return true;
-}
-
 bool IsLifecycleGateEnabled()
 {
     playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
@@ -746,7 +633,102 @@ bool IsForbiddenBattlegroundPathType(PathType pathType)
     return (pathType & forbiddenPathFlags) != 0;
 }
 
-constexpr float PLAYERBOT_BG_PATH_SEGMENT_LENGTH_LIMIT = 700.0f;
+constexpr float PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT = 2400.0f;
+constexpr float PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE = 80.0f;
+constexpr float PLAYERBOT_BG_MIN_FALL_SHORTCUT_DROP = 6.0f;
+constexpr uint32 PLAYERBOT_BG_FALL_SHORTCUT_COOLDOWN_MS = 4000;
+
+bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray const& points, float orientation, Position& segmentDestination)
+{
+    if (!player || points.size() < 2)
+        return false;
+
+    G3D::Vector3 previous(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+    float traversedDistance = 0.0f;
+
+    for (std::size_t i = 1; i < points.size(); ++i)
+    {
+        G3D::Vector3 const& point = points[i];
+        G3D::Vector3 const delta = point - previous;
+        float const segmentLength = delta.length();
+        if (segmentLength <= 0.01f)
+        {
+            previous = point;
+            continue;
+        }
+
+        if (traversedDistance + segmentLength >= PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE)
+        {
+            float const fraction = (PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE - traversedDistance) / segmentLength;
+            G3D::Vector3 const selected = previous + delta * fraction;
+            segmentDestination.Relocate(selected.x, selected.y, selected.z, orientation);
+            return true;
+        }
+
+        traversedDistance += segmentLength;
+        previous = point;
+    }
+
+    G3D::Vector3 const& finalPoint = points.back();
+    segmentDestination.Relocate(finalPoint.x, finalPoint.y, finalPoint.z, orientation);
+    return player->GetDistance(segmentDestination) > 0.5f;
+}
+
+bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const& destination, Position& fallDestination)
+{
+    if (!player || !player->InBattleground() || player->IsFlying() || player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING))
+        return false;
+
+    if (player->IsFalling())
+        return false;
+
+    static std::unordered_map<uint64, uint32> nextAllowedFallShortcutMsByGuid;
+    uint64 const botGuid = player->GetGUID().GetRawValue();
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    uint32 const nextAllowedMs = nextAllowedFallShortcutMsByGuid[botGuid];
+    if (nowMs < nextAllowedMs)
+        return false;
+
+    float const dx = destination.GetPositionX() - player->GetPositionX();
+    float const dy = destination.GetPositionY() - player->GetPositionY();
+    float const planarDistance = std::sqrt(dx * dx + dy * dy);
+    if (planarDistance < 2.0f)
+        return false;
+
+    std::array<float, 5> const probeDistances =
+    {
+        12.0f,
+        20.0f,
+        30.0f,
+        45.0f,
+        60.0f
+    };
+
+    for (float probeDistance : probeDistances)
+    {
+        float const cappedDistance = std::min(planarDistance, probeDistance);
+        if (cappedDistance < 1.0f)
+            continue;
+
+        float const fraction = cappedDistance / planarDistance;
+        float const probeX = player->GetPositionX() + dx * fraction;
+        float const probeY = player->GetPositionY() + dy * fraction;
+        float probeZ = player->GetPositionZ();
+        player->UpdateAllowedPositionZ(probeX, probeY, probeZ);
+
+        if (player->GetPositionZ() - probeZ < PLAYERBOT_BG_MIN_FALL_SHORTCUT_DROP)
+            continue;
+
+        if (!player->IsWithinLOS(probeX, probeY, probeZ + 1.0f))
+            continue;
+
+        fallDestination.Relocate(probeX, probeY, probeZ, destination.GetOrientation());
+        nextAllowedFallShortcutMsByGuid[botGuid] = nowMs + PLAYERBOT_BG_FALL_SHORTCUT_COOLDOWN_MS;
+        return true;
+    }
+
+    return false;
+}
 
 bool TryBuildBattlegroundSegmentDestination(Player* player, Position const& safeDestination, Position& segmentDestination, PathType* resolvedPathType = nullptr)
 {
@@ -761,7 +743,7 @@ bool TryBuildBattlegroundSegmentDestination(Player* player, Position const& safe
         // Allow longer battleground route segments so bots can commit to
         // meaningful navmesh progress toward distant enemies instead of
         // repeatedly selecting tiny local hops that catch on terrain.
-        path.SetPathLengthLimit(PLAYERBOT_BG_PATH_SEGMENT_LENGTH_LIMIT);
+        path.SetPathLengthLimit(PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT);
         bool pathOk = path.CalculatePath(collisionSafeDestination.GetPositionX(), collisionSafeDestination.GetPositionY(), collisionSafeDestination.GetPositionZ(), true);
         PathType pathType = path.GetPathType();
         Movement::PointsArray points = path.GetPath();
@@ -770,7 +752,7 @@ bool TryBuildBattlegroundSegmentDestination(Player* player, Position const& safe
         if ((pathType & PATHFIND_SHORTCUT) != 0)
         {
             PathGenerator retryPath(player);
-            retryPath.SetPathLengthLimit(PLAYERBOT_BG_PATH_SEGMENT_LENGTH_LIMIT);
+            retryPath.SetPathLengthLimit(PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT);
             bool const retryOk = retryPath.CalculatePath(collisionSafeDestination.GetPositionX(), collisionSafeDestination.GetPositionY(), collisionSafeDestination.GetPositionZ(), false);
             PathType const retryType = retryPath.GetPathType();
             if (retryOk && (retryType & PATHFIND_SHORTCUT) == 0)
@@ -786,10 +768,8 @@ bool TryBuildBattlegroundSegmentDestination(Player* player, Position const& safe
             return false;
 
         bool haveResolvedDestination = false;
-        if (points.size() > 1)
+        if (BuildNavPathSegmentDestination(player, points, collisionSafeDestination.GetOrientation(), resolvedDestination))
         {
-            G3D::Vector3 const& lastPoint = points.back();
-            resolvedDestination.Relocate(lastPoint.x, lastPoint.y, lastPoint.z, collisionSafeDestination.GetOrientation());
             haveResolvedDestination = true;
         }
         else
@@ -936,6 +916,9 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     MotionMaster* motionMaster = player->GetMotionMaster();
     MovementGeneratorType const currentMovement = motionMaster->GetCurrentMovementGeneratorType();
+    if (player->InBattleground() && botCurrentlyMoving && (player->IsFalling() || currentMovement == EFFECT_MOTION_TYPE))
+        return true;
+
     if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)
     {
         motionMaster->Clear();
@@ -959,20 +942,36 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     Position issuedDestination = safeDestination;
     if (generatePath && player->InBattleground())
     {
-        Position segmentDestination;
-        PathType pathType = PathType(0);
-        if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
+        Position fallDestination;
+        if (TryBuildBattlegroundFallShortcutDestination(player, safeDestination, fallDestination))
         {
+            motionMaster->LaunchMoveSpline([fallDestination](Movement::MoveSplineInit& init)
+            {
+                init.MoveTo(fallDestination.GetPositionX(), fallDestination.GetPositionY(), fallDestination.GetPositionZ(), false);
+                init.SetFall();
+            }, 0, MOTION_PRIORITY_NORMAL, EFFECT_MOTION_TYPE);
+            issuedDestination = fallDestination;
             EmitBattlegroundGmDebug(player,
-                "movepoint=blocked-no-nav destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 1000);
-            return false;
+                "movepoint=fall-shortcut drop=" + std::to_string(int32(player->GetPositionZ() - fallDestination.GetPositionZ())) +
+                " segDist=" + std::to_string(int32(player->GetDistance(fallDestination))), 1000);
         }
+        else
+        {
+            Position segmentDestination;
+            PathType pathType = PathType(0);
+            if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
+            {
+                EmitBattlegroundGmDebug(player,
+                    "movepoint=blocked-no-nav destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 1000);
+                return false;
+            }
 
-        motionMaster->MovePoint(0, segmentDestination, true);
-        issuedDestination = segmentDestination;
-        EmitBattlegroundGmDebug(player,
-            "movepoint=nav-segment pathType=" + std::to_string(uint32(pathType)) +
-            " segDist=" + std::to_string(int32(player->GetDistance(segmentDestination))), 0);
+            motionMaster->MovePoint(0, segmentDestination, true);
+            issuedDestination = segmentDestination;
+            EmitBattlegroundGmDebug(player,
+                "movepoint=nav-segment pathType=" + std::to_string(uint32(pathType)) +
+                " segDist=" + std::to_string(int32(player->GetDistance(segmentDestination))), 0);
+        }
     }
     else
     {
@@ -1680,17 +1679,6 @@ bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance)
     CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
     if (!player->IsWithinLOSInMap(target))
         return TryRecoverLineOfSight(player, target, profile, "move-toward-unit");
-
-    // WSG should not avoid fall damage while pursuing enemies.
-    if (IsWarsongGulch(player) &&
-        target->GetPositionZ() + 6.0f < player->GetPositionZ() &&
-        player->IsWithinLOS(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ()))
-    {
-        if (!CanIssueMovementCommand(player, 500))
-            return false;
-        ClearEatDrinkAurasForMovement(player);
-        return IssueMovePointThrottled(player, target->GetPosition(), 30.0f, 500);
-    }
 
     if (!player->IsWithinDistInMap(target, desiredDistance))
     {
@@ -2834,11 +2822,8 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     if (TryPursueNearestEnemyInBattleground(player))
         return true;
 
-    if (TryJumpOffWarsongGraveyard(player))
-        return true;
-
-    // Evaluate combat/post-res logic before this guard so stale movement
-    // flags do not suppress target pursuit immediately after graveyard rez.
+    // Evaluate target pursuit before this guard so stale movement flags do not
+    // suppress nearest-enemy pathing after battleground resurrection.
     if (player->isMoving())
         return false;
 


### PR DESCRIPTION
### Motivation

- Improve battleground movement so bots make meaningful navmesh progress toward distant enemies, avoid getting stuck on spawn platforms, and opportunistically use controlled falls to shortcut around geometry, while removing brittle Warsong Gulch graveyard jump heuristics.

### Description

- Added `MoveSplineInit.h` and implemented `BuildNavPathSegmentDestination` to select a navigation path segment target at a fixed distance along the navmesh path.
- Implemented `TryBuildBattlegroundFallShortcutDestination` which probes forward for valid fall-drops, enforces a per-bot cooldown, and returns a fall destination if safe.
- Increased path calculation limit from 700 to `PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT = 2400`, added `PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE`, `PLAYERBOT_BG_MIN_FALL_SHORTCUT_DROP`, and `PLAYERBOT_BG_FALL_SHORTCUT_COOLDOWN_MS` constants, and integrated nav-segment selection into path building via `BuildNavPathSegmentDestination`.
- Integrated fall-shortcut movement into `IssueMovePointThrottled` by launching a spline with `SetFall` using `MotionMaster::LaunchMoveSpline` and added guards to avoid reissuing movement while falling or when an effect motion generator is active.
- Removed the old `TryJumpOffWarsongGraveyard` routine and the WSG-specific fall-avoidance special-case in `MoveTowardUnit` to simplify and consolidate battleground movement logic.

### Testing

- Project compiled successfully after changes (`cmake`/`make` build completed without errors).
- Executed the automated unit and integration tests related to movement, pathfinding, and PvP logic; all tests passed.
- Ran the automated PvP movement simulation suite to validate navmesh segmenting and fall-shortcut behavior; no regressions or failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff946c5d0883279fc54b4423ca8b47)