### PR TITLE
Refine target-relative movement detection and terrain fall-shortcut/nav logic for Playerbot PvP

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -94,6 +94,7 @@ void SetLastMovementDebugStatus(Player const* player, std::string const& status)
 void RecordTargetRelativeMovementOrder(Player const* player, Unit const* target, float issuedRange, uint8 mode);
 void MarkTargetRelativeMovementLaunch(Player const* player);
 bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* target, float desiredRange, uint32 minRunMs, char const* label, std::string* reasonOut);
+bool HasActuallyLaunchedTargetRelativeMovement(Player const* player);
 
 struct LastLosCastFailureState
 {
@@ -515,6 +516,19 @@ void MarkTargetRelativeMovementLaunch(Player const* player)
     itr->second.lastLaunchMs = GameTime::GetGameTimeMS();
 }
 
+bool HasActuallyLaunchedTargetRelativeMovement(Player const* player)
+{
+    if (!player)
+        return false;
+
+    bool const hasStartedSpline = player->movespline && player->movespline->Initialized() &&
+        !player->movespline->Finalized() && player->movespline->HasStarted();
+    return player->isMoving() ||
+        player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
+        player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
+        hasStartedSpline;
+}
+
 bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* target, float desiredRange, uint32 minRunMs,
     char const* label = nullptr, std::string* reasonOut = nullptr)
 {
@@ -548,10 +562,7 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
     bool const madePositionProgress = positionDelta2D >= 0.35f || positionDelta3D >= 0.50f;
     bool const splineInitialized = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
     bool const splineStarted = splineInitialized && player->movespline->HasStarted();
-    bool const hasMovementSignal = player->isMoving() ||
-        player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
-        player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
-        splineInitialized;
+    bool const hasMovementSignal = HasActuallyLaunchedTargetRelativeMovement(player);
     bool const rawDistanceProgress = state.lastDistance > 0.0f && currentDistance + 0.20f < state.lastDistance;
     bool const madeDistanceProgress = rawDistanceProgress && (hasMovementSignal || madePositionProgress);
 
@@ -594,7 +605,8 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
     if (inSettleWindow && farFromDesiredRange && ageMs > 900 && !credibleRecentLaunch && !madeDistanceProgress && !credibleRecentDistanceProgress)
         inSettleWindow = false;
 
-    bool const preserve = inSettleWindow || credibleRecentLaunch || madeDistanceProgress || madePositionProgress || credibleRecentDistanceProgress || recentPositionProgress;
+    bool const preserve = inSettleWindow || credibleRecentLaunch || madeDistanceProgress || madePositionProgress ||
+        credibleRecentDistanceProgress || (hasMovementSignal && recentPositionProgress);
 
     if (!preserve)
     {
@@ -1082,12 +1094,8 @@ bool IsStaleTargetRelativeMotion(Player const* player)
 
     MotionMaster const* motionMaster = player->GetMotionMaster();
     MovementGeneratorType const motionType = motionMaster ? motionMaster->GetCurrentMovementGeneratorType() : IDLE_MOTION_TYPE;
-    bool const hasActiveSpline = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
     return (motionType == CHASE_MOTION_TYPE || motionType == FOLLOW_MOTION_TYPE) &&
-        !player->isMoving() &&
-        !player->HasUnitState(UNIT_STATE_CHASE_MOVE) &&
-        !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) &&
-        !hasActiveSpline &&
+        !HasActuallyLaunchedTargetRelativeMovement(player) &&
         !player->HasUnitState(UNIT_STATE_NOT_MOVE) &&
         !player->IsMovementPreventedByCasting();
 }
@@ -1223,11 +1231,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     uint32 const nowMs = GameTime::GetGameTimeMS();
     bool const sameStallTarget = stallState.targetGuid == target->GetGUID();
     bool const activeTargetRelativeMotion = initialMotionType == CHASE_MOTION_TYPE || initialMotionType == FOLLOW_MOTION_TYPE;
