### PR TITLE
Allow Polearm Specialization to apply to staves

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3316,6 +3316,19 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->ProcChance = 0;
     });
 
+    // Polearm Specialization
+    ApplySpellFix({
+        12165, // (Rank 1)
+        12830, // (Rank 2)
+        12831, // (Rank 3)
+        12832, // (Rank 4)
+        12833  // (Rank 5)
+    }, [](SpellInfo* spellInfo)
+    {
+        // Custom rules allow Polearm Specialization to work with staves too.
+        spellInfo->EquippedItemSubClassMask |= 1 << ITEM_SUBCLASS_WEAPON_STAFF;
+    });
+
     // Maelstrom Weapon
     ApplySpellFix({
         51528, // (Rank 1)


### PR DESCRIPTION
### Motivation
- Players reported Polearm Specialization working for polearms but not for staves, so staff-wielding characters with the talent did not get the intended bonus.

### Description
- Add a spell-info correction in `LoadSpellInfoCorrections()` that updates all Polearm Specialization ranks (12165, 12830, 12831, 12832, 12833) to include the staff subclass in `EquippedItemSubClassMask` so staves satisfy the spell's item requirement. 
- Change implemented in `src/server/game/Spells/SpellMgr.cpp` by OR-ing `1 << ITEM_SUBCLASS_WEAPON_STAFF` into the spell's `EquippedItemSubClassMask` for those ranks.

### Testing
- Ran `git diff --check` to verify there are no whitespace/diff issues and it passed. 
- Built the server target with `cmake --build build --target game -- -j2` and the build completed successfully (compiler emitted unrelated third-party/header warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b325b8ac8327bed91326cb60042e)