### PR TITLE
Guard dispel/spellsteal against non-positive effect values to prevent crash

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2611,6 +2611,11 @@ void Spell::EffectDispel()
     uint32 dispel_type = effectInfo->MiscValue;
     uint32 dispelMask  = SpellInfo::GetDispelMask(DispelType(dispel_type));
 
+    if (damage <= 0)
+        return;
+
+    uint32 dispelCount = uint32(damage);
+
     DispelChargesList dispelList;
     unitTarget->GetDispellableAuraList(m_caster, dispelMask, dispelList, targetMissInfo == SPELL_MISS_REFLECT);
     if (dispelList.empty())
@@ -2621,11 +2626,11 @@ void Spell::EffectDispel()
     // Ok if exist some buffs for dispel try dispel it
     uint32 failCount = 0;
     DispelChargesList successList;
-    successList.reserve(damage);
+    successList.reserve(std::min<size_t>(dispelCount, dispelList.size()));
 
-    WorldPacket dataFail(SMSG_DISPEL_FAILED, 8 + 8 + 4 + 4 + damage * 4);
+    WorldPacket dataFail(SMSG_DISPEL_FAILED, 8 + 8 + 4 + 4 + dispelCount * 4);
     // dispel N = damage buffs (or while exist buffs for dispel)
-    for (int32 count = 0; count < damage && remaining > 0;)
+    for (uint32 count = 0; count < dispelCount && remaining > 0;)
     {
         // Random select buff for dispel
         auto itr = dispelList.begin();
@@ -5425,16 +5430,21 @@ void Spell::EffectStealBeneficialBuff()
     if (stealList.empty())
         return;
 
+    if (damage <= 0)
+        return;
+
+    uint32 dispelCount = uint32(damage);
+
     size_t remaining = stealList.size();
 
     // Ok if exist some buffs for dispel try dispel it
     uint32 failCount = 0;
     DispelList successList;
-    successList.reserve(damage);
+    successList.reserve(std::min<size_t>(dispelCount, stealList.size()));
 
-    WorldPacket dataFail(SMSG_DISPEL_FAILED, 8 + 8 + 4 + 4 + damage * 4);
+    WorldPacket dataFail(SMSG_DISPEL_FAILED, 8 + 8 + 4 + 4 + dispelCount * 4);
     // dispel N = damage buffs (or while exist buffs for dispel)
-    for (int32 count = 0; count < damage && remaining > 0;)
+    for (uint32 count = 0; count < dispelCount && remaining > 0;)
     {
         // Random select buff for dispel
         DispelChargesList::iterator itr = stealList.begin();
@@ -5470,7 +5480,7 @@ void Spell::EffectStealBeneficialBuff()
     if (successList.empty())
         return;
 
-    WorldPacket dataSuccess(SMSG_SPELLSTEALLOG, 8 + 8 + 4 + 1 + 4 + damage * 5);
+    WorldPacket dataSuccess(SMSG_SPELLSTEALLOG, 8 + 8 + 4 + 1 + 4 + successList.size() * 5);
     dataSuccess << unitTarget->GetPackGUID();   // Victim GUID
     dataSuccess << m_caster->GetPackGUID();     // Caster GUID
     dataSuccess << uint32(m_spellInfo->Id);     // dispel spell id


### PR DESCRIPTION
### Motivation
- A segmentation fault was traced to `Spell::EffectDispel()` using the (possibly negative) `damage` effect value as a `reserve()` size / loop bound, which can trigger allocator/length errors and crashes. 
- The same unsafe use of `damage` existed in `Spell::EffectStealBeneficialBuff()`, so both handlers needed protection and safer sizing logic.

### Description
- In `src/server/game/Spells/SpellEffects.cpp` added an early guard `if (damage <= 0) return;` in both `Spell::EffectDispel()` and `Spell::EffectStealBeneficialBuff()` to avoid using non-positive values. 
- Converted the validated dispel request to `uint32 dispelCount = uint32(damage)` and use it as the loop bound to avoid signed/unsigned mismatch. 
- Cap container reservations with `std::min<size_t>(dispelCount, container.size())` to avoid reserving excessively large sizes from malformed effect values. 
- Adjusted packet sizing and success packet length calculation to use the actual `successList.size()` instead of the requested `damage` count, and changed loop counters to unsigned types for clarity.

### Testing
- Ran `git diff --check` with no whitespace/patch errors reported. (safety/style check passed.)
- Started a full build with `cmake --build build --target worldserver -j2`; the modified `SpellEffects.cpp` compiled successfully, but the overall build stopped later due to an unrelated, preexisting compile error in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` (not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e3dc016c8327b25b4d30976fe260)