### PR TITLE
Make Player::IsFalling() const

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -942,7 +942,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         bool IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo const& spellEffectInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute = false) const override;
 
-        bool IsFalling() { return GetPositionZ() < m_lastFallZ; }
+        bool IsFalling() const { return GetPositionZ() < m_lastFallZ; }
         bool IsInAreaTriggerRadius(AreaTriggerEntry const* trigger) const;
 
         void SendInitialPacketsBeforeAddToMap();


### PR DESCRIPTION
### Motivation
- Fix a compile error where `const Player*` contexts in playerbot PvP code could not call `IsFalling()` because it was not marked `const`.

### Description
- Change `bool IsFalling()` to `bool IsFalling() const` in `src/server/game/Entities/Player/Player.h` so the method can be invoked on `const Player*` without changing its behavior.

### Testing
- Ran `git diff --check`, `cmake -S . -B build -DPLAYERBOT=ON -DSCRIPTS_PLAYERBOT=static`, and `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpClassActions.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00bde200ec8327aef2a95efb6afe10)