### PR TITLE
Invoke BG fall shortcut during strict battleground movement (fix Twin Peaks graveyard)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -332,6 +332,15 @@ bool IssueStrictHumanMove(Player* player, Position const& destination, float des
         state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
 
+    // Strict battleground movement is also used by combat range recovery.
+    // Before honoring local point-move throttles or asking navmesh for a walking
+    // segment, allow the shared BG fall shortcut to launch a real falling spline
+    // when the direct human-like route crosses graveyard ledges such as Twin
+    // Peaks. Without this, the strict segment walker can install or preserve a
+    // point generator on top of the graveyard and never step off the drop.
+    if (player->InBattleground() && playerbot::TryIssueBattlegroundFallMovement(player, destination, "strict-human"))
+        return true;
+
     if (!destinationChanged && !canReissueByTime)
     {
         // Treat strict move as unsuccessful when the throttled order is stale


### PR DESCRIPTION
### Motivation
- Playerbots were sometimes stuck on battleground graveyard ledges (e.g., Twin Peaks) because the strict segment walker could install or preserve a point movement on top of the drop instead of falling off.

### Description
- Inserted an early check in `IssueStrictHumanMove` to call `playerbot::TryIssueBattlegroundFallMovement(player, destination, "strict-human")` and return `true` when the fall shortcut launches, allowing a real falling spline to be used before point-move throttles or navmesh segment calculation.
- Change applied in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` around `IssueStrictHumanMove` so strict BG movement can reuse the shared battleground fall shortcut.

### Testing
- Ran `git diff --check` which reported no spacing or patch errors and the change was committed successfully.
- Started a full build with `cmake --build build --target game -- -j2`; the build progressed (reached ~310/460 object builds) with warnings only and no compile error observed for the modified module during that run.
- No targeted unit tests were available for this specific pathing change; behavioral validation recommended in a running server/BG environment to confirm playerbots now fall off Twin Peaks graveyard ledges.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d2c465e08327bd097c02c6d0eda1)