### PR TITLE
Implement Time Travel Blink behavior and cooldown handling for Mage Blink

### DIFF
--- a/sql/updates/world/3.3.5/2026_05_18_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_05_18_00_world.sql
@@ -1,0 +1,4 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (1953, 89780) AND `ScriptName` IN ('spell_mage_blink', 'spell_mage_time_travel_blink');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(1953, 'spell_mage_blink'),
+(89780, 'spell_mage_time_travel_blink');

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -30,8 +30,11 @@
 #include "SpellMgr.h"
 #include "SpellScript.h"
 #include "CellImpl.h"
+#include "Position.h"
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
+
+#include <unordered_map>
 
 enum MageSpells
 {
@@ -77,7 +80,10 @@ enum MageSpells
     SPELL_MAGE_BROKEN_MANA_SHIELD                = 81331,
     SPELL_MAGE_IMPLOSION                         = 81332,
     SPELL_MAGE_RECALIBRATING                     = 81333,
-    SPELL_MAGE_IGNITE_SPREAD_AURA                = 81411
+    SPELL_MAGE_IGNITE_SPREAD_AURA                = 81411,
+    SPELL_MAGE_BLINK                              = 1953,
+    SPELL_MAGE_TIME_TRAVEL_PASSIVE                = 89776,
+    SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY            = 89780
 };
 
 enum MageSpellIcons
@@ -87,6 +93,47 @@ enum MageSpellIcons
     SPELL_ICON_MAGE_CLEARCASTING      = 212,
     SPELL_ICON_MAGE_LIVING_BOMB       = 3000
 };
+
+
+namespace
+{
+struct MageTimeTravelBlinkState
+{
+    WorldLocation ReturnLocation;
+    bool Consumed = false;
+};
+
+std::unordered_map<ObjectGuid, MageTimeTravelBlinkState> MageTimeTravelBlinkStates;
+
+void ClearMageBlinkCooldown(Unit* caster, bool update)
+{
+    SpellInfo const* blink = sSpellMgr->AssertSpellInfo(SPELL_MAGE_BLINK);
+    if (uint32 categoryId = blink->GetCategory())
+        caster->GetSpellHistory()->ResetCategoryCooldown(categoryId, update);
+
+    caster->GetSpellHistory()->ResetCooldown(SPELL_MAGE_BLINK, update);
+}
+
+void StartMageBlinkCooldown(Unit* caster, Spell* spell, int32 cooldownModMs)
+{
+    SpellInfo const* blink = sSpellMgr->AssertSpellInfo(SPELL_MAGE_BLINK);
+    SpellHistory* spellHistory = caster->GetSpellHistory();
+    spellHistory->SendCooldownEvent(blink, 0, spell);
+
+    if (cooldownModMs)
+        spellHistory->ModifyCooldown(SPELL_MAGE_BLINK, cooldownModMs);
+
+    if (Player* player = caster->GetCharmerOrOwnerPlayerOrPlayerItself())
+    {
+        if (uint32 remainingCooldown = spellHistory->GetRemainingCooldown(blink))
+        {
+            WorldPacket data;
+            spellHistory->BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_NONE, SPELL_MAGE_BLINK, remainingCooldown);
+            player->SendDirectMessage(&data);
+        }
+    }
+}
+}
 
 // Incanter's Absorbtion
 class spell_mage_incanters_absorbtion_base_AuraScript : public AuraScript
