### PR TITLE
Allow Arcane Missiles movement while channeling via custom auras

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22741,6 +22741,13 @@ void Player::UpdateStarfireSnare()
         if (spell->GetSpellInfo()->IsStarfire())
             return;
 
+    if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
+    {
+        SpellInfo const* spellInfo = spell->GetSpellInfo();
+        if (spellInfo->IsHurricane() || spellInfo->IsArcaneMissiles())
+            return;
+    }
+
     _pendingStarfireSnareRemoval = false;
     _starfireSnareRemovalGraceUpdates = 0;
     _activeStarfireSnareSpeedRate = 0.0f;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -88,6 +88,8 @@ namespace
 {
 static uint32 constexpr SPELL_SHAMAN_GHOST_WOLF = 2645;
 static uint32 constexpr SPELL_ICE_FANG_SPRINT = 89768;
+static uint32 constexpr SPELL_ARCANE_MISSILES_MOVE_AURA_1 = 89777;
+static uint32 constexpr SPELL_ARCANE_MISSILES_MOVE_AURA_2 = 89778;
 static float constexpr ICE_FANG_SPRINT_TURN_SPEED = 0;
 
 bool IsIceFangSprintTurnRateAura(SpellInfo const* spellInfo)
@@ -737,7 +739,7 @@ void Unit::UpdateInterruptMask()
         if (spell->getState() == SPELL_STATE_CASTING)
         {
             uint32 channelInterruptFlags = spell->m_spellInfo->ChannelInterruptFlags;
-            if (spell->m_spellInfo->IsHurricane())
+            if (spell->m_spellInfo->IsHurricane() || spell->m_spellInfo->IsArcaneMissiles())
                 channelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
 
             m_interruptMask |= channelInterruptFlags;
@@ -3427,7 +3429,7 @@ bool Unit::IsMovementPreventedByCasting() const
         if (spell->getState() != SPELL_STATE_FINISHED && spell->IsChannelActive())
         {
             SpellInfo const* spellInfo = spell->GetSpellInfo();
-            if (spellInfo->IsMoveAllowedChannel() && (!spellInfo->IsHurricane() || GetHurricaneSnareSpeedRate() > 0.0f))
+            if (spellInfo->IsMoveAllowedChannel() && (!spellInfo->IsHurricane() || GetHurricaneSnareSpeedRate() > 0.0f) && (!spellInfo->IsArcaneMissiles() || GetArcaneMissilesSnareSpeedRate() > 0.0f))
                 return false;
         }
     }
@@ -3437,10 +3439,15 @@ bool Unit::IsMovementPreventedByCasting() const
             if (spell->GetSpellInfo()->IsStarfire())
                 return false;
 
-    if (GetHurricaneSnareSpeedRate() > 0.0f)
-        if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
-            if (spell->GetSpellInfo()->IsHurricane())
-                return false;
+    if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
+    {
+        SpellInfo const* spellInfo = spell->GetSpellInfo();
+        if (spellInfo->IsHurricane() && GetHurricaneSnareSpeedRate() > 0.0f)
+            return false;
+
+        if (spellInfo->IsArcaneMissiles() && GetArcaneMissilesSnareSpeedRate() > 0.0f)
+            return false;
+    }
 
     // prohibit movement for all other spell casts
     return true;
@@ -4373,15 +4380,17 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
     if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
     {
         uint32 channelInterruptFlags = spell->m_spellInfo->ChannelInterruptFlags;
-        if (spell->m_spellInfo->IsHurricane())
+        if (spell->m_spellInfo->IsHurricane() || spell->m_spellInfo->IsArcaneMissiles())
             channelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
 
         if (spell->getState() == SPELL_STATE_CASTING
             && (channelInterruptFlags & flag)
             && spell->m_spellInfo->Id != except)
         {
-            bool const hurricaneMovementAllowed = (flag & (AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING)) && spell->m_spellInfo->IsHurricane() && GetHurricaneSnareSpeedRate() > 0.0f;
-            if (!hurricaneMovementAllowed)
+            bool const channelMovementFlag = flag & (AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING);
+            bool const hurricaneMovementAllowed = channelMovementFlag && spell->m_spellInfo->IsHurricane() && GetHurricaneSnareSpeedRate() > 0.0f;
+            bool const arcaneMissilesMovementAllowed = channelMovementFlag && spell->m_spellInfo->IsArcaneMissiles() && GetArcaneMissilesSnareSpeedRate() > 0.0f;
+            if (!hurricaneMovementAllowed && !arcaneMissilesMovementAllowed)
                 InterruptNonMeleeSpells(false);
         }
     }
@@ -5029,6 +5038,35 @@ float Unit::GetHurricaneSnareSpeedRate() const
         }
 
         if (!spellInfo->HasAttribute(SPELL_ATTR0_CU_ALLOW_HURRICANE_SNARE_CAST))
