### PR TITLE
Reset Gurubashi PVP consumables by recreating items and remove redundant refresh calls

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -649,26 +649,38 @@ bool RestoreItemCharges(Item* item, Player* owner)
     if (!itemTemplate || itemTemplate->ItemLimitCategory != PVP_CONSUMABLE_ITEM_LIMIT_CATEGORY)
         return false;
 
-    bool restoredAny = false;
+    bool hasBelowMaxCharges = false;
     for (uint8 spellIndex = 0; spellIndex < MAX_ITEM_PROTO_SPELLS; ++spellIndex)
     {
         int32 const maxCharges = itemTemplate->Spells[spellIndex].SpellCharges;
         if (maxCharges == 0)
             continue;
 
-        int32 const restoredCharges = (maxCharges > 0) ? (maxCharges + 1) : (maxCharges - 1);
         int32 const currentCharges = item->GetSpellCharges(spellIndex);
-        if (currentCharges == restoredCharges)
-            continue;
-
-        item->SetSpellCharges(spellIndex, restoredCharges);
-        restoredAny = true;
+        bool const isBelowMaxCharges = (maxCharges > 0) ? (currentCharges < maxCharges) : (currentCharges > maxCharges);
+        if (isBelowMaxCharges)
+        {
+            hasBelowMaxCharges = true;
+            break;
+        }
     }
 
-    if (restoredAny)
-        item->SetState(ITEM_CHANGED, owner);
+    if (!hasBelowMaxCharges)
+        return false;
 
-    return restoredAny;
+    uint8 const bagSlot = item->GetBagSlot();
+    uint8 const slot = item->GetSlot();
+    uint32 const itemEntry = item->GetEntry();
+    int32 const randomPropertyId = item->GetItemRandomPropertyId();
+
+    owner->DestroyItem(bagSlot, slot, true);
+
+    ItemPosCountVec dest;
+    if (owner->CanStoreNewItem(bagSlot, slot, dest, itemEntry, 1) != EQUIP_ERR_OK)
+        return false;
+
+    owner->StoreNewItem(dest, itemEntry, true, randomPropertyId);
+    return true;
 }
 
 bool RestorePvpConsumableCharges(Player* player)
@@ -726,13 +738,11 @@ public:
 
     void OnMapChanged(Player* player) override
     {
-        RefreshPvpConsumablesIfInStranglethorn(player);
         UpdateGurubashiPlayerTracking(player);
     }
 
     void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
     {
-        RefreshPvpConsumablesIfInStranglethorn(player);
         UpdateGurubashiPlayerTracking(player);
     }
 


### PR DESCRIPTION
### Motivation

- Ensure PVP consumable items in Gurubashi Arena are fully restored to their proper charge state using the item creation path instead of directly mutating charge fields, and avoid redundant refresh calls on zone/map changes.

### Description

- Replace per-spell direct charge mutation in `RestoreItemCharges` with a check for below-max charges and, when needed, recreate the item via `DestroyItem` + `CanStoreNewItem` + `StoreNewItem` to ensure proper initialization and state updates.  
- Return early from `RestoreItemCharges` when no spell is below its max charges to avoid unnecessary item operations.  
- Remove calls to `RefreshPvpConsumablesIfInStranglethorn` from the `OnMapChanged` and `OnUpdateZone` handlers in `gurubashi_arena_exit_tracker` to avoid duplicate refresh attempts.

### Testing

- Project built successfully using the standard build (`cmake --build .`) and no compile errors were produced.  
- Automated test suite executed via `ctest` and relevant tests covering item handling and player scripts passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0efb6b311883279fc34e71ef2fc495)