### PR TITLE
Fix virtual playerbots standing on water by syncing swim flag

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3495,6 +3495,10 @@ void Unit::ProcessTerrainStatusUpdate(ZLiquidStatus /*oldLiquidStatus*/, Optiona
     if (!IsControlledByPlayer())
         return;
 
+    if (Player* player = ToPlayer())
+        if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
+            SetSwim(CanSwim() && IsInWater());
+
     // remove appropriate auras if we are swimming/not swimming respectively
     if (IsInWater())
     {


### PR DESCRIPTION
### Motivation
- Managed playerbots running on virtual sessions could fail to enter swimming movement state when entering water, causing them to stand on top of water (observed in Twin Peaks); the intent is to synchronize swim movement flags for virtual-session players on terrain/liquid updates.

### Description
- Add a virtual-session-only sync in `Unit::ProcessTerrainStatusUpdate` that calls `SetSwim(CanSwim() && IsInWater())` for `Player` units, implemented in `src/server/game/Entities/Unit/Unit.cpp`.

### Testing
- Applied the patch (`apply_patch`) and verified the change with `git diff` and committed it (`git commit`) successfully; no build or runtime tests were executed in this changelist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1706ab2db48327b50b17e6f03dd11c)