### PR TITLE
Fix unsafe erase iteration in Player::Update instance reset cleanup

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1379,7 +1379,7 @@ void Player::Update(uint32 p_time)
         for (InstanceTimeMap::iterator itr = _instanceResetTimes.begin(); itr != _instanceResetTimes.end();)
         {
             if (itr->second < now)
-                _instanceResetTimes.erase(itr++);
+                itr = _instanceResetTimes.erase(itr);
             else
                 ++itr;
         }


### PR DESCRIPTION
### Motivation
- Prevent a potential crash caused by unsafe iterator usage when erasing entries from `_instanceResetTimes` during `Player::Update`, as indicated by a stacktrace pointing to `std::unordered_map::erase`.

### Description
- Replace `_instanceResetTimes.erase(itr++)` with the iterator-safe form `itr = _instanceResetTimes.erase(itr)` in `src/server/game/Entities/Player/Player.cpp` so erase progression is explicit and well-defined.

### Testing
- No automated tests were executed for this change; a rebuild and CI run are recommended to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0efb1837448327a7a895658dedd277)