### PR TITLE
Playerbot: Add battleground downhill shortcut movement and replace direct-drop logic

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -28,6 +28,7 @@
 #include "DBCStores.h"
 #include "Time/GameTime.h"
 #include "GameObject.h"
+#include "GenericMovementGenerator.h"
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "CharacterCache.h"
@@ -37,6 +38,7 @@
 #include "Map.h"
 #include "MotionMaster.h"
 #include "MovementTypedefs.h"
+#include "MoveSplineInit.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
 #include "Item.h"
@@ -714,41 +716,119 @@ bool IsForbiddenBattlegroundPathType(PathType pathType)
 constexpr float PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT = 2400.0f;
 constexpr float PLAYERBOT_BG_MOVEMENT_SEGMENT_DISTANCE = 80.0f;
 
-Position BuildDownhillEscapeDestination(Player* player, Position const& destination)
+constexpr float PLAYERBOT_BG_SHORTCUT_MAX_STEP_DISTANCE = 12.0f;
+
+enum class BattlegroundShortcutMoveType
+{
+    None,
+    GroundedSlope,
+    ControlledFall
+};
+
+struct BattlegroundShortcutDestination
+{
+    Position position;
+    BattlegroundShortcutMoveType moveType = BattlegroundShortcutMoveType::None;
+};
+
+// Battleground shortcuts are intentionally generic: walk short validated slope
+// steps when terrain supports it, but allow a real falling spline when the
+// terrain is a cliff (for example elevated graveyard exits). What we avoid is
+// the old long direct point spline that visually dragged bots through the air.
+bool BuildBattlegroundDownhillShortcutDestination(Player* player, Position const& destination, BattlegroundShortcutDestination& shortcut)
 {
     if (!player)
-        return destination;
+        return false;
 
     float const dx = destination.GetPositionX() - player->GetPositionX();
     float const dy = destination.GetPositionY() - player->GetPositionY();
     float const planarDistance = std::sqrt(dx * dx + dy * dy);
-    if (planarDistance < 0.5f)
-        return BuildCollisionSafeDestination(player, destination);
+    if (planarDistance < 3.0f)
+        return false;
 
-    float const stepDistance = std::min(12.0f, std::max(4.0f, planarDistance * 0.35f));
+    float const destinationDrop = player->GetPositionZ() - destination.GetPositionZ();
+    if (destinationDrop < 1.5f)
+        return false;
+
     float const nx = dx / planarDistance;
     float const ny = dy / planarDistance;
+    float const stepDistance = std::min(PLAYERBOT_BG_SHORTCUT_MAX_STEP_DISTANCE, std::max(4.0f, planarDistance * 0.20f));
+    uint8 constexpr sampleCount = 4;
 
-    Position probe(
-        player->GetPositionX() + nx * stepDistance,
-        player->GetPositionY() + ny * stepDistance,
-        player->GetPositionZ() - 6.0f,
-        destination.GetOrientation());
+    Position previous = player->GetPosition();
+    Position selected = previous;
+    bool cliffLikeDrop = false;
+    for (uint8 i = 1; i <= sampleCount; ++i)
+    {
+        float const sampleDistance = stepDistance * (static_cast<float>(i) / static_cast<float>(sampleCount));
+        Position sample(
+            player->GetPositionX() + nx * sampleDistance,
+            player->GetPositionY() + ny * sampleDistance,
+            player->GetPositionZ(),
+            destination.GetOrientation());
+        sample = BuildCollisionSafeDestination(player, sample);
 
-    return BuildCollisionSafeDestination(player, probe);
+        float const sampleDx = sample.GetPositionX() - previous.GetPositionX();
+        float const sampleDy = sample.GetPositionY() - previous.GetPositionY();
+        float const samplePlanar = std::sqrt(sampleDx * sampleDx + sampleDy * sampleDy);
+        if (samplePlanar < 0.1f)
+            return false;
+
+        float const sampleRise = sample.GetPositionZ() - previous.GetPositionZ();
+        float const sampleDrop = previous.GetPositionZ() - sample.GetPositionZ();
+        if (sampleRise > 0.75f)
+            return false;
+
+        if (sampleDrop > std::max(2.25f, samplePlanar * 0.95f + 0.25f))
+        {
+            cliffLikeDrop = true;
+            break;
+        }
+
+        selected = sample;
+        previous = sample;
+    }
+
+    if (!cliffLikeDrop)
+    {
+        float const totalDrop = player->GetPositionZ() - selected.GetPositionZ();
+        if (totalDrop < 0.5f)
+            return false;
+
+        shortcut.position = selected;
+        shortcut.moveType = BattlegroundShortcutMoveType::GroundedSlope;
+        return player->GetDistance(shortcut.position) > 0.5f;
+    }
+
+    float landingZ = player->GetPositionZ();
+    float const landingX = player->GetPositionX() + nx * stepDistance;
+    float const landingY = player->GetPositionY() + ny * stepDistance;
+    player->UpdateAllowedPositionZ(landingX, landingY, landingZ);
+
+    float const fallDrop = player->GetPositionZ() - landingZ;
+    if (fallDrop < 2.0f || fallDrop > 45.0f)
+        return false;
+
+    Position landing(landingX, landingY, landingZ, destination.GetOrientation());
+    if (player->GetDistance(landing) <= 0.5f)
+        return false;
+
+    shortcut.position = landing;
+    shortcut.moveType = BattlegroundShortcutMoveType::ControlledFall;
+    return true;
 }
 
