### PR TITLE
Battleground movement: graveyard fall shortcut, strict-move fallback, and pursue-enemy tactic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Do **not** implement gameplay/code changes under `playerbot reference/`; that directory is reference-only.
 - If playerbot behavior changes are requested, apply them in the active/source code location used by this repository build, not in the reference mirror.
+- Do **not** add new per-battleground gameplay or movement special cases; prefer generic playerbot pathing fixes that work across battlegrounds.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -332,6 +332,15 @@ bool IssueStrictHumanMove(Player* player, Position const& destination, float des
         state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
 
+    // Strict battleground movement is also used by combat range recovery.
+    // Before honoring local point-move throttles or asking navmesh for a walking
+    // segment, allow the shared BG fall shortcut to launch a real falling spline
+    // when the direct human-like route crosses graveyard ledges such as Twin
+    // Peaks. Without this, the strict segment walker can install or preserve a
+    // point generator on top of the graveyard and never step off the drop.
+    if (player->InBattleground() && playerbot::TryIssueBattlegroundFallMovement(player, destination, "strict-human"))
+        return true;
+
     if (!destinationChanged && !canReissueByTime)
     {
         // Treat strict move as unsuccessful when the throttled order is stale

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2988,7 +2988,7 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
     std::array<TacticalRule, 4> const rules =
     {{
         { "bg waiting", bgWaiting, "bg move to start", 50.0f },
-        { "bg active", bgActive, "bg check objective", 60.0f },
+        { "bg active", bgActive, "bg pursue enemy", 60.0f },
         { "low health", lowHealth, "bg use buff", 45.0f },
         { "low mana", lowMana, "bg use buff", 45.0f }
     }};

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -78,6 +78,13 @@ bool EngageNearestEnemyPlayer(Player* player, float scanDistance);
 namespace
 {
 std::unordered_map<uint64, uint32> g_HunterAutoShotPauseUntilMs;
+
+struct PendingBattlegroundFallShortcut
+{
+    Position landing;
+};
+
+std::unordered_map<uint64, PendingBattlegroundFallShortcut> g_PendingBattlegroundFallShortcutByGuid;
 std::unordered_map<uint64, uint32> g_BattlegroundNoHumanSinceMsByInstance;
 constexpr uint32 PLAYERBOT_BG_NO_HUMAN_END_DELAY_MS = 45000;
 constexpr uint32 PLAYERBOT_BG_WAIT_JOIN_NO_HUMAN_END_DELAY_MS = 15000;
@@ -389,6 +396,7 @@ bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance);
 float GetAggressiveCombatScanDistance(Player const* player, float fallbackDistance);
 bool CanIssueBotMovement(Player* player);
 bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000);
+bool TryGetObjectivePosition(Battleground* battleground, Player* player, Position& destination);
 Position BuildFollowDestination(Player* player, Unit* target, float desiredDistance);
 bool IssueHumanLikeFollow(Player* player, Unit* target, float desiredDistance, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000);
 void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs);
@@ -473,7 +481,7 @@ bool RecoverStaleBattlegroundState(Player* player)
     return true;
 }
 
-bool MoveToClosestBattlegroundGraveyard(Player* player)
+bool MoveToBattlegroundObjectivePosition(Player* player)
 {
     if (!player || !player->InBattleground())
         return false;
@@ -482,15 +490,17 @@ bool MoveToClosestBattlegroundGraveyard(Player* player)
     if (!battleground)
         return false;
 
-    if (WorldSafeLocsEntry const* graveyard = battleground->GetClosestGraveyard(player))
+    Position destination;
+    if (!TryGetObjectivePosition(battleground, player, destination))
+        return false;
+
+    if (player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
     {
-        Position destination(graveyard->Loc.X, graveyard->Loc.Y, graveyard->Loc.Z, player->GetOrientation());
-        if (!player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))
-            IssueMovePointThrottled(player, destination, 6.0f, 2000);
+        EmitBattlegroundGmDebug(player, "objective-skip reason=already-near-objective range=12", 1000);
         return true;
     }
 
-    return false;
+    return IssueMovePointThrottled(player, destination);
 }
 
 bool IsLifecycleGateEnabled()
@@ -566,6 +576,8 @@ void ClearMovementBeforeBattlegroundTeleport(Player* player)
     if (!player)
         return;
 
+    g_PendingBattlegroundFallShortcutByGuid.erase(player->GetGUID().GetRawValue());
+
     player->AttackStop();
     player->SetSelection(ObjectGuid::Empty);
 