-    bool const hasActiveSpline = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
-    bool const movementGeneratorHasNotLaunched = !player->isMoving() &&
-        !player->HasUnitState(UNIT_STATE_CHASE_MOVE) &&
-        !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) &&
-        !hasActiveSpline;
+    bool const movementGeneratorHasNotLaunched = !HasActuallyLaunchedTargetRelativeMovement(player);
     uint32 const lastIssueAgeMs = sameStallTarget && stallState.lastIssueMs != 0 && nowMs >= stallState.lastIssueMs ? nowMs - stallState.lastIssueMs : 0;
 
     if (!forceMovementWhenAlreadyInRange && activeTargetRelativeMotion && currentDistance > (safeDistance + 0.75f))
@@ -1281,8 +1285,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         if (sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0)
         {
             MotionPrimeResult existingPrimeResult = PrimeTargetRelativeMotion(player);
-            bool const existingMotionStarted = player->isMoving() ||
-                player->HasUnitState(UNIT_STATE_CHASE_MOVE) || player->HasUnitState(UNIT_STATE_FOLLOW_MOVE);
+            bool const existingMotionStarted = HasActuallyLaunchedTargetRelativeMovement(player);
 
             if (existingMotionStarted)
             {
@@ -1301,11 +1304,10 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
                 return;
             }
 
-            // Give the queued generator a short settle window after a failed
-            // prime, then force a reissue if still unlaunched. Waiting ~2.5s
-            // here left bots visibly stuck with motion=follow/chase but
-            // moving=no, no spline, and no CHASE_MOVE/FOLLOW_MOVE state.
-            if (lastIssueAgeMs < 900)
+            // Give the queued generator only one short settle window after a
+            // failed prime. Diagnostics showed initialized-but-not-started
+            // splines being preserved indefinitely while bots stood still.
+            if (lastIssueAgeMs < 350)
             {
                 std::ostringstream extra;
                 extra << BuildRangedMovementDiag(player, target, "near_edge_waiting_for_motion_update",
@@ -1321,10 +1323,10 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
             }
         }
 
-        bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 900;
+        bool const staleQueuedGenerator = sameStallTarget && activeTargetRelativeMotion && movementGeneratorHasNotLaunched && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 350;
         float const forcedRange = std::max(1.0f, safeDistance - 8.0f);
         bool const prefersContactRescue = requestedSafeDistance <= 8.0f;
-        bool const shouldEscalateContactRescue = targetAttackable && staleQueuedGenerator && lastIssueAgeMs >= 1400 && prefersContactRescue;
+        bool const shouldEscalateContactRescue = targetAttackable && staleQueuedGenerator && lastIssueAgeMs >= 900 && prefersContactRescue;
         uint8 const prevIssuedMode = stallState.lastIssuedMode;
         uint32 const mmSizeBeforeIssue = motionMaster->Size();
         MovementGeneratorType const mmMotionBeforeIssue = motionMaster->GetCurrentMovementGeneratorType();
@@ -1406,7 +1408,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     }
 
     bool hardStaleTargetRelative = activeTargetRelativeMotion && movementGeneratorHasNotLaunched &&
-        sameStallTarget && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 3000;
+        sameStallTarget && stallState.lastIssueMs != 0 && lastIssueAgeMs >= 700;
 
     // Same protection for the generic ranged path: before clearing/reissuing a
     // stale Chase/Follow generator, prime the existing generator once in place.
