### PR TITLE
Add Arcane Missiles movement/snare handling and movement-aura exceptions

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22741,6 +22741,13 @@ void Player::UpdateStarfireSnare()
         if (spell->GetSpellInfo()->IsStarfire())
             return;
 
+    if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
+    {
+        SpellInfo const* spellInfo = spell->GetSpellInfo();
+        if (spellInfo->IsHurricane() || spellInfo->IsArcaneMissiles())
+            return;
+    }
+
     _pendingStarfireSnareRemoval = false;
     _starfireSnareRemovalGraceUpdates = 0;
     _activeStarfireSnareSpeedRate = 0.0f;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -88,11 +88,18 @@ namespace
 {
 static uint32 constexpr SPELL_SHAMAN_GHOST_WOLF = 2645;
 static uint32 constexpr SPELL_ICE_FANG_SPRINT = 89768;
+static uint32 constexpr SPELL_ARCANE_MISSILES_MOVE_AURA_1 = 89777;
+static uint32 constexpr SPELL_ARCANE_MISSILES_MOVE_AURA_2 = 89778;
 static float constexpr ICE_FANG_SPRINT_TURN_SPEED = 0;
 
 bool IsIceFangSprintTurnRateAura(SpellInfo const* spellInfo)
 {
     return spellInfo->Id == SPELL_ICE_FANG_SPRINT;
+}
+
+bool IsArcaneMissilesMovementAura(SpellInfo const* spellInfo)
+{
+    return spellInfo->Id == SPELL_ARCANE_MISSILES_MOVE_AURA_1 || spellInfo->Id == SPELL_ARCANE_MISSILES_MOVE_AURA_2;
 }
 }
 
@@ -739,6 +746,8 @@ void Unit::UpdateInterruptMask()
             uint32 channelInterruptFlags = spell->m_spellInfo->ChannelInterruptFlags;
             if (spell->m_spellInfo->IsHurricane())
                 channelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
+            else if (spell->m_spellInfo->IsArcaneMissiles())
+                channelInterruptFlags = (channelInterruptFlags | AURA_INTERRUPT_FLAG_MOVE) & ~AURA_INTERRUPT_FLAG_TURNING;
 
             m_interruptMask |= channelInterruptFlags;
         }
@@ -3427,7 +3436,7 @@ bool Unit::IsMovementPreventedByCasting() const
         if (spell->getState() != SPELL_STATE_FINISHED && spell->IsChannelActive())
         {
             SpellInfo const* spellInfo = spell->GetSpellInfo();
-            if (spellInfo->IsMoveAllowedChannel() && (!spellInfo->IsHurricane() || GetHurricaneSnareSpeedRate() > 0.0f))
+            if (spellInfo->IsMoveAllowedChannel() && (!spellInfo->IsHurricane() || GetHurricaneSnareSpeedRate() > 0.0f) && (!spellInfo->IsArcaneMissiles() || GetArcaneMissilesSnareSpeedRate() > 0.0f))
                 return false;
         }
     }
@@ -3437,10 +3446,15 @@ bool Unit::IsMovementPreventedByCasting() const
             if (spell->GetSpellInfo()->IsStarfire())
                 return false;
 
-    if (GetHurricaneSnareSpeedRate() > 0.0f)
-        if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
-            if (spell->GetSpellInfo()->IsHurricane())
-                return false;
+    if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
+    {
+        SpellInfo const* spellInfo = spell->GetSpellInfo();
+        if (spellInfo->IsHurricane() && GetHurricaneSnareSpeedRate() > 0.0f)
+            return false;
+
+        if (spellInfo->IsArcaneMissiles() && GetArcaneMissilesSnareSpeedRate() > 0.0f)
+            return false;
+    }
 
     // prohibit movement for all other spell casts
     return true;
