### PR TITLE
Allow Arcanum enchants (22840/22846) to stack like ZG enchants

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3557,7 +3557,7 @@ Aura* Unit::_TryStackingOrRefreshingExistingAura(AuraCreateInfo& createInfo)
         // find current aura from spell and change it's stackamount, or refresh it's duration
         if (Aura* foundAura = GetOwnedAura(createInfo.GetSpellInfo()->Id, createInfo.GetSpellInfo()->IsStackableOnOneSlotWithDifferentCasters() ? ObjectGuid::Empty : createInfo.CasterGUID, createInfo.GetSpellInfo()->HasAttribute(SPELL_ATTR0_CU_ENCHANT_PROC) ? castItemGUID : ObjectGuid::Empty))
         {
-            if (IsZulGurubClassEnchant(createInfo.GetSpellInfo()->Id) && foundAura->GetCastItemGUID() != castItemGUID)
+            if ((IsZulGurubClassEnchant(createInfo.GetSpellInfo()->Id) || IsArcanumEnchant(createInfo.GetSpellInfo()->Id)) && foundAura->GetCastItemGUID() != castItemGUID)
                 return nullptr;
 
             // effect masks do not match

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1879,9 +1879,10 @@ bool Aura::CanStackWith(Aura const* existingAura) const
     if (this == existingAura)
         return true;
 
-    // HACK: Allow ZG class head/leg enchants to stack with each other (e.g. helm + legs)
+    // HACK: Allow ZG class head/leg enchants and Arcanums to stack with each other (e.g. helm + legs)
     uint32 const existingSpellId = existingAura->GetSpellInfo()->Id;
-    if (IsZulGurubClassEnchant(m_spellInfo->Id) && IsZulGurubClassEnchant(existingSpellId))
+    if ((IsZulGurubClassEnchant(m_spellInfo->Id) && IsZulGurubClassEnchant(existingSpellId)) ||
+        (IsArcanumEnchant(m_spellInfo->Id) && IsArcanumEnchant(existingSpellId)))
         return true;
 
     bool sameCaster = GetCasterGUID() == existingAura->GetCasterGUID();

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -72,6 +72,18 @@ bool IsZulGurubClassEnchant(uint32 spellId)
     return false;
 }
 
+bool IsArcanumEnchant(uint32 spellId)
+{
+    switch (spellId)
+    {
+        case 22840: // Arcanum of Focus
+        case 22846: // Arcanum of Protection
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool IsPrimaryProfessionSkill(uint32 skill)
 {
     SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);
@@ -486,7 +498,8 @@ SpellGroupStackRule SpellMgr::CheckSpellGroupStackRules(SpellInfo const* spellIn
     ASSERT(spellInfo1);
     ASSERT(spellInfo2);
 
-    if (IsZulGurubClassEnchant(spellInfo1->Id) && IsZulGurubClassEnchant(spellInfo2->Id))
+    if ((IsZulGurubClassEnchant(spellInfo1->Id) && IsZulGurubClassEnchant(spellInfo2->Id)) ||
+        (IsArcanumEnchant(spellInfo1->Id) && IsArcanumEnchant(spellInfo2->Id)))
         return SPELL_GROUP_STACK_RULE_DEFAULT;
 
     uint32 spellid_1 = spellInfo1->GetFirstRankSpell()->Id;

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -738,6 +738,7 @@ class TC_GAME_API SpellMgr
 
 bool IsNaturesGraspAura(uint32 spellId);
 bool IsZulGurubClassEnchant(uint32 spellId);
+bool IsArcanumEnchant(uint32 spellId);
 
 #define sSpellMgr SpellMgr::instance()
 


### PR DESCRIPTION
### Motivation

- Zul'Gurub class head/leg enchants are currently allowed to stack with each other, but Arcanum enchants (e.g. `22840`, `22846`) were not treated the same; this change aligns Arcanums with the existing ZG stacking behavior.

### Description

- Added `IsArcanumEnchant(uint32 spellId)` helper in `SpellMgr` and declared it in `SpellMgr.h` to identify Arcanum enchant spells (`22840`, `22846`).
- Updated `SpellMgr::CheckSpellGroupStackRules` to bypass exclusive stack rules for Arcanum-vs-Arcanum pairs, matching the ZG exception path.
- Updated `Aura::CanStackWith` in `src/server/game/Spells/Auras/SpellAuras.cpp` so Arcanum enchants can stack with each other similarly to Zul'Gurub class enchants.
- Updated `Unit::_TryStackingOrRefreshingExistingAura` in `src/server/game/Entities/Unit/Unit.cpp` so Arcanum enchants from different cast-item GUIDs remain separate instances (mirrors existing ZG handling).

### Testing

- No automated build or unit tests were executed during this rollout.
- Performed repository checks and metadata operations: `git commit` succeeded and quick code searches (`rg`) confirmed the edits to `SpellMgr`, `SpellAuras.cpp`, and `Unit.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a4a63cf883278d06ed36f94f5152)