### PR TITLE
Lock Ice Fang Sprint turning

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -90,16 +90,9 @@ static uint32 constexpr SPELL_SHAMAN_GHOST_WOLF = 2645;
 static uint32 constexpr SPELL_ICE_FANG_SPRINT = 89768;
 static float constexpr ICE_FANG_SPRINT_TURN_SPEED = 0;
 
-bool IsRogueSprintSpell(SpellInfo const* spellInfo)
-{
-    return spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE
-        && (spellInfo->SpellFamilyFlags[0] & 0x40)
-        && spellInfo->GetCategory() == 44;
-}
-
 bool IsIceFangSprintTurnRateAura(SpellInfo const* spellInfo)
 {
-    return spellInfo->Id == SPELL_ICE_FANG_SPRINT || IsRogueSprintSpell(spellInfo);
+    return spellInfo->Id == SPELL_ICE_FANG_SPRINT;
 }
 }
 
@@ -9158,6 +9151,11 @@ float Unit::GetSpeed(UnitMoveType mtype) const
     return m_speed_rate[mtype]*(IsControlledByPlayer() ? playerBaseMoveSpeed[mtype] : baseMoveSpeed[mtype]);
 }
 
+bool Unit::IsIceFangSprintTurnLocked() const
+{
+    return HasAura(SPELL_ICE_FANG_SPRINT);
+}
+
 void Unit::SetSpeed(UnitMoveType mtype, float newValue)
 {
     SetSpeedRate(mtype, newValue / (IsControlledByPlayer() ? playerBaseMoveSpeed[mtype] : baseMoveSpeed[mtype]));
@@ -9165,27 +9163,7 @@ void Unit::SetSpeed(UnitMoveType mtype, float newValue)
 
 void Unit::UpdateIceFangSprintTurnRate()
 {
-    bool hasIceFangSprint = false;
-    bool hasRogueSprint = false;
-
-    for (AuraApplicationMap::value_type const& appliedAura : m_appliedAuras)
-    {
-        SpellInfo const* spellInfo = appliedAura.second->GetBase()->GetSpellInfo();
-        if (spellInfo->Id == SPELL_ICE_FANG_SPRINT)
-        {
-            hasIceFangSprint = true;
-            if (hasRogueSprint)
-                break;
-        }
-        else if (IsRogueSprintSpell(spellInfo))
-        {
-            hasRogueSprint = true;
-            if (hasIceFangSprint)
-                break;
-        }
-    }
-
-    if (hasIceFangSprint && hasRogueSprint)
+    if (IsIceFangSprintTurnLocked())
         SetSpeed(MOVE_TURN_RATE, ICE_FANG_SPRINT_TURN_SPEED);
     else
         SetSpeedRate(MOVE_TURN_RATE, 1.0f);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1671,6 +1671,7 @@ class TC_GAME_API Unit : public WorldObject
         float GetSpeedRate(UnitMoveType mtype) const { return m_speed_rate[mtype]; }
         void SetSpeed(UnitMoveType mtype, float newValue);
         void SetSpeedRate(UnitMoveType mtype, float rate);
+        bool IsIceFangSprintTurnLocked() const;
     private:
         void UpdateIceFangSprintTurnRate();
         void SetSpeedRateReal(UnitMoveType mtype, float rate);

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -377,6 +377,12 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
     if (!mover->movespline->Finalized())
         return;
 
+    if (mover->IsIceFangSprintTurnLocked())
+    {
+        movementInfo.pos.SetOrientation(mover->GetOrientation());
+        movementInfo.RemoveMovementFlag(MOVEMENTFLAG_MASK_TURNING);
+    }
+
     /* handle special cases */
     if (movementInfo.HasMovementFlag(MOVEMENTFLAG_ONTRANSPORT))
     {


### PR DESCRIPTION
### Motivation
- Players could still change facing while Ice Fang Sprint was active because the turn-lock required Rogue Sprint to coexist; the intent is to make the Ice Fang Sprint aura itself enforce a zero turn-rate lock and prevent client-side turning from persisting server-side.

### Description
- Make the Ice Fang Sprint check require only `SPELL_ICE_FANG_SPRINT` (id `89768`) and remove the previous dependency on rogue Sprint detection in `Unit.cpp` by simplifying `IsIceFangSprintTurnRateAura` and `UpdateIceFangSprintTurnRate`.
- Add `Unit::IsIceFangSprintTurnLocked()` as a reusable helper that returns whether the unit has the Ice Fang Sprint aura in `Unit.h`/`Unit.cpp`.
- In `WorldSession::HandleMovementOpcodes` (`MovementHandler.cpp`) clamp incoming movement packet orientation to the server-side orientation and strip turn flags when the Ice Fang Sprint lock is active so client-side facing changes are discarded.
- Minor header/API update: expose `IsIceFangSprintTurnLocked()` in `Unit` public API.

### Testing
- Ran `git diff --check` with no reported issues.
- Built the `game` target with `cmake --build build --target game -- -j2`, which completed successfully (compiler emitted existing/warnings but the build finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0277940d2c8327a8a004582a45fce3)