### PR TITLE
Add custom item flag to show class-restricted items on vendors

### DIFF
--- a/src/server/game/Entities/Item/ItemTemplate.h
+++ b/src/server/game/Entities/Item/ItemTemplate.h
@@ -223,7 +223,8 @@ enum ItemFlagsCustom
 {
     ITEM_FLAGS_CU_DURATION_REAL_TIME    = 0x0001,   // Item duration will tick even if player is offline
     ITEM_FLAGS_CU_IGNORE_QUEST_STATUS   = 0x0002,   // No quest status will be checked when this item drops
-    ITEM_FLAGS_CU_FOLLOW_LOOT_RULES     = 0x0004    // Item will always follow group/master/need before greed looting rules
+    ITEM_FLAGS_CU_FOLLOW_LOOT_RULES     = 0x0004,   // Item will always follow group/master/need before greed looting rules
+    ITEM_FLAGS_CU_VENDOR_SHOW_ALL_CLASSES = 0x0008  // Item is always shown in vendor inventory regardless of buyer class restriction
 };
 
 enum BAG_FAMILY_MASK

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -665,7 +665,10 @@ void WorldSession::SendListInventory(ObjectGuid vendorGuid)
         {
             if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(item->item))
             {
-                if (!(itemTemplate->AllowableClass & _player->GetClassMask()) && itemTemplate->Bonding == BIND_WHEN_PICKED_UP && !_player->IsGameMaster())
+                if (!(itemTemplate->AllowableClass & _player->GetClassMask()) &&
+                    itemTemplate->Bonding == BIND_WHEN_PICKED_UP &&
+                    !itemTemplate->HasFlag(ITEM_FLAGS_CU_VENDOR_SHOW_ALL_CLASSES) &&
+                    !_player->IsGameMaster())
                     continue;
                 // Only display items in vendor lists for the team the
                 // player is on. If GM on, display all items.


### PR DESCRIPTION
### Motivation
- Provide a simple item-template toggle so class-restricted, bind-on-pickup items can be made visible in vendor lists even when the buyer is a different class.

### Description
- Added `ITEM_FLAGS_CU_VENDOR_SHOW_ALL_CLASSES = 0x0008` to `ItemFlagsCustom` in `src/server/game/Entities/Item/ItemTemplate.h` and updated `WorldSession::SendListInventory` in `src/server/game/Handlers/ItemHandler.cpp` to skip the class-visibility filter when an item has this custom flag.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119c12c3008327afd24ca473631c39)