### PR TITLE
Fix Chromie PvP consumable restore charge mismatch and whisper gating

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -653,10 +653,15 @@ bool RestoreItemCharges(Item* item)
     for (uint8 spellIndex = 0; spellIndex < MAX_ITEM_PROTO_SPELLS; ++spellIndex)
     {
         int32 const maxCharges = itemTemplate->Spells[spellIndex].SpellCharges;
-        if (maxCharges == 0 || item->GetSpellCharges(spellIndex) == maxCharges)
+        if (maxCharges == 0)
             continue;
 
-        item->SetSpellCharges(spellIndex, maxCharges);
+        int32 const restoredCharges = (maxCharges > 0) ? (maxCharges + 1) : (maxCharges - 1);
+        int32 const currentCharges = item->GetSpellCharges(spellIndex);
+        if (currentCharges == restoredCharges)
+            continue;
+
+        item->SetSpellCharges(spellIndex, restoredCharges);
         restoredAny = true;
     }
 


### PR DESCRIPTION
### Motivation
- Chromie restoration for PvP consumables was setting an off-by-one charge value and also whispered the player even when no actual charge value changed, causing misleading notifications.

### Description
- Adjusted `RestoreItemCharges` in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` to compute a `restoredCharges` target from the item template and only call `SetSpellCharges` when `item->GetSpellCharges(spellIndex)` differs from `restoredCharges`, ensuring the restored value matches the full usable charge count and preventing unnecessary updates and whispers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef623f3c88327b1d1a8772a08266a)