### PR TITLE
Restore broadcast messages for node capture and flag interactions in BFG battleground

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
@@ -91,7 +91,7 @@ void BattlegroundBFG::PostUpdateImpl(uint32 diff)
                     NodeOccupied(node);
                     SendNodeUpdate(node);
 
-                    // SendBroadcastText(LANG_BG_BFG_NODE_TAKEN, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, NULL, teamId == TEAM_ALLIANCE ? LANG_BG_BFG_ALLY : LANG_BG_BFG_HORDE, LANG_BG_BFG_NODE_LIGHTHOUSE + node);
+                    SendBroadcastText(LANG_BG_BFG_NODE_TAKEN, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, NULL, teamId == TEAM_ALLIANCE ? LANG_BG_BFG_ALLY : LANG_BG_BFG_HORDE, LANG_BG_BFG_NODE_LIGHTHOUSE + node);
                     PlaySoundToAll(teamId == TEAM_ALLIANCE ? GILNEAS_BG_SOUND_NODE_CAPTURED_ALLIANCE : GILNEAS_BG_SOUND_NODE_CAPTURED_HORDE);
                     break;
                 }
@@ -334,8 +334,8 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
     player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
 
     uint32 sound = 0;
-    // uint32 message = 0;
-    // uint32 message2 = 0;
+    uint32 message = 0;
+    uint32 message2 = 0;
     DeleteBanner(node);
     CreateBanner(node, true);
 
@@ -346,8 +346,8 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
         _capturePointInfo[node]._ownerTeamId = TEAM_NEUTRAL;
         _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
         sound = GILNEAS_BG_SOUND_NODE_CLAIMED;
-        // message = LANG_BG_BFG_NODE_CLAIMED;
-        // message2 = player->GetTeamId() == TEAM_ALLIANCE ? LANG_BG_BFG_ALLY : LANG_BG_BFG_HORDE;
+        message = LANG_BG_BFG_NODE_CLAIMED;
+        message2 = player->GetTeamId() == TEAM_ALLIANCE ? LANG_BG_BFG_ALLY : LANG_BG_BFG_HORDE;
     }
     else if (_capturePointInfo[node]._state == GILNEAS_BG_NODE_STATUS_ALLY_CONTESTED || _capturePointInfo[node]._state == GILNEAS_BG_NODE_STATUS_HORDE_CONTESTED)
     {
@@ -357,7 +357,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
             _capturePointInfo[node]._state = static_cast<uint8>(GILNEAS_BG_NODE_STATUS_ALLY_CONTESTED) + player->GetTeamId();
             _capturePointInfo[node]._ownerTeamId = TEAM_NEUTRAL;
             _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
-            // message = LANG_BG_BFG_NODE_ASSAULTED;
+            message = LANG_BG_BFG_NODE_ASSAULTED;
         }
         else
         {
@@ -366,7 +366,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
             _capturePointInfo[node]._ownerTeamId = player->GetTeamId();
             _bgEvents.CancelEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node);
             NodeOccupied(node); // after setting team owner
-            // message = LANG_BG_BFG_NODE_DEFENDED;
+            message = LANG_BG_BFG_NODE_DEFENDED;
         }
         sound = player->GetTeamId() == TEAM_ALLIANCE ? GILNEAS_BG_SOUND_NODE_ASSAULTED_ALLIANCE : GILNEAS_BG_SOUND_NODE_ASSAULTED_HORDE;
     }
@@ -379,13 +379,13 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
 
         ApplyPhaseMask();
         _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
-        // message = LANG_BG_BFG_NODE_ASSAULTED;
+        message = LANG_BG_BFG_NODE_ASSAULTED;
         sound = player->GetTeamId() == TEAM_ALLIANCE ? GILNEAS_BG_SOUND_NODE_ASSAULTED_ALLIANCE : GILNEAS_BG_SOUND_NODE_ASSAULTED_HORDE;
     }
 
     SendNodeUpdate(node);
     PlaySoundToAll(sound);
-    // SendBroadcastText(message, player->GetTeamId() == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, player, LANG_BG_BFG_NODE_LIGHTHOUSE + node, message2);
+    SendBroadcastText(message, player->GetTeamId() == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, player, LANG_BG_BFG_NODE_LIGHTHOUSE + node, message2);
 }
 
 uint32 BattlegroundBFG::GetPrematureWinner()


### PR DESCRIPTION
### Motivation
- Re-enable in-game broadcast messages when nodes are claimed/assaulted/defended and when players interact with banners so teams receive appropriate system notifications during Battleground: Gilneas (BFG) events.

### Description
- Un-commented and restored `message` and `message2` variables and their assignments in `EventPlayerClickedOnFlag` to populate localized message IDs for claim/assault/defend flows.
- Re-enabled `SendBroadcastText` calls in both the capture event handling and the flag-interaction handler so broadcasts are sent to the proper team channels.
- Minor cleanup of commented-out lines related to node broadcast logic in `BattlegroundBFG.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a170a98951883278e1cbeb3f4d136f5)