@@ -289,6 +336,155 @@ class spell_mage_burnout : public AuraScript
     {
         DoCheckProc += AuraCheckProcFn(spell_mage_burnout::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_mage_burnout::HandleProc, EFFECT_1, SPELL_AURA_DUMMY);
+    }
+};
+
+// 1953 - Blink
+class spell_mage_blink : public SpellScript
+{
+    PrepareSpellScript(spell_mage_blink);
+
+public:
+    spell_mage_blink() : _recordOrigin(false), _returnBlink(false), _returned(false), _origin() { }
+
+private:
+    SpellCastResult CheckCast()
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !caster->HasAura(SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY))
+            return SPELL_CAST_OK;
+
+        if (!caster->HasAura(SPELL_MAGE_TIME_TRAVEL_PASSIVE))
+            return SPELL_CAST_OK;
+
+        if (caster->HasUnitState(UNIT_STATE_STUNNED) || caster->HasAuraType(SPELL_AURA_MOD_STUN))
+            return SPELL_FAILED_STUNNED;
+
+        // If the return aura survived without stored position state (for example after a reload),
+        // remove it and let Blink behave as a fresh cast instead of teleporting to an invalid location.
+        if (MageTimeTravelBlinkStates.find(caster->GetGUID()) == MageTimeTravelBlinkStates.end())
+            caster->RemoveAurasDueToSpell(SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY);
+
+        return SPELL_CAST_OK;
+    }
+
+    void HandleBeforeCast()
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !caster->HasAura(SPELL_MAGE_TIME_TRAVEL_PASSIVE))
+            return;
+
+        ObjectGuid const casterGuid = caster->GetGUID();
+        if (caster->HasAura(SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY))
+        {
+            _returnBlink = MageTimeTravelBlinkStates.find(casterGuid) != MageTimeTravelBlinkStates.end();
+            return;
+        }
+
+        _origin = caster->GetWorldLocation();
+        _recordOrigin = true;
+    }
+
+    bool ReturnToStoredLocation(Unit* caster)
+    {
+        auto itr = MageTimeTravelBlinkStates.find(caster->GetGUID());
+        if (itr == MageTimeTravelBlinkStates.end())
+            return false;
+
+        itr->second.Consumed = true;
+
+        WorldLocation const& loc = itr->second.ReturnLocation;
+        if (caster->GetMapId() == loc.GetMapId())
+            caster->NearTeleportTo(loc.GetPositionX(), loc.GetPositionY(), loc.GetPositionZ(), loc.GetOrientation(), true);
+        else if (Player* player = caster->ToPlayer())
+            player->TeleportTo(loc.GetMapId(), loc.GetPositionX(), loc.GetPositionY(), loc.GetPositionZ(), loc.GetOrientation(), TELE_TO_NOT_LEAVE_COMBAT);
+        else
+            return false;
+
+        _returned = true;
+        return true;
+    }
+
+    void HandleTeleport(SpellEffIndex effIndex)
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !_returnBlink)
+            return;
+
+        PreventHitDefaultEffect(effIndex);
+        ReturnToStoredLocation(caster);
+    }
+
+    void HandleAfterCast()
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !caster->HasAura(SPELL_MAGE_TIME_TRAVEL_PASSIVE))
+            return;
+
+        ObjectGuid const casterGuid = caster->GetGUID();
+        if (_returnBlink)
+        {
+            if (!_returned)
+                ReturnToStoredLocation(caster);
+
+            caster->RemoveAurasDueToSpell(SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY);
+            MageTimeTravelBlinkStates.erase(casterGuid);
+            ClearMageBlinkCooldown(caster, true);
+            StartMageBlinkCooldown(caster, GetSpell(), 4 * IN_MILLISECONDS);
+            return;
+        }
+
+        if (!_recordOrigin)
+            return;
+
+        ClearMageBlinkCooldown(caster, true);
+        MageTimeTravelBlinkStates[casterGuid] = { _origin, false };
+        caster->CastSpell(caster, SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY, true);
+    }
+
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_mage_blink::CheckCast);
+        BeforeCast += SpellCastFn(spell_mage_blink::HandleBeforeCast);
+        OnEffectHitTarget += SpellEffectFn(spell_mage_blink::HandleTeleport, EFFECT_0, SPELL_EFFECT_TELEPORT_UNITS);
+        AfterCast += SpellCastFn(spell_mage_blink::HandleAfterCast);
+    }
+
+    bool _recordOrigin;
+    bool _returnBlink;
+    bool _returned;
+    WorldLocation _origin;
+};
+
+// 89780 - Time Travel Blink opportunity
+class spell_mage_time_travel_blink : public AuraScript
+{
+    PrepareAuraScript(spell_mage_time_travel_blink);
+
+    void OnRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        ObjectGuid const targetGuid = target->GetGUID();
+        auto itr = MageTimeTravelBlinkStates.find(targetGuid);
+        if (itr == MageTimeTravelBlinkStates.end())
+            return;
+
+        bool const consumed = itr->second.Consumed;
+        MageTimeTravelBlinkStates.erase(itr);
+
+        if (consumed || !target->HasAura(SPELL_MAGE_TIME_TRAVEL_PASSIVE))
+            return;
+
+        int32 elapsedMs = aurEff->GetBase()->GetMaxDuration();
+        if (elapsedMs < 0)
+            elapsedMs = 0;
+
+        StartMageBlinkCooldown(target, nullptr, -elapsedMs);
+    }
+
+    void Register() override
+    {
+        AfterEffectRemove += AuraEffectRemoveFn(spell_mage_time_travel_blink::OnRemove, EFFECT_FIRST_FOUND, SPELL_AURA_ANY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 
@@ -1425,6 +1621,7 @@ void AddSC_mage_spell_scripts()
     RegisterSpellScript(spell_mage_arcane_potency);
     RegisterSpellScript(spell_mage_arcane_missiles);
     RegisterSpellScript(spell_mage_blast_wave);
+    RegisterSpellScript(spell_mage_blink);
     RegisterSpellScript(spell_mage_blazing_speed);
     RegisterSpellScript(spell_mage_burning_determination);
     RegisterSpellScript(spell_mage_burnout);
@@ -1444,6 +1641,7 @@ void AddSC_mage_spell_scripts()
     RegisterSpellScript(spell_mage_glyph_of_icy_veins);
     RegisterSpellScript(spell_mage_glyph_of_ice_block);
     RegisterSpellScript(spell_mage_hot_streak);
+    RegisterSpellScript(spell_mage_time_travel_blink);
     RegisterSpellScript(spell_mage_ice_barrier);
     RegisterSpellScript(spell_mage_ice_block);
     RegisterSpellScript(spell_mage_ignite);


### PR DESCRIPTION
### Motivation

- Add support for a time-travel Blink mechanic that stores a Blink origin and allows a return Blink while correctly handling Blink cooldowns and edge cases.
- Ensure Blink interacts safely with the new passive/opportunity auras and recovers cooldowns when the opportunity expires or is consumed.
- Persist script name entries for the new aura/script bindings in the SQL update.

### Description

- Added SQL update `2026_05_18_00_world.sql` to insert `spell_script_names` rows for `1953` => `spell_mage_blink` and `89780` => `spell_mage_time_travel_blink`.
- Introduced enums for `SPELL_MAGE_BLINK`, `SPELL_MAGE_TIME_TRAVEL_PASSIVE`, and `SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY` and included required headers and an `unordered_map` to store per-player `MageTimeTravelBlinkState` with return location and consumed flag.
- Implemented helper functions `ClearMageBlinkCooldown` and `StartMageBlinkCooldown` to manipulate Blink cooldown and send cooldown packets.
- Implemented `spell_mage_blink` `SpellScript` to record origin on Blink, perform a return Blink to a stored location when `Time Travel` opportunity is active, consume/erase stored state, and correctly apply/reset cooldowns (including a small cooldown penalty on return).
- Implemented `spell_mage_time_travel_blink` `AuraScript` to handle aura removal, restore Blink cooldown based on remaining duration if the opportunity expires without being consumed, and to erase stored state.
- Registered the new spell scripts in `AddSC_mage_spell_scripts` and added necessary includes (`Position.h`) for teleport handling.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acc5f9dec8327a4e0b043b5f44d40)