### PR TITLE
Fix BFG SendBroadcastText compile errors

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
@@ -91,7 +91,7 @@ void BattlegroundBFG::PostUpdateImpl(uint32 diff)
                     NodeOccupied(node);
                     SendNodeUpdate(node);
 
-                    SendBroadcastText(LANG_BG_BFG_NODE_TAKEN, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, NULL, teamId == TEAM_ALLIANCE ? LANG_BG_BFG_ALLY : LANG_BG_BFG_HORDE, LANG_BG_BFG_NODE_LIGHTHOUSE + node);
+                    SendBroadcastText(LANG_BG_BFG_NODE_TAKEN, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE);
                     PlaySoundToAll(teamId == TEAM_ALLIANCE ? GILNEAS_BG_SOUND_NODE_CAPTURED_ALLIANCE : GILNEAS_BG_SOUND_NODE_CAPTURED_HORDE);
                     break;
                 }
@@ -335,7 +335,6 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
 
     uint32 sound = 0;
     uint32 message = 0;
-    uint32 message2 = 0;
     DeleteBanner(node);
     CreateBanner(node, true);
 
@@ -347,7 +346,6 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
         _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
         sound = GILNEAS_BG_SOUND_NODE_CLAIMED;
         message = LANG_BG_BFG_NODE_CLAIMED;
-        message2 = player->GetTeamId() == TEAM_ALLIANCE ? LANG_BG_BFG_ALLY : LANG_BG_BFG_HORDE;
     }
     else if (_capturePointInfo[node]._state == GILNEAS_BG_NODE_STATUS_ALLY_CONTESTED || _capturePointInfo[node]._state == GILNEAS_BG_NODE_STATUS_HORDE_CONTESTED)
     {
@@ -385,7 +383,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
 
     SendNodeUpdate(node);
     PlaySoundToAll(sound);
-    SendBroadcastText(message, player->GetTeamId() == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, player, LANG_BG_BFG_NODE_LIGHTHOUSE + node, message2);
+    SendBroadcastText(message, player->GetTeamId() == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE, player);
 }
 
 uint32 BattlegroundBFG::GetPrematureWinner()


### PR DESCRIPTION
### Motivation
- The Battle for Gilneas battleground code called `SendBroadcastText` with extra formatting arguments while the current `Battleground::SendBroadcastText` API accepts at most three parameters, causing compilation failures.

### Description
- Updated two `SendBroadcastText` call sites in `BattlegroundBFG.cpp` to use the three-argument signature expected by `Battleground::SendBroadcastText`.
- Removed the now-unused local `message2` variable and its assignment from `EventPlayerClickedOnFlag` since the extra format argument was removed.
- Change is limited to `src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp` and is aimed at restoring compilation compatibility with the battleground API.

### Testing
- Attempted to build the `game` target with `cmake --build . --target game -j4`, which failed due to the local workspace not having a CMake cache configured (`Error: could not load cache`).
- No automated unit tests were executed in this environment; changes were committed locally after the fix was applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171510dd188327a740f374d98dadb7)