### PR TITLE
Fix battleground movement stalls by detecting unlaunched target-relative motion and adding downhill direct-drop recovery

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -586,12 +586,41 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
     bool const recentPositionProgress = state.lastPositionProgressMs != 0 && positionProgressAgeMs < minRunMs;
     bool const credibleRecentDistanceProgress = recentDistanceProgress && (hasMovementSignal || recentPositionProgress || madePositionProgress);
     bool const farFromDesiredRange = desiredRange > 0.0f && currentDistance > (desiredRange + 4.0f);
+    bool const aggressiveUnlaunchedBattleground =
+        player->InBattleground() &&
+        farFromDesiredRange &&
+        !hasMovementSignal &&
+        !player->isMoving() &&
+        !splineStarted &&
+        !splineInitialized;
+    bool const pathologicalUnlaunchedHold =
+        player->InBattleground() &&
+        farFromDesiredRange &&
+        !hasMovementSignal &&
+        !player->isMoving() &&
+        !splineStarted &&
+        !splineInitialized &&
+        !madeDistanceProgress &&
+        !madePositionProgress &&
+        distanceProgressAgeMs > 1500 &&
+        positionProgressAgeMs > 1500;
 
     // Elegant fail-safe for the "stuck but preserved" state:
     // if we are still significantly outside desired range and have neither
     // recent launch nor distance progress, stop preserving and reissue a fresh
     // target-relative order immediately.
     if (inSettleWindow && farFromDesiredRange && ageMs > 900 && !credibleRecentLaunch && !madeDistanceProgress && !credibleRecentDistanceProgress)
+        inSettleWindow = false;
+
+    // Battleground cliff/ledge stalls regularly present as repeated CHASE/FOLLOW
+    // orders that never launch (no spline, no movement signal, moving=no) while
+    // still very far from desired range. These can be reissued every tick, which
+    // keeps age_ms near zero and would bypass any age-based gate. Break preserve
+    // immediately so callers can clear/reissue and recovery paths can engage.
+    if (aggressiveUnlaunchedBattleground)
+        inSettleWindow = false;
+
+    if (pathologicalUnlaunchedHold)
         inSettleWindow = false;
 
     bool const preserve = inSettleWindow || credibleRecentLaunch || madeDistanceProgress || madePositionProgress || credibleRecentDistanceProgress || recentPositionProgress;
@@ -626,7 +655,13 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
                  << " far_desired=" << (farFromDesiredRange ? "yes" : "no")
                  << " not_move=" << (player->HasUnitState(UNIT_STATE_NOT_MOVE) ? "yes" : "no")
                  << " casting_prevent=" << (player->IsMovementPreventedByCasting() ? "yes" : "no")
-                 << " reason=" << (!hasMovementSignal && ageMs >= effectiveSettleMs ? "unlaunched_settle_expired" : "no_position_or_distance_progress");
+                 << " aggressive_unlaunched_bg=" << (aggressiveUnlaunchedBattleground ? "yes" : "no")
+                 << " pathological_unlaunched_hold=" << (pathologicalUnlaunchedHold ? "yes" : "no")
+                 << " reason=" << (aggressiveUnlaunchedBattleground
+                    ? "aggressive_unlaunched_bg"
+                    : (pathologicalUnlaunchedHold
+                    ? "pathological_unlaunched_hold"
+                    : (!hasMovementSignal && ageMs >= effectiveSettleMs ? "unlaunched_settle_expired" : "no_position_or_distance_progress")));
             *reasonOut = diag.str();
         }
         return false;
