### PR TITLE
Block playerbot movement while falling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2096,9 +2096,20 @@ char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
     }
 }
 
+bool IsPlayerbotActivelyFalling(Player const* player)
+{
+    // Use Unit::IsFalling() instead of Player::IsFalling() so server-authored
+    // falling splines (MoveSplineInit::SetFall) are treated as real gravity
+    // movement and are not interrupted by fresh MovePoint/repath orders.
+    return player && player->Unit::IsFalling();
+}
+
 bool CanIssueFollowCommands(Player const* player)
 {
     if (!player || !player->IsAlive())
+        return false;
+
+    if (IsPlayerbotActivelyFalling(player))
         return false;
 
     if (IsCrowdControlledForAction(player) ||

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -584,9 +584,20 @@ void ClearMovementBeforeBattlegroundTeleport(Player* player)
 }
 
 
+bool IsPlayerbotActivelyFalling(Player const* player)
+{
+    // Use Unit::IsFalling() instead of Player::IsFalling() so server-authored
+    // falling splines (MoveSplineInit::SetFall) are treated as real gravity
+    // movement and are not interrupted by fresh MovePoint/repath orders.
+    return player && player->Unit::IsFalling();
+}
+
 bool CanIssueMovementCommand(Player const* player, uint32 cooldownMs = 500)
 {
     if (!player)
+        return false;
+
+    if (IsPlayerbotActivelyFalling(player))
         return false;
 
     static std::unordered_map<uint64, uint32> nextAllowedMoveCommandMsByGuid;
@@ -679,7 +690,7 @@ bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const&
     if (!player || !player->InBattleground() || player->IsFlying() || player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING))
         return false;
 
-    if (player->IsFalling())
+    if (IsPlayerbotActivelyFalling(player))
         return false;
 
     static std::unordered_map<uint64, uint32> nextAllowedFallShortcutMsByGuid;
@@ -916,7 +927,7 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     MotionMaster* motionMaster = player->GetMotionMaster();
     MovementGeneratorType const currentMovement = motionMaster->GetCurrentMovementGeneratorType();
-    if (player->InBattleground() && botCurrentlyMoving && (player->IsFalling() || currentMovement == EFFECT_MOTION_TYPE))
+    if (player->InBattleground() && botCurrentlyMoving && (IsPlayerbotActivelyFalling(player) || currentMovement == EFFECT_MOTION_TYPE))
         return true;
 
     if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)


### PR DESCRIPTION
### Motivation
- Prevent playerbots from being snapped back uphill by new MovePoint/repath orders while they are genuinely falling so they behave like normal players under gravity.
- Ensure server-authored falling splines created by `MoveSplineInit::SetFall` are treated as active falling so battleground fall shortcuts and fall-resolving movement are not interrupted.

### Description
- Added an `IsPlayerbotActivelyFalling` helper that calls `Unit::IsFalling()` to both `PlayerbotPvpLifecycleActions.cpp` and `PlayerbotPvpClassActions.cpp` so server-side spline falling is recognized as falling.
- Guarded `CanIssueMovementCommand` and `CanIssueFollowCommands` with the new helper to block issuing new movement/repath orders while a bot is falling.
- Switched checks inside `TryBuildBattlegroundFallShortcutDestination` and the battleground move-throttling path in `IssueMovePointThrottled` to use the helper so fall-shortcut launches and reissues are suppressed while falling.
- Changes are limited to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` and preserve existing battleground movement throttling semantics.

### Testing
- Ran `git diff --check` which reported no whitespace or patch errors.
- Performed a syntax-only compile harness using `compile_commands.json` to check `PlayerbotPvpLifecycleActions.cpp` and `PlayerbotPvpClassActions.cpp`, both returned cleanly.
- Started `cmake --build build --target worldserver -j2` (large full build) but it was interrupted after progressing through many units; no errors were produced from the modified files before interruption.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002ebfe3ec8327947c399062fca306)