### PR TITLE
Fix playerbot fall movement linkage

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1999,6 +1999,11 @@ uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint
 
 namespace playerbot
 {
+bool TryIssueBattlegroundFallMovement(Player* player, Position const& destination, char const* reason)
+{
+    return ::TryIssueBattlegroundFallMovement(player, destination, reason);
+}
+
 uint32 QueueEligibleManagedBotsForBattleground(BattlegroundTypeId bgTypeId, uint8 arenaType)
 {
     return ::QueueEligibleManagedBotsForBattleground(bgTypeId, arenaType);


### PR DESCRIPTION
### Motivation
- Resolve linker errors caused by undefined reference to `playerbot::TryIssueBattlegroundFallMovement` when class-action callers in other translation units attempt to call the lifecycle helper.

### Description
- Add an exported wrapper `playerbot::TryIssueBattlegroundFallMovement` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` that forwards to the internal `::TryIssueBattlegroundFallMovement` implementation so callers outside the anonymous namespace can link.

### Testing
- Ran `git diff --check` which reported no whitespace/patch issues and passed.
- Performed a syntax-only compile of `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` using the scripts compile flags from `compile_commands.json`, which succeeded.
- Attempted `cmake --build build --target worldserver -j2` but stopped after CMake reconfigured and initiated a full 1110-step rebuild; a full incremental relink was not completed in this local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cfb7cd08832788461a0c48889a98)