### PR TITLE
Playerbot: stabilize charge/intercept movement handling

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -813,9 +813,6 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     minReissueMs = std::max<uint32>(minReissueMs, 500);
 
-    if (IsWarsongGulch(player))
-        minReissueMs = std::max<uint32>(minReissueMs, 500);
-
     struct MoveOrderState
     {
         Position lastDestination;
@@ -833,15 +830,11 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         state.lastDestination.GetExactDist(destination) >= destinationChangeThreshold;
     bool const canReissueByTime = state.lastIssueMs == 0 || nowMs >= state.lastIssueMs + minReissueMs;
     bool const botCurrentlyMoving = player->isMoving();
-    bool const hardThrottleActive = IsWarsongGulch(player) && !canReissueByTime;
     bool const forcedStationaryReissue = !destinationChanged && !canReissueByTime && !botCurrentlyMoving;
     if (forcedStationaryReissue)
         stationaryReissueCount = std::min<uint8>(uint8(stationaryReissueCount + 1), 20);
     else
         stationaryReissueCount = 0;
-
-    if (hardThrottleActive && botCurrentlyMoving)
-        return false;
 
     if (!destinationChanged && !canReissueByTime && botCurrentlyMoving)
         return false;
@@ -874,8 +867,8 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         currentMovement != CHASE_MOTION_TYPE &&
         currentMovement != POINT_MOTION_TYPE &&
         // Charge/Intercept movement is issued through effect generators.
-        // Do not treat those as stale while they are resolving.
-        currentMovement != EFFECT_MOTION_TYPE)
+        // Clear stale effect movement only once charge state has ended.
+        (currentMovement != EFFECT_MOTION_TYPE || !player->HasUnitState(UNIT_STATE_CHARGING)))
     {
         EmitBattlegroundGmDebug(player,
             "movepoint=clear-stale-generator motionType=" + std::to_string(uint32(currentMovement)), 1000);


### PR DESCRIPTION
### Motivation
- Fix warrior bot behavior where bots teleport/jitter or remain stuck until a server restart by addressing stale movement state handling.
- Ensure Charge/Intercept actually carries the bot toward its target by avoiding premature suppression of effect-based movement.
- Remove a Warsong-Gulch-specific throttling special-case so movement reissue pacing is generic across battlegrounds.

### Description
- Removed the Warsong-Gulch specific `minReissueMs` hard-throttle and the `hardThrottleActive` early-return in `IssueMovePointThrottled` so throttling is generic across battlegrounds.
- Adjusted stale movement-generator cleanup so `EFFECT_MOTION_TYPE` (used for Charge/Intercept) is allowed to continue while the unit has `UNIT_STATE_CHARGING` and only cleared as stale once charging state has ended.
- All edits were made in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and applied to the active Playerbot source (reference mirror untouched).

### Testing
- Ran `git diff --check` to validate there are no whitespace/errors in the diff, and it succeeded.
- Ran `git status --short` to verify only the intended file was modified, and it showed the staged change.
- Created a commit for the change (`git commit`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eef60cee88327bfad9f7d9f03e4a6)