### PR TITLE
Mage Blink: honor Time Travel passive GCD and fix echo appearance

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -450,8 +450,12 @@ private:
         if (!caster || caster->HasAura(SPELL_MAGE_BLINK_NO_GLOBAL_COOLDOWN))
             return;
 
+        uint32 globalCooldownMs = 1500;
+        if (!_returnBlink && caster->HasAura(SPELL_MAGE_TIME_TRAVEL_PASSIVE))
+            globalCooldownMs = 250;
+
         SpellHistory* spellHistory = caster->GetSpellHistory();
-        spellHistory->AddGlobalCooldown(GetSpellInfo(), 1500);
+        spellHistory->AddGlobalCooldown(GetSpellInfo(), globalCooldownMs);
 
         if (Player* player = caster->GetCharmerOrOwnerPlayerOrPlayerItself())
         {
@@ -490,6 +494,7 @@ private:
             return;
 
         ClearMageBlinkCooldown(caster, true);
+        caster->GetSpellHistory()->AddCooldown(SPELL_MAGE_BLINK, 0, Milliseconds(250));
         MageTimeTravelBlinkStates[casterGuid] = { _origin, ObjectGuid::Empty, false };
 
         int32 echoDurationMs = sSpellMgr->AssertSpellInfo(SPELL_MAGE_TIME_TRAVEL_OPPORTUNITY)->GetMaxDuration();
@@ -498,7 +503,14 @@ private:
 
         if (TempSummon* echo = caster->SummonCreature(WORLD_TRIGGER, _origin.GetPositionX(), _origin.GetPositionY(), _origin.GetPositionZ(), _origin.GetOrientation(), TEMPSUMMON_TIMED_DESPAWN, Milliseconds(echoDurationMs)))
         {
-            echo->SetDisplayId(caster->GetDisplayId());
+            if (Player* playerCaster = caster->ToPlayer())
+                echo->CopyAppearanceFromPlayer(playerCaster, false, true, false);
+            else
+            {
+                echo->SetDisplayId(caster->GetDisplayId());
+                echo->SetNativeDisplayId(caster->GetDisplayId());
+            }
+
             echo->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_UNINTERACTIBLE | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC);
             echo->SetReactState(REACT_PASSIVE);
             echo->SetImmuneToAll(true);


### PR DESCRIPTION
### Motivation
- Allow the Time Travel passive to reduce the Blink global cooldown to 250ms for the initial (non-return) Blink. 
- Ensure the Blink echo (time-travel world trigger) mirrors the caster's visible appearance correctly. 
- Preserve existing return-Blink behavior and penalties while applying the new shorter GCD only when appropriate.

### Description
- Added a `globalCooldownMs` variable in `ApplyBlinkGlobalCooldown` and use a 250ms GCD when `_returnBlink` is false and the caster has `SPELL_MAGE_TIME_TRAVEL_PASSIVE`, otherwise use 1500ms. 
- Pass the computed `globalCooldownMs` into `SpellHistory::AddGlobalCooldown` instead of the hardcoded `1500`. 
- When recording an origin for Time Travel Blink, add a 250ms cooldown to the Blink spell via `caster->GetSpellHistory()->AddCooldown(SPELL_MAGE_BLINK, 0, Milliseconds(250))`. 
- When summoning the temporal echo, copy the player's full appearance with `CopyAppearanceFromPlayer` if the caster is a `Player`, and fall back to setting `DisplayId`/`NativeDisplayId` for non-player casters. 

### Testing
- Built the server and ran the automated test suite (`make` and the project unit tests) with no failures. 
- Verified automated spell-history/cooldown logic tests to ensure the GCD and Blink cooldown entries are applied as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be50512988327a856678f185d8e24)