-bool ShouldPreferDirectDropShortcut(Player* player, Position const& destination)
+bool ShouldPreferBattlegroundDownhillShortcut(Player* player, Position const& destination)
 {
     if (!player)
         return false;
 
     float const destinationDistance = player->GetDistance(destination);
-    if (destinationDistance < 15.0f || destinationDistance > 120.0f)
+    if (destinationDistance < 10.0f || destinationDistance > 120.0f)
         return false;
 
     float const verticalDrop = player->GetPositionZ() - destination.GetPositionZ();
-    if (verticalDrop < 8.0f)
+    if (verticalDrop < 4.0f)
         return false;
 
     PathGenerator path(player);
@@ -768,6 +848,46 @@ bool ShouldPreferDirectDropShortcut(Player* player, Position const& destination)
         pathLength += (points[i] - points[i - 1]).length();
 
     return pathLength > destinationDistance * 1.35f;
+}
+
+void IssueBattlegroundShortcutMove(Player* player, MotionMaster* motionMaster, BattlegroundShortcutDestination const& shortcut)
+{
+    if (!player || !motionMaster)
+        return;
+
+    if (shortcut.moveType == BattlegroundShortcutMoveType::ControlledFall)
+    {
+        Position const landing = shortcut.position;
+        std::function<void(Movement::MoveSplineInit&)> initializer = [landing, player](Movement::MoveSplineInit& init)
+        {
+            init.MoveTo(landing.GetPositionX(), landing.GetPositionY(), landing.GetPositionZ(), false);
+            init.SetFall();
+            init.SetVelocity(std::max(1.0f, player->GetSpeed(MOVE_RUN)));
+        };
+
+        GenericMovementGenerator* movement = new GenericMovementGenerator(std::move(initializer), EFFECT_MOTION_TYPE, 0);
+        movement->Priority = MOTION_PRIORITY_HIGHEST;
+        motionMaster->Add(movement);
+        player->SetFallInformation(0, player->GetPositionZ());
+        return;
+    }
+
+    motionMaster->MovePoint(0, shortcut.position, false);
+}
+
+char const* GetBattlegroundShortcutMoveLabel(BattlegroundShortcutMoveType moveType)
+{
+    switch (moveType)
+    {
+        case BattlegroundShortcutMoveType::GroundedSlope:
+            return "grounded-slope";
+        case BattlegroundShortcutMoveType::ControlledFall:
+            return "controlled-fall";
+        case BattlegroundShortcutMoveType::None:
+            break;
+    }
+
+    return "none";
 }
 
 bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray const& points, float orientation, Position& segmentDestination)
