### PR TITLE
BFG: double resource gain for 1-2 captured bases

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
@@ -243,7 +243,7 @@ const float GILNEAS_BG_DoorPositions[4][8] =
 };
 
 const uint32 GILNEAS_BG_TickIntervals[4] = { 0, 12000, 6000, 1000 };
-const uint32 GILNEAS_BG_TickPoints[4] = { 0, 10, 10, 30 };
+const uint32 GILNEAS_BG_TickPoints[4] = { 0, 20, 20, 30 };
 
 
 const uint32 GILNEAS_BG_GraveyardIds[GILNEAS_BG_ALL_NODES_COUNT] = { 1736, 1737, 1735, 1739, 1738 };


### PR DESCRIPTION
### Motivation
- Double the per-tick resource points awarded in Battle for Gilneas when a team controls 1 or 2 bases to increase resource gain for those control states.

### Description
- Changed the battleground scoring table `GILNEAS_BG_TickPoints` in `src/server/game/Battlegrounds/Zones/BattlegroundBFG.h` from `{ 0, 10, 10, 30 }` to `{ 0, 20, 20, 30 }`.

### Testing
- No automated gameplay or unit tests were run for this constant-only change; a local diff confirmed the source modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17679199708327ae9289060582b50b)