### PR TITLE
Reverse Scarlet Chapel buff orientations at two nodes

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -163,16 +163,16 @@ bool BattlegroundSCM::SetupBattleground()
             0.0f, 0.0f, -0.712033f, 0.702146f,
             RESPAWN_IMMEDIATELY)
         || !AddObject(BG_SCM_OBJECT_BUFF1_SPEED, BG_OBJECTID_SPEEDBUFF_ENTRY,
-            939.852112f, 1400.462524f, 18.339478f, 0.0f,
-            0.0f, 0.0f, 0.0f, 1.0f,
+            939.852112f, 1400.462524f, 18.339478f, 3.14159f,
+            0.0f, 0.0f, 1.0f, 0.0f,
             BG_SCM_BUFF_RESPAWN_TIME)
         || !AddObject(BG_SCM_OBJECT_BUFF1_REGEN, BG_OBJECTID_REGENBUFF_ENTRY,
-            939.852112f, 1400.462524f, 18.339478f, 0.0f,
-            0.0f, 0.0f, 0.0f, 1.0f,
+            939.852112f, 1400.462524f, 18.339478f, 3.14159f,
+            0.0f, 0.0f, 1.0f, 0.0f,
             BG_SCM_BUFF_RESPAWN_TIME)
         || !AddObject(BG_SCM_OBJECT_BUFF1_BERSERK, BG_OBJECTID_BERSERKERBUFF_ENTRY,
-            939.852112f, 1400.462524f, 18.339478f, 0.0f,
-            0.0f, 0.0f, 0.0f, 1.0f,
+            939.852112f, 1400.462524f, 18.339478f, 3.14159f,
+            0.0f, 0.0f, 1.0f, 0.0f,
             BG_SCM_BUFF_RESPAWN_TIME)
         || !AddObject(BG_SCM_OBJECT_BUFF2_SPEED, BG_OBJECTID_SPEEDBUFF_ENTRY,
             997.415649f, 1399.062012f, 27.136366f, 0.0f,
@@ -223,16 +223,16 @@ bool BattlegroundSCM::SetupBattleground()
             0.0f, 0.0f, 1.0f, 0.0f,
             BG_SCM_BUFF_RESPAWN_TIME)
         || !AddObject(BG_SCM_OBJECT_BUFF6_SPEED, BG_OBJECTID_SPEEDBUFF_ENTRY,
-            987.244507f, 1343.777466f, 29.146633f, 3.14159f,
-            0.0f, 0.0f, 1.0f, 0.0f,
+            987.244507f, 1343.777466f, 29.146633f, 0.0f,
+            0.0f, 0.0f, 0.0f, 1.0f,
             BG_SCM_BUFF_RESPAWN_TIME)
         || !AddObject(BG_SCM_OBJECT_BUFF6_REGEN, BG_OBJECTID_REGENBUFF_ENTRY,
-            987.244507f, 1343.777466f, 29.146633f, 3.14159f,
-            0.0f, 0.0f, 1.0f, 0.0f,
+            987.244507f, 1343.777466f, 29.146633f, 0.0f,
+            0.0f, 0.0f, 0.0f, 1.0f,
             BG_SCM_BUFF_RESPAWN_TIME)
         || !AddObject(BG_SCM_OBJECT_BUFF6_BERSERK, BG_OBJECTID_BERSERKERBUFF_ENTRY,
-            987.244507f, 1343.777466f, 29.146633f, 3.14159f,
-            0.0f, 0.0f, 1.0f, 0.0f,
+            987.244507f, 1343.777466f, 29.146633f, 0.0f,
+            0.0f, 0.0f, 0.0f, 1.0f,
             BG_SCM_BUFF_RESPAWN_TIME))
     {
         TC_LOG_ERROR("bg.battleground", "BattlegroundSCM::SetupBattleground: failed to spawn one or more Scarlet Chapel gameobjects.");


### PR DESCRIPTION
### Motivation
- Flip the facing of buff gameobjects in the Scarlet Chapel battleground so the buff models/orientation match the requested layout at the two specified locations. 
- This is a placement/orientation adjustment only and does not change gameplay logic or spawn timings. 

### Description
- Updated `BattlegroundSCM::SetupBattleground` in `src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp` to reverse buff facing for six buff spawns (three variants at each node). 
- At `939.852112, 1400.462524, 18.339478` changed yaw from `0.0f` to `3.14159f` and quaternion from `(0.0f, 0.0f, 0.0f, 1.0f)` to `(0.0f, 0.0f, 1.0f, 0.0f)` for the `SPEED`, `REGEN`, and `BERSERK` entries. 
- At `987.244507, 1343.777466, 29.146633` changed yaw from `3.14159f` to `0.0f` and quaternion from `(0.0f, 0.0f, 1.0f, 0.0f)` to `(0.0f, 0.0f, 0.0f, 1.0f)` for the `SPEED`, `REGEN`, and `BERSERK` entries. 

### Testing
- No automated tests were executed for this configuration/orientation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1475c3c7b48327a09a1dc11064021b)