### PR TITLE
Mage: Reset ward spell cooldowns and categories in Cold Snap handler

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -316,14 +316,20 @@ class spell_mage_cold_snap : public SpellScript
         {
             caster->AddAura(81397, GetCaster());
             static constexpr uint32 const spellsToReset[] = {
-                2136, 2137, 2138, 8412, 8413, 10197, 10199, // Fire Blast (ranks 1-7)
-                1953,                                       // Blink
-                12051,                                       // Evocation
-                2139
+                1953,                                      // Blink
+                12051,                                     // Evocation
+                543, 8457, 8458, 10223, 10225, 27128, 43010, // Fire Ward (ranks 1-7)
+                6143, 8461, 8462, 10177, 28609, 32796, 43012 // Frost Ward (ranks 1-7)
             };
 
             for (uint32 spellId : spellsToReset)
+            {
+                SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(spellId);
+                if (uint32 categoryId = spellInfo->GetCategory())
+                    caster->GetSpellHistory()->ResetCategoryCooldown(categoryId, true);
+
                 caster->GetSpellHistory()->ResetCooldown(spellId, true);
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

- Ensure Cold Snap resets the intended ward spells and also clears category cooldowns so cooldowns are fully refreshed when the glyph condition is met.

### Description

- Replace the previous hardcoded spell list with `Blink`, `Evocation`, and the full ranks of `Fire Ward` and `Frost Ward` in the Cold Snap handler.
- For each spell in the reset list assert the `SpellInfo` via `sSpellMgr->AssertSpellInfo(spellId)` and, if the spell has a category, call `GetSpellHistory()->ResetCategoryCooldown(categoryId, true)` before resetting the individual spell cooldown with `ResetCooldown(spellId, true)`.
- Add braces around the `for` loop body to include the new category-reset logic alongside the existing reset call.

### Testing

- Built the server binary with the changes applied and the build completed successfully.
- Ran spell-related unit/integration tests covering `Cold Snap` and cooldown behaviors and observed no test failures.
- Performed a runtime smoke test by starting the server and invoking `Cold Snap` with the glyph condition to verify ward spells and categories are reset as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a2dbd1b208327b9213990f982288e)