### PR TITLE
Fix return Blink destination flash projection

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -364,6 +364,17 @@ public:
     spell_mage_blink() : _recordOrigin(false), _returnBlink(false), _returned(false), _origin() { }
 
 private:
+    void HandleReturnBlinkDestination(WorldLocation& dest)
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !_returnBlink)
+            return;
+
+        // Return Blink should not project the regular forward Blink destination,
+        // otherwise clients can render the teleport flash in front of the caster.
+        dest.Relocate(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ(), caster->GetOrientation());
+    }
+
     SpellCastResult CheckCast()
     {
         Unit* caster = GetCaster();
@@ -521,6 +532,7 @@ private:
     {
         OnCheckCast += SpellCheckCastFn(spell_mage_blink::CheckCast);
         BeforeCast += SpellCastFn(spell_mage_blink::HandleBeforeCast);
+        OnDestinationTargetSelect += SpellDestinationTargetSelectFn(spell_mage_blink::HandleReturnBlinkDestination, EFFECT_0, TARGET_DEST_CASTER_FRONT_LEAP);
         OnEffectHitTarget += SpellEffectFn(spell_mage_blink::HandleReturnBlinkEffect, EFFECT_ALL, SPELL_EFFECT_ANY);
         AfterCast += SpellCastFn(spell_mage_blink::HandleAfterCast);
     }


### PR DESCRIPTION
### Motivation
- Players reported that a Blink recast visual flash is rendered in front of the caster instead of at their actual return location, caused by the client projecting Blink's normal forward destination when performing the Time Travel return Blink. 
- The change aims to prevent the misleading teleport flash while preserving the existing return teleport and cooldown semantics.

### Description
- Added `HandleReturnBlinkDestination(WorldLocation& dest)` to `spell_mage_blink` to override the projected destination to the caster's current position when handling a return Blink. 
- Registered the handler with `OnDestinationTargetSelect` for `TARGET_DEST_CASTER_FRONT_LEAP` so the override applies only to Blink destination selection during recast. 
- Change is confined to `src/server/scripts/Spells/spell_mage.cpp` and does not modify the actual teleport logic in `HandleReturnBlinkEffect` or cooldown behavior.

### Testing
- Ran `git diff --check` to validate whitespace and patch cleanliness, which succeeded.
- Verified the modified file `src/server/scripts/Spells/spell_mage.cpp` compiles locally as part of the standard build (no runtime tests were executed in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d76127edc83278bd7e4897bd9b627)