@@ -4351,8 +4365,15 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
     {
         Aura* aura = (*iter)->GetBase();
         ++iter;
-        if ((aura->GetSpellInfo()->AuraInterruptFlags & flag) && (!except || aura->GetId() != except))
+        SpellInfo const* auraSpellInfo = aura->GetSpellInfo();
+        if ((auraSpellInfo->AuraInterruptFlags & flag) && (!except || aura->GetId() != except))
         {
+            uint32 constexpr movementInterruptFlags = AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
+            if ((flag & movementInterruptFlags) && IsArcaneMissilesMovementAura(auraSpellInfo))
+                if (Spell* channeledSpell = m_currentSpells[CURRENT_CHANNELED_SPELL])
+                    if (channeledSpell->getState() == SPELL_STATE_CASTING && channeledSpell->m_spellInfo->IsArcaneMissiles() && !(auraSpellInfo->AuraInterruptFlags & (flag & ~movementInterruptFlags)))
+                        continue;
+
             if (HasAura(81439) && aura->HasEffectType(SPELL_AURA_MOD_STEALTH))
             {
                 uint32 const protectedFlags = AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE |
@@ -4375,13 +4396,17 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
         uint32 channelInterruptFlags = spell->m_spellInfo->ChannelInterruptFlags;
         if (spell->m_spellInfo->IsHurricane())
             channelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
+        else if (spell->m_spellInfo->IsArcaneMissiles())
+            channelInterruptFlags = (channelInterruptFlags | AURA_INTERRUPT_FLAG_MOVE) & ~AURA_INTERRUPT_FLAG_TURNING;
 
         if (spell->getState() == SPELL_STATE_CASTING
             && (channelInterruptFlags & flag)
             && spell->m_spellInfo->Id != except)
         {
-            bool const hurricaneMovementAllowed = (flag & (AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING)) && spell->m_spellInfo->IsHurricane() && GetHurricaneSnareSpeedRate() > 0.0f;
-            if (!hurricaneMovementAllowed)
+            bool const channelMovementFlag = flag & (AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING);
+            bool const hurricaneMovementAllowed = channelMovementFlag && spell->m_spellInfo->IsHurricane() && GetHurricaneSnareSpeedRate() > 0.0f;
+            bool const arcaneMissilesMovementAllowed = (flag & AURA_INTERRUPT_FLAG_MOVE) && spell->m_spellInfo->IsArcaneMissiles() && GetArcaneMissilesSnareSpeedRate() > 0.0f;
+            if (!hurricaneMovementAllowed && !arcaneMissilesMovementAllowed)
                 InterruptNonMeleeSpells(false);
         }
     }
@@ -5029,6 +5054,35 @@ float Unit::GetHurricaneSnareSpeedRate() const
         }
 
         if (!spellInfo->HasAttribute(SPELL_ATTR0_CU_ALLOW_HURRICANE_SNARE_CAST))
+            continue;
+
+        for (uint8 effIndex = EFFECT_0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+        {
+            if (AuraEffect const* auraEffect = aura->GetEffect(effIndex))
+            {
+                int32 const amount = auraEffect->GetAmount();
+                if (amount <= 0)
+                    continue;
+
+                float const rate = std::clamp(static_cast<float>(amount) / 100.0f, 0.0f, 1.0f);
+                if (rate > bestRate)
+                    bestRate = rate;
+            }
+        }
+    }
+
+    return bestRate;
+}
+
+float Unit::GetArcaneMissilesSnareSpeedRate() const
+{
+    float bestRate = 0.0f;
+
+    for (AuraApplicationMap::const_iterator iter = m_appliedAuras.begin(); iter != m_appliedAuras.end(); ++iter)
+    {
+        Aura const* aura = iter->second->GetBase();
+        SpellInfo const* spellInfo = aura->GetSpellInfo();
+        if (!spellInfo || !IsArcaneMissilesMovementAura(spellInfo))
             continue;
 
         for (uint8 effIndex = EFFECT_0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1427,6 +1427,7 @@ class TC_GAME_API Unit : public WorldObject
         bool HasAuraWithMechanic(uint32 mechanicMask) const;
         float GetStarfireSnareSpeedRate() const;
         float GetHurricaneSnareSpeedRate() const;
+        float GetArcaneMissilesSnareSpeedRate() const;
         bool HasStrongerAuraWithDR(SpellInfo const* auraSpellInfo, Unit* caster, bool triggered) const;
 
         AuraEffect* IsScriptOverriden(SpellInfo const* spell, int32 script) const;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3316,6 +3316,7 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
 
     bool const isStarfire = m_spellInfo->IsStarfire();
     bool const isHurricane = m_spellInfo->IsHurricane();
+    bool const isArcaneMissiles = m_spellInfo->IsArcaneMissiles();
     float movementSnareSpeedRate = 0.0f;
     if (playerCaster)
     {
@@ -3323,13 +3324,16 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
             movementSnareSpeedRate = playerCaster->GetStarfireSnareSpeedRate();
         else if (isHurricane)
             movementSnareSpeedRate = playerCaster->GetHurricaneSnareSpeedRate();
+        else if (isArcaneMissiles)
+            movementSnareSpeedRate = playerCaster->GetArcaneMissilesSnareSpeedRate();
     }
 
-    bool const snareMovementAllowed = ((isStarfire && m_casttime) || isHurricane) && movementSnareSpeedRate > 0.0f;
+    bool const snareMovementAllowed = ((isStarfire && m_casttime) || isHurricane || isArcaneMissiles) && movementSnareSpeedRate > 0.0f;
     bool const needsStarfireMovementInterrupt = isStarfire && !snareMovementAllowed;
     bool const needsHurricaneMovementInterrupt = isHurricane && !snareMovementAllowed;
-    bool const moveAllowedChannel = m_spellInfo->IsMoveAllowedChannel() && !needsHurricaneMovementInterrupt;
-    bool const requiresMovementInterrupt = (m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT) || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt;
+    bool const needsArcaneMissilesMovementInterrupt = isArcaneMissiles && !snareMovementAllowed;
+    bool const moveAllowedChannel = m_spellInfo->IsMoveAllowedChannel() && !needsHurricaneMovementInterrupt && !needsArcaneMissilesMovementInterrupt;
+    bool const requiresMovementInterrupt = (m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT) || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt || needsArcaneMissilesMovementInterrupt;
 
     // don't allow channeled spells / spells with cast time to be cast while moving
     // exception are only channeled spells that have no casttime and SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING
@@ -3807,9 +3811,12 @@ void Spell::handle_immediate()
             Unit* unitCaster = ASSERT_NOTNULL(m_caster->ToUnit());
             uint32 channelInterruptFlags = m_spellInfo->ChannelInterruptFlags;
             if (m_spellInfo->IsHurricane())
-            {
                 channelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
+            else if (m_spellInfo->IsArcaneMissiles())
+                channelInterruptFlags = (channelInterruptFlags | AURA_INTERRUPT_FLAG_MOVE) & ~AURA_INTERRUPT_FLAG_TURNING;
 
+            if (m_spellInfo->IsHurricane())
+            {
                 if (unitCaster->GetTypeId() == TYPEID_PLAYER && unitCaster->HasAura(SPELL_DRUID_BEEFS_TENACITY))
                     if (Aura* unstoppable = unitCaster->AddAura(SPELL_DRUID_UNSTOPPABLE, unitCaster))
                     {
@@ -4036,14 +4043,16 @@ void Spell::update(uint32 difftime)
         bool const playerMoved = playerCaster->isMoving();
         bool const isStarfire = m_spellInfo->IsStarfire();
         bool const isHurricane = m_spellInfo->IsHurricane();
-        bool const snareMovementAllowed = (isStarfire && playerCaster->GetStarfireSnareSpeedRate() > 0.0f) || (isHurricane && playerCaster->GetHurricaneSnareSpeedRate() > 0.0f);
+        bool const isArcaneMissiles = m_spellInfo->IsArcaneMissiles();
+        bool const snareMovementAllowed = (isStarfire && playerCaster->GetStarfireSnareSpeedRate() > 0.0f) || (isHurricane && playerCaster->GetHurricaneSnareSpeedRate() > 0.0f) || (isArcaneMissiles && playerCaster->GetArcaneMissilesSnareSpeedRate() > 0.0f);
         bool const needsStarfireMovementInterrupt = isStarfire && !snareMovementAllowed;
         bool const needsHurricaneMovementInterrupt = isHurricane && !snareMovementAllowed;
+        bool const needsArcaneMissilesMovementInterrupt = isArcaneMissiles && !snareMovementAllowed;
         bool const hasMovementInterruptFlag = m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT;
-        bool const moveAllowedChannel = IsChannelActive() && m_spellInfo->IsMoveAllowedChannel() && !needsHurricaneMovementInterrupt;
+        bool const moveAllowedChannel = IsChannelActive() && m_spellInfo->IsMoveAllowedChannel() && !needsHurricaneMovementInterrupt && !needsArcaneMissilesMovementInterrupt;
 
         if (playerMoved && !snareMovementAllowed &&
-            (hasMovementInterruptFlag || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt) &&
+            (hasMovementInterruptFlag || needsStarfireMovementInterrupt || needsHurricaneMovementInterrupt || needsArcaneMissilesMovementInterrupt) &&
             (!m_spellInfo->HasEffect(SPELL_EFFECT_STUCK) || !playerCaster->HasUnitMovementFlag(MOVEMENTFLAG_FALLING_FAR)))
         {
             // don't cancel for melee, autorepeat, triggered and instant spells
@@ -7622,7 +7631,8 @@ void Spell::Delayed() // only called in DealDamage()
     bool const hasPushbackInterruptFlag = m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_PUSH_BACK;
     bool const needsStarfirePushbackInterrupt = m_spellInfo->IsStarfire() && playerCaster->GetStarfireSnareSpeedRate() <= 0.0f;
     bool const needsHurricanePushbackInterrupt = m_spellInfo->IsHurricane() && playerCaster->GetHurricaneSnareSpeedRate() <= 0.0f;
-    if (!hasPushbackInterruptFlag && !needsStarfirePushbackInterrupt && !needsHurricanePushbackInterrupt)
+    bool const needsArcaneMissilesPushbackInterrupt = m_spellInfo->IsArcaneMissiles() && playerCaster->GetArcaneMissilesSnareSpeedRate() <= 0.0f;
+    if (!hasPushbackInterruptFlag && !needsStarfirePushbackInterrupt && !needsHurricanePushbackInterrupt && !needsArcaneMissilesPushbackInterrupt)
         return;
 
     //check pushback reduce

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1257,6 +1257,12 @@ bool SpellInfo::IsHurricane() const
     return firstRankSpellInfo && firstRankSpellInfo->Id == 16914;
 }
 
+bool SpellInfo::IsArcaneMissiles() const
+{
+    SpellInfo const* firstRankSpellInfo = GetFirstRankSpell();
+    return firstRankSpellInfo && firstRankSpellInfo->Id == 5143;
+}
+
 bool SpellInfo::IsMindVision() const
 {
     return Id == 2096 || Id == 10909;

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -420,6 +420,7 @@ class TC_GAME_API SpellInfo
         bool IsMoveAllowedChannel() const;
         bool IsStarfire() const;
         bool IsHurricane() const;
+        bool IsArcaneMissiles() const;
         bool IsMindVision() const;
         float GetStarfireSnareSpeedRate() const;
         float GetHurricaneSnareSpeedRate() const;


### PR DESCRIPTION
### Motivation
- Implement Arcane Missiles channel-specific movement behavior so channeled `Arcane Missiles` interacts with movement snares and interrupt flags similarly to `Hurricane` and `Starfire`.

### Description
- Add `IsArcaneMissiles()` to `SpellInfo` and use it throughout spell and unit logic to detect Arcane Missiles channels (first-rank id `5143`).
- Introduce `GetArcaneMissilesSnareSpeedRate()` and movement-aura identifiers `SPELL_ARCANE_MISSILES_MOVE_AURA_1/2` (`89777/89778`) and the helper `IsArcaneMissilesMovementAura()` in `Unit` to compute snare rates from applied auras.
- Adjust interrupt and movement checks in `Unit` and `Spell` to treat Arcane Missiles like other channelled spells: allow movement (but not turning) when a corresponding snare is active, avoid interrupting channels for Arcane Missiles when the snare rate permits, and prevent certain movement auras from being removed while Arcane Missiles is being cast.
- Update `Player::UpdateStarfireSnare()` to not clear the snare removal when Arcane Missiles is the active channeled spell.

### Testing
- Project compiles successfully with the changes (`make` build completed without errors`).
- Automated unit / server spell tests were executed (`make test` / server spell regression suite) and passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac3e38e608327b9f38542ba512350)