### PR TITLE
Make Stoneclaw Totem effect remove stealth

### DIFF
--- a/sql/updates/world/3.3.5/2026_05_17_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_05_17_00_world.sql
@@ -1,0 +1,4 @@
+-- Attach Stoneclaw Totem Effect script so the pulse removes stealth/prowl from hit targets.
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_sha_stoneclaw_totem_effect';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(-5729, 'spell_sha_stoneclaw_totem_effect');

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -1585,6 +1585,23 @@ class spell_sha_shamanistic_rage : public AuraScript
     }
 };
 
+// 5729, 6393, 6394, 6395, 10423, 10424, 25512, 58586, 58587, 58588 - Stoneclaw Totem Effect
+class spell_sha_stoneclaw_totem_effect : public SpellScript
+{
+    PrepareSpellScript(spell_sha_stoneclaw_totem_effect);
+
+    void RemoveStealth()
+    {
+        if (Unit* target = GetHitUnit())
+            target->RemoveAurasByType(SPELL_AURA_MOD_STEALTH);
+    }
+
+    void Register() override
+    {
+        AfterHit += SpellHitFn(spell_sha_stoneclaw_totem_effect::RemoveStealth);
+    }
+};
+
 // 55278, 55328, 55329, 55330, 55332, 55333, 55335, 58589, 58590, 58591 - Stoneclaw Totem
 class spell_sha_stoneclaw_totem : public SpellScript
 {
@@ -2784,6 +2801,7 @@ void AddSC_shaman_spell_scripts()
     RegisterSpellScript(spell_sha_nature_guardian);
     RegisterSpellScript(spell_sha_sentry_totem);
     RegisterSpellScript(spell_sha_shamanistic_rage);
+    RegisterSpellScript(spell_sha_stoneclaw_totem_effect);
     RegisterSpellScript(spell_sha_stoneclaw_totem);
     RegisterSpellScript(spell_sha_spirit_hunt);
     RegisterSpellScript(spell_sha_ghost_wolf_charge);


### PR DESCRIPTION
### Motivation
- The Stoneclaw Totem pulse should break stealth/prowl on hit targets by removing stealth-type auras.

### Description
- Added a new spell script `spell_sha_stoneclaw_totem_effect` in `src/server/scripts/Spells/spell_shaman.cpp` that calls `RemoveAurasByType(SPELL_AURA_MOD_STEALTH)` on each hit target during `AfterHit`.
- Registered the new script in the shaman script loader via `RegisterSpellScript(spell_sha_stoneclaw_totem_effect)` inside `AddSC_shaman_spell_scripts()`.
- Added a DB update `sql/updates/world/3.3.5/2026_05_17_00_world.sql` to attach the script name `spell_sha_stoneclaw_totem_effect` to the Stoneclaw Totem Effect rank chain (spell id `-5729`).

### Testing
- Ran `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Spells/spell_shaman.cpp.o` and the targeted script compilation succeeded.
- Started a full `ninja -C build worldserver` build (long rebuild); it was interrupted, but the targeted script compile above verifies the new code compiles in the scripts object.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0c8e874c8327bd7f0154c01394bd)