### PR TITLE
Playerbots: prioritize enemy flag carrier pursuit while in combat

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -2897,7 +2897,21 @@ bool BattlegroundTacticalActions::MoveToObjectivePrimitive(Player* player, Battl
     }
 
     if (player->IsInCombat())
+    {
+        if (context.flagCarrierDirective == FlagCarrierDirective::AttackEnemyCarrier)
+        {
+            if (Player* enemyCarrier = FindFlagCarrierForDirective(player, FlagCarrierDirective::AttackEnemyCarrier))
+            {
+                if (player->GetTarget() != enemyCarrier->GetGUID())
+                    player->SetTarget(enemyCarrier->GetGUID());
+
+                if (MoveTowardUnit(player, enemyCarrier, 15.0f))
+                    return true;
+            }
+        }
+
         return EngageNearestEnemyPlayer(player, GetAggressiveCombatScanDistance(player, 100.0f));
+    }
 
     if (TryPursueNearestEnemyInBattleground(player))
         return true;


### PR DESCRIPTION
### Motivation
- Playerbots in capture-the-flag battlegrounds (e.g., WSG and Twin Peaks) were staying on incidental combat targets instead of pursuing the enemy flag carrier once combat started, causing poor escort/assault behavior.
- The intent is to make bots honor the `AttackEnemyCarrier` directive during combat so they actively pursue the carrier rather than immediately falling back to generic nearest-enemy engagement.

### Description
- Update `MoveToObjectivePrimitive` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` so that when `player->IsInCombat()` and `context.flagCarrierDirective == FlagCarrierDirective::AttackEnemyCarrier`, the bot resolves the carrier via `FindFlagCarrierForDirective`, calls `player->SetTarget(...)` for retargeting, and attempts `MoveTowardUnit(player, enemyCarrier, 15.0f)` before falling back to `EngageNearestEnemyPlayer`.
- The change is directive-driven and generic and does not add per-battleground special-case pathing logic.
- The modification is localized to a single function in one file (`PlayerbotPvpLifecycleActions.cpp`) and adds behavior to prefer carrier pursuit while in combat.

### Testing
- No automated test suite was executed in this environment; no automated tests ran for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172a159ac88327abb43f49771de70c)