### PR TITLE
Guard player visibility broadcasts when not in world

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6606,6 +6606,9 @@ void Player::SendMessageToSet(WorldPacket const* data, Player const* skipped_rcv
     if (skipped_rcvr != this)
         SendDirectMessage(data);
 
+    if (!IsInWorld())
+        return;
+
     // we use World::GetMaxVisibleDistance() because i cannot see why not use a distance
     // update: replaced by GetMap()->GetVisibilityDistance()
     Trinity::MessageDistDeliverer notifier(this, data, GetVisibilityRange(), false, skipped_rcvr);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1735,7 +1735,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void ProcessTerrainStatusUpdate(ZLiquidStatus oldLiquidStatus, Optional<LiquidData> const& newLiquidData) override;
         void AtExitCombat() override;
 
-        void SendMessageToSet(WorldPacket const* data, bool self) const override { SendMessageToSetInRange(data, GetVisibilityRange(), self); }
+        void SendMessageToSet(WorldPacket const* data, bool self) const override { if (IsInWorld()) SendMessageToSetInRange(data, GetVisibilityRange(), self); }
         void SendMessageToSetInRange(WorldPacket const* data, float dist, bool self) const override;
         void SendMessageToSetInRange(WorldPacket const* data, float dist, bool self, bool own_team_only, bool required3dDist = false) const;
         void SendMessageToSet(WorldPacket const* data, Player const* skipped_rcvr) const override;


### PR DESCRIPTION
### Motivation
- Crash logs showed `WorldObject::GetMap` asserting during logout cleanup when aura removal triggered client updates that call visibility/broadcast code on a player detached from its `Map`, so visibility-dependent operations must be avoided for out-of-world players. 

### Description
- Added an `IsInWorld()` guard to the inline overload `Player::SendMessageToSet(WorldPacket const* data, bool self)` so it only calls `SendMessageToSetInRange` when the player is still in-world. 
- Added an early `if (!IsInWorld()) return;` guard in `Player::SendMessageToSet(WorldPacket const* data, Player const* skipped_rcvr)` after sending the direct/self packet to avoid calling `GetVisibilityRange()`/`GetMap()` on a detached player. 
- Changes made in `src/server/game/Entities/Player/Player.h` and `src/server/game/Entities/Player/Player.cpp`.

### Testing
- Ran repository checks with `git diff --check` which completed without reported whitespace or patch issues. 
- Verified working patterns and replacements by searching code paths that lead to visibility broadcasts using `rg` and inspecting the modified functions to ensure the guards are present. 
- No full build or runtime tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f00122964832799a43062958598ed)