### PR TITLE
Use configured flag-capture honor for Twin Peaks

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundTP.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundTP.cpp
@@ -361,7 +361,8 @@ void BattlegroundTP::EventPlayerCapturedFlag(Player* player)
     UpdatePlayerScore(player, SCORE_FLAG_CAPTURES, 1);      // +1 flag captures
     _lastFlagCaptureTeam = player->GetTeamId();
 
-    RewardHonorToTeam(GetBonusHonorFromKill(2), player->GetTeamId());
+    uint32 flagHonor = sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP);
+    RewardHonorToTeam(flagHonor, player->GetTeam());
 
     if (GetTeamScore(TEAM_ALLIANCE) == BG_TP_MAX_TEAM_SCORE || GetTeamScore(TEAM_HORDE) == BG_TP_MAX_TEAM_SCORE)
     {


### PR DESCRIPTION
### Motivation
- Make Twin Peaks flag captures award the configured incremental flag-capture honor (matching Warsong Gulch) instead of a hard-coded value.

### Description
- In `BattlegroundTP::EventPlayerCapturedFlag` replace the hard-coded bonus honor call with reading `sWorld->getIntConfig(CONFIG_CENTURION_BG_REWARD_HONOR_FLAG_CAP)` and call `RewardHonorToTeam(flagHonor, player->GetTeam())` so the capturing team receives the configured honor amount.

### Testing
- Built the modified translation unit with `cmake --build build --target src/server/game/CMakeFiles/game.dir/Battlegrounds/Zones/BattlegroundTP.cpp.o -j2` which succeeded.
- Started a full `worldserver` build with `cmake --build build --target worldserver -j2` but stopped after verifying the changed object compiled due to the lengthy full build; no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f4be9ab083279fb61d8d62a48c7d)