### PR TITLE
Add inner-auras for specified outer auras (polearm/staff only) and melee-range bonus handling

### DIFF
--- a/sql/updates/world/3.3.5/2026_05_12_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_05_12_00_world.sql
@@ -1,0 +1,15 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (12165, 12830, 12831, 12832, 12833) AND `ScriptName`='spell_polearm_staff_outer_aura';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(12165, 'spell_polearm_staff_outer_aura'),
+(12830, 'spell_polearm_staff_outer_aura'),
+(12831, 'spell_polearm_staff_outer_aura'),
+(12832, 'spell_polearm_staff_outer_aura'),
+(12833, 'spell_polearm_staff_outer_aura');
+
+DELETE FROM `spell_dbc` WHERE `Id` IN (89769, 89770, 89771, 89772, 89773);
+INSERT INTO `spell_dbc` (`Id`, `DurationIndex`, `Effect1`, `EffectImplicitTargetA1`, `EffectApplyAuraName1`, `EffectBasePoints1`, `SpellName`) VALUES
+(89769, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 1'),
+(89770, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 2'),
+(89771, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 3'),
+(89772, 21, 6, 1, 4, 1, 'Polearm/Staff Inner Aura - Melee Range 1'),
+(89773, 21, 6, 1, 4, 2, 'Polearm/Staff Inner Aura - Melee Range 2');

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -134,6 +134,11 @@ namespace HiddenSets
     void OnEquipmentChanged(Player* player);
 }
 
+namespace PolearmStaffInnerAuras
+{
+    void OnEquipmentChanged(Player* player);
+}
+
 namespace
 {
     bool IsBattlegroundEquipChangeAllowed(Player const* player, uint8 slot)
@@ -12697,7 +12702,10 @@ Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
         ApplyEquipCooldown(pItem2);
 
         if (bag == INVENTORY_SLOT_BAG_0 && slot < EQUIPMENT_SLOT_END)
+        {
             HiddenSets::OnEquipmentChanged(this);
+            PolearmStaffInnerAuras::OnEquipmentChanged(this);
+        }
 
         return pItem2;
     }
@@ -12710,7 +12718,10 @@ Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
     UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM, slot, pItem->GetEntry());
 
     if (bag == INVENTORY_SLOT_BAG_0 && slot < EQUIPMENT_SLOT_END)
+    {
         HiddenSets::OnEquipmentChanged(this);
+        PolearmStaffInnerAuras::OnEquipmentChanged(this);
+    }
 
     return pItem;
 }
@@ -12738,7 +12749,10 @@ void Player::QuickEquipItem(uint16 pos, Item* pItem)
         UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_EQUIP_EPIC_ITEM, slot, pItem->GetEntry());
 
         if (slot < EQUIPMENT_SLOT_END)
+        {
             HiddenSets::OnEquipmentChanged(this);
+            PolearmStaffInnerAuras::OnEquipmentChanged(this);
+        }
     }
 }
 
@@ -12860,6 +12874,7 @@ void Player::RemoveItem(uint8 bag, uint8 slot, bool update)
                     CheckTitanGripPenalty();
 
                 HiddenSets::OnEquipmentChanged(this);
+                PolearmStaffInnerAuras::OnEquipmentChanged(this);
             }
         }
         else if (Bag* pBag = GetBagByPos(bag))
@@ -12990,6 +13005,7 @@ void Player::DestroyItem(uint8 bag, uint8 slot, bool update)
                 SetVisibleItemSlot(slot, nullptr);
 
                 HiddenSets::OnEquipmentChanged(this);
