### PR TITLE
Playerbot PvP: prioritize flag-carrier pursuit in active CTF

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3019,11 +3019,17 @@ TacticalDecision SelectBattlegroundTacticalDecision(Player const* player, player
         float priority;
     };
 
-    // Blind pressure model for battlegrounds: once active, always drive toward
-    // enemy players rather than objective-specific behavior.
-    std::array<TacticalRule, 4> const rules =
+    // Keep pressure behavior generic, but elevate flag-carrier directives when
+    // objective triggers report an active carrier. This ensures CTF matches
+    // chase carriers instead of defaulting to midfield skirmishes.
+    bool const enemyFlagCarrierActive = values.enemyFlagCarrierActive;
+    bool const teamFlagCarrierNear = values.teamFlagCarrierNear;
+
+    std::array<TacticalRule, 6> const rules =
     {{
         { "bg waiting", bgWaiting, "bg move to start", 50.0f },
+        { "enemy flag carrier active", bgActive && enemyFlagCarrierActive, "attack enemy flag carrier", 95.0f },
+        { "team flag carrier near", bgActive && teamFlagCarrierNear, "bg protect fc", 80.0f },
         { "bg active", bgActive, "bg pursue enemy", 60.0f },
         { "low health", lowHealth, "bg use buff", 45.0f },
         { "low mana", lowMana, "bg use buff", 45.0f }


### PR DESCRIPTION
### Motivation
- Playerbots were favoring generic midfield skirmishes during active CTF matches (e.g., WSG/Twin Peaks) instead of switching to pursue or defend flag carriers, so the tactical decision selection needs to elevate flag-carrier directives when appropriate.
- The change aims to remain generic and trigger-driven (no per-battleground movement special-cases) while making bots respond to existing objective triggers for carrier activity.

### Description
- Updated `SelectBattlegroundTacticalDecision` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` to consider `values.enemyFlagCarrierActive` and `values.teamFlagCarrierNear` when building tactical rules.
- Inserted two new tactical rules: an `attack enemy flag carrier` rule that fires when the battleground is active and an enemy carrier exists, with high priority, and a `bg protect fc` rule that triggers when our team carrier is nearby, with elevated priority.
- Kept all behavior trigger-driven and reused existing action handlers (`AttackEnemyFlagCarrierPrimitive` / `ProtectFlagCarrierPrimitive`) rather than adding map-specific movement logic.

### Testing
- Ran the build invocation `cmake --build build --target game -- -j4` to validate the change compiles; the build progressed through configuration and many compilation stages without immediate errors related to the modified file.
- Commit recorded successfully and no compile-time errors were observed in the touched translation unit during the observed build progression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a176701e5dc832789e0a1d936fa375b)