@@ -597,20 +609,47 @@ bool IsResolvingBattlegroundGravityFall(Player const* player)
 
 bool FinishCompletedBattlegroundGravityFall(Player* player)
 {
-    if (!IsResolvingBattlegroundGravityFall(player))
+    if (!player)
+        return false;
+
+    uint64 const botGuid = player->GetGUID().GetRawValue();
+    auto pendingItr = g_PendingBattlegroundFallShortcutByGuid.find(botGuid);
+    bool const hasPendingShortcut = pendingItr != g_PendingBattlegroundFallShortcutByGuid.end();
+
+    if (!IsResolvingBattlegroundGravityFall(player) && !hasPendingShortcut)
         return false;
 
     if (player->movespline && !player->movespline->Finalized())
         return false;
 
-    float groundZ = player->GetMapHeight(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), true, MAX_FALL_DISTANCE);
-    if (groundZ <= INVALID_HEIGHT || std::fabs(player->GetPositionZ() - groundZ) > 1.0f)
-        return false;
+    if (hasPendingShortcut)
+    {
+        Position landing = pendingItr->second.landing;
+        float landingZ = landing.GetPositionZ();
+        player->UpdateAllowedPositionZ(landing.GetPositionX(), landing.GetPositionY(), landingZ);
+        landing.Relocate(landing.GetPositionX(), landing.GetPositionY(), landingZ, landing.GetOrientation());
+
+        // Player MoveSpline finalization for virtual-session bots can leave the
+        // authoritative server position at the takeoff ledge while observers see
+        // the falling spline below. Commit the server position to the spline's
+        // landing point once the spline is done; otherwise the next movement tick
+        // starts from the graveyard again and appears as an endless fall/snap loop.
+        player->UpdatePosition(landing, true);
+        g_PendingBattlegroundFallShortcutByGuid.erase(pendingItr);
+    }
+    else
+    {
+        float groundZ = player->GetMapHeight(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), true, MAX_FALL_DISTANCE);
+        if (groundZ <= INVALID_HEIGHT || std::fabs(player->GetPositionZ() - groundZ) > 1.0f)
+            return false;
+    }
 
     player->RemoveUnitMovementFlag(MOVEMENTFLAG_FALLING);
     player->RemoveUnitMovementFlag(MOVEMENTFLAG_SPLINE_ENABLED);
     player->RemoveUnitMovementFlag(MOVEMENTFLAG_FORWARD);
     player->SetFallInformation(0, player->GetPositionZ());
+    if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
+        player->SendMovementFlagUpdate();
     return true;
 }
 
@@ -824,6 +863,56 @@ bool TryBuildBattlegroundFallShortcutDestination(Player* player, Position const&
     return false;
 }
 
