### PR TITLE
Restore warrior polearm/staff specialization on resurrection

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -229,6 +229,11 @@ public:
     {
         PolearmStaffInnerAuras::Sync(player);
     }
+
+    void OnPlayerResurrect(Player* player) override
+    {
+        PolearmStaffInnerAuras::Sync(player);
+    }
 };
 
 // 71, 2457, 2458 - Warrior Stances


### PR DESCRIPTION
### Motivation
- Players lose the warrior polearm/staff inner specialization aura after dying and it should be restored automatically when they revive while still wielding a polearm or staff.

### Description
- Added an `OnPlayerResurrect` override to `spell_warr_polearm_staff_inner_aura_player` that calls `PolearmStaffInnerAuras::Sync(player)` to reapply inner auras; change made in `src/server/scripts/Spells/spell_warrior.cpp`.

### Testing
- No automated tests were run for this trivial script change; change was validated by inspecting the updated diff and committing the file.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142375e3f083278a126ff628bc7c89)