### PR TITLE
Playerbot: prefer nearest-enemy pursuit and gate fall-shortcuts by navmesh distance

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -674,7 +674,37 @@ bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray 
     return player->GetDistance(segmentDestination) > 0.5f;
 }
 
-bool TryBuildTerrainFallShortcutDestination(Player* player, Position const& destination, Position& fallDestination)
+float CalculatePathDistance(Movement::PointsArray const& points)
+{
+    if (points.size() < 2)
+        return 0.0f;
+
+    float distance = 0.0f;
+    for (std::size_t i = 1; i < points.size(); ++i)
+        distance += (points[i] - points[i - 1]).length();
+
+    return distance;
+}
+
+float CalculateNavigationDistance(Player* player, Position const& destination)
+{
+    if (!player)
+        return std::numeric_limits<float>::max();
+
+    PathGenerator path(player);
+    path.SetPathLengthLimit(PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT);
+    if (!path.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), true))
+        return std::numeric_limits<float>::max();
+
+    PathType const pathType = path.GetPathType();
+    if (IsForbiddenBattlegroundPathType(pathType))
+        return std::numeric_limits<float>::max();
+
+    float const pathDistance = CalculatePathDistance(path.GetPath());
+    return pathDistance > 0.0f ? pathDistance : std::numeric_limits<float>::max();
+}
+
+bool TryBuildTerrainFallShortcutDestination(Player* player, Position const& destination, Position& fallDestination, float navigationDistance)
 {
     if (!player || player->IsFlying() || player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING))
         return false;
