### PR TITLE
Playerbot: require snare before warrior disarm attempt

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2622,7 +2622,9 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
     Unit const* nearbyMeleeTarget = SelectNearbyMeleeTarget(player, activeTarget, 8.0f);
     Unit const* nearbyCastingTarget = SelectEnemyCastingTarget(player, 8.0f, activeTarget);
     bool const hasNearbyMeleeThreat = HasHostileTarget(player, nearbyMeleeTarget);
+    bool const nearbyMeleeThreatSnared = hasNearbyMeleeThreat && nearbyMeleeTarget->HasAuraWithMechanic(1 << MECHANIC_SNARE);
     bool const canDisarmNearbyMeleeThreat = hasNearbyMeleeThreat &&
+        nearbyMeleeThreatSnared &&
         player->IsWithinMeleeRange(nearbyMeleeTarget) &&
         nearbyMeleeTarget->CanUseAttackType(BASE_ATTACK) &&
         !HasAuraFromSpellChain(nearbyMeleeTarget, 676);


### PR DESCRIPTION
### Motivation
- Tighten warrior playerbot PvP behavior so Disarm is only considered for nearby melee threats that are already affected by a snare mechanic to avoid wasting the cooldown on unsnared targets.

### Description
- Added a `nearbyMeleeThreatSnared` check and required it in the existing `canDisarmNearbyMeleeThreat` condition in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` so Disarm candidates are only added when the target has `MECHANIC_SNARE`.

### Testing
- Verified the change with `git diff` and committed the update using `git commit` and inspected the modified lines with `nl`/`sed`; these commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef3661b308327989c7a5dcbf662ff)