### PR TITLE
Playerbot: throttle Hand of Sacrifice across ranks

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -58,6 +58,7 @@ bool IsLifeTapSpell(SpellInfo const* spellInfo)
 }
 
 constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
+constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 constexpr std::chrono::seconds kPlayerbotDispelCooldown = std::chrono::seconds(5);
 
 bool IsPlayerbotDispelSpell(uint32 spellId)
@@ -2936,8 +2937,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if ((context.spellId == 11719 || context.spellId == 11713) && target)
         playerbot::PvpClassActions::RegisterWarlockCurseTargetCooldown(player, target, context.spellId, std::chrono::seconds(12));
-    if (context.spellId == 6940)
-        playerbot::PvpClassActions::RegisterCasterSpellCooldown(player, context.spellId, std::chrono::seconds(10));
+    if (resolvedSpellId && IsPartOfSpellChain(resolvedSpellId, 6940))
+        playerbot::PvpClassActions::RegisterCasterSpellCooldown(player, kPlayerbotHandOfSacrificeCooldownToken, std::chrono::seconds(10));
 
     // Shared tactical cooldown for dispel/decurse effects. This keeps
     // playerbots from spam-casting into protected or undispellable auras while

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -57,6 +57,7 @@ constexpr float kRangedSpacingEnterOutOfRangeBuffer = 2.0f;
 constexpr float kRangedSpacingEnterTooCloseBuffer = 1.0f;
 constexpr uint32 kHunterAutoShotSpellId = 75;
 constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
+constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 std::unordered_map<ObjectGuid, bool> g_HunterRangedModeByBot;
 std::mutex g_HunterRangedModeByBotLock;
 std::unordered_map<ObjectGuid, uint8> g_CombatNoTargetTicksByBot;
@@ -2510,7 +2511,7 @@ SpellDecision SelectPaladinSpell(Player const* player, Unit const* target)
     AddDecisionCandidate(candidates,
         sacrificeTarget && sacrificeTarget != player &&
         !player->HasAura(6940) &&
-        !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, 6940) &&
+        !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, kPlayerbotHandOfSacrificeCooldownToken) &&
         !HasAuraFromSpellChain(sacrificeTarget, 6940) &&
         !HasAuraFromSpellChain(sacrificeTarget, 1022) &&
         !HasAuraFromSpellChain(sacrificeTarget, 1044), 53.0f,


### PR DESCRIPTION
### Motivation
- Playerbots could bypass the intended anti-spam throttle for Paladin "Hand of Sacrifice" when casting higher ranks that are part of the same spell chain, causing repeated immediate reapplication. 
- Provide a single tactical cooldown token that covers the Hand of Sacrifice spell chain so decision logic and cooldown registration remain consistent across ranks (including `6940` and `20729`).

### Description
- Added a new cooldown token `kPlayerbotHandOfSacrificeCooldownToken = 900005` to `PlayerbotPvpCore.cpp` and `PlayerbotPvpClassActions.cpp` to represent a shared tactical cooldown for the Hand of Sacrifice chain. 
- Updated paladin decision gating in `SelectPaladinSpell` to check `IsCasterSpellCooldownActive(player, kPlayerbotHandOfSacrificeCooldownToken)` before selecting Hand of Sacrifice, replacing the previous check keyed to the literal spell id. 
- Modified cast post-processing in `CastDirectSpell` to register the new token for any resolved spell that `IsPartOfSpellChain(..., 6940)`, so all ranks of the Hand of Sacrifice chain will trigger the same 10-second tactical cooldown.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141e91c5f4832790666478dcc0b741)