@@ -741,10 +771,14 @@ bool TryBuildTerrainFallShortcutDestination(Player* player, Position const& dest
             Position candidate(probeX, probeY, probeZ, destination.GetOrientation());
             float const candidateDestinationDistance = candidate.GetExactDist2d(destination);
             float const distanceImprovement = currentDestinationDistance - candidateDestinationDistance;
-            if (distanceImprovement < -5.0f)
+            float const shortcutRouteDistance = cappedDistance + candidateDestinationDistance;
+            bool const hasKnownNavRoute = navigationDistance < std::numeric_limits<float>::max();
+            bool const beatsKnownNavRoute = hasKnownNavRoute && shortcutRouteDistance + 3.0f < navigationDistance;
+            bool const makesDirectProgressWithoutKnownNav = !hasKnownNavRoute && distanceImprovement > 1.0f && std::fabs(angleOffset) <= 0.60f;
+            if (!beatsKnownNavRoute && !makesDirectProgressWithoutKnownNav)
                 continue;
 
-            float const score = std::max(distanceImprovement, 0.0f) + drop * 0.50f -
+            float const score = (beatsKnownNavRoute ? navigationDistance - shortcutRouteDistance : distanceImprovement) + drop * 0.50f -
                 cappedDistance * 0.08f - std::fabs(angleOffset) * 2.0f;
             if (score <= bestScore)
                 continue;
@@ -767,7 +801,7 @@ bool TryBuildTerrainFallShortcutDestination(Player* player, Position const& dest
 // here; falling behavior must remain generic terrain behavior.
 bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const& destination, Position& fallDestination)
 {
-    return TryBuildTerrainFallShortcutDestination(player, destination, fallDestination);
+    return TryBuildTerrainFallShortcutDestination(player, destination, fallDestination, CalculateNavigationDistance(player, destination));
 }
 
 bool TryBuildBattlegroundSegmentDestination(Player* player, Position const& safeDestination, Position& segmentDestination, PathType* resolvedPathType = nullptr)
@@ -981,7 +1015,8 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     Position issuedDestination = safeDestination;
     Position fallDestination;
-    if (generatePath && TryBuildTerrainFallShortcutDestination(player, safeDestination, fallDestination))
+    float const navigationDistance = generatePath ? CalculateNavigationDistance(player, safeDestination) : std::numeric_limits<float>::max();
+    if (generatePath && TryBuildTerrainFallShortcutDestination(player, safeDestination, fallDestination, navigationDistance))
     {
         motionMaster->MovePoint(0, fallDestination, false);
         issuedDestination = fallDestination;
@@ -991,40 +1026,20 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     }
     else if (generatePath && player->InBattleground())
     {
-        motionMaster->MovePoint(0, fallDestination, false);
-        issuedDestination = fallDestination;
-        EmitBattlegroundGmDebug(player,
-            "movepoint=fall-shortcut drop=" + std::to_string(int32(player->GetPositionZ() - fallDestination.GetPositionZ())) +
-            " segDist=" + std::to_string(int32(player->GetDistance(fallDestination))), 1000);
-    }
-    else if (generatePath && player->InBattleground())
-    {
-        Position fallDestination;
-        if (TryBuildBattlegroundFallShortcutDestination(player, safeDestination, fallDestination))
+        Position segmentDestination;
+        PathType pathType = PathType(0);
+        if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
         {
-            motionMaster->MovePoint(0, fallDestination, false);
-            issuedDestination = fallDestination;
             EmitBattlegroundGmDebug(player,
-                "movepoint=fall-shortcut drop=" + std::to_string(int32(player->GetPositionZ() - fallDestination.GetPositionZ())) +
-                " segDist=" + std::to_string(int32(player->GetDistance(fallDestination))), 1000);
+                "movepoint=blocked-no-nav destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 1000);
+            return false;
         }
-        else
-        {
-            Position segmentDestination;
-            PathType pathType = PathType(0);
-            if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
-            {
-                EmitBattlegroundGmDebug(player,
-                    "movepoint=blocked-no-nav destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 1000);
-                return false;
-            }
 
-            motionMaster->MovePoint(0, segmentDestination, true);
-            issuedDestination = segmentDestination;
-            EmitBattlegroundGmDebug(player,
-                "movepoint=nav-segment pathType=" + std::to_string(uint32(pathType)) +
-                " segDist=" + std::to_string(int32(player->GetDistance(segmentDestination))), 0);
-        }
+        motionMaster->MovePoint(0, segmentDestination, true);
+        issuedDestination = segmentDestination;
+        EmitBattlegroundGmDebug(player,
+            "movepoint=nav-segment pathType=" + std::to_string(uint32(pathType)) +
+            " segDist=" + std::to_string(int32(player->GetDistance(segmentDestination))), 0);
     }
     else
     {
@@ -2884,15 +2899,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         context.movement == BattlegroundMovementPrimitive::None &&
         context.flagCarrierDirective == FlagCarrierDirective::None)
     {
-        if (battleground && battleground->GetTypeID() == BATTLEGROUND_SCM)
-        {
-            float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
-            if (EngageNearestEnemyPlayer(player, engageDistance))
-                return true;
+        float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
+        if (EngageNearestEnemyPlayer(player, engageDistance))
+            return true;
 
-            if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
-                return MoveTowardUnit(player, nearestEnemy, 20.0f);
-        }
+        if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
+            return MoveTowardUnit(player, nearestEnemy, 20.0f);
 
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP movement skipped: bot={} reason=no-objective-and-no-directive.",
@@ -2928,15 +2940,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
                 return true;
             }
 
-            if (battleground->GetTypeID() == BATTLEGROUND_SCM)
-            {
-                float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
-                if (EngageNearestEnemyPlayer(player, engageDistance))
-                    return true;
+            float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
+            if (EngageNearestEnemyPlayer(player, engageDistance))
+                return true;
 
-                if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
-                    return MoveTowardUnit(player, nearestEnemy, 20.0f);
-            }
+            if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
+                return MoveTowardUnit(player, nearestEnemy, 20.0f);
 
             return false;
         }


### PR DESCRIPTION
### Motivation
- Prevent playerbots from pathing around short cliff drops and from idling instead of pursuing nearby enemies in battlegrounds by preferring direct pursuit and allowing safe fall shortcuts when they are actually faster.

### Description
- Add `CalculatePathDistance` and `CalculateNavigationDistance` helpers to estimate navmesh route distance for a destination and use that metric to decide whether a ledge/fall shortcut is worthwhile. 
- Change `TryBuildTerrainFallShortcutDestination` to accept a `navigationDistance` and only accept fall shortcuts when they beat the computed nav route or (if no nav route exists) when the probe makes direct progress toward the destination. 
- Compute `navigationDistance` in `IssueMovePointThrottled` and pass it into the terrain shortcut logic, and remove the duplicated/unsafe fall branch so bots no longer `MovePoint` to an uninitialized fall destination. 
- Relax battleground tactical fallback so `MoveToObjectivePrimitive` will engage or pursue the nearest enemy player in any battleground (remove prior SCM-only gating). 
- All modifications are contained in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and preserve generic terrain/fall behavior rather than map- or battleground-specific logic.

### Testing
- Configured scripts with `cmake -S . -B build -DPLAYERBOT=1 -DSCRIPTS_PLAYERBOT=static` which completed successfully. (success)
- Compiled the modified compilation unit with `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o` which completed successfully. (success)
- Ran `git diff --check` to validate no whitespace/merge errors; no issues were found. (success)
- A full `cmake --build` / worldserver build was started to sanity-check broader integration but was not completed due to long dependency build time in this environment; partial build steps executed without showing file-level errors for the changed unit. (partial)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fffd6717808327bfd1b72c6ad9c237)