### PR TITLE
Guard and delay Polearm/Staff inner-aura sync on login; add debug logging

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -27,6 +27,7 @@
 #include "PathGenerator.h"
 #include "Player.h"
 #include "Random.h"
+#include "Log.h"
 #include "SpellAuraEffects.h"
 #include "SpellHistory.h"
 #include "SpellMgr.h"
@@ -158,18 +159,35 @@ void Sync(Player* player)
     if (!player)
         return;
 
+    if (!player->IsInWorld())
+    {
+        TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::Sync skipped for player {} ({}) because player is not in world yet", player->GetName(), player->GetGUID().ToString());
+        return;
+    }
+
+    TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::Sync start for player {} ({})", player->GetName(), player->GetGUID().ToString());
+
     for (AuraMapping const& mapping : AuraMappings)
     {
         bool const shouldHaveInnerAura = ShouldHaveInnerAura(player, mapping);
         bool const hasInnerAura = player->HasAura(mapping.InnerSpellId);
 
+        TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::Sync player {} outer {} inner {} shouldHave={} hasInner={}",
+            player->GetGUID().ToString(), mapping.OuterSpellId, mapping.InnerSpellId, shouldHaveInnerAura, hasInnerAura);
+
         if (shouldHaveInnerAura)
         {
             if (!hasInnerAura)
+            {
                 player->CastSpell(player, mapping.InnerSpellId, true);
+                TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::Sync applied inner aura {} for player {}", mapping.InnerSpellId, player->GetGUID().ToString());
+            }
         }
         else if (hasInnerAura)
+        {
             player->RemoveAurasDueToSpell(mapping.InnerSpellId);
+            TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::Sync removed inner aura {} for player {}", mapping.InnerSpellId, player->GetGUID().ToString());
+        }
     }
 }
 
@@ -227,7 +245,20 @@ public:
 
     void OnLogin(Player* player, bool /*firstLogin*/) override
     {
-        PolearmStaffInnerAuras::Sync(player);
+        if (!player)
+            return;
+
+        ObjectGuid const playerGuid = player->GetGUID();
+        player->m_Events.AddEventAtOffset([playerGuid]()
+        {
+            if (Player* loadedPlayer = ObjectAccessor::FindConnectedPlayer(playerGuid))
+            {
+                TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::OnLogin delayed sync for player {} ({})", loadedPlayer->GetName(), loadedPlayer->GetGUID().ToString());
+                PolearmStaffInnerAuras::Sync(loadedPlayer);
+            }
+            else
+                TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::OnLogin delayed sync skipped because player {} is no longer connected", playerGuid.ToString());
+        }, 1s);
     }
 
     void OnPlayerResurrect(Player* player) override


### PR DESCRIPTION
### Motivation
- A crash during login traced to `PolearmStaffInnerAuras::Sync` calling spell/state accessors during a fragile login window required a timing-safety fix and better diagnostics. 
- The goal is to avoid unsafe calls to `Player::HasSpell()` / spell lookups while the player is not fully in-world and to make the sync behaviour easier to debug.

### Description
- Added `#include "Log.h"` and detailed debug logging inside `PolearmStaffInnerAuras::Sync` to record sync start/skip, per-mapping `outer/inner` evaluation, and explicit apply/remove events via `TC_LOG_DEBUG`.
- Added an early guard in `Sync` to return if `!player->IsInWorld()` to prevent running the logic before the player is fully present.
- Changed `spell_warr_polearm_staff_inner_aura_player::OnLogin` to defer the `Sync` by scheduling a 1s delayed event with `player->m_Events.AddEventAtOffset`, resolving the player by guid inside the event with `ObjectAccessor::FindConnectedPlayer` before calling `Sync`.
- Kept `OnPlayerResurrect` behaviour unchanged and added null checks where appropriate to avoid dereferencing invalid pointers.

### Testing
- Ran `cmake --build build --target worldserver -j2` to validate integration, which progressed through configuration and compilation without errors in this run. 
- The modified translation unit compiled and appears in the build outputs as `src/server/scripts/CMakeFiles/scripts.dir/Spells/spell_warrior.cpp.o`.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172ef3e9488327b0420e7fdfe3bef4)