### PR TITLE
Reset PvP consumable charges by recreating items and refactor restoration logic

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -640,35 +640,50 @@ bool ShouldTrackGurubashiPlayer(Player const* player)
     return player && player->IsInWorld() && player->GetMapId() == GURUBASHI_ARENA_MAP_ID && player->GetZoneId() == STRANGLETHORN_VALE_ZONE_ID;
 }
 
-bool RestoreItemCharges(Item* item, Player* owner)
+bool HasBelowMaxCharges(Item const* item)
 {
-    if (!item || !owner)
+    if (!item)
         return false;
 
     ItemTemplate const* itemTemplate = item->GetTemplate();
     if (!itemTemplate || itemTemplate->ItemLimitCategory != PVP_CONSUMABLE_ITEM_LIMIT_CATEGORY)
         return false;
 
-    bool restoredAny = false;
     for (uint8 spellIndex = 0; spellIndex < MAX_ITEM_PROTO_SPELLS; ++spellIndex)
     {
         int32 const maxCharges = itemTemplate->Spells[spellIndex].SpellCharges;
         if (maxCharges == 0)
             continue;
 
-        int32 const restoredCharges = (maxCharges > 0) ? (maxCharges + 1) : (maxCharges - 1);
         int32 const currentCharges = item->GetSpellCharges(spellIndex);
-        if (currentCharges == restoredCharges)
-            continue;
-
-        item->SetSpellCharges(spellIndex, restoredCharges);
-        restoredAny = true;
+        bool const isBelowMaxCharges = (maxCharges > 0) ? (currentCharges < maxCharges) : (currentCharges > maxCharges);
+        if (isBelowMaxCharges)
+            return true;
     }
 
-    if (restoredAny)
-        item->SetState(ITEM_CHANGED, owner);
+    return false;
+}
 
-    return restoredAny;
+bool RestoreItemCharges(Player* owner, uint8 bagSlot, uint8 slot)
+{
+    if (!owner)
+        return false;
+
+    Item* item = owner->GetItemByPos(bagSlot, slot);
+    if (!HasBelowMaxCharges(item))
+        return false;
+
+    uint32 const itemEntry = item->GetEntry();
+    int32 const randomPropertyId = item->GetItemRandomPropertyId();
+
+    owner->DestroyItem(bagSlot, slot, true);
+
+    ItemPosCountVec dest;
+    if (owner->CanStoreNewItem(bagSlot, slot, dest, itemEntry, 1) != EQUIP_ERR_OK)
+        return false;
+
+    owner->StoreNewItem(dest, itemEntry, true, randomPropertyId);
+    return true;
 }
 
 bool RestorePvpConsumableCharges(Player* player)
@@ -676,20 +691,21 @@ bool RestorePvpConsumableCharges(Player* player)
     if (!player)
         return false;
 
-    bool restoredAny = false;
-
-    auto tryRestoreItem = [player, &restoredAny](Item* item)
-    {
-        restoredAny = RestoreItemCharges(item, player) || restoredAny;
-    };
+    std::vector<std::pair<uint8, uint8>> itemsToRestore;
 
     for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
-        tryRestoreItem(player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot));
+        if (HasBelowMaxCharges(player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot)))
+            itemsToRestore.emplace_back(INVENTORY_SLOT_BAG_0, slot);
 
     for (uint8 bagSlot = INVENTORY_SLOT_BAG_START; bagSlot < INVENTORY_SLOT_BAG_END; ++bagSlot)
         if (Bag* bag = player->GetBagByPos(bagSlot))
             for (uint8 slot = 0; slot < bag->GetBagSize(); ++slot)
-                tryRestoreItem(bag->GetItemByPos(slot));
+                if (HasBelowMaxCharges(bag->GetItemByPos(slot)))
+                    itemsToRestore.emplace_back(bagSlot, slot);
+
+    bool restoredAny = false;
+    for (auto const& [bagSlot, slot] : itemsToRestore)
+        restoredAny = RestoreItemCharges(player, bagSlot, slot) || restoredAny;
 
     return restoredAny;
 }
@@ -726,13 +742,11 @@ public:
 
     void OnMapChanged(Player* player) override
     {
-        RefreshPvpConsumablesIfInStranglethorn(player);
         UpdateGurubashiPlayerTracking(player);
     }
 
     void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
     {
-        RefreshPvpConsumablesIfInStranglethorn(player);
         UpdateGurubashiPlayerTracking(player);
     }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect in-place charge restoration for PvP consumables and avoid modifying item containers while iterating them. 
- Ensure items that are below their maximum charges are reliably reset to full charges. 
- Remove redundant calls to refresh consumables on map/zone updates to avoid unnecessary work.

### Description
- Introduce `HasBelowMaxCharges(Item const*)` to detect items with charges below their configured maximum. 
- Replace `RestoreItemCharges(Item*, Player*)` with `RestoreItemCharges(Player*, uint8 bagSlot, uint8 slot)` that destroys and recreates the item (preserving `randomPropertyId`) to reset charges. 
- Change `RestorePvpConsumableCharges` to first collect candidate `(bagSlot, slot)` pairs using `HasBelowMaxCharges` and then restore them to avoid mutating containers during iteration. 
- Remove calls to `RefreshPvpConsumablesIfInStranglethorn` from `OnMapChanged` and `OnUpdateZone` handlers in the player script.

### Testing
- Project build succeeded after the changes. 
- Existing automated unit/integration tests were executed and passed. 
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0efb6b311883279fc34e71ef2fc495)