### PR TITLE
Fix priest Spirit of Redemption Flash Heal mana gating

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -57,6 +57,21 @@ bool IsLifeTapSpell(SpellInfo const* spellInfo)
     return firstRank && firstRank->Id == 1454; // Life Tap (rank 1)
 }
 
+bool IsPriestFlashHealSpell(SpellInfo const* spellInfo)
+{
+    if (!spellInfo)
+        return false;
+
+    SpellInfo const* firstRank = spellInfo->GetFirstRankSpell();
+    return firstRank && firstRank->Id == 2061; // Flash Heal (rank 1)
+}
+
+bool IsSpiritOfRedemptionFreeHeal(Player const* player, SpellInfo const* spellInfo)
+{
+    return player && player->GetClass() == CLASS_PRIEST && IsPriestFlashHealSpell(spellInfo) &&
+        player->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION);
+}
+
 constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
 constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 constexpr std::chrono::seconds kPlayerbotDispelCooldown = std::chrono::seconds(5);
@@ -2842,7 +2857,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // by the core cast pipeline and should not be blocked by this local
     // pre-check. For low-mana caster fallbacks we intentionally allow entering
     // the cast flow so the server can apply the spell-specific resource rules.
-    bool const bypassPowerPrecheck = spellInfo->IsAutoRepeatRangedSpell() || IsLifeTapSpell(spellInfo);
+    bool const bypassPowerPrecheck = spellInfo->IsAutoRepeatRangedSpell() || IsLifeTapSpell(spellInfo) ||
+        IsSpiritOfRedemptionFreeHeal(player, spellInfo);
     if (!bypassPowerPrecheck && spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
         if (player->GetPower(Powers(spellInfo->PowerType)) < int32(spellInfo->CalcPowerCost(player, spellInfo->GetSchoolMask())))
         {

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -54,6 +54,7 @@ struct SpellDecision;
 bool HasHostileTarget(Player const* player, Unit const* target);
 bool IsPetSpellReady(Player const* player, uint32 spellId);
 bool IsFriendlySupportTarget(Player const* player, Unit const* target);
+bool HasAuraFromSpellChain(Unit const* unit, uint32 baseSpellId);
 SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player);
 
 constexpr float kReferenceHunterSwitchDistance = 8.0f;
@@ -68,6 +69,27 @@ std::unordered_map<ObjectGuid, uint8> g_CombatNoTargetTicksByBot;
 std::mutex g_CombatNoTargetTicksByBotLock;
 thread_local ObjectGuid g_CurrentDecisionBotGuid = ObjectGuid::Empty;
 thread_local uint32 g_SuppressedDecisionSpellId = 0;
+
+bool IsPriestFlashHealSpell(uint32 spellId)
+{
+    if (!spellId)
+        return false;
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    uint32 const firstRankSpellId = spellInfo && spellInfo->GetFirstRankSpell() ? spellInfo->GetFirstRankSpell()->Id : spellId;
+    return firstRankSpellId == 2061; // Flash Heal (rank 1)
+}
+
+bool IsPriestInSpiritOfRedemption(Player const* player)
+{
+    return player && player->GetClass() == CLASS_PRIEST &&
+        (player->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION) || HasAuraFromSpellChain(player, 27827));
+}
+
+bool IsSpiritOfRedemptionFreeHeal(Player const* player, uint32 spellId)
+{
+    return IsPriestInSpiritOfRedemption(player) && IsPriestFlashHealSpell(spellId);
+}
 
 bool IsPlayerbotDispelSpell(uint32 spellId)
 {
@@ -511,7 +533,7 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     // choose a castable alternative (wand, movement, etc.) instead of
     // repeatedly selecting an OOM support spell.
     Unit const* powerCaster = knownByPet ? static_cast<Unit const*>(player->GetPet()) : static_cast<Unit const*>(player);
-    if (powerCaster && spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
+    if (powerCaster && !IsSpiritOfRedemptionFreeHeal(player, decision.spellId) && spellInfo->PowerType >= 0 && spellInfo->PowerType < MAX_POWERS)
     {
         Powers const powerType = Powers(spellInfo->PowerType);
         int32 const powerCost = spellInfo->CalcPowerCost(powerCaster, spellInfo->GetSchoolMask());
@@ -2845,7 +2867,7 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
     Unit const* rogueTarget = IsSpellReady(player, 27605) ? SelectEnemyClassTarget(player, CLASS_ROGUE, GetConfiguredLongRange()) : nullptr;
     bool const isHolyPriest = profileSelection.profile == ClassicClassProfile::SecondaryClassic;
     bool const isHealingPriest = profileSelection.profile == ClassicClassProfile::PrimaryClassic || isHolyPriest;
-    Unit const* spiritHealTarget = (isHolyPriest && HasAuraFromSpellChain(player, 27827) && IsSpellReady(player, 10917)) ? SelectFriendlyHealthTarget(player, 40.0f, 100.0f) : nullptr;
+    Unit const* spiritHealTarget = (isHolyPriest && IsPriestInSpiritOfRedemption(player) && IsSpellReady(player, 10917)) ? SelectFriendlyHealthTarget(player, 40.0f, 100.0f) : nullptr;
     Unit const* fearWardTarget = (player->GetRace() == RACE_DWARF && IsSpellReady(player, 6346)) ? SelectFriendlyMissingBuffTarget(player, 6346, 40.0f) : nullptr;
 
     std::vector<PrioritizedSpellDecision> candidates;


### PR DESCRIPTION
### Motivation
- Holy priests in Spirit of Redemption should be able to spam `Flash Heal` because the aura makes healing effectively free, but playerbot PvP logic was blocking those heals due to local mana affordability checks.

### Description
- Add helpers to detect `Flash Heal` and Spirit of Redemption state: `IsPriestFlashHealSpell`, `IsPriestInSpiritOfRedemption`, and `IsSpiritOfRedemptionFreeHeal` in `PlayerbotPvpCore.cpp` and `PlayerbotPvpClassActions.cpp`.
- Use the new Spirit detection when selecting spirit healing so the priest decision tree uses `IsPriestInSpiritOfRedemption` for `spiritHealTarget` in `SelectPriestSpell` (`PlayerbotPvpCore.cpp`).
- Exempt Spirit-of-Redemption `Flash Heal` from local mana gating by skipping the decision-layer power check in `IsDecisionImmediatelyCastable` and by adding the same exemption to the direct execution pre-check (`bypassPowerPrecheck`) in `CastDirectSpell` so the core cast pipeline handles the zero-cost behavior (`PlayerbotPvpCore.cpp` and `PlayerbotPvpClassActions.cpp`).
- Add a forward declaration for `HasAuraFromSpellChain` where needed to keep references consistent.

### Testing
- Ran `git diff --check` with no blocking issues (success).
- Built the `game` target with `cmake --build build --target game -- -j2`, which completed successfully (compile warnings only, no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1978a72a0c8327aba67b9680167707)