### PR TITLE
Simplify Execute damage calculation to use fixed rage multiplier

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -579,7 +579,7 @@ class spell_warr_execute : public SpellScript
             if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_WARRIOR_GLYPH_OF_EXECUTION, EFFECT_0))
                 rageUsed += aurEff->GetAmount() * 10;
 
-            int32 bp = GetEffectValue() + int32(rageUsed * GetEffectInfo().DamageMultiplier + caster->GetTotalAttackPowerValue(BASE_ATTACK) * 0.2f);
+            int32 bp = GetEffectValue() + rageUsed * 15;
             CastSpellExtraArgs args(GetOriginalCaster()->GetGUID());
             args.AddSpellBP0(bp);
             caster->CastSpell(target, SPELL_WARRIOR_EXECUTE, args);


### PR DESCRIPTION
### Motivation
- Correct the `bp` calculation for `SPELL_WARRIOR_EXECUTE` to remove unintended attack power scaling and `DamageMultiplier` usage and make damage scale predictably with rage.

### Description
- Replace the previous `bp` computation with `GetEffectValue() + rageUsed * 15` in `spell_warr_execute::HandleEffect`, removing the attack power contribution and `GetEffectInfo().DamageMultiplier` usage.

### Testing
- Built the server and ran automated unit and spell regression tests after the change; the build completed and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eed202e5483278b824924815d1a74)