### PR TITLE
Apply Vanish aura (89783) on Vanish and remove 81439/89783 when stealth breaks

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1532,6 +1532,9 @@ void AuraEffect::HandleModStealth(AuraApplication const* aurApp, uint8 mode, boo
             if (target->HasAura(81439))
                 target->RemoveAurasDueToSpell(81439);
 
+            if (target->HasAura(89783))
+                target->RemoveAurasDueToSpell(89783);
+
             target->RemoveVisFlag(UNIT_VIS_FLAGS_CREEP);
             if (target->GetTypeId() == TYPEID_PLAYER)
                 target->RemoveByteFlag(PLAYER_FIELD_BYTES2, PLAYER_FIELD_BYTES_2_OFFSET_AURA_VISION, PLAYER_FIELD_BYTE2_STEALTH);

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -70,6 +70,8 @@ enum RogueSpells
     SPELL_ROGUE_IMPROVED_EVASION_TRIGGER        = 81403,
     SPELL_ROGUE_IMPROVED_EVASION_AURA           = 81404,
     SPELL_ROGUE_GOUGE_DOT_REMOVAL_AURA          = 81410,
+    SPELL_ROGUE_STEALTH_AURA_STALKER            = 81439,
+    SPELL_ROGUE_VANISH_AURA                     = 89783,
     SPELL_ROGUE_DEADLY_SHOT_INTERRUPT_TRIGGER   = 89159
 };
 
@@ -1205,7 +1207,7 @@ class spell_rog_vanish : public AuraScript
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo({ SPELL_ROGUE_STEALTH });
+        return ValidateSpellInfo({ SPELL_ROGUE_STEALTH, SPELL_ROGUE_VANISH_AURA, SPELL_ROGUE_STEALTH_AURA_STALKER });
     }
 
     void ApplyStealth(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
@@ -1225,8 +1227,10 @@ class spell_rog_vanish : public AuraScript
 
         unitTarget->CastSpell(nullptr, SPELL_ROGUE_STEALTH, true);
 
+        unitTarget->AddAura(SPELL_ROGUE_VANISH_AURA, unitTarget);
+
         if (unitTarget->HasAura(81412))
-            unitTarget->AddAura(81439, unitTarget);
+            unitTarget->AddAura(SPELL_ROGUE_STEALTH_AURA_STALKER, unitTarget);
     }
 
     void Register() override


### PR DESCRIPTION
### Motivation
- Ensure Vanish always applies helper aura `89783` when it grants stealth and ensure both `89783` and existing `81439` are removed whenever the rogue leaves stealth for any reason.

### Description
- Added named constants `SPELL_ROGUE_STEALTH_AURA_STALKER = 81439` and `SPELL_ROGUE_VANISH_AURA = 89783` in `src/server/scripts/Spells/spell_rogue.cpp` to avoid hardcoded IDs.
- Extended Vanish `ValidateSpellInfo` to include `SPELL_ROGUE_VANISH_AURA` and `SPELL_ROGUE_STEALTH_AURA_STALKER` in `spell_rog_vanish`.
- Modified Vanish `ApplyStealth` to always call `AddAura(SPELL_ROGUE_VANISH_AURA, ...)` after casting stealth and keep the conditional application of the stalker aura tied to the existing `81412` check.
- Updated stealth removal logic in `src/server/game/Spells/Auras/SpellAuraEffects.cpp` to remove both `81439` and `89783` when the last `SPELL_AURA_MOD_STEALTH` is removed.

### Testing
- No automated tests or CI/build were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c248425348327886cf105db627b58)