### PR TITLE
Fix compile errors: blink destination signature and missing Bag include

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Chat.h"
+#include "Bag.h"
 #include "Creature.h"
 #include "DBCStores.h"
 #include "GameObject.h"

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -364,7 +364,7 @@ public:
     spell_mage_blink() : _recordOrigin(false), _returnBlink(false), _returned(false), _origin() { }
 
 private:
-    void HandleReturnBlinkDestination(WorldLocation& dest)
+    void HandleReturnBlinkDestination(SpellDestination& dest)
     {
         Unit* caster = GetCaster();
         if (!caster || !_returnBlink)


### PR DESCRIPTION
### Motivation
- Resolve CI compile failures caused by a callback signature mismatch for the Blink spell destination handler and incomplete-type errors for `Bag` usage in the Gurubashi arena script.

### Description
- Change the Blink handler signature from `HandleReturnBlinkDestination(WorldLocation&)` to `HandleReturnBlinkDestination(SpellDestination&)` in `src/server/scripts/Spells/spell_mage.cpp` to match the `SpellDestinationTargetSelectFn` expectation, and add `#include "Bag.h"` to `src/server/scripts/Custom/custom_gurubashi_arena.cpp` so `Bag` methods (`GetBagSize`, `GetItemByPos`) are available.

### Testing
- No automated tests were executed for this change; edits are limited to two small build-fix adjustments that address the original compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef0e2115c8327b9062b31342017ca)