### PR TITLE
Fix playerbot battleground fall shortcut speed

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -35,7 +35,9 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "MoveSpline.h"
 #include "MoveSplineInit.h"
+#include "MovementTypedefs.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
 #include "Item.h"
@@ -593,6 +595,42 @@ bool IsResolvingBattlegroundGravityFall(Player const* player)
         !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
 }
 
+bool FinishCompletedBattlegroundGravityFall(Player* player)
+{
+    if (!IsResolvingBattlegroundGravityFall(player))
+        return false;
+
+    if (player->movespline && !player->movespline->Finalized())
+        return false;
+
+    float groundZ = player->GetMapHeight(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), true, MAX_FALL_DISTANCE);
+    if (groundZ > INVALID_HEIGHT && std::fabs(player->GetPositionZ() - groundZ) > 1.0f)
+        return false;
+
+    player->RemoveUnitMovementFlag(MOVEMENTFLAG_FALLING);
+    player->RemoveUnitMovementFlag(MOVEMENTFLAG_SPLINE_ENABLED);
+    player->RemoveUnitMovementFlag(MOVEMENTFLAG_FORWARD);
+    player->SetFallInformation(0, player->GetPositionZ());
+    return true;
+}
+
+float GetHumanLikeFallHorizontalSpeed(Player const* player)
+{
+    if (!player)
+        return 0.0f;
+
+    if (player->movespline && !player->movespline->Finalized() && player->movespline->Velocity() > 0.0f)
+        return player->movespline->Velocity();
+
+    if (player->HasUnitMovementFlag(MOVEMENTFLAG_WALKING))
+        return player->GetSpeed(MOVE_WALK);
+
+    if (player->HasUnitMovementFlag(MOVEMENTFLAG_BACKWARD))
+        return player->GetSpeed(MOVE_RUN_BACK);
+
+    return player->GetSpeed(MOVE_RUN);
+}
+
 bool CanIssueMovementCommand(Player const* player, uint32 cooldownMs = 500)
 {
     if (!player)
@@ -645,6 +683,7 @@ bool IsForbiddenBattlegroundPathType(PathType pathType)
 constexpr float PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT = 2400.0f;
 constexpr float PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE = 80.0f;
 constexpr float PLAYERBOT_BG_MIN_FALL_SHORTCUT_DROP = 6.0f;
+constexpr float PLAYERBOT_BG_FALL_SHORTCUT_SPEED_TOLERANCE = 0.75f;
 constexpr uint32 PLAYERBOT_BG_FALL_SHORTCUT_COOLDOWN_MS = 4000;
 
 bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray const& points, float orientation, Position& segmentDestination)
@@ -704,8 +743,15 @@ bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const&
     if (planarDistance < 2.0f)
         return false;
 
-    std::array<float, 5> const probeDistances =
+    float const horizontalSpeed = GetHumanLikeFallHorizontalSpeed(player);
+    if (horizontalSpeed <= 0.0f)
+        return false;
+
+    std::array<float, 8> const probeDistances =
     {
+        3.0f,
+        5.0f,
+        8.0f,
         12.0f,
         20.0f,
         30.0f,
@@ -725,7 +771,19 @@ bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const&
         float probeZ = player->GetPositionZ();
         player->UpdateAllowedPositionZ(probeX, probeY, probeZ);
 
-        if (player->GetPositionZ() - probeZ < PLAYERBOT_BG_MIN_FALL_SHORTCUT_DROP)
+        float const drop = player->GetPositionZ() - probeZ;
+        if (drop < PLAYERBOT_BG_MIN_FALL_SHORTCUT_DROP)
+            continue;
+
+        // A falling spline derives total duration from vertical gravity.  If we
+        // choose a far-away landing point for a shallow drop, the bot is forced
+        // to cover that horizontal distance during the short gravity duration,
+        // producing the visible "rocket forward, then stop" behavior.  Keep
+        // horizontal travel close to the speed the bot already had, matching how
+        // a real client preserves horizontal velocity after stepping off a ledge.
+        float const fallTimeSeconds = Movement::computeFallTime(drop, false);
+        float const maxHumanLikeHorizontalDistance = horizontalSpeed * fallTimeSeconds + PLAYERBOT_BG_FALL_SHORTCUT_SPEED_TOLERANCE;
+        if (cappedDistance > maxHumanLikeHorizontalDistance)
             continue;
 
         if (!player->IsWithinLOS(probeX, probeY, probeZ + 1.0f))
@@ -869,6 +927,8 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 {
     if (!player)
         return false;
+
+    FinishCompletedBattlegroundGravityFall(player);
 
     if (IsResolvingBattlegroundGravityFall(player))
         return true;
@@ -1464,6 +1524,8 @@ bool CanIssueBotMovement(Player* player)
     // cliffs), do not let combat/objective steering replace the fall with a
     // fresh ground-snapped MovePoint/Follow/Chase order. The core fall state
     // should resolve at normal gravity, after which pathing can resume.
+    FinishCompletedBattlegroundGravityFall(player);
+
     if (IsResolvingBattlegroundGravityFall(player))
         return false;
 


### PR DESCRIPTION
### Motivation
- Bots were using battleground fall shortcuts that produced an unrealistic "rocket forward then stop" motion because the chosen landing point required horizontal travel faster than the bot's pre-fall horizontal velocity over the gravity-derived fall time.
- The goal is to make bot falls behave like a real client: vertical motion governed by gravity while preserving the bot's existing horizontal speed, and to ensure bots recover from server-driven fall splines and resume normal movement.

### Description
- Added `MoveSpline.h` and `MovementTypedefs.h` includes and a small tolerance constant `PLAYERBOT_BG_FALL_SHORTCUT_SPEED_TOLERANCE` so the code can read spline velocity and compute gravity-based fall time. 
- Implemented `GetHumanLikeFallHorizontalSpeed` to derive the bot's current horizontal speed from an active `movespline` or movement flags, and used it when evaluating fall shortcut candidates. 
- Implemented `FinishCompletedBattlegroundGravityFall` to detect a completed server-driven battleground fall (spline finalized and near-ground) and clear `MOVEMENTFLAG_FALLING`, `MOVEMENTFLAG_SPLINE_ENABLED`, and `MOVEMENTFLAG_FORWARD` so bots resume normal movement. 
- In `TryBuildBattlegroundFallShortcutDestination` replaced the simple probe set with nearer probe distances and added a check that computes `fallTimeSeconds = Movement::computeFallTime(drop, false)` and rejects landing probes whose horizontal distance exceeds `horizontalSpeed * fallTimeSeconds + tolerance`, preventing unrealistic high-speed horizontal teleportation during short falls. 
- Call `FinishCompletedBattlegroundGravityFall` before issuing new movement (`IssueMovePointThrottled`) and inside `CanIssueBotMovement` so completed falls are cleaned up and movement decisions behave correctly.

### Testing
- Ran `git diff --check` to validate no whitespace or obvious diff issues; success. 
- Configured a playerbot-enabled build with `cmake -S . -B build-playerbot-check -DPLAYERBOT=1 -DSCRIPTS=static -DCMAKE_BUILD_TYPE=RelWithDebInfo`; configuration succeeded. 
- Compiled the modified script object with `make -C build-playerbot-check -f src/server/scripts/CMakeFiles/scripts.dir/build.make src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o -j2`; compilation of the script source succeeded. 
- A full `cmake --build build --target worldserver -j2` run was started to validate the global tree but was intentionally interrupted because the existing build tree was not configured with `PLAYERBOT`; configuration portion completed before interruption.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c0c09afc83278c0a503de810b0e8)