### PR TITLE
Fix PvP consumable refill after BG return to STV

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -742,11 +742,13 @@ public:
 
     void OnMapChanged(Player* player) override
     {
+        RefreshPvpConsumablesIfInStranglethorn(player);
         UpdateGurubashiPlayerTracking(player);
     }
 
     void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
     {
+        RefreshPvpConsumablesIfInStranglethorn(player);
         UpdateGurubashiPlayerTracking(player);
     }
 


### PR DESCRIPTION
### Motivation
- Players who AFK out of battlegrounds and are teleported back to Stranglethorn Vale (via Chromie/Gurubashi flow) were not getting their PvP consumable charges restored because restoration only ran on login, not on map/zone changes.

### Description
- Call `RefreshPvpConsumablesIfInStranglethorn(player)` from `OnMapChanged` and `OnUpdateZone` in the `gurubashi_arena_exit_tracker` `PlayerScript` to trigger consumable charge restoration when a player teleports/returns to STV without relogging; change made in `src/server/scripts/Custom/custom_gurubashi_arena.cpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f02b7a79483278929072cd57db598)