### PR TITLE
Fix Arcane Missiles movement aura turning interrupts

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -739,7 +739,7 @@ void Unit::UpdateInterruptMask()
         if (spell->getState() == SPELL_STATE_CASTING)
         {
             uint32 channelInterruptFlags = spell->m_spellInfo->ChannelInterruptFlags;
-            if (spell->m_spellInfo->IsHurricane() || spell->m_spellInfo->IsArcaneMissiles())
+            if (spell->m_spellInfo->IsHurricane())
                 channelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
             else if (spell->m_spellInfo->IsArcaneMissiles())
                 channelInterruptFlags = (channelInterruptFlags | AURA_INTERRUPT_FLAG_MOVE) & ~AURA_INTERRUPT_FLAG_TURNING;
@@ -4382,7 +4382,7 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
     if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
     {
         uint32 channelInterruptFlags = spell->m_spellInfo->ChannelInterruptFlags;
-        if (spell->m_spellInfo->IsHurricane() || spell->m_spellInfo->IsArcaneMissiles())
+        if (spell->m_spellInfo->IsHurricane())
             channelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
         else if (spell->m_spellInfo->IsArcaneMissiles())
             channelInterruptFlags = (channelInterruptFlags | AURA_INTERRUPT_FLAG_MOVE) & ~AURA_INTERRUPT_FLAG_TURNING;


### PR DESCRIPTION
### Motivation
- Arcane Missiles movement auras (89777/89778) should allow moving and turning during the channel, but the unit-side interrupt logic treated Arcane Missiles as turning-interruptible and caused random channel breaks when the player turned.

### Description
- Update `Unit::UpdateInterruptMask()` and `Unit::RemoveAurasWithInterruptFlags()` in `src/server/game/Entities/Unit/Unit.cpp` so `IsArcaneMissiles()` no longer sets the turning interrupt flag and only `IsHurricane()` sets both movement and turning interrupt flags, aligning unit interrupt checks with spell channel handling.

### Testing
- Compiled `src/server/game/Entities/Unit/Unit.cpp` using the build entry from `compile_commands.json`, and the single-file compile completed successfully.
- Began a full build with `cmake --build build --target game -- -j2`, but the multi-target build was interrupted after dependencies started rebuilding and was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad26e8440832784afe357425f0fd7)