### PR TITLE
Harden game event AI dispatch for GameObjects

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1722,9 +1722,12 @@ public:
         VisitSnapshot(gameObjectMap, [this](ObjectGuid const& guid)
         {
             GameObject* gameObject = _map->GetGameObject(guid);
-            if (!gameObject || !gameObject->IsInWorld())
+            if (!gameObject || !gameObject->IsInWorld() || gameObject->GetMap() != _map)
                 return;
 
+            // OnGameEvent handlers can despawn or relocate gameobjects while
+            // events are being processed. Re-check that the looked up object
+            // is still owned by this map before touching AI state.
             if (GameObjectAI* ai = gameObject->AI())
                 ai->OnGameEvent(_activate, _eventId);
         });


### PR DESCRIPTION
### Motivation
- Prevent crashes when `OnGameEvent` is dispatched for a `GameObject` that may have been despawned or relocated to a different `Map` while iterating event targets.

### Description
- Add an ownership guard in `GameEventAIHookWorker::Visit` so the `GameObject` lookup is only used when `gameObject->GetMap() == _map`, and document the mutation risk (change in `src/server/game/Events/GameEventMgr.cpp`).

### Testing
- Ran `git diff --check` which succeeded; no other automated tests were executed for this small defensive change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172bf10e208327921fde62904b3727)