### PR TITLE
Add account-based playerbot PvP queue segmentation

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -52,6 +52,8 @@
 #include "Util.h"
 #include "Containers.h"
 #include "CommonHelpers.h"
+#include "Configuration/Config.h"
+#include "StringConvert.h"
 
 #include <cstring>
 #include <cstdint>
@@ -110,6 +112,63 @@ bool IsScmManagedBotCandidate(Player const* player)
 
     WorldSession const* session = player->GetSession();
     return session && session->IsVirtualSession();
+}
+
+std::unordered_set<uint32> ParseAccountIdSetFromConfig(char const* key)
+{
+    std::unordered_set<uint32> accountIds;
+    std::string const raw = sConfigMgr->GetStringDefault(key, "");
+    for (std::string_view token : Trinity::Tokenize(raw, ',', false))
+    {
+        if (Optional<uint32> accountId = Trinity::StringTo<uint32>(token))
+            if (*accountId > 0)
+                accountIds.insert(*accountId);
+    }
+
+    return accountIds;
+}
+
+BattlegroundTypeId ResolveManagedBotQueueTargetForAccount(Player const* player)
+{
+    if (!player)
+        return BATTLEGROUND_SCM;
+
+    uint32 const accountId = player->GetSession() ? player->GetSession()->GetAccountId() : 0;
+    if (!accountId)
+        return BATTLEGROUND_SCM;
+
+    if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.ScarletChapelAccounts").count(accountId))
+        return BATTLEGROUND_SCM;
+
+    uint32 const blackrockThroneBgType = std::max<int32>(0, sConfigMgr->GetIntDefault("Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneBgTypeId", 0));
+    if (blackrockThroneBgType > 0 && ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneAccounts").count(accountId))
+        return static_cast<BattlegroundTypeId>(blackrockThroneBgType);
+
+    if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.BattleForGilneasAccounts").count(accountId))
+        return BATTLEGROUND_BFG;
+
+    if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.TwinPeaksAccounts").count(accountId))
+        return BATTLEGROUND_TP;
+
+    if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.ArathiBasinAccounts").count(accountId))
+        return BATTLEGROUND_AB;
+
+    if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.WarsongGulchAccounts").count(accountId))
+        return BATTLEGROUND_WS;
+
+    return BATTLEGROUND_SCM;
+}
+
+bool IsArenaOnlyManagedBotAccount(Player const* player)
+{
+    if (!player || !player->GetSession())
+        return false;
+
+    uint32 const accountId = player->GetSession()->GetAccountId();
+    if (!accountId)
+        return false;
+
+    return ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.ArenaAccounts").count(accountId) != 0;
 }
 
 uint32 ComputeOverstackDepartureJitterMs(Player const* player, Battleground const* battleground)
@@ -2586,7 +2645,10 @@ bool BattlegroundLifecycleActions::JoinQueuePrimitive(Player* player)
     if (!player || !IsLifecycleGateEnabled())
         return false;
 
-    constexpr BattlegroundTypeId kManagedBattleground = BATTLEGROUND_SCM;
+    if (IsArenaOnlyManagedBotAccount(player))
+        return false;
+
+    BattlegroundTypeId const kManagedBattleground = ResolveManagedBotQueueTargetForAccount(player);
     uint32 const nowMs = GameTime::GetGameTimeMS();
     bool const hasHumanInterest = HasAnyRealHumanInterestInBattleground(kManagedBattleground);
 

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -55,6 +55,34 @@ Playerbot.PvpTactics.Enable = 0
 
 Playerbot.PvpLifecycle.Enable = 0
 
+#    Playerbot.PvpLifecycle.QueueOnly.ScarletChapelAccounts
+#    Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneAccounts
+#    Playerbot.PvpLifecycle.QueueOnly.BattleForGilneasAccounts
+#    Playerbot.PvpLifecycle.QueueOnly.TwinPeaksAccounts
+#    Playerbot.PvpLifecycle.QueueOnly.ArathiBasinAccounts
+#    Playerbot.PvpLifecycle.QueueOnly.WarsongGulchAccounts
+#    Playerbot.PvpLifecycle.QueueOnly.ArenaAccounts
+#        Description: Comma-separated account IDs for queue segmentation. Managed bots on these accounts
+#                     are constrained to the corresponding queue family only.
+#                     ArenaAccounts suppress battleground queue joins so those bots can queue arena only.
+#                     BlackrockThrone uses QueueOnly.BlackrockThroneBgTypeId for its battleground type ID.
+#        Default:     "" (empty list)
+
+Playerbot.PvpLifecycle.QueueOnly.ScarletChapelAccounts =
+Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneAccounts =
+Playerbot.PvpLifecycle.QueueOnly.BattleForGilneasAccounts =
+Playerbot.PvpLifecycle.QueueOnly.TwinPeaksAccounts =
+Playerbot.PvpLifecycle.QueueOnly.ArathiBasinAccounts =
+Playerbot.PvpLifecycle.QueueOnly.WarsongGulchAccounts =
+Playerbot.PvpLifecycle.QueueOnly.ArenaAccounts =
+
+#    Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneBgTypeId
+#        Description: Battleground type ID used for Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneAccounts.
+#                     Set this to your custom Blackrock Throne battleground type ID.
+#        Default:     0 (disabled; accounts in BlackrockThroneAccounts fall back to other configured rules)
+
+Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneBgTypeId = 0
+
 #    Playerbot.PvpClassSpells.Enable
 #        Description: Enables Phase-4 class/spec PvP spell decision slices.
 #                     Current implementation provides reference-aligned trigger/action vocabulary


### PR DESCRIPTION
### Motivation
- Provide per-account segregation so managed playerbot accounts can be forced to queue only for a specific battleground or only for arenas. 
- Allow mapping an account pool to Scarlet Chapel, Blackrock Throne (custom bg id), Battle for Gilneas, Twin Peaks, Arathi Basin, Warsong Gulch, or arena-only behavior to support separate bot fleets.

### Description
- Added `ParseAccountIdSetFromConfig`, `ResolveManagedBotQueueTargetForAccount`, and `IsArenaOnlyManagedBotAccount` helpers and included `Configuration/Config.h` and `StringConvert.h` to `PlayerbotPvpLifecycleActions.cpp` to resolve per-account queue targets at runtime.
- Replaced the hardcoded SCM-only join target in `BattlegroundLifecycleActions::JoinQueuePrimitive` with a dynamic target resolved by account and short-circuited battleground joins for accounts marked as arena-only via `IsArenaOnlyManagedBotAccount`.
- Introduced new configuration keys documented in `playerbots.conf.dist`: `Playerbot.PvpLifecycle.QueueOnly.ScarletChapelAccounts`, `Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneAccounts`, `Playerbot.PvpLifecycle.QueueOnly.BattleForGilneasAccounts`, `Playerbot.PvpLifecycle.QueueOnly.TwinPeaksAccounts`, `Playerbot.PvpLifecycle.QueueOnly.ArathiBasinAccounts`, `Playerbot.PvpLifecycle.QueueOnly.WarsongGulchAccounts`, `Playerbot.PvpLifecycle.QueueOnly.ArenaAccounts`, and `Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneBgTypeId` (for a custom Blackrock Throne type id).
- Files changed: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and `src/server/worldserver/playerbots.conf.dist`.

### Testing
- Ran repository searches with `rg` to verify the `BATTLEGROUND_BFG` symbol is referenced and to inspect playerbot lifecycle code paths, which returned expected matches.
- Verified working tree and created a commit with `git status --short` and `git commit` which completed successfully.
- Created PR metadata with `make_pr` which returned the prepared title/body; no automated unit tests or builds were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a180efd2aec83278f806d227812c2c9)