### PR TITLE
Add Hurricane movement aura support (89760)

### DIFF
--- a/sql/custom/world/2026_05_11_00_world_hurricane_walk.sql
+++ b/sql/custom/world/2026_05_11_00_world_hurricane_walk.sql
@@ -1,0 +1,4 @@
+-- Flag the custom Hurricane movement aura with the snare-enabled Hurricane channeling attribute.
+INSERT INTO `spell_custom_attr` (`entry`, `attributes`) VALUES
+(89760, 0x04000000)
+ON DUPLICATE KEY UPDATE `attributes` = `attributes` | VALUES(`attributes`);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3410,6 +3410,11 @@ bool Unit::IsMovementPreventedByCasting() const
             if (spell->GetSpellInfo()->IsStarfire())
                 return false;
 
+    if (GetHurricaneSnareSpeedRate() > 0.0f)
+        if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
+            if (spell->GetSpellInfo()->IsHurricane())
+                return false;
+
     // prohibit movement for all other spell casts
     return true;
 }
@@ -4336,7 +4341,11 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
         if (spell->getState() == SPELL_STATE_CASTING
             && (spell->m_spellInfo->ChannelInterruptFlags & flag)
             && spell->m_spellInfo->Id != except)
-            InterruptNonMeleeSpells(false);
+        {
+            bool const hurricaneMovementAllowed = (flag & AURA_INTERRUPT_FLAG_MOVE) && spell->m_spellInfo->IsHurricane() && GetHurricaneSnareSpeedRate() > 0.0f;
+            if (!hurricaneMovementAllowed)
+                InterruptNonMeleeSpells(false);
+        }
 
     UpdateInterruptMask();
 }
@@ -4940,6 +4949,47 @@ float Unit::GetStarfireSnareSpeedRate() const
         }
 
         if (!spellInfo->HasAttribute(SPELL_ATTR0_CU_ALLOW_STARFIRE_SNARE_CAST))
