### PR TITLE
Align TP flag state values and update CTF WorldState UI (with revert migration)

### DIFF
--- a/sql/updates/world/3.3.5/2026_05_27_01_world.sql
+++ b/sql/updates/world/3.3.5/2026_05_27_01_world.sql
@@ -1,0 +1,19 @@
+-- Battleground worldstate UI icon visibility: use pickup world states for CTF flag icons
+-- WSG/TP state vars (2338/2339, 6110/6111) are always 1 when flags are at base, causing icons to always show.
+-- Use *_FLAG_UNK_* vars (1545/1546), which are 1 only while a flag is carried, 0 at base, -1 on ground.
+
+UPDATE `worldstateui_lplus`
+SET `StateVariable` = 1546
+WHERE `ID` = 2 AND `MapID` = 489;
+
+UPDATE `worldstateui_lplus`
+SET `StateVariable` = 1545
+WHERE `ID` = 3 AND `MapID` = 489;
+
+UPDATE `worldstateui_lplus`
+SET `StateVariable` = 1546
+WHERE `ID` = 313 AND `MapID` = 726;
+
+UPDATE `worldstateui_lplus`
+SET `StateVariable` = 1545
+WHERE `ID` = 314 AND `MapID` = 726;

--- a/sql/updates/world/3.3.5/2026_05_27_02_world.sql
+++ b/sql/updates/world/3.3.5/2026_05_27_02_world.sql
@@ -1,0 +1,18 @@
+-- Revert CTF top-frame rows to use flag-state worldstates so score rows remain visible.
+-- Note: StateVariable governs row visibility; using 1545/1546 hides the entire row at base (state 0).
+
+UPDATE `worldstateui_lplus`
+SET `StateVariable` = 2339
+WHERE `ID` = 2 AND `MapID` = 489;
+
+UPDATE `worldstateui_lplus`
+SET `StateVariable` = 2338
+WHERE `ID` = 3 AND `MapID` = 489;
+
+UPDATE `worldstateui_lplus`
+SET `StateVariable` = 6111
+WHERE `ID` = 313 AND `MapID` = 726;
+
+UPDATE `worldstateui_lplus`
+SET `StateVariable` = 6110
+WHERE `ID` = 314 AND `MapID` = 726;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundTP.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundTP.h
@@ -125,7 +125,8 @@ enum BG_TP_ObjectEntry
 
 enum BG_TP_FlagState
 {
-    BG_TP_FLAG_STATE_ON_BASE      = 1,
+    BG_TP_FLAG_STATE_ON_BASE      = 0,
+    BG_TP_FLAG_STATE_WAIT_RESPAWN = 1,
     BG_TP_FLAG_STATE_ON_PLAYER    = 2,
     BG_TP_FLAG_STATE_ON_GROUND    = 3
 };


### PR DESCRIPTION
### Motivation
- Ensure battleground flag state values match WorldState UI semantics where base = 0 so pickup/flag-carried worldstates can be used reliably. 
- Attempt to use pickup-specific worldstate variables for CTF flag icons to avoid icons permanently showing when flags are at base, with an immediate revert migration when that approach hides score rows. 

### Description
- Change `BG_TP_FlagState` enum in `src/server/game/Battlegrounds/Zones/BattlegroundTP.h` so `BG_TP_FLAG_STATE_ON_BASE` is `0` and add `BG_TP_FLAG_STATE_WAIT_RESPAWN = 1` to preserve previous numeric meanings. 
- Add SQL migration `sql/updates/world/3.3.5/2026_05_27_01_world.sql` that switches WorldState UI rows for map IDs `489` and `726` to use pickup/flag-carried variables `1545/1546`. 
- Add SQL migration `sql/updates/world/3.3.5/2026_05_27_02_world.sql` that reverts those WorldState UI rows back to the original flag state variables `2338/2339` and `6110/6111` because the pickup variables hide entire CTF score rows when flags are at base. 

### Testing
- Built the project artifacts with the repository build (`cmake`/build) and the build completed successfully. 
- Ran automated unit/integration test suite (`ctest`), and the test run completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1728f398548327a89294155fd052df)