### PR TITLE
playerbot: avoid unordered_set assignment in RandomBotParticipation OnWorldUpdate

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -49,6 +49,7 @@
 #include <deque>
 #include <limits>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <sstream>
 #include <unordered_map>
@@ -1199,7 +1200,7 @@ void RandomBotParticipationManager::OnStartupBootstrap()
 
 void RandomBotParticipationManager::OnWorldUpdate(uint32 diffMs)
 {
-    std::unordered_set<uint32> botAccountsForSweep;
+    std::optional<std::unordered_set<uint32>> botAccountsForSweep;
     bool shouldRunScmSweep = false;
 
     {
@@ -1208,12 +1209,15 @@ void RandomBotParticipationManager::OnWorldUpdate(uint32 diffMs)
         if (!g_RandomPopulation.config.enabled || !g_RandomPopulation.runtimeEnabled)
             return;
 
-        botAccountsForSweep = g_RandomPopulation.config.botAccountIds;
-        if (botAccountsForSweep.empty())
+        if (g_RandomPopulation.config.botAccountIds.empty())
         {
             g_RandomPopulation.skippedNoCandidatePool++;
             return;
         }
+
+        // Use copy-construction instead of assignment to avoid allocator-heavy
+        // unordered_set assignment internals on the world update thread.
+        botAccountsForSweep.emplace(g_RandomPopulation.config.botAccountIds);
 
         if (g_RandomPopulation.rebalanceTimerMs < g_RandomPopulation.config.rebalanceIntervalMs)
             g_RandomPopulation.rebalanceTimerMs += diffMs;
@@ -1231,7 +1235,7 @@ void RandomBotParticipationManager::OnWorldUpdate(uint32 diffMs)
         }
     }
 
-    RecoverManagedVirtualBotTeleports(botAccountsForSweep);
+    RecoverManagedVirtualBotTeleports(*botAccountsForSweep);
 
     // Avoid running the SCM sweep while holding g_RandomPopulationLock:
     // lifecycle queue operations can call TriggerImmediateRebalance(), which
@@ -1239,7 +1243,7 @@ void RandomBotParticipationManager::OnWorldUpdate(uint32 diffMs)
     if (!shouldRunScmSweep)
         return;
 
-    ForceManagedScmQueueSweep(botAccountsForSweep);
+    ForceManagedScmQueueSweep(*botAccountsForSweep);
 }
 
 void RandomBotParticipationManager::OnPlayerLogout(Player const* player)


### PR DESCRIPTION
### Motivation
- A server crash stack trace implicated `std::unordered_set` assignment internals (`_M_assign_elements`) during the random bot world update path, with allocator/jemalloc frames present. 
- The change aims to remove the assignment path on this hot loop to reduce allocator churn and avoid the crash scenario. 
- The fix is applied to the active playerbot code (not the `playerbot reference/` directory) and preserves existing lifecycle/locking behavior.

### Description
- Replaced the local `std::unordered_set<uint32> botAccountsForSweep` with `std::optional<std::unordered_set<uint32>> botAccountsForSweep` to defer construction. 
- Copy-constructs the snapshot under `g_RandomPopulationLock` via `botAccountsForSweep.emplace(g_RandomPopulation.config.botAccountIds)` instead of using `operator=`. 
- Dereferences the optional when calling `RecoverManagedVirtualBotTeleports` and `ForceManagedScmQueueSweep` to keep call sites unchanged. 
- Added `#include <optional>` and left rebalance/teleport/sweep flow and locks intact.

### Testing
- No automated build or unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eeb97324c832799f455f5255d3582)