+            continue;
+
+        for (uint8 effIndex = EFFECT_0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+        {
+            if (AuraEffect const* auraEffect = aura->GetEffect(effIndex))
+            {
+                int32 const amount = auraEffect->GetAmount();
+                if (amount <= 0)
+                    continue;
+
+                float const rate = std::clamp(static_cast<float>(amount) / 100.0f, 0.0f, 1.0f);
+                if (rate > bestRate)
+                    bestRate = rate;
+            }
+        }
+    }
+
+    return bestRate;
+}
+
+float Unit::GetArcaneMissilesSnareSpeedRate() const
+{
+    float bestRate = 0.0f;
+
+    for (AuraApplicationMap::const_iterator iter = m_appliedAuras.begin(); iter != m_appliedAuras.end(); ++iter)
+    {
+        Aura const* aura = iter->second->GetBase();
+        SpellInfo const* spellInfo = aura->GetSpellInfo();
+        if (!spellInfo || (spellInfo->Id != SPELL_ARCANE_MISSILES_MOVE_AURA_1 && spellInfo->Id != SPELL_ARCANE_MISSILES_MOVE_AURA_2))
             continue;
 
         for (uint8 effIndex = EFFECT_0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1427,6 +1427,7 @@ class TC_GAME_API Unit : public WorldObject
         bool HasAuraWithMechanic(uint32 mechanicMask) const;
         float GetStarfireSnareSpeedRate() const;
         float GetHurricaneSnareSpeedRate() const;
+        float GetArcaneMissilesSnareSpeedRate() const;
         bool HasStrongerAuraWithDR(SpellInfo const* auraSpellInfo, Unit* caster, bool triggered) const;
 
         AuraEffect* IsScriptOverriden(SpellInfo const* spell, int32 script) const;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3316,6 +3316,7 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
 
     bool const isStarfire = m_spellInfo->IsStarfire();
     bool const isHurricane = m_spellInfo->IsHurricane();
+    bool const isArcaneMissiles = m_spellInfo->IsArcaneMissiles();
     float movementSnareSpeedRate = 0.0f;
     if (playerCaster)
     {
@@ -3323,13 +3324,16 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
             movementSnareSpeedRate = playerCaster->GetStarfireSnareSpeedRate();
         else if (isHurricane)
             movementSnareSpeedRate = playerCaster->GetHurricaneSnareSpeedRate();
+        else if (isArcaneMissiles)
+            movementSnareSpeedRate = playerCaster->GetArcaneMissilesSnareSpeedRate();
     }
 
-    bool const snareMovementAllowed = ((isStarfire && m_casttime) || isHurricane) && movementSnareSpeedRate > 0.0f;
+    bool const snareMovementAllowed = ((isStarfire && m_casttime) || isHurricane || isArcaneMissiles) && movementSnareSpeedRate > 0.0f;
     bool const needsStarfireMovementInterrupt = isStarfire && !snareMovementAllowed;
     bool const needsHurricaneMovementInterrupt = isHurricane && !snareMovementAllowed;
-    bool const moveAllowedChannel = m_spellInfo->IsMoveAllowedChannel() && !needsHurricaneMovementInterrupt;
-    bool const requiresMovementInterrupt = (m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT) || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt;
+    bool const needsArcaneMissilesMovementInterrupt = isArcaneMissiles && !snareMovementAllowed;
+    bool const moveAllowedChannel = m_spellInfo->IsMoveAllowedChannel() && !needsHurricaneMovementInterrupt && !needsArcaneMissilesMovementInterrupt;
+    bool const requiresMovementInterrupt = (m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT) || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt || needsArcaneMissilesMovementInterrupt;
 
     // don't allow channeled spells / spells with cast time to be cast while moving
     // exception are only channeled spells that have no casttime and SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING
@@ -3806,10 +3810,11 @@ void Spell::handle_immediate()
             // GameObjects shouldn't cast channeled spells
             Unit* unitCaster = ASSERT_NOTNULL(m_caster->ToUnit());
             uint32 channelInterruptFlags = m_spellInfo->ChannelInterruptFlags;
-            if (m_spellInfo->IsHurricane())
-            {
+            if (m_spellInfo->IsHurricane() || m_spellInfo->IsArcaneMissiles())
                 channelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
 
+            if (m_spellInfo->IsHurricane())
+            {
                 if (unitCaster->GetTypeId() == TYPEID_PLAYER && unitCaster->HasAura(SPELL_DRUID_BEEFS_TENACITY))
                     if (Aura* unstoppable = unitCaster->AddAura(SPELL_DRUID_UNSTOPPABLE, unitCaster))
                     {
@@ -4036,14 +4041,16 @@ void Spell::update(uint32 difftime)
         bool const playerMoved = playerCaster->isMoving();
         bool const isStarfire = m_spellInfo->IsStarfire();
         bool const isHurricane = m_spellInfo->IsHurricane();
-        bool const snareMovementAllowed = (isStarfire && playerCaster->GetStarfireSnareSpeedRate() > 0.0f) || (isHurricane && playerCaster->GetHurricaneSnareSpeedRate() > 0.0f);
+        bool const isArcaneMissiles = m_spellInfo->IsArcaneMissiles();
+        bool const snareMovementAllowed = (isStarfire && playerCaster->GetStarfireSnareSpeedRate() > 0.0f) || (isHurricane && playerCaster->GetHurricaneSnareSpeedRate() > 0.0f) || (isArcaneMissiles && playerCaster->GetArcaneMissilesSnareSpeedRate() > 0.0f);
         bool const needsStarfireMovementInterrupt = isStarfire && !snareMovementAllowed;
         bool const needsHurricaneMovementInterrupt = isHurricane && !snareMovementAllowed;
+        bool const needsArcaneMissilesMovementInterrupt = isArcaneMissiles && !snareMovementAllowed;
         bool const hasMovementInterruptFlag = m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT;
-        bool const moveAllowedChannel = IsChannelActive() && m_spellInfo->IsMoveAllowedChannel() && !needsHurricaneMovementInterrupt;
+        bool const moveAllowedChannel = IsChannelActive() && m_spellInfo->IsMoveAllowedChannel() && !needsHurricaneMovementInterrupt && !needsArcaneMissilesMovementInterrupt;
 
         if (playerMoved && !snareMovementAllowed &&
-            (hasMovementInterruptFlag || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt) &&
+            (hasMovementInterruptFlag || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt || needsArcaneMissilesMovementInterrupt) &&
             (!m_spellInfo->HasEffect(SPELL_EFFECT_STUCK) || !playerCaster->HasUnitMovementFlag(MOVEMENTFLAG_FALLING_FAR)))
         {
             // don't cancel for melee, autorepeat, triggered and instant spells
@@ -7622,7 +7629,8 @@ void Spell::Delayed() // only called in DealDamage()
     bool const hasPushbackInterruptFlag = m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_PUSH_BACK;
     bool const needsStarfirePushbackInterrupt = m_spellInfo->IsStarfire() && playerCaster->GetStarfireSnareSpeedRate() <= 0.0f;
     bool const needsHurricanePushbackInterrupt = m_spellInfo->IsHurricane() && playerCaster->GetHurricaneSnareSpeedRate() <= 0.0f;
-    if (!hasPushbackInterruptFlag && !needsStarfirePushbackInterrupt && !needsHurricanePushbackInterrupt)
+    bool const needsArcaneMissilesPushbackInterrupt = m_spellInfo->IsArcaneMissiles() && playerCaster->GetArcaneMissilesSnareSpeedRate() <= 0.0f;
+    if (!hasPushbackInterruptFlag && !needsStarfirePushbackInterrupt && !needsHurricanePushbackInterrupt && !needsArcaneMissilesPushbackInterrupt)
         return;
 
     //check pushback reduce

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1257,6 +1257,12 @@ bool SpellInfo::IsHurricane() const
     return firstRankSpellInfo && firstRankSpellInfo->Id == 16914;
 }
 
+bool SpellInfo::IsArcaneMissiles() const
+{
+    SpellInfo const* firstRankSpellInfo = GetFirstRankSpell();
+    return firstRankSpellInfo && firstRankSpellInfo->Id == 5143;
+}
+
 bool SpellInfo::IsMindVision() const
 {
     return Id == 2096 || Id == 10909;

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -420,6 +420,7 @@ class TC_GAME_API SpellInfo
         bool IsMoveAllowedChannel() const;
         bool IsStarfire() const;
         bool IsHurricane() const;
+        bool IsArcaneMissiles() const;
         bool IsMindVision() const;
         float GetStarfireSnareSpeedRate() const;
         float GetHurricaneSnareSpeedRate() const;


### PR DESCRIPTION
### Motivation
- Add support so Arcane Missiles can be channeled while moving when the caster has custom movement auras (IDs `89777` / `89778`) that specify a percentage-based allowed movespeed, matching existing Hurricane/Starfire handling.

### Description
- Introduce `SpellInfo::IsArcaneMissiles()` to detect Arcane Missiles ranks by their first-rank spell ID and expose the check in `SpellInfo.h/SpellInfo.cpp`.
- Add `Unit::GetArcaneMissilesSnareSpeedRate()` and a couple of constants for the two custom Arcane Missiles movement auras, and expose it in `Unit.h` to read the aura effect amount as a clamped 0..1 movement rate.
- Update channeled-cast logic in `Spell::prepare`, `Spell::update`, `Spell::handle_immediate`, and `Spell::Delayed` to consider Arcane Missiles alongside Starfire/Hurricane for movement/pushback exceptions and to use the new snare rate where appropriate.
- Extend movement-interrupt and channel-interrupt handling in `Unit::IsMovementPreventedByCasting`, `Unit::UpdateInterruptMask`, and `Unit::RemoveAurasWithInterruptFlags` so Arcane Missiles are exempt from move/turn interrupts while the custom aura provides a positive speed rate, preserving normal behavior otherwise.
- Ensure the existing Starfire/Hurricane snare reference and cleanup logic in `Player::UpdateStarfireSnare` also respects an active Arcane Missiles channel so the temporary speed cap remains in effect while appropriate.

### Testing
- Ran `git diff --check` to validate whitespace/patch sanity, which returned clean results.
- Built the modified objects with `ninja -C build` for the changed files (`Spell.cpp`, `SpellInfo.cpp`, `Unit.cpp`, `Player.cpp`) and those object builds completed successfully (targeted compile of changed units passed).
- Initiated a full `cmake --build build --target worldserver -j2`; configuration and initial build steps started successfully but a complete full rebuild was not completed in this run due to the large build tree (targeted object compilation succeeded as above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac3e38e608327b9f38542ba512350)