### PR TITLE
Fix Stoneclaw Totem: remove stealth/prowl on hit (ranks 1–6)

### DIFF
--- a/sql/updates/world/master/2026_05_17_00_world.sql
+++ b/sql/updates/world/master/2026_05_17_00_world.sql
@@ -1,0 +1,8 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_sha_stoneclaw_totem_effect';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(5729, 'spell_sha_stoneclaw_totem_effect'),
+(6393, 'spell_sha_stoneclaw_totem_effect'),
+(6394, 'spell_sha_stoneclaw_totem_effect'),
+(6395, 'spell_sha_stoneclaw_totem_effect'),
+(10423, 'spell_sha_stoneclaw_totem_effect'),
+(10424, 'spell_sha_stoneclaw_totem_effect');

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3225,8 +3225,19 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
             break;
         case SPELLFAMILY_GENERIC:
             // Stoneclaw Totem effect
-            if (spellInfoMutable->Id == 5729)
-                spellInfoMutable->AttributesCu |= SPELL_ATTR0_CU_AURA_CC;
+            switch (spellInfoMutable->Id)
+            {
+                case 5729:
+                case 6393:
+                case 6394:
+                case 6395:
+                case 10423:
+                case 10424:
+                    spellInfoMutable->AttributesCu |= SPELL_ATTR0_CU_AURA_CC;
+                    break;
+                default:
+                    break;
+            }
             break;
         default:
             break;

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -1584,6 +1584,21 @@ class spell_sha_t3_6p_bonus : public AuraScript
     }
 };
 
+// 5729, 6393, 6394, 6395, 10423, 10424 - Stoneclaw Totem Effect
+class spell_sha_stoneclaw_totem_effect : public SpellScript
+{
+    void HandleHit()
+    {
+        if (Unit* target = GetHitUnit())
+            target->RemoveAurasByType(SPELL_AURA_MOD_STEALTH);
+    }
+
+    void Register() override
+    {
+        OnHit += SpellHitFn(spell_sha_stoneclaw_totem_effect::HandleHit);
+    }
+};
+
 // 28820 - Lightning Shield
 class spell_sha_t3_8p_bonus : public AuraScript
 {
@@ -1955,6 +1970,7 @@ void AddSC_shaman_spell_scripts()
     RegisterSpellScript(spell_sha_path_of_flames_spread);
     RegisterSpellScript(spell_sha_restorative_mists);
     RegisterSpellScript(spell_sha_spirit_wolf);
+    RegisterSpellScript(spell_sha_stoneclaw_totem_effect);
     RegisterSpellScript(spell_sha_tidal_waves);
     RegisterSpellScript(spell_sha_t3_6p_bonus);
     RegisterSpellScript(spell_sha_t3_8p_bonus);


### PR DESCRIPTION
### Motivation
- Stoneclaw Totem effect did not clear stealth/prowl from targets it hit, so stealthed units could remain hidden after totem damage. 
- Ensure all classic Stoneclaw Totem effect ranks are handled and treated as crowd-control so they properly interrupt stealth.

### Description
- Added a new spell script `spell_sha_stoneclaw_totem_effect` that removes `SPELL_AURA_MOD_STEALTH` from the target when the Stoneclaw Totem effect hits, implemented in `src/server/scripts/Spells/spell_shaman.cpp`.
- Registered the new script in the shaman script loader by calling `RegisterSpellScript(spell_sha_stoneclaw_totem_effect)` in `AddSC_shaman_spell_scripts()`.
- Marked Stoneclaw Totem effect ranks as crowd-control auras by setting `SPELL_ATTR0_CU_AURA_CC` for the spell IDs `5729, 6393, 6394, 6395, 10423, 10424` in `src/server/game/Spells/SpellMgr.cpp` to ensure CC/interrupt handling applies consistently.
- Added a world update SQL `sql/updates/world/master/2026_05_17_00_world.sql` to bind the script to the Stoneclaw Totem effect spell IDs (inserts into `spell_script_names` for the listed ranks).

### Testing
- Ran static check `git diff --check -- src/server/game/Spells/SpellMgr.cpp src/server/scripts/Spells/spell_shaman.cpp sql/updates/world/master/2026_05_17_00_world.sql` and it returned clean results.
- Incremental compile of the affected translation units via `ninja -C build src/server/game/CMakeFiles/game.dir/Spells/SpellMgr.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Spells/spell_shaman.cpp.o` completed successfully, indicating the changes compile.
- A full `ninja -C build worldserver` was started to exercise a full rebuild but was intentionally interrupted (rebuild of the entire target graph was not completed in this run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a077b37008327a0a99e9fbd65ea5c)