@@ -949,21 +1069,11 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
         Position lastDestination;
         uint32 lastIssueMs = 0;
     };
-    struct DirectDropState
-    {
-        Position startPosition;
-        uint32 issueMs = 0;
-        uint32 suppressUntilMs = 0;
-        bool pending = false;
-    };
-
     static std::unordered_map<uint64, MoveOrderState> stateByGuid;
     static std::unordered_map<uint64, uint8> stationaryReissueCountByGuid;
-    static std::unordered_map<uint64, DirectDropState> directDropStateByGuid;
     uint64 const botGuid = player->GetGUID().GetRawValue();
     MoveOrderState& state = stateByGuid[player->GetGUID().GetRawValue()];
     uint8& stationaryReissueCount = stationaryReissueCountByGuid[botGuid];
-    DirectDropState& directDropState = directDropStateByGuid[botGuid];
     uint32 const nowMs = GameTime::GetGameTimeMS();
 
     bool const destinationChanged = state.lastIssueMs == 0 ||
@@ -1020,74 +1130,44 @@ bool IssueMovePointThrottled(Player* player, Position const& destination, float 
 
     if (generatePath && player->InBattleground())
     {
-        if (directDropState.pending &&
-            nowMs > directDropState.issueMs + 1200 &&
-            !player->isMoving())
+        BattlegroundShortcutDestination shortcutDestination;
+        if (ShouldPreferBattlegroundDownhillShortcut(player, safeDestination) &&
+            BuildBattlegroundDownhillShortcutDestination(player, safeDestination, shortcutDestination))
         {
-            // Two failure shapes:
-            // 1) Never launched from the start point.
-            // 2) Launched, then settled/stuck on terrain partway down.
-            float const fromStart = player->GetDistance(directDropState.startPosition);
-            float const toDestination = player->GetDistance(safeDestination);
-            if (fromStart < 3.0f || toDestination > 8.0f)
-            {
-                directDropState.pending = false;
-                directDropState.suppressUntilMs = nowMs + 8000;
-                Position const escapeDestination = BuildDownhillEscapeDestination(player, safeDestination);
-                motionMaster->MovePoint(0, escapeDestination, false);
-                EmitBattlegroundGmDebug(player,
-                    "movepoint=direct-drop-stalled fallback=nav-segment fromStart=" + std::to_string(int32(fromStart)) +
-                    " toDest=" + std::to_string(int32(toDestination)) +
-                    " escapeDist=" + std::to_string(int32(player->GetDistance(escapeDestination))), 0);
-
-                state.lastDestination = destination;
-                state.lastIssueMs = nowMs;
-                return true;
-            }
-        }
-
-        if (nowMs >= directDropState.suppressUntilMs && ShouldPreferDirectDropShortcut(player, safeDestination))
-        {
-            Position const shortcutDestination = BuildDownhillEscapeDestination(player, safeDestination);
-            motionMaster->MovePoint(0, shortcutDestination, false);
+            IssueBattlegroundShortcutMove(player, motionMaster, shortcutDestination);
             EmitBattlegroundGmDebug(player,
-                "movepoint=direct-drop-shortcut destDist=" + std::to_string(int32(player->GetDistance(safeDestination))) +
-                " stepDist=" + std::to_string(int32(player->GetDistance(shortcutDestination))), 0);
-            directDropState.startPosition = player->GetPosition();
-            directDropState.issueMs = nowMs;
-            directDropState.pending = true;
+                "movepoint=downhill-shortcut type=" + std::string(GetBattlegroundShortcutMoveLabel(shortcutDestination.moveType)) +
+                " destDist=" + std::to_string(int32(player->GetDistance(safeDestination))) +
+                " stepDist=" + std::to_string(int32(player->GetDistance(shortcutDestination.position))), 0);
 
             state.lastDestination = destination;
             state.lastIssueMs = nowMs;
             return true;
-        }
-        else
-        {
-            directDropState.pending = false;
         }
 
         Position segmentDestination;
         PathType pathType = PathType(0);
         if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
         {
-            // Recovery path for segmented-nav failures (for example, after a
-            // partial drop where local nav probing can't find a legal segment):
-            // issue a direct movement order so the bot keeps progressing
-            // instead of stalling in place waiting on nav segment recovery.
-            Position const fallbackDestination = BuildDownhillEscapeDestination(player, safeDestination);
-            motionMaster->MovePoint(0, fallbackDestination, false);
+            if (BuildBattlegroundDownhillShortcutDestination(player, safeDestination, shortcutDestination))
+            {
+                IssueBattlegroundShortcutMove(player, motionMaster, shortcutDestination);
+                EmitBattlegroundGmDebug(player,
+                    "movepoint=blocked-no-nav fallback=downhill type=" + std::string(GetBattlegroundShortcutMoveLabel(shortcutDestination.moveType)) +
+                    " stepDist=" + std::to_string(int32(player->GetDistance(shortcutDestination.position))), 0);
+
+                state.lastDestination = destination;
+                state.lastIssueMs = nowMs;
+                return true;
+            }
+
+            // Do not fall back to unrestricted direct/no-path movement in
+            // battlegrounds. Only the downhill shortcut above may bypass navmesh, because
+            // it either walks a short grounded slope step or uses a real fall
+            // spline for cliff exits instead of a large direct glide.
             EmitBattlegroundGmDebug(player,
-                "movepoint=blocked-no-nav fallback=direct destDist=" + std::to_string(int32(player->GetDistance(safeDestination))) +
-                " stepDist=" + std::to_string(int32(player->GetDistance(fallbackDestination))), 0);
-
-            directDropState.startPosition = player->GetPosition();
-            directDropState.issueMs = nowMs;
-            directDropState.pending = true;
-            directDropState.suppressUntilMs = std::max(directDropState.suppressUntilMs, nowMs + 2500);
-
-            state.lastDestination = destination;
-            state.lastIssueMs = nowMs;
-            return true;
+                "movepoint=blocked-no-nav fallback=none destDist=" + std::to_string(int32(player->GetDistance(safeDestination))), 0);
+            return false;
         }
 
         motionMaster->MovePoint(0, segmentDestination, true);


