### PR TITLE
Fix Chromie PvP consumable charge refresh sync

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -640,9 +640,9 @@ bool ShouldTrackGurubashiPlayer(Player const* player)
     return player && player->IsInWorld() && player->GetMapId() == GURUBASHI_ARENA_MAP_ID && player->GetZoneId() == STRANGLETHORN_VALE_ZONE_ID;
 }
 
-bool RestoreItemCharges(Item* item)
+bool RestoreItemCharges(Item* item, Player* owner)
 {
-    if (!item)
+    if (!item || !owner)
         return false;
 
     ItemTemplate const* itemTemplate = item->GetTemplate();
@@ -665,6 +665,9 @@ bool RestoreItemCharges(Item* item)
         restoredAny = true;
     }
 
+    if (restoredAny)
+        item->SetState(ITEM_CHANGED, owner);
+
     return restoredAny;
 }
 
@@ -675,9 +678,9 @@ bool RestorePvpConsumableCharges(Player* player)
 
     bool restoredAny = false;
 
-    auto tryRestoreItem = [&restoredAny](Item* item)
+    auto tryRestoreItem = [player, &restoredAny](Item* item)
     {
-        restoredAny = RestoreItemCharges(item) || restoredAny;
+        restoredAny = RestoreItemCharges(item, player) || restoredAny;
     };
 
     for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)


### PR DESCRIPTION
### Motivation
- Address Chromie notifying players about PvP consumable charges that still appeared cached (stale) on the client and ensure she only whispers when charges actually change.

### Description
- Change `RestoreItemCharges` to `RestoreItemCharges(Item* item, Player* owner)` and call `item->SetState(ITEM_CHANGED, owner)` when charges were modified, and update `RestorePvpConsumableCharges` to pass the owning `Player*` so updates are pushed to the client immediately.

### Testing
- No automated tests were run; only repository verification commands were executed (`git diff`, `git status`, `git add` and `git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef825ab34832788b3790969c0cebc)