### PR TITLE
Have playerbots actively engage and attack flag carriers in battlegrounds

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -2453,9 +2453,9 @@ namespace playerbot
         return true;
     }
 
-    bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
+    bool EngageSelectedEnemyPlayer(Player* player, Unit* target, char const* reason)
     {
-        if (!player || !player->IsAlive())
+        if (!player || !player->IsAlive() || !target || !target->IsAlive() || !player->IsValidAttackTarget(target))
             return false;
 
         if (IsCrowdControlledForAction(player))
@@ -2464,14 +2464,7 @@ namespace playerbot
             return false;
         }
 
-        Unit* target = AcquireCombatTarget(player, scanDistance);
-        if (!target)
-        {
-            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-                "Playerbot PvP movement skipped: bot={} reason=no-combat-target scanDistance={}.",
-                player ? player->GetGUID().ToString() : ObjectGuid::Empty.ToString(), scanDistance);
-            return false;
-        }
+        player->SetSelection(target->GetGUID());
 
         // Ensure mounted bots immediately transition into combat posture once an
         // enemy target is acquired. Without this, bots that don't cast right away
@@ -2519,11 +2512,28 @@ namespace playerbot
         }
 
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP positioning profile: bot={} profile={} ranged={} createDistance={} meleeFallback={}.",
-            player->GetGUID().ToString(), profile.label, profile.primarilyRanged, profile.createDistanceWhenCrowded,
-            profile.meleeFallbackAcceptable);
+            "Playerbot PvP positioning profile: bot={} target={} reason={} profile={} ranged={} createDistance={} meleeFallback={}.",
+            player->GetGUID().ToString(), target->GetGUID().ToString(), reason ? reason : "combat", profile.label,
+            profile.primarilyRanged, profile.createDistanceWhenCrowded, profile.meleeFallbackAcceptable);
 
         return DriveCombatPositioning(player, target, profile);
+    }
+
+    bool EngageNearestEnemyPlayer(Player* player, float scanDistance)
+    {
+        if (!player || !player->IsAlive())
+            return false;
+
+        Unit* target = AcquireCombatTarget(player, scanDistance);
+        if (!target)
+        {
+            TC_LOG_DEBUG("playerbots.pvp.lifecycle",
+                "Playerbot PvP movement skipped: bot={} reason=no-combat-target scanDistance={}.",
+                player ? player->GetGUID().ToString() : ObjectGuid::Empty.ToString(), scanDistance);
+            return false;
+        }
+
+        return EngageSelectedEnemyPlayer(player, target, "nearest-enemy");
     }
 
     void ApplyDeterministicObjectiveOffset(Battleground const* battleground, Player const* player, Position& destination)
@@ -2961,16 +2971,9 @@ namespace playerbot
         if (player->IsInCombat())
         {
             if (context.flagCarrierDirective == FlagCarrierDirective::AttackEnemyCarrier)
-            {
                 if (Player* enemyCarrier = FindFlagCarrierForDirective(player, FlagCarrierDirective::AttackEnemyCarrier))
-                {
-                    if (player->GetTarget() != enemyCarrier->GetGUID())
-                        player->SetTarget(enemyCarrier->GetGUID());
-
-                    if (MoveTowardUnit(player, enemyCarrier, 15.0f))
+                    if (EngageSelectedEnemyPlayer(player, enemyCarrier, "enemy-flag-carrier"))
                         return true;
-                }
-            }
 
             return EngageNearestEnemyPlayer(player, GetAggressiveCombatScanDistance(player, 100.0f));
         }
@@ -3087,7 +3090,8 @@ namespace playerbot
                 "Playerbot PvP enemy-FC support selected: guid={} target={}.",
                 player->GetGUID().ToString(), enemyCarrier->GetGUID().ToString());
         }
-        return MoveTowardUnit(player, enemyCarrier, 15.0f);
+
+        return EngageSelectedEnemyPlayer(player, enemyCarrier, "enemy-flag-carrier");
     }
 
     bool BattlegroundTacticalActions::ProtectFlagCarrierPrimitive(Player* player, BattlegroundTacticalContext const& context)


### PR DESCRIPTION
### Motivation
- Bots that follow or move toward flag carriers were not reliably selecting and engaging the carrier as a combat target, leaving flag-carrier objectives under-defended or unpressured.

### Description
- Added a new helper `EngageSelectedEnemyPlayer(Player*, Unit*, char const* reason)` that selects a specific enemy target, forces dismount if necessary, primes auto-attacks (including hunter auto-shot handling), and drives combat positioning against the selected target.
- Preserved existing behavior by routing nearest-enemy acquisition through the new helper via `EngageNearestEnemyPlayer` so the fallback path remains intact.
- Updated battleground tactical flows to use the new engagement helper for flag-carrier directives in `MoveToObjectivePrimitive` / `AttackEnemyFlagCarrierPrimitive`, causing bots to actively attack carriers instead of only moving toward them.
- Enhanced debug logging to include the selected target and engagement reason to improve lifecycle observability.

### Testing
- Per-file object build: ran `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o` which completed successfully.
- CMake configuration: ran `cmake -S . -B build -DPLAYERBOT=ON -DSCRIPTS_PLAYERBOT=static` and validated that Playerbot PvP sources are present in `compile_commands.json` and build targets.
- Static checks: ran `git diff --check` and inspected relevant compile command entries with no issues reported.
- Full build: attempted a full `cmake --build build --target worldserver -j2`; the build began and compiled many dependencies but was intentionally interrupted to avoid a large rebuild, so a complete worldserver link/run was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bc8d67988327abae8e7a0cfd68b7)