### PR TITLE
Fix BFG header compile error from undeclared dynamic node count

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
@@ -76,13 +76,6 @@ struct BFGNodeInfo
     uint32 TextHordeClaims;
 };
 
-BFGNodeInfo const BFGNodes[GILNEAS_BG_DYNAMIC_NODES_COUNT] =
-{
-    { 910055, 910056, 910057, 910058, 910059, 910060, 910061, 910062 }, // Lighthouse
-    { 910063, 910064, 910065, 910066, 910067, 910068, 910069, 910070 }, // Waterworks
-    { 910071, 910072, 910073, 910074, 910075, 910076, 910077, 910078 }  // Mine
-};
-
 enum GILNEAS_BG_WorldStates
 {
     GILNEAS_BG_OP_OCCUPIED_BASES_HORDE      = 6201,
@@ -192,6 +185,13 @@ enum GILNEAS_BG_BattlegroundNodes
     GILNEAS_BG_SPIRIT_HORDE         = 4,
 
     GILNEAS_BG_ALL_NODES_COUNT      = 5,                        // All nodes (dynamic and static)
+};
+
+BFGNodeInfo const BFGNodes[GILNEAS_BG_DYNAMIC_NODES_COUNT] =
+{
+    { 910055, 910056, 910057, 910058, 910059, 910060, 910061, 910062 }, // Lighthouse
+    { 910063, 910064, 910065, 910066, 910067, 910068, 910069, 910070 }, // Waterworks
+    { 910071, 910072, 910073, 910074, 910075, 910076, 910077, 910078 }  // Mine
 };
 
 enum GILNEAS_BG_NodeStatus


### PR DESCRIPTION
### Motivation
- A CI build reported `use of undeclared identifier 'GILNEAS_BG_DYNAMIC_NODES_COUNT'` because the `BFGNodes` array was declared before `GILNEAS_BG_DYNAMIC_NODES_COUNT` was defined in the same header.

### Description
- Moved the `BFGNodeInfo const BFGNodes[...]` array in `src/server/game/Battlegrounds/Zones/BattlegroundBFG.h` to a location after the `enum GILNEAS_BG_BattlegroundNodes` so `GILNEAS_BG_DYNAMIC_NODES_COUNT` is declared before it is used; no node values or gameplay logic were changed.

### Testing
- Verified the declaration order with `rg -n "BFGNodes\\[|GILNEAS_BG_DYNAMIC_NODES_COUNT"` and inspected the file lines with `nl -ba src/server/game/Battlegrounds/Zones/BattlegroundBFG.h | sed -n '170,210p'`, and committed the change with `git commit`; these checks succeeded, and the header now contains the constant before the array definition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172209fd188327bf40ab8feaedcec3)