### PR TITLE
Recreate Chromie PvP consumables when charges are below max

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -649,7 +649,7 @@ bool RestoreItemCharges(Item* item, Player* owner)
     if (!itemTemplate || itemTemplate->ItemLimitCategory != PVP_CONSUMABLE_ITEM_LIMIT_CATEGORY)
         return false;
 
-    bool restoredAny = false;
+    bool hasBelowMaxCharges = false;
     for (uint8 spellIndex = 0; spellIndex < MAX_ITEM_PROTO_SPELLS; ++spellIndex)
     {
         int32 const maxCharges = itemTemplate->Spells[spellIndex].SpellCharges;
@@ -657,18 +657,29 @@ bool RestoreItemCharges(Item* item, Player* owner)
             continue;
 
         int32 const restoredCharges = (maxCharges > 0) ? (maxCharges + 1) : (maxCharges - 1);
-        int32 const currentCharges = item->GetSpellCharges(spellIndex);
-        if (currentCharges == restoredCharges)
-            continue;
-
-        item->SetSpellCharges(spellIndex, restoredCharges);
-        restoredAny = true;
+        if (item->GetSpellCharges(spellIndex) != restoredCharges)
+        {
+            hasBelowMaxCharges = true;
+            break;
+        }
     }
 
-    if (restoredAny)
-        item->SetState(ITEM_CHANGED, owner);
+    if (!hasBelowMaxCharges)
+        return false;
 
-    return restoredAny;
+    uint8 const bagSlot = item->GetBagSlot();
+    uint8 const slot = item->GetSlot();
+    uint32 const itemEntry = item->GetEntry();
+    int32 const randomPropertyId = item->GetItemRandomPropertyId();
+
+    owner->DestroyItem(bagSlot, slot, true);
+
+    ItemPosCountVec dest;
+    if (owner->CanStoreNewItem(bagSlot, slot, dest, itemEntry, 1) != EQUIP_ERR_OK)
+        return false;
+
+    owner->StoreNewItem(dest, itemEntry, true, randomPropertyId);
+    return true;
 }
 
 bool RestorePvpConsumableCharges(Player* player)


### PR DESCRIPTION
### Motivation
- Stop mutating per-spell charge fields on existing PvP consumable items and instead restore them by recreating the item to ensure default creation behavior is used.
- Ensure Chromie’s Gurubashi arena logic returns consumables to their original (max) charge state without directly setting internal charge values.
- Keep the behavior restricted to entries in the PvP consumable item limit category so only intended items are affected.

### Description
- Rewrote `RestoreItemCharges` in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` to detect if any spell charge slot is below its restored maximum and bail out early if not.
- When a below-max charge is detected, the function captures the item identity (`GetEntry`, `GetItemRandomPropertyId`, bag/slot), calls `owner->DestroyItem`, and then uses `CanStoreNewItem`/`StoreNewItem` to create a fresh copy in the same location. 
- Removed the previous logic that directly called `SetSpellCharges` and `SetState(ITEM_CHANGED, owner)` and now return `true` only when an item was recreated.

### Testing
- Ran `git diff -- src/server/scripts/Custom/custom_gurubashi_arena.cpp` to verify the patch was applied, which succeeded. 
- Ran `git status --short` to confirm only the intended file was modified, which succeeded. 
- Committed the change with `git commit -m "Update Chromie consumable charge restore to recreate items"` and created the PR via `make_pr`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0efb6b311883279fc34e71ef2fc495)