### PR TITLE
Fix playerbot flag-carrier targeting in CTF battlegrounds and reduce water-surface hovering

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -171,6 +171,20 @@ Position BuildCollisionSafeDestination(Player* player, Position const& destinati
     Position adjustedDestination = destination;
     float adjustedZ = adjustedDestination.GetPositionZ();
     player->UpdateAllowedPositionZ(adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(), adjustedZ);
+
+    if (Map const* map = player->FindMap())
+    {
+        float liquidLevel = INVALID_HEIGHT;
+        float floorLevel = INVALID_HEIGHT;
+        if (map->getLiquidStatus(player->GetPhaseMask(), adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(),
+                adjustedZ + 0.5f, MAP_ALL_LIQUIDS, &liquidLevel, &floorLevel))
+        {
+            bool const canWalkOnWater = player->HasAuraType(SPELL_AURA_WATER_WALK);
+            if (!canWalkOnWater && liquidLevel != INVALID_HEIGHT && floorLevel != INVALID_HEIGHT)
+                adjustedZ = std::max(floorLevel + 0.05f, std::min(adjustedZ, liquidLevel - 0.25f));
+        }
+    }
+
     adjustedDestination.Relocate(adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(), adjustedZ, adjustedDestination.GetOrientation());
     return adjustedDestination;
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -258,7 +258,9 @@ void PopulateObjectiveStateTriggers(Player const* player, playerbot::PvpValues& 
     if (!battleground || battleground->GetStatus() != STATUS_IN_PROGRESS)
         return;
 
-    TeamId const botTeam = player->GetTeamId();
+    uint32 const botTeamValue = player->GetBGTeam() ? player->GetBGTeam() : player->GetTeam();
+    TeamId const botTeam = (botTeamValue == ALLIANCE || botTeamValue == TEAM_ALLIANCE) ? TEAM_ALLIANCE :
+        (botTeamValue == HORDE || botTeamValue == TEAM_HORDE) ? TEAM_HORDE : player->GetTeamId();
     TeamId const enemyTeam = (botTeam == TEAM_ALLIANCE) ? TEAM_HORDE : TEAM_ALLIANCE;
     ObjectGuid const playerGuid = player->GetGUID();
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -612,6 +612,22 @@ Position BuildCollisionSafeDestination(Player const* player, Position const& des
     Position adjustedDestination = destination;
     float adjustedZ = adjustedDestination.GetPositionZ();
     player->UpdateAllowedPositionZ(adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(), adjustedZ);
+
+    // Prefer a physically grounded/swimming destination over liquid surface
+    // hovering when the location is in water and the bot is not water-walking.
+    if (Map const* map = player->FindMap())
+    {
+        float liquidLevel = INVALID_HEIGHT;
+        float floorLevel = INVALID_HEIGHT;
+        if (map->getLiquidStatus(player->GetPhaseMask(), adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(),
+                adjustedZ + 0.5f, MAP_ALL_LIQUIDS, &liquidLevel, &floorLevel))
+        {
+            bool const canWalkOnWater = player->HasAuraType(SPELL_AURA_WATER_WALK);
+            if (!canWalkOnWater && liquidLevel != INVALID_HEIGHT && floorLevel != INVALID_HEIGHT)
+                adjustedZ = std::max(floorLevel + 0.05f, std::min(adjustedZ, liquidLevel - 0.25f));
+        }
+    }
+
     adjustedDestination.Relocate(adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(), adjustedZ, adjustedDestination.GetOrientation());
     return adjustedDestination;
 }
@@ -1665,7 +1681,7 @@ Player* FindFlagCarrierForDirective(Player* player, playerbot::FlagCarrierDirect
     if (!battleground || battleground->GetStatus() != STATUS_IN_PROGRESS)
         return nullptr;
 
-    TeamId const botTeam = player->GetTeamId();
+    TeamId const botTeam = ResolveBotTeamId(player);
     TeamId const enemyTeam = (botTeam == TEAM_ALLIANCE) ? TEAM_HORDE : TEAM_ALLIANCE;
 
     if (BattlegroundWS* bgWs = dynamic_cast<BattlegroundWS*>(battleground))


### PR DESCRIPTION
### Motivation
- Bots sometimes misidentify which team holds the flag in CTF battlegrounds (e.g., Twin Peaks) when battleground-assigned teams differ from the player’s base team, causing poor pursuit/protect behavior.
- Bots occasionally hover on the liquid surface instead of standing on the floor or swimming, producing visual artifacts.

### Description
- Prefer battleground-assigned team when resolving the bot team: use `GetBGTeam()` (when available) to determine `botTeam` in `PopulateObjectiveStateTriggers` so carrier identification for CTFs is correct (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`).
- Use the resolved battleground team when selecting a flag-carrier target in directive execution by switching to `ResolveBotTeamId(player)` in `FindFlagCarrierForDirective` so `AttackEnemyCarrier` / `ProtectTeamCarrier` choose the right GUIDs (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`).
- Reduce water-surface hovering by clamping collision-safe destination Z inside liquid/floor bounds for non-water-walking bots using `map->getLiquidStatus(...)` and adjusting `adjustedZ` accordingly in both lifecycle and class movement builders (`PlayerbotPvpLifecycleActions.cpp` and `PlayerbotPvpClassActions.cpp`).

### Testing
- Ran repository symbol/usage searches with `rg` and inspected changed source ranges with file previews to verify affected call sites and logic branches; the searches completed successfully.
- Examined the produced diffs to confirm team-resolution and Z-clamping logic were added to the intended functions and files; diff inspection succeeded.
- Created the PR record (via the repo tooling) to capture the changeset for review; the PR metadata was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1717bef4608327bb7138c2fdeb8371)