@@ -660,6 +695,8 @@ bool ShouldPreserveTargetRelativeMovement(Player const* player, Unit const* targ
              << " far_desired=" << (farFromDesiredRange ? "yes" : "no")
              << " not_move=" << (player->HasUnitState(UNIT_STATE_NOT_MOVE) ? "yes" : "no")
              << " casting_prevent=" << (player->IsMovementPreventedByCasting() ? "yes" : "no")
+             << " aggressive_unlaunched_bg=" << (aggressiveUnlaunchedBattleground ? "yes" : "no")
+             << " pathological_unlaunched_hold=" << (pathologicalUnlaunchedHold ? "yes" : "no")
              << " reason=" << (inSettleWindow
                     ? (hasMovementSignal ? "settle_window" : "unlaunched_short_settle")
                     : (credibleRecentLaunch ? "recent_launch" : (madePositionProgress || recentPositionProgress ? "position_progress" : "distance_progress")));
@@ -1203,6 +1240,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     MovementGeneratorType const initialMotionType = motionMaster->GetCurrentMovementGeneratorType();
     bool const currentlyMoving = player->isMoving();
     bool const strictPathing = RequiresStrictHumanPathing(player);
+    bool const battleground = player->InBattleground();
+    float const verticalDeltaToTarget = player->GetPositionZ() - target->GetPositionZ();
+    float const dxToTarget = target->GetPositionX() - player->GetPositionX();
+    float const dyToTarget = target->GetPositionY() - player->GetPositionY();
+    float const planarDistanceToTarget = std::sqrt(dxToTarget * dxToTarget + dyToTarget * dyToTarget);
 
     // Important: SPELL_FAILED_LINE_OF_SIGHT is more authoritative than the
     // generic IsWithinLOSInMap() diagnostic. On custom BG maps/vmaps the simple
@@ -1224,14 +1266,51 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
     bool const sameStallTarget = stallState.targetGuid == target->GetGUID();
     bool const activeTargetRelativeMotion = initialMotionType == CHASE_MOTION_TYPE || initialMotionType == FOLLOW_MOTION_TYPE;
     bool const hasActiveSpline = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
+    bool const hasFinalizedSpline = player->movespline && player->movespline->Initialized() && player->movespline->Finalized();
     bool const movementGeneratorHasNotLaunched = !player->isMoving() &&
         !player->HasUnitState(UNIT_STATE_CHASE_MOVE) &&
         !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) &&
         !hasActiveSpline;
     uint32 const lastIssueAgeMs = sameStallTarget && stallState.lastIssueMs != 0 && nowMs >= stallState.lastIssueMs ? nowMs - stallState.lastIssueMs : 0;
+    bool const staleUnlaunchedTargetRelative =
+        sameStallTarget &&
+        activeTargetRelativeMotion &&
+        movementGeneratorHasNotLaunched &&
+        stallState.lastIssueMs != 0 &&
+        lastIssueAgeMs >= 700;
 
     if (!forceMovementWhenAlreadyInRange && activeTargetRelativeMotion && currentDistance > (safeDistance + 0.75f))
     {
+        bool const staleFinalizedSplineHold =
+            sameStallTarget &&
+            activeTargetRelativeMotion &&
+            hasFinalizedSpline &&
+            !player->isMoving() &&
+            !player->HasUnitState(UNIT_STATE_CHASE_MOVE) &&
+            !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) &&
+            stallState.lastIssueMs != 0 &&
+            lastIssueAgeMs >= 500;
+
+        if (staleFinalizedSplineHold)
+        {
+            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+            std::ostringstream resetDiag;
+            resetDiag << BuildRangedMovementDiag(player, target, "ranged_stale_finalized_spline_cleared",
+                safeDistance, safeDistance, targetLos, targetAttackable, true, initialMotionType, "none")
+                     << " issue_age_ms=" << lastIssueAgeMs;
+            SetLastMovementDebugStatus(player, resetDiag.str());
+        }
+
+        if (staleUnlaunchedTargetRelative)
+        {
+            motionMaster->Clear(MOTION_SLOT_ACTIVE);
+            std::ostringstream resetDiag;
+            resetDiag << BuildRangedMovementDiag(player, target, "ranged_stale_unlaunched_cleared",
+                safeDistance, safeDistance, targetLos, targetAttackable, true, initialMotionType, "none")
+                     << " issue_age_ms=" << lastIssueAgeMs;
+            SetLastMovementDebugStatus(player, resetDiag.str());
+        }
+
         std::string preserveDiag;
         if (ShouldPreserveTargetRelativeMovement(player, target, safeDistance, 3000, "ranged_existing_motion_preserved", &preserveDiag))
         {
@@ -1260,6 +1339,48 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         TC_LOG_DEBUG("playerbots.pvp.classspell",
             "Ranged approach cleared stalled point movement: guid={} target={} desiredRange={} currentDistance={}.",
             player->GetGUID().ToString(), target->GetGUID().ToString(), safeDistance, currentDistance);
+    }
+
+    // Battleground cliff descent recovery:
+    // When chasing a distant lower target from elevated terrain, repeatedly
+    // issuing CHASE/FOLLOW can route bots back uphill. Force a short direct
+    // downhill step toward the target to commit the descent before resuming
+    // target-relative pathing.
+    bool const shouldForceDownhillCommit =
+        battleground &&
+        strictPathing &&
+        verticalDeltaToTarget > 8.0f &&
+        planarDistanceToTarget > 30.0f &&
+        !currentlyMoving &&
+        !player->HasUnitState(UNIT_STATE_CHASE_MOVE) &&
+        !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE);
+    if (shouldForceDownhillCommit)
+    {
+        float const stepDistance = std::min(16.0f, std::max(6.0f, planarDistanceToTarget * 0.3f));
+        float const invPlanar = 1.0f / std::max(0.01f, planarDistanceToTarget);
+        Position downhillProbe(
+            player->GetPositionX() + dxToTarget * invPlanar * stepDistance,
+            player->GetPositionY() + dyToTarget * invPlanar * stepDistance,
+            player->GetPositionZ() - std::min(12.0f, std::max(4.0f, verticalDeltaToTarget * 0.5f)),
+            player->GetOrientation());
+        Position const downhillDestination = BuildCollisionSafeDestination(player, downhillProbe);
+        motionMaster->MovePoint(0, downhillDestination, false);
+
+        stallState.targetGuid = target->GetGUID();
+        stallState.lastDistance = currentDistance;
+        stallState.lastSampleMs = nowMs;
+        stallState.lastIssueMs = nowMs;
+        stallState.lastIssuedRange = safeDistance;
+        stallState.lastIssuedMode = 1;
+
+        std::ostringstream diag;
+        diag << BuildRangedMovementDiag(player, target, "bg_downhill_commit_direct",
+            safeDistance, safeDistance, targetLos, targetAttackable, true, initialMotionType, "direct")
+             << " vertical_delta=" << verticalDeltaToTarget
+             << " planar_delta=" << planarDistanceToTarget
+             << " commit_dist=" << player->GetDistance(downhillDestination);
+        SetLastMovementDebugStatus(player, diag.str());
+        return;
     }
 
     // For target-relative ranged approach, do NOT use MovePoint here.

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -639,6 +639,62 @@ bool IsForbiddenBattlegroundPathType(PathType pathType)
 constexpr float PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT = 2400.0f;
 constexpr float PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE = 80.0f;
 
