### PR TITLE
Playerbots: prefer direct drop shortcuts when battleground pathing is inefficient

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -639,6 +639,31 @@ bool IsForbiddenBattlegroundPathType(PathType pathType)
 constexpr float PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT = 2400.0f;
 constexpr float PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE = 80.0f;
 
+bool ShouldPreferDirectDropShortcut(Player* player, Position const& destination)
+{
+    if (!player)
+        return false;
+
+    float const destinationDistance = player->GetDistance(destination);
+    if (destinationDistance < 15.0f || destinationDistance > 120.0f)
+        return false;
+
+    float const verticalDrop = player->GetPositionZ() - destination.GetPositionZ();
+    if (verticalDrop < 8.0f)
+        return false;
+
+    PathGenerator path(player);
+    path.SetPathLengthLimit(PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT);
+    if (!path.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), true))
+        return false;
+
+    if (IsForbiddenBattlegroundPathType(path.GetPathType()))
+        return false;
+
+    float const pathLength = path.GetTotalLength();
+    return pathLength > destinationDistance * 1.35f;
+}
+
 bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray const& points, float orientation, Position& segmentDestination)
 {
     if (!player || points.size() < 2)
@@ -880,6 +905,17 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     if (generatePath && player->InBattleground())
     {
+        if (ShouldPreferDirectDropShortcut(player, safeDestination))
+        {
+            motionMaster->MovePoint(0, safeDestination, false);
+            EmitBattlegroundGmDebug(player,
+                "movepoint=direct-drop-shortcut destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 0);
+
+            state.lastDestination = destination;
+            state.lastIssueMs = nowMs;
+            return true;
+        }
+
         Position segmentDestination;
         PathType pathType = PathType(0);
         if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))


### PR DESCRIPTION
### Motivation

- Enable playerbots to take downhill/drop shortcuts (e.g. Warsong Gulch graveyard jumps) when those are meaningfully faster than navmesh routing. 
- Avoid adding per-battleground hardcoded cases by providing a generic heuristic used by battleground movement logic. 
- Respect repository guidance to keep changes out of the `playerbot reference/` mirror and implement behavior in the active playerbot scripts.

### Description

- Added a new heuristic function `ShouldPreferDirectDropShortcut(Player* player, Position const& destination)` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` that checks distance bounds, vertical drop, and compares navmesh route length to direct distance to determine if a direct drop is preferable. 
- When issuing movement in `IssueMovePointThrottled`, call the heuristic before building navmesh segments and, if it returns true, issue a direct `motionMaster->MovePoint(0, safeDestination, false)` so bots will take the faster downward shortcut and emit a battleground GM debug line. 
- Keep existing segmented navmesh pathing behavior as the fallback and update the movement state (`lastDestination` / `lastIssueMs`) when the direct-drop shortcut is used. 
- No changes were made inside `playerbot reference/`; the new logic is implemented only in the active playerbot code path.

### Testing

- Invoked `cmake --build build --target worldserver -j2`; the build started and object files were produced (compile output observed), but the logged output was truncated before a final success/failure line could be observed in this environment. 
- Invoked `cmake --build build --target scripts -j2`; the build started and progressed, but the run returned before completion so no final pass/fail status was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16cad4e48c8327ac6d340092fb1b15)