### PR TITLE
Align Battle for Gilneas scoring with reference

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
@@ -156,8 +156,8 @@ enum GILNEAS_BG_Timers
 
 enum GILNEAS_BG_Score
 {
-    GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE = 1400,
-    GILNEAS_BG_MAX_TEAM_SCORE             = 1600
+    GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE = 1800,
+    GILNEAS_BG_MAX_TEAM_SCORE             = 2000
 };
 
 enum GILNEAS_BG_BattlegroundNodes
@@ -222,8 +222,8 @@ const float GILNEAS_BG_DoorPositions[4][8] =
     { 1396.15f, 977.014f, 0.33169f, 6.27043f, 0.0f, 0.0f, 0.006378f, -0.99998f }
 };
 
-const uint32 GILNEAS_BG_TickIntervals[4] = { 0, 12000, 9000, 6000 };
-const uint32 GILNEAS_BG_TickPoints[4] = { 0, 10, 10, 10 };
+const uint32 GILNEAS_BG_TickIntervals[4] = { 0, 12000, 6000, 1000 };
+const uint32 GILNEAS_BG_TickPoints[4] = { 0, 10, 10, 30 };
 
 const uint32 GILNEAS_BG_GraveyardIds[GILNEAS_BG_ALL_NODES_COUNT] = { 1736, 1737, 1735, 1739, 1738 };
 


### PR DESCRIPTION
### Motivation
- Bring the active core Battle for Gilneas implementation in line with the playerbot reference so resource caps, near-victory warnings and tick scoring behave as expected.

### Description
- Changed `GILNEAS_BG_WARNING_NEAR_VICTORY_SCORE` from `1400` to `1800` and `GILNEAS_BG_MAX_TEAM_SCORE` from `1600` to `2000` in `src/server/game/Battlegrounds/Zones/BattlegroundBFG.h` to match the reference.
- Restored the reference tick cadence by updating `GILNEAS_BG_TickIntervals` to `{ 0, 12000, 6000, 1000 }` and `GILNEAS_BG_TickPoints` to `{ 0, 10, 10, 30 }` in the same header.

### Testing
- Compiled the updated translation unit with `ninja -C build src/server/game/CMakeFiles/game.dir/Battlegrounds/Zones/BattlegroundBFG.cpp.o`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fff0c4a8f88327aa60e8249644d4c0)