### PR TITLE
Use caster orientation when returning from Time Travel Blink

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -394,10 +394,11 @@ private:
         itr->second.Consumed = true;
 
         WorldLocation const& loc = itr->second.ReturnLocation;
+        float const orientation = caster->GetOrientation();
         if (caster->GetMapId() == loc.GetMapId())
-            caster->NearTeleportTo(loc.GetPositionX(), loc.GetPositionY(), loc.GetPositionZ(), loc.GetOrientation(), true);
+            caster->NearTeleportTo(loc.GetPositionX(), loc.GetPositionY(), loc.GetPositionZ(), orientation, true);
         else if (Player* player = caster->ToPlayer())
-            player->TeleportTo(loc.GetMapId(), loc.GetPositionX(), loc.GetPositionY(), loc.GetPositionZ(), loc.GetOrientation(), TELE_TO_NOT_LEAVE_COMBAT);
+            player->TeleportTo(loc.GetMapId(), loc.GetPositionX(), loc.GetPositionY(), loc.GetPositionZ(), orientation, TELE_TO_NOT_LEAVE_COMBAT);
         else
             return false;
 


### PR DESCRIPTION
### Motivation
- Ensure the caster's facing is preserved when returning from the Time Travel/Blink return effect because the code previously used the stored return location's orientation which could produce incorrect facing after teleport.

### Description
- In `ReturnToStoredLocation` capture `caster->GetOrientation()` and use it for both `NearTeleportTo` and `Player::TeleportTo` calls instead of `loc.GetOrientation()` so the caster keeps their current orientation when returned.

### Testing
- Rebuilt the server and ran the spell/teleportation related unit tests (`spell_mage`/teleportation tests); all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae01e13ac8327bf2bd482ab1f2c73)