### PR TITLE
Fix prot warrior stance gap-close loop

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3316,6 +3316,8 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
     float const interceptMinRange = interceptInfo ? interceptInfo->GetMinRange(false) : 8.0f;
     bool const canChargeByRange = !player->IsWithinDistInMap(gapCloseTarget, chargeMinRange);
     bool const canInterceptByRange = !player->IsWithinDistInMap(gapCloseTarget, interceptMinRange);
+    bool const shouldUseChargeGapCloser = !player->IsWithinMeleeRange(gapCloseTarget) && !player->IsInCombat() && canChargeByRange && IsSpellReady(player, 11578);
+    bool const shouldUseInterceptGapCloser = !player->IsWithinMeleeRange(gapCloseTarget) && player->IsInCombat() && canInterceptByRange && IsSpellReady(player, 20617);
     Unit const* nearbyMeleeTarget = SelectNearbyMeleeTarget(player, activeTarget, 8.0f);
     Unit const* nearbyCastingTarget = SelectEnemyCastingTarget(player, 8.0f, activeTarget);
     Unit const* tauntTarget = isProtWarrior && IsSpellReady(player, 355) ? SelectWarriorTauntTarget(player, activeTarget, 30.0f) : nullptr;
@@ -3343,7 +3345,7 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
         { "warrior disarm", "disarm threatening melee weapon users", 81492, playerbot::PvpClassSpellContext::TargetMode::Enemy, nearbyMeleeTarget ? nearbyMeleeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, canDisarmNearbyMeleeThreat && !inDefensiveStance && IsSpellReady(player, 81492) && IsSpellReady(player, 71) && player->GetPower(POWER_RAGE) >= 200, 57.0f,
         { "warrior defensive stance", "swap defensive before disarm against melee", 71, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, tauntTarget && !inDefensiveStance && IsSpellReady(player, 71), 57.2f,
+    AddDecisionCandidate(candidates, tauntTarget && !inDefensiveStance && !shouldUseInterceptGapCloser && IsSpellReady(player, 71), 57.2f,
         { "warrior defensive stance", "swap defensive before taunt", 71, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, revengeReady && !inDefensiveStance && IsSpellReady(player, 71), 57.1f,
         { "warrior defensive stance", "swap defensive before revenge", 71, playerbot::PvpClassSpellContext::TargetMode::Self });
@@ -3358,13 +3360,13 @@ SpellDecision SelectWarriorSpell(Player const* player, Unit const* target, Class
         { "warrior bloodrage", "generate rage to unlock rotational abilities", 2687, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, !isProtWarrior && inDefensiveStance && (!IsSpellReady(player, 81492) || !hasNearbyMeleeThreat) && IsSpellReady(player, 2458), 53.0f,
         { "warrior berserker stance", "leave defensive stance when disarm is unavailable or no melee threat is nearby", 2458, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(gapCloseTarget) && !player->IsInCombat() && !inBattleStance && IsSpellReady(player, 2457), 52.5f,
+    AddDecisionCandidate(candidates, shouldUseChargeGapCloser && !inBattleStance && IsSpellReady(player, 2457), 52.5f,
         { "warrior battle stance", "switch to battle stance before out-of-combat charge", 2457, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(gapCloseTarget) && !player->IsInCombat() && canChargeByRange && IsSpellReady(player, 11578), 52.0f,
+    AddDecisionCandidate(candidates, shouldUseChargeGapCloser, 52.0f,
         { "warrior charge", "close gap to target from out of combat", 11578, playerbot::PvpClassSpellContext::TargetMode::Enemy, gapCloseTarget ? gapCloseTarget->GetGUID() : ObjectGuid::Empty });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(gapCloseTarget) && player->IsInCombat() && !inBerserkerStance && IsSpellReady(player, 2458), 51.5f,
+    AddDecisionCandidate(candidates, shouldUseInterceptGapCloser && !inBerserkerStance && IsSpellReady(player, 2458), 51.5f,
         { "warrior berserker stance", "switch to berserker stance before intercept gap close", 2458, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, !player->IsWithinMeleeRange(gapCloseTarget) && player->IsInCombat() && canInterceptByRange && IsSpellReady(player, 20617), 51.0f,
+    AddDecisionCandidate(candidates, shouldUseInterceptGapCloser, 51.0f,
         { "warrior intercept", "close gap to target while in combat", 20617, playerbot::PvpClassSpellContext::TargetMode::Enemy, gapCloseTarget ? gapCloseTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !isProtWarrior && player->IsWithinMeleeRange(activeTarget) && !inBerserkerStance &&
             IsSpellReady(player, 1680) && IsSpellReady(player, 2458), 50.4f,


### PR DESCRIPTION
### Motivation
- Prot warriors were oscillating between defensive and berserker/battle stances because stance-swap decisions could run even when the actual gap-closer (Charge/Intercept) was not usable, causing repeated unnecessary swaps.

### Description
- Add local checks `shouldUseChargeGapCloser` and `shouldUseInterceptGapCloser` that combine min-range checks, combat state and `IsSpellReady` for the gap-closers.
- Gate the `Charge`/`Intercept` decision candidates and related stance-swap candidates to use these new checks and prevent a taunt-triggered defensive swap from preempting an available `Intercept` setup.

### Testing
- Ran `git diff --check` which reported no issues and succeeded.
- Built the `game` target with `cmake --build build --target game -- -j2` which completed successfully (compile warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1983af778883278f98fd2e9578ca1b)