+Position BuildDownhillEscapeDestination(Player* player, Position const& destination)
+{
+    if (!player)
+        return destination;
+
+    float const dx = destination.GetPositionX() - player->GetPositionX();
+    float const dy = destination.GetPositionY() - player->GetPositionY();
+    float const planarDistance = std::sqrt(dx * dx + dy * dy);
+    if (planarDistance < 0.5f)
+        return BuildCollisionSafeDestination(player, destination);
+
+    float const stepDistance = std::min(12.0f, std::max(4.0f, planarDistance * 0.35f));
+    float const nx = dx / planarDistance;
+    float const ny = dy / planarDistance;
+
+    Position probe(
+        player->GetPositionX() + nx * stepDistance,
+        player->GetPositionY() + ny * stepDistance,
+        player->GetPositionZ() - 6.0f,
+        destination.GetOrientation());
+
+    return BuildCollisionSafeDestination(player, probe);
+}
+
+bool ShouldPreferDirectDropShortcut(Player* player, Position const& destination)
+{
+    if (!player)
+        return false;
+
+    float const destinationDistance = player->GetDistance(destination);
+    if (destinationDistance < 15.0f || destinationDistance > 120.0f)
+        return false;
+
+    float const verticalDrop = player->GetPositionZ() - destination.GetPositionZ();
+    if (verticalDrop < 8.0f)
+        return false;
+
+    PathGenerator path(player);
+    path.SetPathLengthLimit(PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT);
+    if (!path.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), true))
+        return false;
+
+    if (IsForbiddenBattlegroundPathType(path.GetPathType()))
+        return false;
+
+    Movement::PointsArray const& points = path.GetPath();
+    if (points.size() < 2)
+        return false;
+
+    float pathLength = 0.0f;
+    for (std::size_t i = 1; i < points.size(); ++i)
+        pathLength += (points[i] - points[i - 1]).length();
+
+    return pathLength > destinationDistance * 1.35f;
+}
+
 bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray const& points, float orientation, Position& segmentDestination)
 {
     if (!player || points.size() < 2)
@@ -818,12 +874,21 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         Position lastDestination;
         uint32 lastIssueMs = 0;
     };
+    struct DirectDropState
+    {
+        Position startPosition;
+        uint32 issueMs = 0;
+        uint32 suppressUntilMs = 0;
+        bool pending = false;
+    };
 
     static std::unordered_map<uint64, MoveOrderState> stateByGuid;
     static std::unordered_map<uint64, uint8> stationaryReissueCountByGuid;
+    static std::unordered_map<uint64, DirectDropState> directDropStateByGuid;
     uint64 const botGuid = player->GetGUID().GetRawValue();
     MoveOrderState& state = stateByGuid[player->GetGUID().GetRawValue()];
     uint8& stationaryReissueCount = stationaryReissueCountByGuid[botGuid];
+    DirectDropState& directDropState = directDropStateByGuid[botGuid];
     uint32 const nowMs = GameTime::GetGameTimeMS();
 
     bool const destinationChanged = state.lastIssueMs == 0 ||
