### PR TITLE
Fix playerbot pet action cadence and ensure pets chase targets

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2142,16 +2142,31 @@ void CommandPetAttackTarget(Player* player, Unit* target)
     if (!pet || !pet->IsAlive() || !pet->IsValidAttackTarget(target))
         return;
 
-    if (pet->GetVictim() != target)
-        pet->Attack(target, true);
-
     if (CharmInfo* charmInfo = pet->GetCharmInfo())
     {
+        // Mirror an owner pet-attack command before issuing combat movement so
+        // passive/stay pets are allowed to leave their current command state and
+        // pursue the selected target.
         charmInfo->SetIsCommandAttack(true);
         charmInfo->SetIsAtStay(false);
         charmInfo->SetIsCommandFollow(false);
         charmInfo->SetCommandState(COMMAND_ATTACK);
     }
+
+    if (pet->GetVictim() != target)
+    {
+        pet->AttackStop();
+        pet->Attack(target, true);
+    }
+
+    if (!pet->IsWithinMeleeRange(target) ||
+        !pet->HasUnitState(UNIT_STATE_CHASE | UNIT_STATE_CHASE_MOVE))
+    {
+        if (MotionMaster* motionMaster = pet->GetMotionMaster())
+            motionMaster->MoveChase(target, ChaseRange(0.0f, pet->GetPetChaseDistance()));
+    }
+
+    pet->SetUnitFlag(UNIT_FLAG_PET_IN_COMBAT);
 }
 
 void NotifyDuelDecision(Player* player, playerbot::PvpClassSpellContext const& context, bool casted, std::string const& failureReason)
@@ -2537,6 +2552,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 failureReason = "invalid_enemy_target";
                 return false;
             }
+
+            // Pet utility spells are off the owner's global cooldown, but the
+            // pet still needs an explicit attack/chase command when the target
+            // is not already in its face. Issue that command before range/LOS
+            // validation so an out-of-range pet begins closing immediately
+            // instead of spending repeated decision ticks on failed casts.
+            CommandPetAttackTarget(player, target);
 
             if (!petCaster->IsWithinLOSInMap(target))
             {
@@ -3257,6 +3279,11 @@ bool PvpClassActions::HasRecentTargetRelativeMovementOrder(Player const* player,
     uint32 const nowMs = GameTime::GetGameTimeMS();
     uint32 const ageMs = order.lastIssueMs != 0 && nowMs >= order.lastIssueMs ? nowMs - order.lastIssueMs : std::numeric_limits<uint32>::max();
     return ageMs <= maxAgeMs;
+}
+
+bool PvpClassActions::IsPetSpellAction(Player const* player, PvpClassSpellContext const& context)
+{
+    return player && context.spellId != 0 && ResolveKnownPetSpellInChain(player, context.spellId) != 0;
 }
 
 bool PvpClassActions::Execute(Player* player, PvpClassSpellContext const& context)

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.h
@@ -39,6 +39,7 @@ public:
     static std::string GetLastExecutionStatus(Player const* player);
     static std::string GetLastMovementDebugStatus(Player const* player);
     static bool HasRecentTargetRelativeMovementOrder(Player const* player, Unit const* target, uint32 maxAgeMs = 1500);
+    static bool IsPetSpellAction(Player const* player, PvpClassSpellContext const& context);
 };
 }
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -570,7 +570,11 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
         classContext.shouldExecute &&
         classContext.movementDirective != playerbot::PvpClassSpellContext::MovementDirective::None &&
         movementIdle;
-    bool const didExecuteClassSpell = shouldForceClassMovementTick && playerbot::PvpClassActions::Execute(player, classContext);
+    bool const shouldForcePetSpellTick = classContext.classSpellsEnabled &&
+        classContext.shouldExecute &&
+        playerbot::PvpClassActions::IsPetSpellAction(player, classContext);
+    bool const didExecuteClassSpell = (shouldForceClassMovementTick || shouldForcePetSpellTick) &&
+        playerbot::PvpClassActions::Execute(player, classContext);
 
     playerbot::BattlegroundLifecycleContext inProgressContext;
     inProgressContext.lifecycleEnabled = true;
@@ -584,6 +588,7 @@ void ProcessActiveBattlegroundTacticalTick(Player* player)
     uint32 const assignedTeam = battleground->GetPlayerTeam(player->GetGUID());
     tickDetail << "bg-fasttick tactical=" << (didExecuteTactical ? 1 : 0)
                << " class_force=" << (shouldForceClassMovementTick ? 1 : 0)
+               << " pet_spell_force=" << (shouldForcePetSpellTick ? 1 : 0)
                << " class_exec=" << (didExecuteClassSpell ? 1 : 0)
                << " class_directive=" << static_cast<uint32>(classContext.movementDirective)
                << " class_spell=" << classContext.spellId
@@ -1574,12 +1579,13 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext);
     if (didExecuteClassSpell &&
         (classSpellContext.spellId == 16166 ||
-         classSpellContext.spellId == 17116))
+         classSpellContext.spellId == 17116 ||
+         PvpClassActions::IsPetSpellAction(player, classSpellContext)))
     {
         std::lock_guard<std::mutex> cadenceLock(g_RandomBotLifecycleCadenceLock);
         g_NextRandomBotLifecycleProcessTimeByGuid[guid.GetRawValue()] = LifecycleCadenceClock::now();
         TC_LOG_DEBUG("playerbots.pvp.lifecycle",
-            "Playerbot PvP cadence bypass applied: guid={} spell={} reason=off-gcd-burst-window.",
+            "Playerbot PvP cadence bypass applied: guid={} spell={} reason=off-gcd-or-pet-action.",
             guidRaw, classSpellContext.spellId);
     }
 


### PR DESCRIPTION
### Motivation
- Pet spells are off the owner GCD and must not consume the playerbot lifecycle decision cadence, and pets should actively chase/attack targets instead of only attacking when already on top of them.

### Description
- Add `PvpClassActions::IsPetSpellAction(Player const*, PvpClassSpellContext const&)` to identify pet-owned spells separately from owner spells. (header + implementation)
- Update `CommandPetAttackTarget` to set commanded-attack state before issuing combat movement, clear/replace the pet victim when switching targets, explicitly call `MoveChase` when the pet is out of melee or has no chase state, and set `UNIT_FLAG_PET_IN_COMBAT` so pets will close and engage reliably. (Playerbot PvP class actions)
- Before validating pet spell range/LOS in `CastDirectSpell`, call `CommandPetAttackTarget` so out-of-range pet utility attempts cause the pet to start closing immediately rather than repeatedly failing without movement. (Playerbot PvP class actions)
- In the fast battleground lifecycle path, add detection for pet spell actions and allow a `pet_spell_force` fast-tick path so pet actions can be executed without consuming the normal cadence, and include pet spell actions in the cadence bypass logic used for off-GCD bursts. (Random bot participation manager)

### Testing
- Ran `git diff --check` to validate whitespace/patch sanity: succeeded.
- Built the two modified script objects with `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpClassActions.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp.o`: succeeded for those targets.
- Performed a full `cmake --build build --target scripts -- -j2`; build progressed but ultimately failed due to an unrelated preexisting compile error in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` (naming collision of a `Position` field), so a full scripts build could not be validated in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1976db1bd883279f006b9020926dc5)