### PR TITLE
Reset auras when running spells_keep_mounts and rebuild gear/talent auras

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23817,6 +23817,12 @@ void Player::ResetNonQuestAndMountSpells()
     if (HasAtLoginFlag(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS))
         RemoveAtLoginFlag(AT_LOGIN_RESET_SPELLS_KEEP_MOUNTS, true);
 
+    // Strip currently applied equipment state before clearing all auras so the
+    // equipment pass below can rebuild only the auras and bonuses the character
+    // should still have after the spell/talent reset.
+    _RemoveAllItemMods();
+    RemoveAllAuras();
+
     PlayerSpellMap spells = GetSpellMap();
     std::unordered_set<uint32> mountSpells;
     std::unordered_set<uint32> customSpells;
@@ -23889,6 +23895,25 @@ void Player::ResetNonQuestAndMountSpells()
     SetActiveSpec(activeSpec);
     m_usedTalentCount = 0;
     SetFreeTalentPoints(CalculateTalentsPoints());
+
+    _ApplyAllItemMods();
+
+    PlayerSpellMap rebuiltSpells = GetSpellMap();
+    for (PlayerSpellMap::const_iterator itr = rebuiltSpells.begin(); itr != rebuiltSpells.end(); ++itr)
+    {
+        if (itr->second.state == PLAYERSPELL_REMOVED || itr->second.disabled || !itr->second.active)
+            continue;
+
+        if (!HasSpell(itr->first))
+            continue;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itr->first);
+        if (!spellInfo || !spellInfo->IsPassive())
+            continue;
+
+        if (HandlePassiveSpellLearn(spellInfo))
+            CastSpell(this, spellInfo->Id, true);
+    }
 
     SendTalentsInfoData(false);
 }


### PR DESCRIPTION
### Motivation
- `ResetNonQuestAndMountSpells` (triggered by `spells_keep_mounts`) should clear all currently applied auras so the character gets a clean state and then rebuild the auras that should remain from talents and equipped gear.
- This prevents stale or invalid auras from persisting after a spell/talent reset and ensures equipment-dependent passive effects are restored correctly.

### Description
- In `Player::ResetNonQuestAndMountSpells()` added an equipment strip and aura clear sequence by calling `_RemoveAllItemMods()` followed by `RemoveAllAuras()` before pruning spells. (file: `src/server/game/Entities/Player/Player.cpp`)
- After talent resets and restoring mounts the code reapplies equipment mods with `_ApplyAllItemMods()` so gear-based auras and stat bonuses are rebuilt.
- The spell list is re-read (`GetSpellMap()`) and remaining known passive spells are re-evaluated and recast via `HandlePassiveSpellLearn()` + `CastSpell()` to restore passive/talent-style auras the player should retain.
- Existing mount preservation and class/talent pruning behavior is preserved; checks skip removed/disabled/inactive spells and guard against missing `SpellInfo`.

### Testing
- Compiled the modified translation unit successfully with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/Player/Player.cpp.o` and observed no compile errors for `Player.cpp`.
- Began a full `ninja -C build worldserver` build and confirmed `Player.cpp` compiled as part of the build before the full build was intentionally interrupted; no compile-time errors were observed for the changes.
- Verified no new warnings relevant to the change were introduced for the modified unit during compilation.
- No automated unit tests were run for gameplay logic; functional verification should be performed on a running server to confirm passive and equipment auras are restored as expected after `spells_keep_mounts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d1b87ce48327ab667f9fb281eb84)