### PR TITLE
Playerbot: avoid unnecessary battleground travel dismounts

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2775,9 +2775,12 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     }
 
 
-    // Most combat/utility spells require an unmounted caster. Dismount before
-    // non-mount spell execution so bots do not keep kiting while mounted.
-    if (player->IsMounted() && !isMountSpell)
+    // Only force dismount when the bot is actually transitioning into combat
+    // pressure. Allow benign out-of-combat utility/self-maintenance actions to
+    // execute without unnecessarily dropping travel speed in battlegrounds.
+    bool const shouldForceCombatDismount = context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy ||
+        player->IsInCombat();
+    if (player->IsMounted() && !isMountSpell && shouldForceCombatDismount)
         ForcePlayerbotDismount(player);
 
     // Food/drink should immediately break when the bot transitions into active


### PR DESCRIPTION
### Motivation
- Prevent playerbots from unnecessarily dismounting during benign out-of-combat actions while traveling in battlegrounds, preserving mounted travel speed and reducing unexpected dismounts.

### Description
- Replace the unconditional dismount in `CastDirectSpell` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` with a combat-aware gate that only calls `ForcePlayerbotDismount` when `context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy` or `player->IsInCombat()`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1701fd241c832787db90750d835089)