### PR TITLE
Ensure spirit guides match owning faction and fix node position ordering in BFG battleground

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.cpp
@@ -165,6 +165,12 @@ void BattlegroundBFG::StartingEventCloseDoors()
 
 void BattlegroundBFG::StartingEventOpenDoors()
 {
+    // Ensure home base spirit guides are always the correct faction at round start.
+    DelCreature(GILNEAS_BG_SPIRIT_ALLIANCE);
+    DelCreature(GILNEAS_BG_SPIRIT_HORDE);
+    AddSpiritGuide(GILNEAS_BG_SPIRIT_ALLIANCE, GILNEAS_BG_SpiritGuidePos[GILNEAS_BG_SPIRIT_ALLIANCE][0], GILNEAS_BG_SpiritGuidePos[GILNEAS_BG_SPIRIT_ALLIANCE][1], GILNEAS_BG_SpiritGuidePos[GILNEAS_BG_SPIRIT_ALLIANCE][2], GILNEAS_BG_SpiritGuidePos[GILNEAS_BG_SPIRIT_ALLIANCE][3], TEAM_ALLIANCE);
+    AddSpiritGuide(GILNEAS_BG_SPIRIT_HORDE, GILNEAS_BG_SpiritGuidePos[GILNEAS_BG_SPIRIT_HORDE][0], GILNEAS_BG_SpiritGuidePos[GILNEAS_BG_SPIRIT_HORDE][1], GILNEAS_BG_SpiritGuidePos[GILNEAS_BG_SPIRIT_HORDE][2], GILNEAS_BG_SpiritGuidePos[GILNEAS_BG_SPIRIT_HORDE][3], TEAM_HORDE);
+
     // spawn neutral banners
     for (uint32 banner = GILNEAS_BG_OBJECT_BANNER_NEUTRAL, i = 0; i < GILNEAS_BG_DYNAMIC_NODES_COUNT; banner += GILNEAS_BG_OBJECT_PER_NODE, ++i)
         SpawnBGObject(banner, RESPAWN_IMMEDIATELY);
@@ -287,6 +293,9 @@ void BattlegroundBFG::SendNodeUpdate(uint8 node)
 void BattlegroundBFG::NodeOccupied(uint8 node)
 {
     ApplyPhaseMask();
+
+    // Ensure spirit guide always matches current owner after node control changes.
+    DelCreature(node);
     AddSpiritGuide(node, GILNEAS_BG_SpiritGuidePos[node][0], GILNEAS_BG_SpiritGuidePos[node][1], GILNEAS_BG_SpiritGuidePos[node][2], GILNEAS_BG_SpiritGuidePos[node][3], _capturePointInfo[node]._ownerTeamId);
 
     ++_controlledPoints[_capturePointInfo[node]._ownerTeamId];

--- a/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBFG.h
@@ -229,8 +229,8 @@ enum GILNEAS_BG_Objectives
 const float GILNEAS_BG_NodePositions[GILNEAS_BG_DYNAMIC_NODES_COUNT][4] =
 {
     { 1057.790f, 1278.285f, 3.1500f, 1.945662f },       // Lighthouse
-    { 980.0446f, 948.7411f, 12.650f, 5.904071f },       // Mine
-    { 1251.010f, 958.2685f, 5.6000f, 5.892280f }        // Waterworks
+    { 1251.010f, 958.2685f, 5.6000f, 5.892280f },       // Waterworks
+    { 980.0446f, 948.7411f, 12.650f, 5.904071f }        // Mine
 };
 
 // x, y, z, o, rot0, rot1, rot2, rot3


### PR DESCRIPTION
### Motivation

- Prevent spirit guide NPCs from being left with the wrong faction at round start or after a node changes owner by ensuring they are removed and respawned with the correct team.
- Fix an inconsistency in node position ordering so node coordinates align with the spirit guide positions.

### Description

- In `StartingEventOpenDoors` remove any existing home-base spirit guides with `DelCreature` and re-add them via `AddSpiritGuide` using the correct `TEAM_ALLIANCE` / `TEAM_HORDE` values. 
- In `NodeOccupied` call `DelCreature(node)` before `AddSpiritGuide(...)` so the spirit guide is recreated to match the node's new owner. 
- Reordered entries in `GILNEAS_BG_NodePositions` to match the existing `GILNEAS_BG_SpiritGuidePos` layout (swapped Mine and Waterworks). 
- Added brief explanatory comments where spirit guides are ensured to match the correct faction.

### Testing

- Project was compiled using `make` (build succeeded). 
- Automated test suite was run via `ctest` / `make test` and completed without failures. 
- Automated battleground simulation checks for BFG start and node-capture flows were executed and confirmed that spirit guides spawn with the correct faction after round start and after node ownership changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1766a19ebc8327982776ee100aecd1)