### PR TITLE
Playerbots pursue enemy flag carriers in CTF battlegrounds

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -267,6 +267,7 @@ void PopulateObjectiveStateTriggers(Player const* player, playerbot::PvpValues& 
         ObjectGuid const teamCarrierGuid = bgWs->GetFlagPickerGUID(enemyTeam);
 
         values.playerHasFlag = (teamCarrierGuid == playerGuid);
+        values.enemyFlagCarrierActive = !enemyCarrierGuid.IsEmpty();
         values.enemyFlagCarrierNear = IsFlagCarrierNear(player, enemyCarrierGuid, 100.0f);
 
         bool const bothFlagsNotAtBase =
@@ -292,7 +293,10 @@ void PopulateObjectiveStateTriggers(Player const* player, playerbot::PvpValues& 
         if (carrier->GetTeamId() == botTeam)
             values.teamFlagCarrierNear = player->IsWithinDistInMap(carrier, 200.0f);
         else
+        {
+            values.enemyFlagCarrierActive = true;
             values.enemyFlagCarrierNear = player->IsWithinDistInMap(carrier, 100.0f);
+        }
     }
 }
 
@@ -3136,6 +3140,8 @@ bool PvpCore::IsTriggerActive(PvpTrigger trigger, PvpValues const& values)
             return values.inBattleground;
         case PvpTrigger::PlayerHasFlag:
             return values.playerHasFlag;
+        case PvpTrigger::EnemyFlagCarrierActive:
+            return values.enemyFlagCarrierActive;
         case PvpTrigger::EnemyFlagCarrierNear:
             return values.enemyFlagCarrierNear;
         case PvpTrigger::TeamFlagCarrierNear:
@@ -3807,12 +3813,7 @@ BattlegroundObjectiveSelection PvpCore::SelectObjectiveSkeleton(PvpValues const&
 {
     BattlegroundObjectiveSelection objective;
 
-    // WSG brawl mode: ignore flag/objective play and let tactical movement
-    // converge bots to the shared midfield fight anchor.
-    if (values.battlegroundTypeId == BATTLEGROUND_WS)
-        return objective;
-
-    if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierNear, values))
+    if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierActive, values))
         objective.type = BattlegroundObjectiveType::AttackFlagCarrier;
     else if ((!values.battlegroundTeamHasHumans && IsTriggerActive(PvpTrigger::PlayerHasFlag, values)) ||
         IsTriggerActive(PvpTrigger::TeamFlagCarrierNear, values))
@@ -3844,10 +3845,7 @@ BattlegroundMovementPrimitive PvpCore::SelectMovementPrimitiveSkeleton(PvpValues
 
 FlagCarrierDirective PvpCore::SelectFlagCarrierDirectiveSkeleton(PvpValues const& values)
 {
-    if (values.battlegroundTypeId == BATTLEGROUND_WS)
-        return FlagCarrierDirective::None;
-
-    if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierNear, values))
+    if (IsTriggerActive(PvpTrigger::EnemyFlagCarrierActive, values))
         return FlagCarrierDirective::AttackEnemyCarrier;
 
     if ((!values.battlegroundTeamHasHumans && IsTriggerActive(PvpTrigger::PlayerHasFlag, values)) ||

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.h
@@ -60,6 +60,7 @@ struct PvpValues
     bool hasArenaInvite = false;
     bool hasArenaTeamInvite = false;
     bool playerHasFlag = false;
+    bool enemyFlagCarrierActive = false;
     bool enemyFlagCarrierNear = false;
     bool teamFlagCarrierNear = false;
     uint32 battlegroundTeamHumanCount = 0;
@@ -75,6 +76,7 @@ enum class PvpTrigger : uint8
     BgInviteActive,
     InBattlegroundWithoutFlag,
     PlayerHasFlag,
+    EnemyFlagCarrierActive,
     EnemyFlagCarrierNear,
     TeamFlagCarrierNear
 };


### PR DESCRIPTION
### Motivation
- Make playerbot PvP behavior actively pursue enemy flag carriers in CTF-style battlegrounds (Warsong Gulch / Twin Peaks) rather than only reacting when a carrier is nearby. 
- Keep behavior generic across CTF maps and avoid map-specific bypass logic that prevented active pursuit in WSG.

### Description
- Added a new PvP value `enemyFlagCarrierActive` to `PvpValues` and a corresponding `PvpTrigger::EnemyFlagCarrierActive` to represent when the enemy team currently has an active flag carrier. 
- Populated `enemyFlagCarrierActive` in `PopulateObjectiveStateTriggers` from CTF carrier state for `BattlegroundWS` and when an enemy carrier is present for `BattlegroundEY`. 
- Exposed the new trigger via `IsTriggerActive` and updated `SelectObjectiveSkeleton` to prefer `AttackFlagCarrier` when the carrier is active (map-wide), instead of requiring proximity. 
- Updated `SelectFlagCarrierDirectiveSkeleton` to return `AttackEnemyCarrier` on the new active-carrier trigger and removed the prior WSG-only bypass so CTF pursuit logic applies consistently.

### Testing
- Performed static verification of the changes by searching and inspecting affected code paths with `rg` and viewing regions with `sed`, confirming the new field, trigger, and decisions are wired into `PvpCore` flow. 
- Verified the source diffs show the intended additions and control-flow changes for `PopulateObjectiveStateTriggers`, `IsTriggerActive`, `SelectObjectiveSkeleton`, and `SelectFlagCarrierDirectiveSkeleton`. 
- No automated unit or integration tests were present for this script-level behavior and no build/test run was executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17011b148883278635e920029800a7)