### PR TITLE
Fix playerbot PvP compile errors in aura and spell-chain checks

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2937,7 +2937,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if ((context.spellId == 11719 || context.spellId == 11713) && target)
         playerbot::PvpClassActions::RegisterWarlockCurseTargetCooldown(player, target, context.spellId, std::chrono::seconds(12));
-    if (resolvedSpellId && IsPartOfSpellChain(resolvedSpellId, 6940))
+    if (resolvedSpellId && sSpellMgr->GetFirstSpellInChain(resolvedSpellId) == sSpellMgr->GetFirstSpellInChain(6940))
         playerbot::PvpClassActions::RegisterCasterSpellCooldown(player, kPlayerbotHandOfSacrificeCooldownToken, std::chrono::seconds(10));
 
     // Shared tactical cooldown for dispel/decurse effects. This keeps

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -33,6 +33,7 @@
 #include "Pet.h"
 #include "Spell.h"
 #include "SpellAuras.h"
+#include "SpellAuraEffects.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
 #include "Unit.h"


### PR DESCRIPTION
### Motivation
- Resolve two compile-time errors observed when building the playerbot PvP scripts: an incomplete type use of `AuraEffect` and an undeclared `IsPartOfSpellChain` identifier.
- Ensure playerbot PvP code compiles against the current spell/aura APIs without changing runtime behavior.

### Description
- Added `#include "SpellAuraEffects.h"` to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` so `AuraEffect` is a complete type where `GetCasterGUID()` is used. 
- Replaced the missing `IsPartOfSpellChain(resolvedSpellId, 6940)` call in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` with an equivalent rank-chain comparison using `sSpellMgr->GetFirstSpellInChain(resolvedSpellId) == sSpellMgr->GetFirstSpellInChain(6940)`.

### Testing
- Ran `cmake --build . --target scripts game -j4` from the `build/` directory to validate compilation, and the build progressed through script and game compilation without reproducing the previously reported immediate errors in the modified files. 
- No automated unit tests were run; the change is limited to include and a local spell-chain check and was validated by the build progression above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142747e28483279187e1ae4a94efa9)