### PR TITLE
Fix Tauren mount cast time reduction

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3310,10 +3310,6 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
     else
         m_casttime = m_spellInfo->CalcCastTime(this);
 
-    if (playerCaster && playerCaster->GetRace() == RACE_TAUREN
-        && (m_spellInfo->HasAura(SPELL_AURA_MOUNTED) || m_spellInfo->Mechanic == MECHANIC_MOUNT))
-        m_casttime = std::max(m_casttime - 1000, 0);
-
     bool const isStarfire = m_spellInfo->IsStarfire();
     float starfireSnareSpeedRate = 0.0f;
     if (playerCaster && m_casttime && isStarfire)


### PR DESCRIPTION
### Motivation
- Prevent Tauren mount spells from having the 1s cast-time reduction applied twice (3s → 1s) so they correctly end up at 2s total.

### Description
- Remove the extra Tauren-specific `m_casttime = std::max(m_casttime - 1000, 0);` from `Spell::prepare` so the single reduction in `WorldObject::ModSpellCastTime` is the only one applied.

### Testing
- Ran `git diff --check` which succeeded.
- Built the modified translation unit with `cmake --build build --target src/server/game/CMakeFiles/game.dir/Spells/Spell.cpp.o -- -j2` which succeeded.
- A full `cmake --build build --target game -- -j2` was started but the overall full rebuild was interrupted to keep the test focused on the changed file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cdbea4148327b4858f232dea47a8)