### PR TITLE
Fix rogue Vanish (89783) projectile immunity and stealth protections

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4362,7 +4362,7 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
         ++iter;
         if ((aura->GetSpellInfo()->AuraInterruptFlags & flag) && (!except || aura->GetId() != except))
         {
-            if (HasAura(81439) && aura->HasEffectType(SPELL_AURA_MOD_STEALTH))
+            if ((HasAura(81439) || HasAura(89783)) && aura->HasEffectType(SPELL_AURA_MOD_STEALTH))
             {
                 uint32 const protectedFlags = AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE |
                                              AURA_INTERRUPT_FLAG_DIRECT_DAMAGE | AURA_INTERRUPT_FLAG_MELEE_ATTACK |

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -976,7 +976,7 @@ bool Aura::ModCharges(int32 num, AuraRemoveMode removeMode)
         if (num < 0 && GetId() == 1784)
         {
             if (Unit* owner = m_owner->ToUnit())
-                if (owner->HasAura(81439))
+                if (owner->HasAura(81439) || owner->HasAura(89783))
                     return false;
         }
 
@@ -2211,8 +2211,8 @@ void Aura::PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInf
     {
         Unit* target = aurApp->GetTarget();
 
-        // Do not consume stealth proc charges when the unit is protected by aura 81439 (Stealth Aura Stalker)
-        if (!(GetId() == 1784 && target && target->HasAura(81439)))
+        // Do not consume stealth proc charges when the unit is protected by aura 81439 (Stealth Aura Stalker) or 89783 (Vanish Aura)
+        if (!(GetId() == 1784 && target && (target->HasAura(81439) || target->HasAura(89783))))
         {
             --m_procCharges;
             SetNeedClientUpdateForTargets();

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2879,6 +2879,10 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
     if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster))
         return SPELL_MISS_IMMUNE;
 
+    // Vanish aura protects against hostile projectiles that were already in flight before stealth was gained
+    if (m_spellInfo->Speed > 0.0f && unit->HasAura(89783) && m_caster && m_caster != unit && m_caster->IsValidAttackTarget(unit, m_spellInfo))
+        return SPELL_MISS_IMMUNE;
+
     if (Player* player = unit->ToPlayer())
     {
         player->StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_SPELL_TARGET, m_spellInfo->Id);


### PR DESCRIPTION
### Motivation
- Prevent hostile projectiles already in flight from hitting a rogue that Vanishes midflight. 
- Ensure the Vanish aura `89783` behaves like stealth aura `81439` for proc charge protection and for preventing certain stealth-breaking interrupts.

### Description
- In `Spell::PreprocessSpellHit` added a check that makes delayed/projectile spells (`Speed > 0`) miss targets that have aura `89783` when the caster is an enemy. (`src/server/game/Spells/Spell.cpp`)
- Updated `Aura::ModCharges` to skip decrementing charges for stealth procs when the owner has aura `89783` in addition to `81439`. (`src/server/game/Spells/Auras/SpellAuras.cpp`)
- Updated `Aura::PrepareProcToTrigger` to treat `89783` the same as `81439` so stealth proc charges are not consumed while Vanish protection is active. (`src/server/game/Spells/Auras/SpellAuras.cpp`)
- Updated `Unit::RemoveAurasWithInterruptFlags` to consider `89783` alongside `81439` when deciding to ignore certain interrupt flags so Vanish does not break from those protected effects. (`src/server/game/Entities/Unit/Unit.cpp`)

### Testing
- No automated test suite was executed as part of this change; only repository-level checks (diff/commit) were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eec0ea780832797f79a3f7371d0cb)