### PR TITLE
Playerbots: skip fear/polymorph targets with any DR level

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1609,7 +1609,7 @@ Unit const* SelectPolymorphTarget(Player const* player, Unit const* primaryTarge
             continue;
         if (IsTargetInvalidByImmunity(player, candidate))
             continue;
-        if (polymorphDrGroup != DIMINISHING_NONE && candidate->GetDiminishing(polymorphDrGroup) >= DIMINISHING_LEVEL_IMMUNE)
+        if (polymorphDrGroup != DIMINISHING_NONE && candidate->GetDiminishing(polymorphDrGroup) > DIMINISHING_LEVEL_0)
             continue;
 
         if (candidate->GetClass() == CLASS_PALADIN || candidate->GetClass() == CLASS_PRIEST)
@@ -1732,7 +1732,7 @@ Unit const* SelectWarlockFearTarget(Player const* player, float maxDistance)
         if (fearInfo && candidate->IsImmunedToSpell(fearInfo, player))
             return true;
 
-        if (fearDrGroup != DIMINISHING_NONE && candidate->GetDiminishing(fearDrGroup) >= DIMINISHING_LEVEL_IMMUNE)
+        if (fearDrGroup != DIMINISHING_NONE && candidate->GetDiminishing(fearDrGroup) > DIMINISHING_LEVEL_0)
             return true;
 
         return false;


### PR DESCRIPTION
### Motivation
- Ensure playerbots do not attempt to cast polymorph or fear on enemies that already have any diminishing-returns (DR) stack for those effects, matching expected PvP behavior.

### Description
- Change two DR checks in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` from comparing against `DIMINISHING_LEVEL_IMMUNE` to rejecting any DR greater than `DIMINISHING_LEVEL_0` (use `> DIMINISHING_LEVEL_0`) for both polymorph and fear target selection.

### Testing
- Ran code searches with `rg` to verify the updated checks and `git diff`/`nl` to inspect the changed lines, and committed the change; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eed5cc84c832784bdb7695233e44e)