### PR DESCRIPTION
### Motivation

- Improve bot movement in battlegrounds by replacing the brittle long direct-drop behavior with safer, shorter downhill shortcuts or controlled fall splines.  
- Avoid bots getting stuck or visually gliding through the air while still allowing progress when navmesh segments are not available.  

### Description

- Introduce a new downhill shortcut system with `BattlegroundShortcutDestination` and `BattlegroundShortcutMoveType` to choose between a short grounded slope step and a controlled fall spline.  
- Add `BuildBattlegroundDownhillShortcutDestination` to validate and sample intermediate positions toward the destination and decide whether a grounded slope or controlled fall is appropriate.  
- Add `ShouldPreferBattlegroundDownhillShortcut`, `IssueBattlegroundShortcutMove`, and `GetBattlegroundShortcutMoveLabel` to select and execute shortcut moves (using `GenericMovementGenerator`+`MoveSplineInit` for controlled falls or `MovePoint` for slope steps).  
- Replace the old direct-drop state machinery and heuristics with the new shortcut flow inside `IssueMovePointThrottled`, and change fallback behavior so battlegrounds do not fall back to unrestricted direct/no-path movement; instead attempt a shortcut or fail gracefully.  
- Tune thresholds and sampling parameters (distances and vertical-drop limits) and add explanatory comments to clarify the intent.  
- Add necessary includes (`GenericMovementGenerator.h`, `MoveSplineInit.h`) and remove no-longer-used direct-drop state structures.  

### Testing

- Project was built successfully using the normal build (`cmake --build` / `make`) with no compile errors.  
- Existing automated test suite was executed via `ctest` and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186e4a210c83278fb828fe98dcb0ee)