### PR TITLE
Ignore stealth-derived slow effects in playerbot snare/root checks

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -2405,13 +2405,53 @@ Unit const* SelectFriendlySnaredTarget(Player const* player, float maxDistance)
 }
 
 
+bool IsStealthMovementPenalty(SpellInfo const* spellInfo)
+{
+    return spellInfo && spellInfo->HasAura(SPELL_AURA_MOD_STEALTH);
+}
+
+bool HasNonStealthDecreaseSpeedAura(Unit const* unit)
+{
+    Unit::AuraEffectList const& slowAuras = unit->GetAuraEffectsByType(SPELL_AURA_MOD_DECREASE_SPEED);
+    for (AuraEffect const* slowAura : slowAuras)
+        if (slowAura && !IsStealthMovementPenalty(slowAura->GetSpellInfo()))
+            return true;
+
+    return false;
+}
+
+bool HasNonStealthRootOrSnareMechanic(Unit const* unit)
+{
+    uint32 const rootOrSnareMask = (1 << MECHANIC_ROOT) | (1 << MECHANIC_SNARE);
+
+    for (Unit::AuraApplicationMap::value_type const& appliedAura : unit->GetAppliedAuras())
+    {
+        AuraApplication const* aurApp = appliedAura.second;
+        SpellInfo const* spellInfo = aurApp ? aurApp->GetBase()->GetSpellInfo() : nullptr;
+        if (!spellInfo || IsStealthMovementPenalty(spellInfo))
+            continue;
+
+        if (spellInfo->Mechanic && (rootOrSnareMask & (1 << spellInfo->Mechanic)))
+            return true;
+
+        for (SpellEffectInfo const& spellEffectInfo : spellInfo->GetEffects())
+            if (aurApp->HasEffect(spellEffectInfo.EffectIndex) && spellEffectInfo.IsEffect() && spellEffectInfo.Mechanic &&
+                (rootOrSnareMask & (1 << spellEffectInfo.Mechanic)))
+                return true;
+    }
+
+    return false;
+}
+
 bool IsRootedOrSnared(Unit const* unit)
 {
     if (!unit)
         return false;
 
-    return unit->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED) ||
-        unit->HasAuraWithMechanic((1 << MECHANIC_ROOT) | (1 << MECHANIC_SNARE));
+    return unit->HasUnitState(UNIT_STATE_ROOT) ||
+        unit->HasAuraType(SPELL_AURA_MOD_ROOT) ||
+        HasNonStealthDecreaseSpeedAura(unit) ||
+        HasNonStealthRootOrSnareMechanic(unit);
 }
 
 bool HasShieldEquipped(Player const* player)


### PR DESCRIPTION
### Motivation
- Playerbot PvP logic treated movement penalties from stealth spells as snares, causing rogues to trigger `Sprint`/`Vanish` escapes when they were merely stealthed. 
- The intent is to preserve legitimate `root`/`snare` detection while excluding stealth-state movement penalties so rogues don't consider their own `Stealth` a disable. 

### Description
- Added `IsStealthMovementPenalty`, `HasNonStealthDecreaseSpeedAura`, and `HasNonStealthRootOrSnareMechanic` helpers to distinguish stealth-based slows from actual snares. 
- Reworked `IsRootedOrSnared` to check for `UNIT_STATE_ROOT`/`SPELL_AURA_MOD_ROOT` and only count non-stealth `SPELL_AURA_MOD_DECREASE_SPEED` and mechanic-based root/snare auras. 
- Changes are implemented in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and update playerbot PvP decision behavior to avoid treating stealth as a snare. 

### Testing
- Ran `git diff --check` to validate there are no whitespace or basic diff issues and it succeeded. 
- Performed a syntax-only compile of `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` using the project compile flags and it succeeded. 
- Started `cmake --build build --target scripts -- -j2` but stopped the cold rebuild after it began rebuilding many targets, so a full integrated build was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197e72479c83278e499b1d3679c7e2)