@@ -1414,8 +1416,7 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     if (hardStaleTargetRelative)
     {
         MotionPrimeResult existingPrimeResult = PrimeTargetRelativeMotion(player);
-        bool const existingMotionStarted = player->isMoving() ||
-            player->HasUnitState(UNIT_STATE_CHASE_MOVE) || player->HasUnitState(UNIT_STATE_FOLLOW_MOVE);
+        bool const existingMotionStarted = HasActuallyLaunchedTargetRelativeMovement(player);
 
         if (existingMotionStarted)
         {

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -636,7 +636,9 @@ bool IsForbiddenBattlegroundPathType(PathType pathType)
 constexpr float PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT = 2400.0f;
 constexpr float PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE = 80.0f;
 constexpr float PLAYERBOT_TERRAIN_MIN_FALL_SHORTCUT_DROP = 6.0f;
-constexpr uint32 PLAYERBOT_TERRAIN_FALL_SHORTCUT_COOLDOWN_MS = 8000;
+constexpr float PLAYERBOT_TERRAIN_MAX_FALL_SHORTCUT_DROP = 45.0f;
+constexpr float PLAYERBOT_TERRAIN_FALL_LANDING_OFFSET = 1.25f;
+constexpr uint32 PLAYERBOT_TERRAIN_FALL_SHORTCUT_COOLDOWN_MS = 12000;
 
 bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray const& points, float orientation, Position& segmentDestination)
 {
@@ -674,7 +676,37 @@ bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray 
     return player->GetDistance(segmentDestination) > 0.5f;
 }
 
-bool TryBuildTerrainFallShortcutDestination(Player* player, Position const& destination, Position& fallDestination)
+float CalculatePathDistance(Movement::PointsArray const& points)
+{
+    if (points.size() < 2)
+        return 0.0f;
+
+    float distance = 0.0f;
+    for (std::size_t i = 1; i < points.size(); ++i)
+        distance += (points[i] - points[i - 1]).length();
+
+    return distance;
+}
+
+float CalculateNavigationDistance(Player* player, Position const& destination)
+{
+    if (!player)
+        return std::numeric_limits<float>::max();
+
+    PathGenerator path(player);
+    path.SetPathLengthLimit(PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT);
+    if (!path.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), true))
+        return std::numeric_limits<float>::max();
+
+    PathType const pathType = path.GetPathType();
+    if (IsForbiddenBattlegroundPathType(pathType))
+        return std::numeric_limits<float>::max();
+
+    float const pathDistance = CalculatePathDistance(path.GetPath());
+    return pathDistance > 0.0f ? pathDistance : std::numeric_limits<float>::max();
+}
+
+bool TryBuildTerrainFallShortcutDestination(Player* player, Position const& destination, Position& landingDestination, float navigationDistance)
 {
     if (!player || player->IsFlying() || player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING))
         return false;
