### PR TITLE
Reduce turn rate during Ice Fang Sprint

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -87,6 +87,20 @@
 namespace
 {
 static uint32 constexpr SPELL_SHAMAN_GHOST_WOLF = 2645;
+static uint32 constexpr SPELL_ICE_FANG_SPRINT = 89768;
+static float constexpr ICE_FANG_SPRINT_TURN_SPEED = 0.7f;
+
+bool IsRogueSprintSpell(SpellInfo const* spellInfo)
+{
+    return spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE
+        && (spellInfo->SpellFamilyFlags[0] & 0x40)
+        && spellInfo->GetCategory() == 44;
+}
+
+bool IsIceFangSprintTurnRateAura(SpellInfo const* spellInfo)
+{
+    return spellInfo->Id == SPELL_ICE_FANG_SPRINT || IsRogueSprintSpell(spellInfo);
+}
 }
 
 float baseMoveSpeed[MAX_MOVE_TYPE] =
@@ -3712,6 +3726,9 @@ void Unit::_ApplyAura(AuraApplication* aurApp, uint8 effMask)
             aurApp->_HandleEffect(i, true);
     }
 
+    if (IsIceFangSprintTurnRateAura(aura->GetSpellInfo()))
+        UpdateIceFangSprintTurnRate();
+
     if (Player* player = ToPlayer())
         if (sConditionMgr->IsSpellUsedInSpellClickConditions(aurApp->GetBase()->GetId()))
             player->UpdateVisibleGameobjectsOrSpellClicks();
@@ -3802,6 +3819,9 @@ void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMo
     aura->HandleAuraSpecificMods(aurApp, caster, false, false);
 
     aura->LogHeartbeatRemoval(this, removeMode);
+
+    if (IsIceFangSprintTurnRateAura(aura->GetSpellInfo()))
+        UpdateIceFangSprintTurnRate();
 
     if (Player* player = ToPlayer())
         if (sConditionMgr->IsSpellUsedInSpellClickConditions(aurApp->GetBase()->GetId()))
@@ -9141,6 +9161,34 @@ float Unit::GetSpeed(UnitMoveType mtype) const
 void Unit::SetSpeed(UnitMoveType mtype, float newValue)
 {
     SetSpeedRate(mtype, newValue / (IsControlledByPlayer() ? playerBaseMoveSpeed[mtype] : baseMoveSpeed[mtype]));
+}
+
+void Unit::UpdateIceFangSprintTurnRate()
+{
+    bool hasIceFangSprint = false;
+    bool hasRogueSprint = false;
+
+    for (AuraApplicationMap::value_type const& appliedAura : m_appliedAuras)
+    {
+        SpellInfo const* spellInfo = appliedAura.second->GetBase()->GetSpellInfo();
+        if (spellInfo->Id == SPELL_ICE_FANG_SPRINT)
+        {
+            hasIceFangSprint = true;
+            if (hasRogueSprint)
+                break;
+        }
+        else if (IsRogueSprintSpell(spellInfo))
+        {
+            hasRogueSprint = true;
+            if (hasIceFangSprint)
+                break;
+        }
+    }
+
+    if (hasIceFangSprint && hasRogueSprint)
+        SetSpeed(MOVE_TURN_RATE, ICE_FANG_SPRINT_TURN_SPEED);
+    else
+        SetSpeedRate(MOVE_TURN_RATE, 1.0f);
 }
 
 void Unit::SetSpeedRate(UnitMoveType mtype, float rate)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1672,6 +1672,7 @@ class TC_GAME_API Unit : public WorldObject
         void SetSpeed(UnitMoveType mtype, float newValue);
         void SetSpeedRate(UnitMoveType mtype, float rate);
     private:
+        void UpdateIceFangSprintTurnRate();
         void SetSpeedRateReal(UnitMoveType mtype, float rate);
 
     public:


### PR DESCRIPTION
### Motivation
- When a player has aura `89768` (Ice Fang Sprint) and then gains Sprint, their turning becomes vehicle-like and should be reduced while both effects are present.

### Description
- Add constants and detection helpers for Ice Fang Sprint (`SPELL_ICE_FANG_SPRINT = 89768`) and Rogue Sprint-family auras and a target turn rate `ICE_FANG_SPRINT_TURN_SPEED = 0.7f` in `Unit.cpp`.
- Invoke a new update on aura application and removal by calling `UpdateIceFangSprintTurnRate()` from `Unit::_ApplyAura` and `Unit::_UnapplyAura` when a relevant aura is changed.
- Implement `Unit::UpdateIceFangSprintTurnRate()` to scan `m_appliedAuras` and set `MOVE_TURN_RATE` to `0.7` using `SetSpeed` while both Ice Fang Sprint and a Sprint-family aura are active, and restore normal turn behavior with `SetSpeedRate(..., 1.0f)` otherwise.
- Declare the new helper as a private method in `Unit.h` to keep the change encapsulated within the `Unit` class.

### Testing
- Built the unit changes with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/Unit/Unit.cpp.o` and the compilation step completed successfully.
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02705e5afc8327ab44bcec863f32e2)