### PR TITLE
Skip player-known cooldowns during playerbot class-spell decision selection

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -52,6 +52,7 @@ namespace
 {
 struct SpellDecision;
 bool HasHostileTarget(Player const* player, Unit const* target);
+uint32 ResolveKnownPlayerSpellInChain(Player const* player, uint32 spellId);
 bool IsPetSpellReady(Player const* player, uint32 spellId);
 bool IsFriendlySupportTarget(Player const* player, Unit const* target);
 SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player);
@@ -451,9 +452,13 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     if (!decision.spellId)
         return false;
 
-    bool const knownByPlayer = player->HasSpell(decision.spellId);
+    uint32 const knownPlayerSpellId = ResolveKnownPlayerSpellInChain(player, decision.spellId);
+    bool const knownByPlayer = knownPlayerSpellId != 0;
     bool const knownByPet = IsPetSpellReady(player, decision.spellId);
     if (!knownByPlayer && !knownByPet)
+        return false;
+
+    if (knownByPlayer && player->GetSpellHistory()->HasCooldown(knownPlayerSpellId))
         return false;
 
     // Treat the shared playerbot dispel cooldown as an immediate castability
@@ -662,14 +667,14 @@ ClassicProfileSelection DetectClassicClassProfile(Player const* player)
     return selection;
 }
 
-bool IsSpellReady(Player const* player, uint32 spellId)
+uint32 ResolveKnownPlayerSpellInChain(Player const* player, uint32 spellId)
 {
     if (!player || !spellId)
-        return false;
+        return 0;
 
     SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(spellId);
     if (!baseSpellInfo)
-        return false;
+        return 0;
 
     uint32 resolvedSpellId = 0;
     for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
@@ -678,6 +683,12 @@ bool IsSpellReady(Player const* player, uint32 spellId)
             resolvedSpellId = chainSpellId;
     }
 
+    return resolvedSpellId;
+}
+
+bool IsSpellReady(Player const* player, uint32 spellId)
+{
+    uint32 const resolvedSpellId = ResolveKnownPlayerSpellInChain(player, spellId);
     if (!resolvedSpellId)
         return false;
 

--- a/tests/game/PlayerbotRandomPopulation.cpp
+++ b/tests/game/PlayerbotRandomPopulation.cpp
@@ -73,3 +73,11 @@ TEST_CASE("Playerbot battleground queue target remains Warsong", "[playerbot][po
     CHECK(source.find("ManagedRandomBotQueueTarget") != std::string::npos);
     CHECK(source.find("BATTLEGROUND_WS") != std::string::npos);
 }
+
+TEST_CASE("Playerbot class spell fallback skips player spell cooldowns during selection", "[playerbot][pvp]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp");
+    CHECK(source.find("knownPlayerSpellId") != std::string::npos);
+    CHECK(source.find("player->GetSpellHistory()->HasCooldown(knownPlayerSpellId)") != std::string::npos);
+    CHECK(source.find("suppressedSpellId = candidate.spellId") != std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Playerbots could select a player-known spell that is currently on cooldown and then appear to idle until the next decision cadence instead of immediately falling through to a fallback action.
- The decision/fallback loop already suppressed a chosen spell and retried, but the central immediate-castability gate did not reject normal player spell cooldowns.

### Description
- Added `ResolveKnownPlayerSpellInChain(Player const*, uint32)` to resolve the player's known rank for a base spell ID and reused it from `IsSpellReady` to unify rank resolution.
- Updated `IsDecisionImmediatelyCastable` to use the resolved player-known spell and return false if that known spell is on cooldown so the fallback/suppression loop can pick another action in the same pass.
- Preserved existing pet-spell and dispel-throttle checks and kept the suppression retry loop (`suppressedSpellId = candidate.spellId`) behavior intact.
- Added a small source-level regression check in `tests/game/PlayerbotRandomPopulation.cpp` to guard the new wiring (`knownPlayerSpellId` / cooldown check / suppression presence).

### Testing
- Ran automated source assertions via a Python script that verified the new resolver and cooldown-check strings are present in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and the regression test was added to `tests/game/PlayerbotRandomPopulation.cpp`, and the assertions succeeded.
- Ran `git diff --check` (no source errors) and committed the changes successfully.
- Attempted `ninja -C build scripts` to exercise the build, but the build stopped before reaching the Playerbot code because `SCRIPTS_PLAYERBOT` is disabled in the current CMake cache and unrelated compilation failures/warnings in other script modules prevented completion; this prevented running the test binary here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1975c2518483279adc75ddf2c4bf24)