### PR TITLE
Fix Blink echo to copy full player appearance

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -498,7 +498,14 @@ private:
 
         if (TempSummon* echo = caster->SummonCreature(WORLD_TRIGGER, _origin.GetPositionX(), _origin.GetPositionY(), _origin.GetPositionZ(), _origin.GetOrientation(), TEMPSUMMON_TIMED_DESPAWN, Milliseconds(echoDurationMs)))
         {
-            echo->SetDisplayId(caster->GetDisplayId());
+            if (Player* playerCaster = caster->ToPlayer())
+                echo->CopyAppearanceFromPlayer(playerCaster, false, true, false);
+            else
+            {
+                echo->SetDisplayId(caster->GetDisplayId());
+                echo->SetNativeDisplayId(caster->GetDisplayId());
+            }
+
             echo->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_UNINTERACTIBLE | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC);
             echo->SetReactState(REACT_PASSIVE);
             echo->SetImmuneToAll(true);


### PR DESCRIPTION
### Motivation
- Blink's summoned echo previously only had `SetDisplayId` applied, which missed player customization and equipment visuals causing the ghost to not match the caster. 
- The change aligns the echo behavior with existing appearance-copying code paths (e.g. `.npc set copy` / warchief appearance copy) so the echo mirrors player appearance fully.

### Description
- When summoning the Blink echo in `src/server/scripts/Spells/spell_mage.cpp`, call `CopyAppearanceFromPlayer(playerCaster, false, true, false)` if the caster is a player to copy model/customization and visible equipment.
- Preserve prior behavior for non-player casters by setting both `SetDisplayId` and `SetNativeDisplayId` as a fallback.
- All other echo properties (flags, react state, immunity, visual spell, and GUID tracking) remain unchanged.

### Testing
- Ran `git diff -- src/server/scripts/Spells/spell_mage.cpp` to inspect the patch and it displayed the intended modification successfully. 
- Committed the change with `git commit -m "Fix blink echo ghost to copy caster player appearance"` and the commit succeeded. 
- Verified the modified snippet with `nl -ba src/server/scripts/Spells/spell_mage.cpp | sed -n '492,520p'` and confirmed the new `CopyAppearanceFromPlayer` branch is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be50512988327a856678f185d8e24)