### PR TITLE
Fix Blink client GCD packet for casts without aura 89781

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -456,7 +456,7 @@ private:
         if (Player* player = caster->GetCharmerOrOwnerPlayerOrPlayerItself())
         {
             WorldPacket data;
-            spellHistory->BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_INCLUDE_GCD, SPELL_MAGE_BLINK, 0);
+            spellHistory->BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_INCLUDE_GCD, 6119, 0);
             player->SendDirectMessage(&data);
         }
     }


### PR DESCRIPTION
### Motivation
- Blink was applying the global cooldown server-side but the client packet used the Blink spell ID, which prevented other spells from showing on the client GCD when aura `89781` (no-GCD) is not present. 
- The intent is to mirror the working Nature's Grasp implementation that advertises the canonical GCD spell to the client so the client UI properly locks other abilities.

### Description
- Updated `spell_mage_blink::ApplyBlinkGlobalCooldown` in `src/server/scripts/Spells/spell_mage.cpp` to build the cooldown packet using spell `6119` instead of `SPELL_MAGE_BLINK`. 
- The change causes the client to receive the canonical GCD spell in the cooldown packet (`BuildCooldownPacket(..., 6119, 0)`), matching the `spell_dru_natures_grasp_proc` pattern.
- No other behavior or server-side GCD logic was altered.

### Testing
- Verified the source change with `git diff -- src/server/scripts/Spells/spell_mage.cpp` and inspected the modified lines with `nl -ba src/server/scripts/Spells/spell_mage.cpp`, both succeeded. 
- Confirmed the change was added to the repo via `git status --short` and committed successfully with the message `Fix Blink client GCD packet for non-noGCD aura`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1e97dfc48327933ea6d0ad1416d6)