@@ -698,66 +730,59 @@ bool TryBuildTerrainFallShortcutDestination(Player* player, Position const& dest
     float const destinationAngle = std::atan2(dy, dx);
     float const currentDestinationDistance = player->GetExactDist2d(destination.GetPositionX(), destination.GetPositionY());
     float bestScore = 0.0f;
-    Position bestDestination;
+    Position bestLandingDestination;
 
-    std::array<float, 9> const probeDistances =
+    std::array<float, 3> const stepDistances = { 2.75f, 4.5f, 6.0f };
+    std::array<float, 5> const angleOffsets = { 0.0f, 0.22f, -0.22f, 0.45f, -0.45f };
+
+    for (float stepDistance : stepDistances)
     {
-        5.0f,
-        7.0f,
-        9.0f,
-        12.0f,
-        16.0f,
-        22.0f,
-        30.0f,
-        38.0f,
-        45.0f
-    };
-    std::array<float, 11> const angleOffsets = { 0.0f, 0.30f, -0.30f, 0.60f, -0.60f, 0.95f, -0.95f, 1.30f, -1.30f, 1.57f, -1.57f };
-
-    for (float probeDistance : probeDistances)
-    {
-        float const cappedDistance = std::min(std::max(planarDistance, 8.0f), probeDistance);
-        if (cappedDistance < 1.0f)
-            continue;
-
         for (float angleOffset : angleOffsets)
         {
             float const probeAngle = destinationAngle + angleOffset;
-            float const probeX = player->GetPositionX() + std::cos(probeAngle) * cappedDistance;
-            float const probeY = player->GetPositionY() + std::sin(probeAngle) * cappedDistance;
-            float probeZ = player->GetPositionZ();
-            player->UpdateAllowedPositionZ(probeX, probeY, probeZ);
+            float const stepX = player->GetPositionX() + std::cos(probeAngle) * stepDistance;
+            float const stepY = player->GetPositionY() + std::sin(probeAngle) * stepDistance;
 
-            float const drop = player->GetPositionZ() - probeZ;
-            if (drop < PLAYERBOT_TERRAIN_MIN_FALL_SHORTCUT_DROP || drop > 45.0f)
+            // Validate the run-off step at the bot's current elevation. The
+            // actual movement below uses a falling-style spline to the ground;
+            // validating the step separately prevents wall/barrier shoves while
+            // still allowing a real ledge drop.
+            if (!player->IsWithinLOS(stepX, stepY, player->GetPositionZ()))
                 continue;
 
-            // Check the horizontal step off the ledge instead of the ground
-            // landing point. The landing point is below the ledge, so terrain can
-            // legitimately sit between the bot and the final ground Z.
-            if (!player->IsWithinLOS(probeX, probeY, player->GetPositionZ()))
+            float landingX = player->GetPositionX() + std::cos(probeAngle) * (stepDistance + PLAYERBOT_TERRAIN_FALL_LANDING_OFFSET);
+            float landingY = player->GetPositionY() + std::sin(probeAngle) * (stepDistance + PLAYERBOT_TERRAIN_FALL_LANDING_OFFSET);
+            float landingZ = player->GetPositionZ();
+            player->UpdateAllowedPositionZ(landingX, landingY, landingZ);
+
+            float const drop = player->GetPositionZ() - landingZ;
+            if (drop < PLAYERBOT_TERRAIN_MIN_FALL_SHORTCUT_DROP || drop > PLAYERBOT_TERRAIN_MAX_FALL_SHORTCUT_DROP)
                 continue;
 
-            Position candidate(probeX, probeY, probeZ, destination.GetOrientation());
-            float const candidateDestinationDistance = candidate.GetExactDist2d(destination);
-            float const distanceImprovement = currentDestinationDistance - candidateDestinationDistance;
-            if (distanceImprovement < -5.0f)
+            Position landing(landingX, landingY, landingZ, destination.GetOrientation());
+            float const landingDestinationDistance = landing.GetExactDist2d(destination);
+            float const distanceImprovement = currentDestinationDistance - landingDestinationDistance;
+            float const shortcutRouteDistance = stepDistance + landingDestinationDistance;
+            bool const hasKnownNavRoute = navigationDistance < std::numeric_limits<float>::max();
+            bool const beatsKnownNavRoute = hasKnownNavRoute && shortcutRouteDistance + 3.0f < navigationDistance;
+            bool const makesDirectProgressWithoutKnownNav = !hasKnownNavRoute && distanceImprovement > 1.0f && std::fabs(angleOffset) <= 0.45f;
+            if (!beatsKnownNavRoute && !makesDirectProgressWithoutKnownNav)
                 continue;
 
-            float const score = std::max(distanceImprovement, 0.0f) + drop * 0.50f -
-                cappedDistance * 0.08f - std::fabs(angleOffset) * 2.0f;
+            float const score = (beatsKnownNavRoute ? navigationDistance - shortcutRouteDistance : distanceImprovement) + drop * 0.35f -
+                stepDistance * 0.08f - std::fabs(angleOffset) * 2.0f;
             if (score <= bestScore)
                 continue;
 
             bestScore = score;
-            bestDestination = candidate;
+            bestLandingDestination = landing;
         }
     }
 
     if (bestScore <= 0.0f)
         return false;
 
-    fallDestination = bestDestination;
+    landingDestination = bestLandingDestination;
     nextAllowedFallShortcutMsByGuid[botGuid] = nowMs + PLAYERBOT_TERRAIN_FALL_SHORTCUT_COOLDOWN_MS;
     return true;
 }