+bool TryBuildBattlegroundGraveyardFallShortcutDestination(Player* player, Position const& destination, Position& fallDestination)
+{
+    if (!player || !player->InBattleground())
+        return false;
+
+    Battleground* battleground = player->GetBattleground();
+    if (!battleground)
+        return false;
+
+    WorldSafeLocsEntry const* graveyard = battleground->GetClosestGraveyard(player);
+    if (!graveyard)
+        return false;
+
+    float const graveyardDx = player->GetPositionX() - graveyard->Loc.X;
+    float const graveyardDy = player->GetPositionY() - graveyard->Loc.Y;
+    float const graveyardDistance2D = std::sqrt(graveyardDx * graveyardDx + graveyardDy * graveyardDy);
+    if (graveyardDistance2D > 80.0f || std::fabs(player->GetPositionZ() - graveyard->Loc.Z) > 35.0f)
+        return false;
+
+    float const destinationAngle = player->GetAbsoluteAngle(destination);
+    float const awayFromGraveyardAngle = graveyardDistance2D > 1.0f ? std::atan2(graveyardDy, graveyardDx) : destinationAngle;
+    std::array<float, 10> const probeAngles =
+    {
+        destinationAngle,
+        awayFromGraveyardAngle,
+        player->GetOrientation(),
+        awayFromGraveyardAngle + static_cast<float>(M_PI) * 0.25f,
+        awayFromGraveyardAngle - static_cast<float>(M_PI) * 0.25f,
+        awayFromGraveyardAngle + static_cast<float>(M_PI) * 0.5f,
+        awayFromGraveyardAngle - static_cast<float>(M_PI) * 0.5f,
+        awayFromGraveyardAngle + static_cast<float>(M_PI) * 0.75f,
+        awayFromGraveyardAngle - static_cast<float>(M_PI) * 0.75f,
+        awayFromGraveyardAngle + static_cast<float>(M_PI)
+    };
+
+    for (float angle : probeAngles)
+    {
+        Position probeDestination(
+            player->GetPositionX() + std::cos(angle) * 40.0f,
+            player->GetPositionY() + std::sin(angle) * 40.0f,
+            player->GetPositionZ(),
+            angle);
+
+        if (TryBuildBattlegroundFallShortcutDestination(player, probeDestination, fallDestination))
+            return true;
+    }
+
+    return false;
+}
+
 bool TryBuildBattlegroundSegmentDestination(Player* player, Position const& safeDestination, Position& segmentDestination, PathType* resolvedPathType = nullptr)
 {
     if (!player)
@@ -960,7 +1049,8 @@ bool TryIssueBattlegroundFallMovementInternal(Player* player, Position const& de
         return true;
 
     Position fallDestination;
-    if (!TryBuildBattlegroundFallShortcutDestination(player, destination, fallDestination))
+    if (!TryBuildBattlegroundFallShortcutDestination(player, destination, fallDestination) &&
+        !TryBuildBattlegroundGraveyardFallShortcutDestination(player, destination, fallDestination))
         return false;
 
     MotionMaster* motionMaster = player->GetMotionMaster();
@@ -976,6 +1066,7 @@ bool TryIssueBattlegroundFallMovementInternal(Player* player, Position const& de
     // snap back up and restart the fall repeatedly.
     player->AddUnitMovementFlag(MOVEMENTFLAG_FALLING);
     player->SetFallInformation(0, player->GetPositionZ());
+    g_PendingBattlegroundFallShortcutByGuid[player->GetGUID().GetRawValue()] = { fallDestination };
 
     motionMaster->LaunchMoveSpline([fallDestination](Movement::MoveSplineInit& init)
     {
@@ -1096,14 +1187,9 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     bool const generatePath = !player->IsFlying() && !player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
     Position const safeDestination = generatePath ? BuildCollisionSafeDestination(player, destination) : destination;
 
-    Position issuedDestination = safeDestination;
     if (generatePath && player->InBattleground())
     {
-        if (TryIssueBattlegroundFallMovementInternal(player, safeDestination, "move-point"))
-        {
-            issuedDestination = safeDestination;
-        }
-        else
+        if (!TryIssueBattlegroundFallMovementInternal(player, safeDestination, "move-point"))
         {
             Position segmentDestination;
             PathType pathType = PathType(0);
@@ -1115,7 +1201,6 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
             }
 
             motionMaster->MovePoint(0, segmentDestination, true);
-            issuedDestination = segmentDestination;
             EmitBattlegroundGmDebug(player,
                 "movepoint=nav-segment pathType=" + std::to_string(uint32(pathType)) +
                 " segDist=" + std::to_string(int32(player->GetDistance(segmentDestination))), 0);
@@ -1124,10 +1209,14 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
     else
     {
         motionMaster->MovePoint(0, safeDestination, generatePath);
-        issuedDestination = safeDestination;
     }
 
-    state.lastDestination = issuedDestination;
+    // Throttle against the caller's tactical destination, not the intermediate
+    // navmesh segment we just issued. Battleground segment walking intentionally
+    // advances in chunks; storing the chunk endpoint here made the next tick see
+    // the real objective as a different destination, clear the active spline,
+    // and reinstall a fresh segment before bots could make visible progress.
+    state.lastDestination = destination;
     state.lastIssueMs = nowMs;
     return true;
 }
@@ -2874,7 +2963,7 @@ bool BattlegroundLifecycleActions::HandleInProgressStatusPrimitive(Player* playe
     }
 
     // Reference module parity: in-progress movement/combat are handled by
-    // tactical actions (move to objective / check objective), not lifecycle.
+    // tactical actions (enemy pursuit / movement), not lifecycle.
     return false;
 }
 
@@ -2909,10 +2998,10 @@ bool BattlegroundTacticalActions::Execute(Player* player, BattlegroundTacticalCo
 
     if (IsTacticalAction(context.actionName, "bg move to start"))
         return MoveToStartPrimitive(player);
+    if (IsTacticalAction(context.actionName, "bg pursue enemy"))
+        return PursueEnemyPrimitive(player);
     if (IsTacticalAction(context.actionName, "bg move to objective"))
         return MoveToObjectivePrimitive(player, context);
-    if (IsTacticalAction(context.actionName, "bg check objective"))
-        return CheckObjectivePrimitive(player, context);
     if (IsTacticalAction(context.actionName, "bg reset objective force"))
         return ResetObjectiveForcePrimitive(player);
     if (IsTacticalAction(context.actionName, "bg use buff"))
@@ -3028,7 +3117,7 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
                 if (!withinObjectiveRange)
                     IssueMovePointThrottled(player, destination);
                 else
-                    EmitBattlegroundGmDebug(player, "objective-skip reason=already-near-objective range=12");
+                    EmitBattlegroundGmDebug(player, "objective-skip reason=already-near-objective range=12", 1000);
                 return true;
             }
 
@@ -3049,17 +3138,12 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     return false;
 }
 
-bool BattlegroundTacticalActions::CheckObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context)
+bool BattlegroundTacticalActions::PursueEnemyPrimitive(Player* player)
 {
-    (void)context;
-
     if (!player || !player->InBattleground())
         return false;
 
-    if (TryPursueNearestEnemyInBattleground(player))
-        return true;
-
-    return MoveToClosestBattlegroundGraveyard(player);
+    return TryPursueNearestEnemyInBattleground(player);
 }
 
 bool BattlegroundTacticalActions::ResetObjectiveForcePrimitive(Player* player)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.h
@@ -48,7 +48,7 @@ public:
 
     static bool MoveToStartPrimitive(Player* player);
     static bool MoveToObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context);
-    static bool CheckObjectivePrimitive(Player* player, BattlegroundTacticalContext const& context);
+    static bool PursueEnemyPrimitive(Player* player);
     static bool ResetObjectiveForcePrimitive(Player* player);
     static bool UseBuffPrimitive(Player* player);
     static bool AttackEnemyFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context);


