### PR TITLE
Fix Blink return destination handling and add missing include

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Chat.h"
+#include "Bag.h"
 #include "Creature.h"
 #include "DBCStores.h"
 #include "GameObject.h"

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -364,7 +364,7 @@ public:
     spell_mage_blink() : _recordOrigin(false), _returnBlink(false), _returned(false), _origin() { }
 
 private:
-    void HandleReturnBlinkDestination(WorldLocation& dest)
+    void HandleReturnBlinkDestination(SpellDestination& dest)
     {
         Unit* caster = GetCaster();
         if (!caster || !_returnBlink)
@@ -372,7 +372,7 @@ private:
 
         // Return Blink should not project the regular forward Blink destination,
         // otherwise clients can render the teleport flash in front of the caster.
-        dest.Relocate(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ(), caster->GetOrientation());
+        dest.Relocate(Position(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ(), caster->GetOrientation()));
     }
 
     SpellCastResult CheckCast()


### PR DESCRIPTION
### Motivation

- Fix Blink return behavior to use the correct destination type after API changes to prevent incorrect client rendering of teleport flash. 
- Add a missing include required by the custom Gurubashi arena script to resolve compilation dependency on bag-related types.

### Description

- Change the Blink handler signature to accept `SpellDestination` instead of `WorldLocation` and update logic to use `Position` when calling `Relocate` to preserve orientation and coordinates. 
- Update the `Relocate` call to `dest.Relocate(Position(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ(), caster->GetOrientation()))` to avoid projecting the forward Blink destination for return blinks. 
- Add the `#include "Bag.h"` header to `custom_gurubashi_arena.cpp` to satisfy dependencies introduced/required by that script.

### Testing

- Performed a full project build which completed successfully with the changes applied. 
- No automated test suites were modified; no test failures were observed during the build or compilation step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef0e2115c8327b9062b31342017ca)