+            continue;
+
+        for (uint8 effIndex = EFFECT_0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+        {
+            if (AuraEffect const* auraEffect = aura->GetEffect(effIndex))
+            {
+                int32 const amount = auraEffect->GetAmount();
+                if (amount <= 0)
+                    continue;
+
+                float const rate = std::clamp(static_cast<float>(amount) / 100.0f, 0.0f, 1.0f);
+                if (rate > bestRate)
+                    bestRate = rate;
+            }
+        }
+    }
+
+    return bestRate;
+}
+
+float Unit::GetHurricaneSnareSpeedRate() const
+{
+    float bestRate = 0.0f;
+
+    for (AuraApplicationMap::const_iterator iter = m_appliedAuras.begin(); iter != m_appliedAuras.end(); ++iter)
+    {
+        Aura const* aura = iter->second->GetBase();
+        SpellInfo const* spellInfo = aura->GetSpellInfo();
+        if (!spellInfo)
+            continue;
+
+        float const spellDefinedRate = spellInfo->GetHurricaneSnareSpeedRate();
+        if (spellDefinedRate > 0.0f)
+        {
+            if (spellDefinedRate > bestRate)
+                bestRate = spellDefinedRate;
+
+            continue;
+        }
+
+        if (!spellInfo->HasAttribute(SPELL_ATTR0_CU_ALLOW_HURRICANE_SNARE_CAST))
             continue;
 
         for (uint8 effIndex = EFFECT_0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1426,6 +1426,7 @@ class TC_GAME_API Unit : public WorldObject
         bool HasNegativeAuraWithInterruptFlag(uint32 flag, ObjectGuid guid = ObjectGuid::Empty) const;
         bool HasAuraWithMechanic(uint32 mechanicMask) const;
         float GetStarfireSnareSpeedRate() const;
+        float GetHurricaneSnareSpeedRate() const;
         bool HasStrongerAuraWithDR(SpellInfo const* auraSpellInfo, Unit* caster, bool triggered) const;
 
         AuraEffect* IsScriptOverriden(SpellInfo const* spell, int32 script) const;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3311,13 +3311,20 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
         m_casttime = m_spellInfo->CalcCastTime(this);
 
     bool const isStarfire = m_spellInfo->IsStarfire();
-    float starfireSnareSpeedRate = 0.0f;
-    if (playerCaster && m_casttime && isStarfire)
-        starfireSnareSpeedRate = playerCaster->GetStarfireSnareSpeedRate();
+    bool const isHurricane = m_spellInfo->IsHurricane();
+    float movementSnareSpeedRate = 0.0f;
+    if (playerCaster)
+    {
+        if (m_casttime && isStarfire)
+            movementSnareSpeedRate = playerCaster->GetStarfireSnareSpeedRate();
+        else if (isHurricane)
+            movementSnareSpeedRate = playerCaster->GetHurricaneSnareSpeedRate();
+    }
 
-    bool const starfireMovementAllowed = isStarfire && starfireSnareSpeedRate > 0.0f;
-    bool const needsStarfireMovementInterrupt = isStarfire && !starfireMovementAllowed;
-    bool const requiresMovementInterrupt = (m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT) || needsStarfireMovementInterrupt;
+    bool const snareMovementAllowed = ((isStarfire && m_casttime) || isHurricane) && movementSnareSpeedRate > 0.0f;
+    bool const needsStarfireMovementInterrupt = isStarfire && !snareMovementAllowed;
+    bool const needsHurricaneMovementInterrupt = isHurricane && !snareMovementAllowed;
+    bool const requiresMovementInterrupt = (m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT) || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt;
 
     // don't allow channeled spells / spells with cast time to be cast while moving
     // exception are only channeled spells that have no casttime and SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING
@@ -3327,7 +3334,7 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
         // 1. Has casttime, 2. Or doesn't have flag to allow movement during channel
         if (m_casttime || !m_spellInfo->IsMoveAllowedChannel())
         {
-            if (!starfireMovementAllowed)
+            if (!snareMovementAllowed)
             {
                 SendCastResult(SPELL_FAILED_MOVING);
                 finish(false);
@@ -3336,9 +3343,9 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
         }
     }
 
-    if (starfireSnareSpeedRate > 0.0f && playerCaster)
+    if (movementSnareSpeedRate > 0.0f && playerCaster)
     {
-        if (playerCaster->AddStarfireSnareRef(starfireSnareSpeedRate))
+        if (playerCaster->AddStarfireSnareRef(movementSnareSpeedRate))
             m_resetStarfireSnareAfterCast = true;
     }
 
@@ -3996,12 +4003,14 @@ void Spell::update(uint32 difftime)
         Player* playerCaster = m_caster->ToPlayer();
         bool const playerMoved = playerCaster->isMoving();
         bool const isStarfire = m_spellInfo->IsStarfire();
-        bool const starfireMovementAllowed = isStarfire && playerCaster->GetStarfireSnareSpeedRate() > 0.0f;
-        bool const needsStarfireMovementInterrupt = isStarfire && !starfireMovementAllowed;
+        bool const isHurricane = m_spellInfo->IsHurricane();
+        bool const snareMovementAllowed = (isStarfire && playerCaster->GetStarfireSnareSpeedRate() > 0.0f) || (isHurricane && playerCaster->GetHurricaneSnareSpeedRate() > 0.0f);
+        bool const needsStarfireMovementInterrupt = isStarfire && !snareMovementAllowed;
+        bool const needsHurricaneMovementInterrupt = isHurricane && !snareMovementAllowed;
         bool const hasMovementInterruptFlag = m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT;
 
-        if (playerMoved && !starfireMovementAllowed &&
-            (hasMovementInterruptFlag || needsStarfireMovementInterrupt) &&
+        if (playerMoved && !snareMovementAllowed &&
+            (hasMovementInterruptFlag || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt) &&
             (!m_spellInfo->HasEffect(SPELL_EFFECT_STUCK) || !playerCaster->HasUnitMovementFlag(MOVEMENTFLAG_FALLING_FAR)))
         {
             // don't cancel for melee, autorepeat, triggered and instant spells
@@ -7573,7 +7582,8 @@ void Spell::Delayed() // only called in DealDamage()
     // spells not losing casting time
     bool const hasPushbackInterruptFlag = m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_PUSH_BACK;
     bool const needsStarfirePushbackInterrupt = m_spellInfo->IsStarfire() && playerCaster->GetStarfireSnareSpeedRate() <= 0.0f;
-    if (!hasPushbackInterruptFlag && !needsStarfirePushbackInterrupt)
+    bool const needsHurricanePushbackInterrupt = m_spellInfo->IsHurricane() && playerCaster->GetHurricaneSnareSpeedRate() <= 0.0f;
+    if (!hasPushbackInterruptFlag && !needsStarfirePushbackInterrupt && !needsHurricanePushbackInterrupt)
         return;
 
     //check pushback reduce

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1251,6 +1251,12 @@ bool SpellInfo::IsStarfire() const
     return SpellFamilyName == SPELLFAMILY_DRUID && (SpellFamilyFlags[0] & 0x00000004);
 }
 
+bool SpellInfo::IsHurricane() const
+{
+    SpellInfo const* firstRankSpellInfo = GetFirstRankSpell();
+    return firstRankSpellInfo && firstRankSpellInfo->Id == 16914;
+}
+
 bool SpellInfo::IsMindVision() const
 {
     return Id == 2096 || Id == 10909;
@@ -1270,6 +1276,19 @@ float SpellInfo::GetStarfireSnareSpeedRate() const
             return 0.20f;
         case 16862: // Rank 5
             return 0.25f;
+        default:
+            break;
+    }
+
+    return 0.0f;
+}
+
+float SpellInfo::GetHurricaneSnareSpeedRate() const
+{
+    switch (Id)
+    {
+        case 89760: // Custom Hurricane walk-while-channeling aura
+            return 0.10f;
         default:
             break;
     }

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -168,6 +168,7 @@ enum SpellCustomAttributes
     SPELL_ATTR0_CU_IS_TALENT                     = 0x00800000, // reserved for master branch
     SPELL_ATTR0_CU_AURA_CANNOT_BE_SAVED          = 0x01000000,
     SPELL_ATTR0_CU_ALLOW_STARFIRE_SNARE_CAST     = 0x02000000,
+    SPELL_ATTR0_CU_ALLOW_HURRICANE_SNARE_CAST    = 0x04000000,
 
     SPELL_ATTR0_CU_NEGATIVE                      = SPELL_ATTR0_CU_NEGATIVE_EFF0 | SPELL_ATTR0_CU_NEGATIVE_EFF1 | SPELL_ATTR0_CU_NEGATIVE_EFF2
 };
@@ -418,8 +419,10 @@ class TC_GAME_API SpellInfo
         bool IsChanneled() const;
         bool IsMoveAllowedChannel() const;
         bool IsStarfire() const;
+        bool IsHurricane() const;
         bool IsMindVision() const;
         float GetStarfireSnareSpeedRate() const;
+        float GetHurricaneSnareSpeedRate() const;
         bool NeedsComboPoints() const;
         bool IsNextMeleeSwingSpell() const;
         bool IsBreakingStealth() const;


### PR DESCRIPTION
### Motivation
- Provide a custom aura (similar to Feral Aggression / Starfire support) that allows Druids to move while channeling `Hurricane`, capping movement to 10% when the aura is active (spell id `89760`).

### Description
- Add a new custom spell attribute `SPELL_ATTR0_CU_ALLOW_HURRICANE_SNARE_CAST` and expose `SpellInfo::IsHurricane()` / `GetHurricaneSnareSpeedRate()` to detect Hurricane and return `0.10f` for aura `89760`.
- Extend `Spell::prepare`, `Spell::update` and `Spell::Delayed` logic to treat Hurricane similarly to Starfire for movement-interrupt checks and to apply the movement-snare reference when appropriate (`AddStarfireSnareRef` reused for the clamp).
- Add `Unit::GetHurricaneSnareSpeedRate()` and wire checks into `Unit::IsMovementPreventedByCasting()` so an active Hurricane channel with the custom aura allows movement; update `Unit::RemoveAurasWithInterruptFlags()` to avoid interrupting Hurricane channels when the custom hurricane snare is present.
- Add SQL file `sql/custom/world/2026_05_11_00_world_hurricane_walk.sql` to flag spell `89760` with the new custom attribute so it can be used without code-only configuration.

### Testing
- Ran translation-unit syntax checks (`-fsyntax-only`) for the modified files; no syntax errors reported.
- Built the modified objects with `ninja` for `Spell.cpp`, `SpellInfo.cpp` and `Unit.cpp`; targeted object compilation completed successfully.
- Started a full `cmake --build ... worldserver` build to exercise integration; it progressed into game sources but was interrupted due to runtime constraints (partial build progress observed before interruption).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0254d52b648327a23287530c4b05d5)