### PR DESCRIPTION
### Motivation

- Prevent bots from getting stuck on graveyard ledges by allowing a battleground-specific fall shortcut when strict human-like movement would otherwise preserve a point generator on the ledge.
- Make battleground tactical behavior more aggressive by preferring enemy pursuit once a match is active instead of objective-checking.
- Replace specific "move to closest graveyard" semantics with a generic objective-position API and ensure falling splines finalize correctly for virtual sessions.

### Description

- Added guidance to `AGENTS.md` to avoid adding per-battleground movement special cases and prefer generic pathing fixes. 
- In `PlayerbotPvpClassActions.cpp` enabled early battleground fall shortcut checks inside `IssueStrictHumanMove` so strict human moves can trigger a real falling spline when appropriate.
- Introduced `PendingBattlegroundFallShortcut` and `g_PendingBattlegroundFallShortcutByGuid` to track pending fall landings and applied it when launching fall splines in `TryIssueBattlegroundFallMovementInternal`.
- Implemented `TryBuildBattlegroundGraveyardFallShortcutDestination` to probe around graveyards and reuse the existing fall-shortcut builder when applicable.
- Updated `FinishCompletedBattlegroundGravityFall` to handle pending shortcuts by committing the server position to the spline landing and to send movement flag updates for virtual sessions; retained legacy ground-height checks otherwise.
- Changed `IssueMovePointThrottled` to prefer issuing fall shortcuts first and to store `state.lastDestination` as the caller's tactical destination (not the intermediate segment endpoint), avoiding premature re-issuance of nav segments.
- Replaced `MoveToClosestBattlegroundGraveyard` with `MoveToBattlegroundObjectivePosition` and added a `TryGetObjectivePosition` declaration to enable objective-based movement; used `IssueMovePointThrottled` to issue movement toward objectives.
- Switched tactical decision/action mapping from `bg check objective` to `bg pursue enemy` in `SelectBattlegroundTacticalDecision` and wired up `PursueEnemyPrimitive` in tactical action dispatch; removed the old `CheckObjectivePrimitive` in favor of the pursue behavior.
- Minor logging/throttle and flow adjustments to keep behavior consistent during prep and in SCM battlegrounds.

### Testing

- Performed a full server build to validate compilation after the changes and the build succeeded.  
- Ran the existing automated playerbot/PvP unit tests and integration smoke checks available in CI and they passed without regressions.  
- Verified that fall-spline launch and finalization code paths execute and clear pending shortcut state in local integration runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d2c465e08327bd097c02c6d0eda1)