+                PolearmStaffInnerAuras::OnEquipmentChanged(this);
             }
 
             m_items[slot] = nullptr;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -695,8 +695,15 @@ bool Unit::IsWithinMeleeRangeAt(Position const& pos, Unit const* obj) const
 
 float Unit::GetMeleeRange(Unit const* target) const
 {
-    float range = GetCombatReach() + target->GetCombatReach() + 4.0f / 3.0f;
-    return std::max(range, NOMINAL_MELEE_RANGE);
+    float range = std::max(GetCombatReach() + target->GetCombatReach() + 4.0f / 3.0f, NOMINAL_MELEE_RANGE);
+
+    if (AuraEffect const* auraEffect = GetAuraEffect(89772, EFFECT_0))
+        range += auraEffect->GetAmount();
+
+    if (AuraEffect const* auraEffect = GetAuraEffect(89773, EFFECT_0))
+        range += auraEffect->GetAmount();
+
+    return range;
 }
 
 AuraApplication* Unit::GetVisibleAura(uint8 slot) const

--- a/src/server/scripts/Custom/custom_polearm_staff_inner_auras.cpp
+++ b/src/server/scripts/Custom/custom_polearm_staff_inner_auras.cpp
@@ -1,0 +1,150 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Item.h"
+#include "ItemTemplate.h"
+#include "Player.h"
+#include "ScriptMgr.h"
+#include "SpellScript.h"
+
+namespace PolearmStaffInnerAuras
+{
+namespace
+{
+struct AuraMapping
+{
+    uint32 OuterSpellId;
+    uint32 InnerSpellId;
+};
+
+constexpr AuraMapping AuraMappings[] =
+{
+    { 12165, 89769 },
+    { 12830, 89770 },
+    { 12831, 89771 },
+    { 12832, 89772 },
+    { 12833, 89773 }
+};
+
+bool IsPolearmOrStaffEquipped(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Item const* weapon = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+    if (!weapon)
+        return false;
+
+    ItemTemplate const* weaponTemplate = weapon->GetTemplate();
+    if (!weaponTemplate || weaponTemplate->Class != ITEM_CLASS_WEAPON)
+        return false;
+
+    return weaponTemplate->SubClass == ITEM_SUBCLASS_WEAPON_POLEARM || weaponTemplate->SubClass == ITEM_SUBCLASS_WEAPON_STAFF;
+}
+
+uint32 GetInnerSpellForOuter(uint32 outerSpellId)
+{
+    for (AuraMapping const& mapping : AuraMappings)
+        if (mapping.OuterSpellId == outerSpellId)
+            return mapping.InnerSpellId;
+
+    return 0;
+}
+
+bool ShouldHaveInnerAura(Player const* player, AuraMapping const& mapping)
+{
+    return player->HasAura(mapping.OuterSpellId) && IsPolearmOrStaffEquipped(player);
+}
+}
+
+void Sync(Player* player)
+{
+    if (!player)
+        return;
+
+    for (AuraMapping const& mapping : AuraMappings)
+    {
+        bool const shouldHaveInnerAura = ShouldHaveInnerAura(player, mapping);
+        bool const hasInnerAura = player->HasAura(mapping.InnerSpellId);
+
+        if (shouldHaveInnerAura)
+        {
+            if (!hasInnerAura)
+                player->CastSpell(player, mapping.InnerSpellId, true);
+        }
+        else if (hasInnerAura)
+            player->RemoveAurasDueToSpell(mapping.InnerSpellId);
+    }
+}
+
+void OnEquipmentChanged(Player* player)
+{
+    Sync(player);
+}
+}
+
+class spell_polearm_staff_outer_aura : public AuraScript
+{
+    PrepareAuraScript(spell_polearm_staff_outer_aura);
+
+    void HandleApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        if (Player* player = GetTarget() ? GetTarget()->ToPlayer() : nullptr)
+            PolearmStaffInnerAuras::Sync(player);
+    }
+
+    void HandleRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        if (Player* player = GetTarget() ? GetTarget()->ToPlayer() : nullptr)
+            if (uint32 innerSpellId = PolearmStaffInnerAuras::GetInnerSpellForOuter(GetSpellInfo()->Id))
+                player->RemoveAurasDueToSpell(innerSpellId);
+    }
+
+    void Register() override
+    {
+        AfterEffectApply += AuraEffectApplyFn(spell_polearm_staff_outer_aura::HandleApply, EFFECT_FIRST_FOUND, SPELL_AURA_ANY, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_polearm_staff_outer_aura::HandleRemove, EFFECT_FIRST_FOUND, SPELL_AURA_ANY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
+class spell_polearm_staff_outer_aura_loader : public SpellScriptLoader
+{
+public:
+    spell_polearm_staff_outer_aura_loader() : SpellScriptLoader("spell_polearm_staff_outer_aura") { }
+
+    AuraScript* GetAuraScript() const override
+    {
+        return new spell_polearm_staff_outer_aura();
+    }
+};
+
+class polearm_staff_inner_aura_player : public PlayerScript
+{
+public:
+    polearm_staff_inner_aura_player() : PlayerScript("polearm_staff_inner_aura_player") { }
+
+    void OnLogin(Player* player, bool /*firstLogin*/) override
+    {
+        PolearmStaffInnerAuras::Sync(player);
+    }
+};
+
+void AddSC_custom_polearm_staff_inner_auras()
+{
+    new spell_polearm_staff_outer_aura_loader();
+    new polearm_staff_inner_aura_player();
+}

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -28,6 +28,7 @@ void AddSC_mod_pvp_titles();
 void AddSC_custom_diremaul_beads();
 void AddSC_custom_gurubashi_arena();
 void AddSC_custom_depleted_mark_exchange();
+void AddSC_custom_polearm_staff_inner_auras();
 void AddSC_custom_pvpve_dungeon();
 void AddSC_npc_scarlet_chapel_queue();
 void AddSC_npc_account_banker();
@@ -42,6 +43,7 @@ void AddCustomScripts()
     AddSC_custom_diremaul_beads();
     AddSC_custom_gurubashi_arena();
     AddSC_custom_depleted_mark_exchange();
+    AddSC_custom_polearm_staff_inner_auras();
     AddSC_custom_pvpve_dungeon();
     AddSC_npc_scarlet_chapel_queue();
     AddSC_npc_account_banker();


### PR DESCRIPTION
### Motivation
- Map the provided outer aura spell IDs (12165, 12830, 12831, 12832, 12833) to a set of internal "inner" auras so extra effects can be applied only while the outer aura is present and the player wields a polearm or staff.
- Ensure the two inner auras that change melee range apply their configured base points (+1 and +2 yards) to melee distance calculations and are removed when conditions are not met.

### Description
- Added a new script `src/server/scripts/Custom/custom_polearm_staff_inner_auras.cpp` that defines mappings:
  - `12165 -> 89769`, `12830 -> 89770`, `12831 -> 89771`, `12832 -> 89772`, `12833 -> 89773`, and implements `Sync` logic to `CastSpell` the inner aura when the outer aura is present and the player has a polearm or staff equipped, and to remove the inner aura when not.
- Hooked the script into the server by registering `AddSC_custom_polearm_staff_inner_auras()` from `src/server/scripts/Custom/custom_script_loader.cpp`.
- Called `PolearmStaffInnerAuras::OnEquipmentChanged` from equipment change points in `src/server/game/Entities/Player/Player.cpp` so inner auras are updated on equip/unequip and visible-item changes.
- Modified melee range calculation in `src/server/game/Entities/Unit/Unit.cpp::GetMeleeRange` to include the amounts from inner-aura spells `89772` and `89773` (these auras increase melee range by their BasePoints), so the extra yard(s) are applied automatically.
- Added an update SQL file `sql/updates/world/3.3.5/2026_05_12_00_world.sql` that binds the outer spell IDs to the new script (`spell_script_names` entries) and inserts `spell_dbc` entries for the inner spells `89769..89773` with `EffectBasePoints` set for `89772` (1) and `89773` (2) to represent the +1 and +2 yard bonuses.
- The `AuraScript` implementation runs `Sync` on outer aura apply and removes the mapped inner aura on outer aura removal to ensure inner auras do not persist when the outer aura is gone.

### Testing
- Ran a local build attempt of the `worldserver` via `cmake --build build --target worldserver -j2`; the build was started and compilation progressed (many objects compiled) during the session, but the run did not produce a captured final success message before the session output was truncated.  No automated test suite was executed beyond the build attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b424beb88327bc3f7040e32e029c)