### PR TITLE
Add missing ObjectAccessor include in warrior spell script

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -28,6 +28,7 @@
 #include "Player.h"
 #include "Random.h"
 #include "Log.h"
+#include "ObjectAccessor.h"
 #include "SpellAuraEffects.h"
 #include "SpellHistory.h"
 #include "SpellMgr.h"


### PR DESCRIPTION
### Motivation
- Fix a compile error where `ObjectAccessor::FindConnectedPlayer` is used but `ObjectAccessor` was not declared in `src/server/scripts/Spells/spell_warrior.cpp`.

### Description
- Add the line `#include "ObjectAccessor.h"` to `src/server/scripts/Spells/spell_warrior.cpp` to ensure `ObjectAccessor` is available.

### Testing
- No automated tests were run for this change; `git diff` and `git commit` were used to verify the edit and commit succeeded, and CI should be re-run to confirm the compilation error is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1745dad3308327af7b10acc73a59bf)