### PR TITLE
Apply 1500ms Blink GCD when mage lacks aura 89781

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -82,6 +82,7 @@ enum MageSpells
     SPELL_MAGE_RECALIBRATING                     = 81333,
     SPELL_MAGE_IGNITE_SPREAD_AURA                = 81411,
     SPELL_MAGE_BLINK                              = 1953,
+    SPELL_MAGE_BLINK_NO_GLOBAL_COOLDOWN           = 89781,
     SPELL_MAGE_TIME_TRAVEL_PASSIVE                = 89776,
     SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY            = 89780
 };
@@ -429,9 +430,27 @@ private:
         }
     }
 
+    void ApplyBlinkGlobalCooldown(Unit* caster)
+    {
+        if (!caster || caster->HasAura(SPELL_MAGE_BLINK_NO_GLOBAL_COOLDOWN))
+            return;
+
+        SpellHistory* spellHistory = caster->GetSpellHistory();
+        spellHistory->AddGlobalCooldown(GetSpellInfo(), 1500);
+
+        if (Player* player = caster->GetCharmerOrOwnerPlayerOrPlayerItself())
+        {
+            WorldPacket data;
+            spellHistory->BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_INCLUDE_GCD, SPELL_MAGE_BLINK, 0);
+            player->SendDirectMessage(&data);
+        }
+    }
+
     void HandleAfterCast()
     {
         Unit* caster = GetCaster();
+        ApplyBlinkGlobalCooldown(caster);
+
         if (!caster || !caster->HasAura(SPELL_MAGE_TIME_TRAVEL_PASSIVE))
             return;
 


### PR DESCRIPTION
### Motivation
- Blink should incur the normal 1500ms global cooldown unless the mage has the special no-GCD aura (89781), matching behavior implemented for other classes/spells. 
- Make the no-GCD exception explicit in the mage scripts so Blink can be exempted by the dedicated aura rather than implicit checks.

### Description
- Added `SPELL_MAGE_BLINK_NO_GLOBAL_COOLDOWN = 89781` to the `MageSpells` enum in `src/server/scripts/Spells/spell_mage.cpp` to name the exception aura. 
- Introduced `ApplyBlinkGlobalCooldown(Unit* caster)` and invoked it from `spell_mage_blink::HandleAfterCast` to add a 1500ms global cooldown via `SpellHistory::AddGlobalCooldown` when the caster does not have `SPELL_MAGE_BLINK_NO_GLOBAL_COOLDOWN`, and to send the corresponding cooldown packet with `BuildCooldownPacket` to the owning player. 
- The change is localized to the mage spell script and preserves the existing Time Travel Blink logic and cooldown adjustments.

### Testing
- Performed repository diff/style check and found no issues. 
- Ran a syntax-only compile and successfully built the object file for `src/server/scripts/Spells/spell_mage.cpp` (targeted `ninja` object build completed). 
- Started a broader `scripts` rebuild to verify integration; the targeted compilation finished successfully while the full rebuild was left running/interrupted after verification of the modified object file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae7bf7c908327b108e99ecb157b27)