@@ -880,13 +945,74 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     if (generatePath && player->InBattleground())
     {
+        if (directDropState.pending &&
+            nowMs > directDropState.issueMs + 1200 &&
+            !player->isMoving())
+        {
+            // Two failure shapes:
+            // 1) Never launched from the start point.
+            // 2) Launched, then settled/stuck on terrain partway down.
+            float const fromStart = player->GetDistance(directDropState.startPosition);
+            float const toDestination = player->GetDistance(safeDestination);
+            if (fromStart < 3.0f || toDestination > 8.0f)
+            {
+                directDropState.pending = false;
+                directDropState.suppressUntilMs = nowMs + 8000;
+                Position const escapeDestination = BuildDownhillEscapeDestination(player, safeDestination);
+                motionMaster->MovePoint(0, escapeDestination, false);
+                EmitBattlegroundGmDebug(player,
+                    "movepoint=direct-drop-stalled fallback=nav-segment fromStart=" + std::to_string(int32(fromStart)) +
+                    " toDest=" + std::to_string(int32(toDestination)) +
+                    " escapeDist=" + std::to_string(int32(player->GetDistance(escapeDestination))), 0);
+
+                state.lastDestination = destination;
+                state.lastIssueMs = nowMs;
+                return true;
+            }
+        }
+
+        if (nowMs >= directDropState.suppressUntilMs && ShouldPreferDirectDropShortcut(player, safeDestination))
+        {
+            Position const shortcutDestination = BuildDownhillEscapeDestination(player, safeDestination);
+            motionMaster->MovePoint(0, shortcutDestination, false);
+            EmitBattlegroundGmDebug(player,
+                "movepoint=direct-drop-shortcut destDist=" + std::to_string(int32(player->GetDistance(safeDestination))) +
+                " stepDist=" + std::to_string(int32(player->GetDistance(shortcutDestination))), 0);
+            directDropState.startPosition = player->GetPosition();
+            directDropState.issueMs = nowMs;
+            directDropState.pending = true;
+
+            state.lastDestination = destination;
+            state.lastIssueMs = nowMs;
+            return true;
+        }
+        else
+        {
+            directDropState.pending = false;
+        }
+
         Position segmentDestination;
         PathType pathType = PathType(0);
         if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
         {
+            // Recovery path for segmented-nav failures (for example, after a
+            // partial drop where local nav probing can't find a legal segment):
+            // issue a direct movement order so the bot keeps progressing
+            // instead of stalling in place waiting on nav segment recovery.
+            Position const fallbackDestination = BuildDownhillEscapeDestination(player, safeDestination);
+            motionMaster->MovePoint(0, fallbackDestination, false);
             EmitBattlegroundGmDebug(player,
-                "movepoint=blocked-no-nav destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 1000);
-            return false;
+                "movepoint=blocked-no-nav fallback=direct destDist=" + std::to_string(int32(player->GetDistance(safeDestination))) +
+                " stepDist=" + std::to_string(int32(player->GetDistance(fallbackDestination))), 0);
+
+            directDropState.startPosition = player->GetPosition();
+            directDropState.issueMs = nowMs;
+            directDropState.pending = true;
+            directDropState.suppressUntilMs = std::max(directDropState.suppressUntilMs, nowMs + 2500);
+
+            state.lastDestination = destination;
+            state.lastIssueMs = nowMs;
+            return true;
         }
 
         motionMaster->MovePoint(0, segmentDestination, true);


### PR DESCRIPTION
### Motivation

- Address repeated battleground movement stalls where CHASE/FOLLOW/target-relative orders never launch or bots fail to descend cliffs, causing bots to appear stuck or repeatedly reissue orders.
- Prevent age-based gates from being bypassed by orders that never launch and provide a recovery path that avoids routing bots back uphill.

### Description

- Add detection flags and diagnostics in `ShouldPreserveTargetRelativeMovement` for aggressive/pathological unlaunched battleground holds and include them in the preserved/reason output. 
- In ranged approach logic (`IssueRangedApproachMovement`) clear stale target-relative generators when a finalized spline or an unlaunched generator is detected, and add a downhill commit step that issues a short direct `MovePoint` downhill to force descent before resuming target-relative motion.
- Add battleground-specific helpers in `PlayerbotPvpLifecycleActions.cpp`: `BuildDownhillEscapeDestination` and `ShouldPreferDirectDropShortcut` to compute safe downhill probe destinations and decide when a direct-drop shortcut is preferable based on path length vs straight-line distance.
- Enhance `IssueMovePointThrottled` with a `DirectDropState` to attempt direct-drop shortcuts in BGs, handle stalled direct-drop fallbacks to a downhill escape, suppress retries for a period, and fall back to segmented nav or a direct downhill `MovePoint` when segment building fails; include additional debug logging and state updates.

### Testing

- Project built successfully using the standard build (`make`) and no compilation errors were produced. 
- Existing automated test suite was executed (`make test` / `ctest`) and all tests passed. 
- Changes include additional runtime diagnostics and were exercised via battleground movement smoke scenarios to ensure recovery logic triggers and does not regress normal pathing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16cad4e48c8327ac6d340092fb1b15)