### PR TITLE
Playerbot: battleground fall shortcuts (including graveyard) and movement-throttle fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Do **not** implement gameplay/code changes under `playerbot reference/`; that directory is reference-only.
 - If playerbot behavior changes are requested, apply them in the active/source code location used by this repository build, not in the reference mirror.
+- Do **not** add new per-battleground gameplay or movement special cases; prefer generic playerbot pathing fixes that work across battlegrounds.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -332,6 +332,15 @@ bool IssueStrictHumanMove(Player* player, Position const& destination, float des
         state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
 
+    // Strict battleground movement is also used by combat range recovery.
+    // Before honoring local point-move throttles or asking navmesh for a walking
+    // segment, allow the shared BG fall shortcut to launch a real falling spline
+    // when the direct human-like route crosses graveyard ledges such as Twin
+    // Peaks. Without this, the strict segment walker can install or preserve a
+    // point generator on top of the graveyard and never step off the drop.
+    if (player->InBattleground() && playerbot::TryIssueBattlegroundFallMovement(player, destination, "strict-human"))
+        return true;
+
     if (!destinationChanged && !canReissueByTime)
     {
         // Treat strict move as unsuccessful when the throttled order is stale

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -824,6 +824,56 @@ bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const&
     return false;
 }
 
+bool TryBuildBattlegroundGraveyardFallShortcutDestination(Player* player, Position const& destination, Position& fallDestination)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground)
+        return false;
+
+    WorldSafeLocsEntry const* graveyard = battleground->GetClosestGraveyard(player);
+    if (!graveyard)
+        return false;
+
+    float const graveyardDx = player->GetPositionX() - graveyard->Loc.X;
+    float const graveyardDy = player->GetPositionY() - graveyard->Loc.Y;
+    float const graveyardDistance2D = std::sqrt(graveyardDx * graveyardDx + graveyardDy * graveyardDy);
+    if (graveyardDistance2D > 80.0f || std::fabs(player->GetPositionZ() - graveyard->Loc.Z) > 35.0f)
+        return false;
+
+    float const destinationAngle = player->GetAbsoluteAngle(destination);
+    float const awayFromGraveyardAngle = graveyardDistance2D > 1.0f ? std::atan2(graveyardDy, graveyardDx) : destinationAngle;
+    std::array<float, 10> const probeAngles =
+    {
+        destinationAngle,
+        awayFromGraveyardAngle,
+        player->GetOrientation(),
+        awayFromGraveyardAngle + static_cast<float>(M_PI) * 0.25f,
+        awayFromGraveyardAngle - static_cast<float>(M_PI) * 0.25f,
+        awayFromGraveyardAngle + static_cast<float>(M_PI) * 0.5f,
+        awayFromGraveyardAngle - static_cast<float>(M_PI) * 0.5f,
+        awayFromGraveyardAngle + static_cast<float>(M_PI) * 0.75f,
+        awayFromGraveyardAngle - static_cast<float>(M_PI) * 0.75f,
+        awayFromGraveyardAngle + static_cast<float>(M_PI)
+    };
+
+    for (float angle : probeAngles)
+    {
+        Position probeDestination(
+            player->GetPositionX() + std::cos(angle) * 40.0f,
+            player->GetPositionY() + std::sin(angle) * 40.0f,
+            player->GetPositionZ(),
+            angle);
+
+        if (TryBuildBattlegroundFallShortcutDestination(player, probeDestination, fallDestination))
+            return true;
+    }
+
+    return false;
+}
+
 bool TryBuildBattlegroundSegmentDestination(Player* player, Position const& safeDestination, Position& segmentDestination, PathType* resolvedPathType = nullptr)
 {
     if (!player)
@@ -960,7 +1010,8 @@ bool TryIssueBattlegroundFallMovementInternal(Player* player, Position const& de
         return true;
 
     Position fallDestination;
-    if (!TryBuildBattlegroundFallShortcutDestination(player, destination, fallDestination))
+    if (!TryBuildBattlegroundFallShortcutDestination(player, destination, fallDestination) &&
+        !TryBuildBattlegroundGraveyardFallShortcutDestination(player, destination, fallDestination))
         return false;
 
     MotionMaster* motionMaster = player->GetMotionMaster();
@@ -1096,14 +1147,9 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
     Position const safeDestination = generatePath ? BuildCollisionSafeDestination(player, destination) : destination;
 
-    Position issuedDestination = safeDestination;
     if (generatePath && player->InBattleground())
     {
-        if (TryIssueBattlegroundFallMovementInternal(player, safeDestination, "move-point"))
-        {
-            issuedDestination = safeDestination;
-        }
-        else
+        if (!TryIssueBattlegroundFallMovementInternal(player, safeDestination, "move-point"))
         {
             Position segmentDestination;
             PathType pathType = PathType(0);
@@ -1115,7 +1161,6 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
             }
 
             motionMaster->MovePoint(0, segmentDestination, true);
-            issuedDestination = segmentDestination;
             EmitBattlegroundGmDebug(player,
                 "movepoint=nav-segment pathType=" + std::to_string(uint32(pathType)) +
                 " segDist=" + std::to_string(int32(player->GetDistance(segmentDestination))), 0);
@@ -1124,10 +1169,14 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     else
     {
         motionMaster->MovePoint(0, safeDestination, generatePath);
-        issuedDestination = safeDestination;
     }
 
-    state.lastDestination = issuedDestination;
+    // Throttle against the caller's tactical destination, not the intermediate
+    // navmesh segment we just issued. Battleground segment walking intentionally
+    // advances in chunks; storing the chunk endpoint here made the next tick see
+    // the real objective as a different destination, clear the active spline,
+    // and reinstall a fresh segment before bots could make visible progress.
+    state.lastDestination = destination;
     state.lastIssueMs = nowMs;
     return true;
 }


### PR DESCRIPTION
### Motivation

- Prevent bots from getting stuck on graveyard ledges or stale navmesh segments during battleground movement by allowing an immediate falling spline shortcut in more scenarios. 
- Avoid per-battleground special-case gameplay in code and prefer generic pathing fixes reflected in repository guidance. 
- Ensure movement re-issue throttling uses the tactical objective rather than intermediate navmesh chunk endpoints to avoid premature reissue and stale generator reinstalls.

### Description

- Updated `AGENTS.md` to discourage adding per-battleground gameplay or movement special cases and prefer generic playerbot pathing fixes. 
- In `PlayerbotPvpClassActions.cpp` added an early battleground fall movement check by calling `playerbot::TryIssueBattlegroundFallMovement` from `IssueStrictHumanMove` so fall shortcuts can trigger before local move throttles or segment generation. 
- In `PlayerbotPvpLifecycleActions.cpp` implemented `TryBuildBattlegroundGraveyardFallShortcutDestination` which probes multiple angles around the bot and defers to `TryBuildBattlegroundFallShortcutDestination` to detect graveyard-adjacent fall shortcuts, and integrated it into `TryIssueBattlegroundFallMovementInternal` as a fallback. 
- Modified `IssueMovePointThrottled` and related logic to stop storing the intermediate navmesh segment endpoint in `state.lastDestination` and instead store the caller's tactical `destination`, with comments explaining why this prevents repeated re-issuance of fresh segments.

### Testing

- Built the server tree using the project build (`cmake --build`); the build completed successfully. 
- Ran the existing automated test suite via `ctest` and all automated tests passed. 
- Existing pathfinding and playerbot PVP unit tests were executed as part of `ctest` with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d2c465e08327bd097c02c6d0eda1)