### PR TITLE
BFG: add per-node broadcast texts and switch to BFGNodes mapping

### DIFF
--- a/sql/updates/world/3.3.5/2026_05_27_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_05_27_00_world.sql
@@ -1,0 +1,27 @@
+DELETE FROM `broadcast_text` WHERE `ID` BETWEEN 910055 AND 910078;
+
+INSERT INTO `broadcast_text` (`ID`, `LanguageID`, `Text`, `Text1`, `EmoteID1`, `EmoteID2`, `EmoteID3`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `SoundEntriesID`, `EmotesID`, `Flags`, `VerifiedBuild`) VALUES
+(910055, 0, '$N has assaulted the Lighthouse!', '$N has assaulted the Lighthouse!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910056, 0, '$N has assaulted the Lighthouse!', '$N has assaulted the Lighthouse!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910057, 0, 'The Alliance has taken the Lighthouse!', 'The Alliance has taken the Lighthouse!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910058, 0, 'The Horde has taken the Lighthouse!', 'The Horde has taken the Lighthouse!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910059, 0, '$N has defended the Lighthouse!', '$N has defended the Lighthouse!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910060, 0, '$N has defended the Lighthouse!', '$N has defended the Lighthouse!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910061, 0, '$N claims the Lighthouse! If left unchallenged, the Alliance will control it in 1 minute!', '$N claims the Lighthouse! If left unchallenged, the Alliance will control it in 1 minute!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910062, 0, '$N claims the Lighthouse! If left unchallenged, the Horde will control it in 1 minute!', '$N claims the Lighthouse! If left unchallenged, the Horde will control it in 1 minute!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910063, 0, '$N has assaulted the Waterworks!', '$N has assaulted the Waterworks!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910064, 0, '$N has assaulted the Waterworks!', '$N has assaulted the Waterworks!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910065, 0, 'The Alliance has taken the Waterworks!', 'The Alliance has taken the Waterworks!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910066, 0, 'The Horde has taken the Waterworks!', 'The Horde has taken the Waterworks!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910067, 0, '$N has defended the Waterworks!', '$N has defended the Waterworks!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910068, 0, '$N has defended the Waterworks!', '$N has defended the Waterworks!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910069, 0, '$N claims the Waterworks! If left unchallenged, the Alliance will control it in 1 minute!', '$N claims the Waterworks! If left unchallenged, the Alliance will control it in 1 minute!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910070, 0, '$N claims the Waterworks! If left unchallenged, the Horde will control it in 1 minute!', '$N claims the Waterworks! If left unchallenged, the Horde will control it in 1 minute!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910071, 0, '$N has assaulted the Mine!', '$N has assaulted the Mine!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910072, 0, '$N has assaulted the Mine!', '$N has assaulted the Mine!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910073, 0, 'The Alliance has taken the Mine!', 'The Alliance has taken the Mine!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910074, 0, 'The Horde has taken the Mine!', 'The Horde has taken the Mine!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910075, 0, '$N has defended the Mine!', '$N has defended the Mine!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910076, 0, '$N has defended the Mine!', '$N has defended the Mine!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910077, 0, '$N claims the Mine! If left unchallenged, the Alliance will control it in 1 minute!', '$N claims the Mine! If left unchallenged, the Alliance will control it in 1 minute!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+(910078, 0, '$N claims the Mine! If left unchallenged, the Horde will control it in 1 minute!', '$N claims the Mine! If left unchallenged, the Horde will control it in 1 minute!', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
@@ -91,7 +91,10 @@ void BattlegroundBFG::PostUpdateImpl(uint32 diff)
                     NodeOccupied(node);
                     SendNodeUpdate(node);
 
-                    SendBroadcastText(LANG_BG_BFG_NODE_TAKEN, teamId == TEAM_ALLIANCE ? CHAT_MSG_BG_SYSTEM_ALLIANCE : CHAT_MSG_BG_SYSTEM_HORDE);
+                    if (teamId == TEAM_ALLIANCE)
+                        SendBroadcastText(BFGNodes[node].TextAllianceTaken, CHAT_MSG_BG_SYSTEM_ALLIANCE);
+                    else
+                        SendBroadcastText(BFGNodes[node].TextHordeTaken, CHAT_MSG_BG_SYSTEM_HORDE);
                     PlaySoundToAll(teamId == TEAM_ALLIANCE ? GILNEAS_BG_SOUND_NODE_CAPTURED_ALLIANCE : GILNEAS_BG_SOUND_NODE_CAPTURED_HORDE);
                     break;
                 }
@@ -345,7 +348,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
         _capturePointInfo[node]._ownerTeamId = TEAM_NEUTRAL;
         _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
         sound = GILNEAS_BG_SOUND_NODE_CLAIMED;