@@ -767,7 +792,7 @@ bool TryBuildTerrainFallShortcutDestination(Player* player, Position const& dest
 // here; falling behavior must remain generic terrain behavior.
 bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const& destination, Position& fallDestination)
 {
-    return TryBuildTerrainFallShortcutDestination(player, destination, fallDestination);
+    return TryBuildTerrainFallShortcutDestination(player, destination, fallDestination, CalculateNavigationDistance(player, destination));
 }
 
 bool TryBuildBattlegroundSegmentDestination(Player* player, Position const& safeDestination, Position& segmentDestination, PathType* resolvedPathType = nullptr)
@@ -980,51 +1005,33 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     Position const safeDestination = generatePath ? BuildCollisionSafeDestination(player, destination) : destination;
 
     Position issuedDestination = safeDestination;
-    Position fallDestination;
-    if (generatePath && TryBuildTerrainFallShortcutDestination(player, safeDestination, fallDestination))
+    Position fallLandingDestination;
+    float const navigationDistance = generatePath ? CalculateNavigationDistance(player, safeDestination) : std::numeric_limits<float>::max();
+    if (generatePath && TryBuildTerrainFallShortcutDestination(player, safeDestination, fallLandingDestination, navigationDistance))
     {
-        motionMaster->MovePoint(0, fallDestination, false);
-        issuedDestination = fallDestination;
+        motionMaster->MoveJump(fallLandingDestination, player->GetSpeed(MOVE_RUN), 0.1f, 0, true);
+        issuedDestination = fallLandingDestination;
         EmitBattlegroundGmDebug(player,
-            "movepoint=fall-shortcut drop=" + std::to_string(int32(player->GetPositionZ() - fallDestination.GetPositionZ())) +
-            " segDist=" + std::to_string(int32(player->GetDistance(fallDestination))), 1000);
+            "movepoint=fall-shortcut navDist=" + std::to_string(int32(navigationDistance)) +
+            " drop=" + std::to_string(int32(player->GetPositionZ() - fallLandingDestination.GetPositionZ())) +
+            " landDist=" + std::to_string(int32(player->GetDistance(fallLandingDestination))), 1000);
     }
     else if (generatePath && player->InBattleground())
     {
-        motionMaster->MovePoint(0, fallDestination, false);
-        issuedDestination = fallDestination;
-        EmitBattlegroundGmDebug(player,
-            "movepoint=fall-shortcut drop=" + std::to_string(int32(player->GetPositionZ() - fallDestination.GetPositionZ())) +
-            " segDist=" + std::to_string(int32(player->GetDistance(fallDestination))), 1000);
-    }
-    else if (generatePath && player->InBattleground())
-    {
-        Position fallDestination;
-        if (TryBuildBattlegroundFallShortcutDestination(player, safeDestination, fallDestination))
+        Position segmentDestination;
+        PathType pathType = PathType(0);
+        if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
         {
-            motionMaster->MovePoint(0, fallDestination, false);
-            issuedDestination = fallDestination;
             EmitBattlegroundGmDebug(player,
-                "movepoint=fall-shortcut drop=" + std::to_string(int32(player->GetPositionZ() - fallDestination.GetPositionZ())) +
-                " segDist=" + std::to_string(int32(player->GetDistance(fallDestination))), 1000);
+                "movepoint=blocked-no-nav destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 1000);
+            return false;
         }
-        else
-        {
-            Position segmentDestination;
-            PathType pathType = PathType(0);
-            if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
-            {
-                EmitBattlegroundGmDebug(player,
-                    "movepoint=blocked-no-nav destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 1000);
-                return false;
-            }
 
-            motionMaster->MovePoint(0, segmentDestination, true);
-            issuedDestination = segmentDestination;
-            EmitBattlegroundGmDebug(player,
-                "movepoint=nav-segment pathType=" + std::to_string(uint32(pathType)) +
-                " segDist=" + std::to_string(int32(player->GetDistance(segmentDestination))), 0);
-        }
+        motionMaster->MovePoint(0, segmentDestination, true);
+        issuedDestination = segmentDestination;
+        EmitBattlegroundGmDebug(player,
+            "movepoint=nav-segment pathType=" + std::to_string(uint32(pathType)) +
+            " segDist=" + std::to_string(int32(player->GetDistance(segmentDestination))), 0);
     }
     else
     {
@@ -2884,15 +2891,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
         context.movement == BattlegroundMovementPrimitive::None &&
         context.flagCarrierDirective == FlagCarrierDirective::None)
     {
-        if (battleground && battleground->GetTypeID() == BATTLEGROUND_SCM)
-        {
-            float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
-            if (EngageNearestEnemyPlayer(player, engageDistance))
-                return true;
+        float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
+        if (EngageNearestEnemyPlayer(player, engageDistance))
+            return true;
 
-            if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
-                return MoveTowardUnit(player, nearestEnemy, 20.0f);
-        }
+        if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
+            return MoveTowardUnit(player, nearestEnemy, 20.0f);
 
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
             "Playerbot PvP movement skipped: bot={} reason=no-objective-and-no-directive.",
@@ -2928,15 +2932,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
                 return true;
             }
 
-            if (battleground->GetTypeID() == BATTLEGROUND_SCM)
-            {
-                float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
-                if (EngageNearestEnemyPlayer(player, engageDistance))
-                    return true;
+            float const engageDistance = GetAggressiveCombatScanDistance(player, 100.0f);
+            if (EngageNearestEnemyPlayer(player, engageDistance))
+                return true;
 
-                if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
-                    return MoveTowardUnit(player, nearestEnemy, 20.0f);
-            }
+            if (Player* nearestEnemy = FindNearestEnemyBattlegroundPlayer(player, std::numeric_limits<float>::max(), nullptr, nullptr))
+                return MoveTowardUnit(player, nearestEnemy, 20.0f);
 
             return false;
         }


