### PR TITLE
Prevent playerbots moving while casting non-moveable channeled spells (e.g. Drain Life)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2287,9 +2287,41 @@ char const* GetTargetModeLabel(playerbot::PvpClassSpellContext::TargetMode mode)
     }
 }
 
+bool HasActiveStationaryChannel(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Spell const* channel = player->GetCurrentSpell(CURRENT_CHANNELED_SPELL);
+    if (!channel || channel->getState() == SPELL_STATE_FINISHED)
+        return false;
+
+    SpellInfo const* spellInfo = channel->GetSpellInfo();
+    return spellInfo && spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel();
+}
+
+void StopPlayerbotForStationaryCast(Player* player)
+{
+    if (!player)
+        return;
+
+    player->StopMoving();
+    if (MotionMaster* motionMaster = player->GetMotionMaster())
+        motionMaster->Clear(MOTION_SLOT_ACTIVE);
+
+    if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
+    {
+        player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+        player->SendMovementFlagUpdate();
+    }
+}
+
 bool CanIssueFollowCommands(Player const* player)
 {
     if (!player || !player->IsAlive())
+        return false;
+
+    if (HasActiveStationaryChannel(player))
         return false;
 
     if (IsCrowdControlledForAction(player) ||
@@ -2918,7 +2950,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // stop_moving_request reason=cast_time_or_autorepeat killed the spline and
     // left the bot inching or stuck.
     bool const isFoodOrDrinkSpell = resolvedSpellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT || resolvedSpellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK;
-    bool const requiresStationaryCast = spellInfo->CalcCastTime() > 0 || spellInfo->IsAutoRepeatRangedSpell() || isFoodOrDrinkSpell;
+    bool const requiresStationaryCast = spellInfo->CalcCastTime() > 0 || spellInfo->IsAutoRepeatRangedSpell() || isFoodOrDrinkSpell ||
+        (spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel());
     if (requiresStationaryCast)
     {
         std::string stationaryDeferDiag;
@@ -2930,12 +2963,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             return false;
         }
 
-        player->StopMoving();
-        if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
-        {
-            player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
-            player->SendMovementFlagUpdate();
-        }
+        StopPlayerbotForStationaryCast(player);
     }
 
     // Blink (1953) is a leap-forward spell with a destination target
@@ -2995,6 +3023,9 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = reasonText.Title;
         return false;
     }
+
+    if (spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel())
+        StopPlayerbotForStationaryCast(player);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1565,9 +1565,25 @@ namespace
             motionMaster->Clear(MOTION_SLOT_ACTIVE);
     }
 
+    bool HasActiveStationaryChannel(Player const* player)
+    {
+        if (!player)
+            return false;
+
+        Spell const* channel = player->GetCurrentSpell(CURRENT_CHANNELED_SPELL);
+        if (!channel || channel->getState() == SPELL_STATE_FINISHED)
+            return false;
+
+        SpellInfo const* spellInfo = channel->GetSpellInfo();
+        return spellInfo && spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel();
+    }
+
     bool CanIssueBotMovement(Player* player)
     {
         if (!player || !player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
+            return false;
+
+        if (HasActiveStationaryChannel(player))
             return false;
 
         if (IsCrowdControlledForAction(player))


### PR DESCRIPTION
### Motivation
- Playerbot affliction/channel behavior could continue movement orders while casting channeled spells that do not allow movement, causing interrupted channels and visible chase/follow glitches.

### Description
- Add `HasActiveStationaryChannel` and `StopPlayerbotForStationaryCast` helpers to detect non-move-allowed channeled spells and to stop/clear playerbot movement and update virtual sessions; implemented in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` and mirrored in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.
- Prevent movement directives when a stationary channel is active by checking `HasActiveStationaryChannel` in `CanIssueFollowCommands` and `CanIssueBotMovement` so class and lifecycle movement will not interrupt stationary channels.
- Treat non-move-allowed channeled spells as stationary casts in `CastDirectSpell` by extending the `requiresStationaryCast` condition and calling `StopPlayerbotForStationaryCast` before the cast attempt and immediately after a successful channel start so Drain Life-style channels remain stationary.
- Changes are applied to the active playerbot script code (not the reference mirror) and avoid per-battleground special cases.

### Testing
- Ran `git diff --check` to confirm no whitespace issues (success).
- Configured a focused playerbot build with `cmake -S . -B build-playerbot-check -G Ninja -DPLAYERBOT=ON -DSCRIPTS=static -DCMAKE_BUILD_TYPE=RelWithDebInfo` (configuration succeeded).
- Compiled the modified playerbot script objects with `ninja -C build-playerbot-check src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpClassActions.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp.o` (object compilation succeeded).
- Note: attempting to build against the existing `build` directory failed because Playerbot scripts were disabled in that configuration, so a focused `PLAYERBOT=ON` build was used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19827b95008327b8dbc53b2254648f)