### PR TITLE
Fix Playerbot liquid status map API usage

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -174,14 +174,13 @@ Position BuildCollisionSafeDestination(Player* player, Position const& destinati
 
     if (Map const* map = player->FindMap())
     {
-        float liquidLevel = INVALID_HEIGHT;
-        float floorLevel = INVALID_HEIGHT;
-        if (map->getLiquidStatus(player->GetPhaseMask(), adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(),
-                adjustedZ + 0.5f, MAP_ALL_LIQUIDS, &liquidLevel, &floorLevel))
+        LiquidData liquidData{};
+        if (map->GetLiquidStatus(player->GetPhaseMask(), adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(),
+                adjustedZ + 0.5f, MAP_ALL_LIQUIDS, &liquidData, player->GetCollisionHeight()))
         {
             bool const canWalkOnWater = player->HasAuraType(SPELL_AURA_WATER_WALK);
-            if (!canWalkOnWater && liquidLevel != INVALID_HEIGHT && floorLevel != INVALID_HEIGHT)
-                adjustedZ = std::max(floorLevel + 0.05f, std::min(adjustedZ, liquidLevel - 0.25f));
+            if (!canWalkOnWater)
+                adjustedZ = std::max(liquidData.depth_level + 0.05f, std::min(adjustedZ, liquidData.level - 0.25f));
         }
     }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -617,14 +617,13 @@ Position BuildCollisionSafeDestination(Player const* player, Position const& des
     // hovering when the location is in water and the bot is not water-walking.
     if (Map const* map = player->FindMap())
     {
-        float liquidLevel = INVALID_HEIGHT;
-        float floorLevel = INVALID_HEIGHT;
-        if (map->getLiquidStatus(player->GetPhaseMask(), adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(),
-                adjustedZ + 0.5f, MAP_ALL_LIQUIDS, &liquidLevel, &floorLevel))
+        LiquidData liquidData{};
+        if (map->GetLiquidStatus(player->GetPhaseMask(), adjustedDestination.GetPositionX(), adjustedDestination.GetPositionY(),
+                adjustedZ + 0.5f, MAP_ALL_LIQUIDS, &liquidData, player->GetCollisionHeight()))
         {
             bool const canWalkOnWater = player->HasAuraType(SPELL_AURA_WATER_WALK);
-            if (!canWalkOnWater && liquidLevel != INVALID_HEIGHT && floorLevel != INVALID_HEIGHT)
-                adjustedZ = std::max(floorLevel + 0.05f, std::min(adjustedZ, liquidLevel - 0.25f));
+            if (!canWalkOnWater)
+                adjustedZ = std::max(liquidData.depth_level + 0.05f, std::min(adjustedZ, liquidData.level - 0.25f));
         }
     }
 


### PR DESCRIPTION
### Motivation
- The code called a removed/renamed API `map->getLiquidStatus(...)`, causing a compile error and preventing builds.
- The destination building logic must still prefer grounded/swimming positions and respect `SPELL_AURA_WATER_WALK` behavior.

### Description
- Replaced obsolete `map->getLiquidStatus(...)` calls with `map->GetLiquidStatus(...)` and used a `LiquidData` output in `PlayerbotPvpClassActions.cpp` and `PlayerbotPvpLifecycleActions.cpp`.
- Passed `player->GetCollisionHeight()` to `GetLiquidStatus` and mapped the previous `liquidLevel`/`floorLevel` handling to `liquidData.level`/`liquidData.depth_level` when adjusting the target Z.

### Testing
- Verified updated call sites with `rg "map->getLiquidStatus|map->GetLiquidStatus" src/server/scripts/Playerbot/Pvp -n` which shows the new usages.
- Staged and committed the changes with `git commit`, and the commit completed successfully; a full build was not executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1724656f9c8327abcdd73b7261944a)