### PR DESCRIPTION
### Motivation

- Reduce false positives where Chase/Follow generators were considered launched while bots remained stationary, and improve fall-shortcut behavior to pick safer, more effective ledge drops.
- Make battleground movement decisions and navigation probing more robust to VMAP/pathing quirks and avoid bots getting stuck on initialized-but-not-started splines.

### Description

- Added `HasActuallyLaunchedTargetRelativeMovement(Player const*)` to centralize accurate detection of whether target-relative motion truly started (checks moving, chase/follow states, and started splines) and replaced ad-hoc checks across `PlayerbotPvpClassActions.cpp` with this helper.
- Tightened and adjusted settle/timeout thresholds and preservation logic in `ShouldPreserveTargetRelativeMovement` and ranged approach code paths, including changing various time limits (e.g., shorten wait windows from ~900/1400/3000ms to smaller, calibrated values) and updating the final preserve condition to rely on credible position progress combined with movement signals.
- Improved priming/prime-fallback behavior in `IssueRangedApproachMovement` to avoid long-preserved but non-moving motion generators and to better decide when to reissue movement or escalate contact rescue.
- Refactored battleground/terrain fall-shortcut logic in `PlayerbotPvpLifecycleActions.cpp` by adding `CalculatePathDistance` and `CalculateNavigationDistance` helpers, expanding validation for candidate landing spots, and replacing raw long probes with a stepped run-off probe set and improved scoring that accounts for navigation distance and landing drop.
- Introduced new constants (`PLAYERBOT_TERRAIN_MAX_FALL_SHORTCUT_DROP`, `PLAYERBOT_TERRAIN_FALL_LANDING_OFFSET`) and increased the fall-shortcut cooldown from 8s to 12s; use `MoveJump` to perform falling-style movement to the selected landing destination.
- Simplified some battleground movement decision branches to remove redundant special-casing and to prefer nearest-enemy engagement more generally.

### Testing

- Performed a full server build with the changes applied and the build completed successfully (no compile errors).
- Ran the Playerbot movement/unit test suite and movement-related PvP tests (automated) against the modified server and observed no regressions in tests (all automated tests passed).
- Executed automated navigation/pathing probes to validate `CalculateNavigationDistance` and fall-shortcut selection logic; these automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fffd6717808327bfd1b72c6ad9c237)