### PR TITLE
Send physical flag side in MSG_BATTLEGROUND_PLAYER_POSITIONS

### DIFF
--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -332,7 +332,7 @@ void WorldSession::HandleBattlegroundPlayerPositionsOpcode(WorldPacket& /*recvDa
             ++flagCarrierCount;
     }
 
-    WorldPacket data(MSG_BATTLEGROUND_PLAYER_POSITIONS, 4 + 4 + 16 * flagCarrierCount);
+    WorldPacket data(MSG_BATTLEGROUND_PLAYER_POSITIONS, 4 + 4 + 17 * flagCarrierCount);
     // Used to send several player positions (found used in AV)
     data << 0;  // CGBattlefieldInfo__m_numPlayerPositions
     /*
@@ -342,6 +342,7 @@ void WorldSession::HandleBattlegroundPlayerPositionsOpcode(WorldPacket& /*recvDa
     data << flagCarrierCount;
     if (allianceFlagCarrier)
     {
+        data << uint8(TEAM_ALLIANCE);
         data << uint64(allianceFlagCarrier->GetGUID());
         data << float(allianceFlagCarrier->GetPositionX());
         data << float(allianceFlagCarrier->GetPositionY());
@@ -349,6 +350,7 @@ void WorldSession::HandleBattlegroundPlayerPositionsOpcode(WorldPacket& /*recvDa
 
     if (hordeFlagCarrier)
     {
+        data << uint8(TEAM_HORDE);
         data << uint64(hordeFlagCarrier->GetGUID());
         data << float(hordeFlagCarrier->GetPositionX());
         data << float(hordeFlagCarrier->GetPositionY());


### PR DESCRIPTION
### Motivation
- Fix incorrect minimap/map CTF flag icons in cross-faction battlegrounds by ensuring the server communicates the physical flag side instead of letting the client infer it from the carrier's faction/race.

### Description
- In `src/server/game/Handlers/BattleGroundHandler.cpp` inside `WorldSession::HandleBattlegroundPlayerPositionsOpcode` the packet payload for `MSG_BATTLEGROUND_PLAYER_POSITIONS` now prefixes each carried-flag entry with a `uint8` physical-flag-side (`TEAM_ALLIANCE` / `TEAM_HORDE`), and the packet reserve size was increased from `16` to `17` bytes per entry.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a180ce6c94c8327a7f6ee0f9b210a41)