-        message = LANG_BG_BFG_NODE_CLAIMED;
+        message = player->GetTeamId() == TEAM_ALLIANCE ? BFGNodes[node].TextAllianceClaims : BFGNodes[node].TextHordeClaims;
     }
     else if (_capturePointInfo[node]._state == GILNEAS_BG_NODE_STATUS_ALLY_CONTESTED || _capturePointInfo[node]._state == GILNEAS_BG_NODE_STATUS_HORDE_CONTESTED)
     {
@@ -355,7 +358,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
             _capturePointInfo[node]._state = static_cast<uint8>(GILNEAS_BG_NODE_STATUS_ALLY_CONTESTED) + player->GetTeamId();
             _capturePointInfo[node]._ownerTeamId = TEAM_NEUTRAL;
             _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
-            message = LANG_BG_BFG_NODE_ASSAULTED;
+            message = player->GetTeamId() == TEAM_ALLIANCE ? BFGNodes[node].TextAllianceAssaulted : BFGNodes[node].TextHordeAssaulted;
         }
         else
         {
@@ -364,7 +367,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
             _capturePointInfo[node]._ownerTeamId = player->GetTeamId();
             _bgEvents.CancelEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node);
             NodeOccupied(node); // after setting team owner
-            message = LANG_BG_BFG_NODE_DEFENDED;
+            message = player->GetTeamId() == TEAM_ALLIANCE ? BFGNodes[node].TextAllianceDefended : BFGNodes[node].TextHordeDefended;
         }
         sound = player->GetTeamId() == TEAM_ALLIANCE ? GILNEAS_BG_SOUND_NODE_ASSAULTED_ALLIANCE : GILNEAS_BG_SOUND_NODE_ASSAULTED_HORDE;
     }
@@ -377,7 +380,7 @@ void BattlegroundBFG::EventPlayerClickedOnFlag(Player* player, GameObject* gameO
 
         ApplyPhaseMask();
         _bgEvents.RescheduleEvent(BG_BFG_EVENT_CAPTURE_LIGHTHOUSE + node, Milliseconds(GILNEAS_BG_FLAG_CAPTURING_TIME));
-        message = LANG_BG_BFG_NODE_ASSAULTED;
+        message = player->GetTeamId() == TEAM_ALLIANCE ? BFGNodes[node].TextAllianceAssaulted : BFGNodes[node].TextHordeAssaulted;
         sound = player->GetTeamId() == TEAM_ALLIANCE ? GILNEAS_BG_SOUND_NODE_ASSAULTED_ALLIANCE : GILNEAS_BG_SOUND_NODE_ASSAULTED_HORDE;
     }
 
@@ -551,4 +554,3 @@ void BattlegroundBFG::ApplyPhaseMask()
         }
     }
 }
-

--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
@@ -64,6 +64,25 @@ enum BattleForGilneasStrings {
     LANG_BG_BFG_H_NEAR_VICTORY              = 910054,
 };
 
+struct BFGNodeInfo
+{
+    uint32 TextAllianceAssaulted;
+    uint32 TextHordeAssaulted;
+    uint32 TextAllianceTaken;
+    uint32 TextHordeTaken;
+    uint32 TextAllianceDefended;
+    uint32 TextHordeDefended;
+    uint32 TextAllianceClaims;
+    uint32 TextHordeClaims;
+};
+
+BFGNodeInfo const BFGNodes[GILNEAS_BG_DYNAMIC_NODES_COUNT] =
+{
+    { 910055, 910056, 910057, 910058, 910059, 910060, 910061, 910062 }, // Lighthouse
+    { 910063, 910064, 910065, 910066, 910067, 910068, 910069, 910070 }, // Waterworks
+    { 910071, 910072, 910073, 910074, 910075, 910076, 910077, 910078 }  // Mine
+};
+
 enum GILNEAS_BG_WorldStates
 {
     GILNEAS_BG_OP_OCCUPIED_BASES_HORDE      = 6201,


### PR DESCRIPTION
### Motivation

- Provide distinct broadcast text entries for each Battleground (Lighthouse, Waterworks, Mine) and for each team/event so node-specific messages can be used instead of single generic strings.

### Description

- Add SQL update `sql/updates/world/3.3.5/2026_05_27_00_world.sql` that deletes and inserts broadcast text entries `910055`–`910078` for assault/taken/defended/claims messages for each node and team.
- Introduce `BFGNodeInfo` struct and `BFGNodes` array in `BattlegroundBFG.h` mapping node-specific message IDs for Alliance/Horde assaulted, taken, defended and claims messages.
- Replace hardcoded `LANG_BG_BFG_*` usages in `BattlegroundBFG.cpp` with lookups into `BFGNodes[node]` and select the appropriate ID based on `player->GetTeamId()` or `teamId` when sending broadcast messages.
- Minor whitespace/format cleanup in `BattlegroundBFG.cpp`.

### Testing

- Project compiled successfully after the changes with the updated header and source files and the new SQL file included.
- Ran battleground-related unit/build checks and no compile-time errors were reported.
- The SQL file was validated for syntax and contains the expected `DELETE` and `INSERT` statements for IDs `910055`–`910078`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1718418f788327919df318ecb3e3de)