### PR TITLE
Mage: spawn ghostly echo at Time Travel Blink origin

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -33,6 +33,7 @@
 #include "Position.h"
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
+#include "ObjectAccessor.h"
 
 #include <unordered_map>
 
@@ -84,7 +85,8 @@ enum MageSpells
     SPELL_MAGE_BLINK                              = 1953,
     SPELL_MAGE_BLINK_NO_GLOBAL_COOLDOWN           = 89781,
     SPELL_MAGE_TIME_TRAVEL_PASSIVE                = 89776,
-    SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY            = 89780
+    SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY            = 89780,
+    SPELL_MAGE_GHOST_VISUAL                       = 8326
 };
 
 enum MageSpellIcons
@@ -101,6 +103,7 @@ namespace
 struct MageTimeTravelBlinkState
 {
     WorldLocation ReturnLocation;
+    ObjectGuid EchoGuid;
     bool Consumed = false;
 };
 
@@ -133,6 +136,17 @@ void StartMageBlinkCooldown(Unit* caster, Spell* spell, int32 cooldownModMs)
             player->SendDirectMessage(&data);
         }
     }
+}
+
+void DespawnMageTimeTravelEcho(Unit* owner, MageTimeTravelBlinkState& state)
+{
+    if (!owner || state.EchoGuid.IsEmpty())
+        return;
+
+    if (Creature* echo = ObjectAccessor::GetCreature(*owner, state.EchoGuid))
+        echo->DespawnOrUnsummon();
+
+    state.EchoGuid.Clear();
 }
 }
 
@@ -461,7 +475,11 @@ private:
                 ReturnToStoredLocation(caster);
 
             caster->RemoveAurasDueToSpell(SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY);
-            MageTimeTravelBlinkStates.erase(casterGuid);
+            if (auto itr = MageTimeTravelBlinkStates.find(casterGuid); itr != MageTimeTravelBlinkStates.end())
+            {
+                DespawnMageTimeTravelEcho(caster, itr->second);
+                MageTimeTravelBlinkStates.erase(itr);
+            }
             ClearMageBlinkCooldown(caster, true);
             StartMageBlinkCooldown(caster, GetSpell(), 4 * IN_MILLISECONDS);
             return;
@@ -471,7 +489,24 @@ private:
             return;
 
         ClearMageBlinkCooldown(caster, true);
-        MageTimeTravelBlinkStates[casterGuid] = { _origin, false };
+        MageTimeTravelBlinkStates[casterGuid] = { _origin, ObjectGuid::Empty, false };
+
+        int32 echoDurationMs = 0;
+        if (SpellInfo const* opportunitySpell = sSpellMgr->GetSpellInfo(SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY, GetCastDifficulty()))
+            echoDurationMs = opportunitySpell->GetMaxDuration();
+        if (echoDurationMs <= 0)
+            echoDurationMs = 6000;
+
+        if (Creature* echo = caster->SummonCreature(WORLD_TRIGGER, _origin.GetPositionX(), _origin.GetPositionY(), _origin.GetPositionZ(), _origin.GetOrientation(), TEMPSUMMON_TIMED_DESPAWN, echoDurationMs))
+        {
+            echo->SetDisplayId(caster->GetDisplayId());
+            echo->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC);
+            echo->SetReactState(REACT_PASSIVE);
+            echo->SetImmuneToAll(true);
+            echo->CastSpell(echo, SPELL_MAGE_GHOST_VISUAL, true);
+            MageTimeTravelBlinkStates[casterGuid].EchoGuid = echo->GetGUID();
+        }
+
         caster->CastSpell(caster, SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY, true);
     }
 
@@ -503,6 +538,7 @@ class spell_mage_time_travel_blink : public AuraScript
             return;
 
         bool const consumed = itr->second.Consumed;
+        DespawnMageTimeTravelEcho(target, itr->second);
         MageTimeTravelBlinkStates.erase(itr);
 
         if (consumed || !target->HasAura(SPELL_MAGE_TIME_TRAVEL_PASSIVE))


### PR DESCRIPTION
### Motivation
- Provide a visible, untargetable, invincible ghost copy at the origin of a Time Travel Blink so the original position is represented while the caster is away.
- Ensure the ghost goes away either when the Blink return is consumed or when the Time Travel opportunity aura naturally expires (spell `89780`).

### Description
- Added `SPELL_MAGE_GHOST_VISUAL` and extended `MageTimeTravelBlinkState` with an `EchoGuid` to track the summoned echo. 
- Added helper `DespawnMageTimeTravelEcho(...)` and included `ObjectAccessor` for explicit echo lookup and cleanup. 
- On the first Blink with Time Travel active, summon a `WORLD_TRIGGER` at the origin, copy the caster display, make it non-selectable/non-attackable/passive/immune, cast the ghost visual, and time its despawn to the opportunity duration (fallback 6000ms). 
- Ensure the echo is explicitly despawned both when the return Blink is consumed and when the `89780` aura is removed so the echo disappears on recast or natural expiry.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd669d9f48327a35e4d6202bb8590)