### PR TITLE
Avoid issuing movement/follow commands while player is actively falling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2096,9 +2096,27 @@ char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
     }
 }
 
+bool IsPlayerbotActivelyFalling(Player const* player)
+{
+    if (!player || !player->Unit::IsFalling())
+        return false;
+
+    // Unit::IsFalling() also reports the MoveSpline falling flag. Completed
+    // falling splines can keep that flag for diagnostics, so only block new
+    // MovePoint/repath orders while a client fall flag is present or a falling
+    // spline is still active.
+    if (player->HasUnitMovementFlag(MOVEMENTFLAG_FALLING | MOVEMENTFLAG_FALLING_FAR))
+        return true;
+
+    return player->movespline->Initialized() && !player->movespline->Finalized() && player->movespline->isFalling();
+}
+
 bool CanIssueFollowCommands(Player const* player)
 {
     if (!player || !player->IsAlive())
+        return false;
+
+    if (IsPlayerbotActivelyFalling(player))
         return false;
 
     if (IsCrowdControlledForAction(player) ||

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -35,6 +35,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "MoveSpline.h"
 #include "MoveSplineInit.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
@@ -584,9 +585,27 @@ void ClearMovementBeforeBattlegroundTeleport(Player* player)
 }
 
 
+bool IsPlayerbotActivelyFalling(Player const* player)
+{
+    if (!player || !player->Unit::IsFalling())
+        return false;
+
+    // Unit::IsFalling() also reports the MoveSpline falling flag. Completed
+    // falling splines can keep that flag for diagnostics, so only block new
+    // MovePoint/repath orders while a client fall flag is present or a falling
+    // spline is still active.
+    if (player->HasUnitMovementFlag(MOVEMENTFLAG_FALLING | MOVEMENTFLAG_FALLING_FAR))
+        return true;
+
+    return player->movespline->Initialized() && !player->movespline->Finalized() && player->movespline->isFalling();
+}
+
 bool CanIssueMovementCommand(Player const* player, uint32 cooldownMs = 500)
 {
     if (!player)
+        return false;
+
+    if (IsPlayerbotActivelyFalling(player))
         return false;
 
     static std::unordered_map<uint64, uint32> nextAllowedMoveCommandMsByGuid;
@@ -679,7 +698,7 @@ bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const&
     if (!player || !player->InBattleground() || player->IsFlying() || player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING))
         return false;
 
-    if (player->IsFalling())
+    if (IsPlayerbotActivelyFalling(player))
         return false;
 
     static std::unordered_map<uint64, uint32> nextAllowedFallShortcutMsByGuid;
@@ -916,7 +935,7 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     MotionMaster* motionMaster = player->GetMotionMaster();
     MovementGeneratorType const currentMovement = motionMaster->GetCurrentMovementGeneratorType();
-    if (player->InBattleground() && botCurrentlyMoving && (player->IsFalling() || currentMovement == EFFECT_MOTION_TYPE))
+    if (player->InBattleground() && botCurrentlyMoving && (IsPlayerbotActivelyFalling(player) || currentMovement == EFFECT_MOTION_TYPE))
         return true;
 
     if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)


### PR DESCRIPTION
### Motivation

- Prevent bots from receiving new movement or follow orders while legitimately falling or while a falling MoveSpline is still active to avoid stale movement flags and client-side asserts.
- Improve falling detection to distinguish completed/diagnostic spline flags from active falling splines so new movement isn't blocked unnecessarily.

### Description

- Added `IsPlayerbotActivelyFalling(Player const*)` helper to detect active falls by checking client fall flags and the `movespline` active/falling state in both `PlayerbotPvpClassActions.cpp` and `PlayerbotPvpLifecycleActions.cpp`.
- Replaced direct `player->IsFalling()` checks with `IsPlayerbotActivelyFalling(player)` in `CanIssueFollowCommands`, `CanIssueMovementCommand`, `TryBuildBattlegroundFallShortcutDestination`, and `IssueMovePointThrottled` to more accurately gate movement/follow commands.
- Included `MoveSpline.h` where needed and updated logic/comments to explain why we check both movement flags and spline state.

### Testing

- Project compiled successfully after the changes using the standard build, with no compile errors. 
- Ran automated unit/integration tests related to movement and battleground navigation, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002ebfe3ec8327947c399062fca306)