### PR TITLE
spell_mage: ensure Time Travel Blink echo keeps player appearance and add short blink cooldown entry

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -490,6 +490,7 @@ private:
             return;
 
         ClearMageBlinkCooldown(caster, true);
+        caster->GetSpellHistory()->AddCooldown(SPELL_MAGE_BLINK, 0, Milliseconds(250));
         MageTimeTravelBlinkStates[casterGuid] = { _origin, ObjectGuid::Empty, false };
 
         int32 echoDurationMs = sSpellMgr->AssertSpellInfo(SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY)->GetMaxDuration();
@@ -498,7 +499,14 @@ private:
 
         if (TempSummon* echo = caster->SummonCreature(WORLD_TRIGGER, _origin.GetPositionX(), _origin.GetPositionY(), _origin.GetPositionZ(), _origin.GetOrientation(), TEMPSUMMON_TIMED_DESPAWN, Milliseconds(echoDurationMs)))
         {
-            echo->SetDisplayId(caster->GetDisplayId());
+            if (Player* playerCaster = caster->ToPlayer())
+                echo->CopyAppearanceFromPlayer(playerCaster, false, true, false);
+            else
+            {
+                echo->SetDisplayId(caster->GetDisplayId());
+                echo->SetNativeDisplayId(caster->GetDisplayId());
+            }
+
             echo->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_UNINTERACTIBLE | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC);
             echo->SetReactState(REACT_PASSIVE);
             echo->SetImmuneToAll(true);


### PR DESCRIPTION
### Motivation
- Ensure the summoned Time Travel Blink echo accurately mirrors a player's full appearance instead of only using the raw display ID.
- Add a short recorded cooldown entry for `SPELL_MAGE_BLINK` to the caster's spell history to prevent immediate recast/client desync after recording the blink origin.

### Description
- Added `caster->GetSpellHistory()->AddCooldown(SPELL_MAGE_BLINK, 0, Milliseconds(250));` when recording the blink origin to register a 250ms cooldown in spell history.
- When summoning the echo, use `echo->CopyAppearanceFromPlayer(playerCaster, false, true, false);` for `Player` casters so the echo copies the player's full appearance, and for non-player casters set both `SetDisplayId` and `SetNativeDisplayId` to the caster's display ID as a fallback.
- Preserved existing behavior of setting unit flags, react state, immunity, visual spell cast, and storing the echo GUID in `MageTimeTravelBlinkStates`.

### Testing
- Project build completed successfully with the changes (`make` / build step succeeded). 
- Automated test suite was executed (`make test` / `ctest`) and relevant server spell tests involving mage blink/time-travel echoes passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be50512988327a856678f185d8e24)