### PR TITLE
Restore druid target-relative movement after shapeshift/cancel and pass target GUID for cat form decision

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2549,6 +2549,120 @@ void RepositionDruidAfterTravelFormRecovery(Player* player)
 }
 
 
+struct DruidShapeshiftMovementResumeState
+{
+    ObjectGuid targetGuid = ObjectGuid::Empty;
+    float desiredRange = 1.5f;
+    uint8 mode = 1; // 1=chase, 2=follow
+    MovementGeneratorType motionType = IDLE_MOTION_TYPE;
+    bool shouldResume = false;
+};
+
+DruidShapeshiftMovementResumeState CaptureDruidShapeshiftMovementResume(Player* player,
+    playerbot::PvpClassSpellContext const& context, SpellInfo const* spellInfo)
+{
+    DruidShapeshiftMovementResumeState state;
+    if (!player || !spellInfo || player->GetClass() != CLASS_DRUID ||
+        context.targetMode != playerbot::PvpClassSpellContext::TargetMode::Self ||
+        !spellInfo->HasAura(SPELL_AURA_MOD_SHAPESHIFT))
+        return state;
+
+    MotionMaster const* motionMaster = player->GetMotionMaster();
+    state.motionType = motionMaster ? motionMaster->GetCurrentMovementGeneratorType() : IDLE_MOTION_TYPE;
+    bool const targetRelativeMotion = state.motionType == CHASE_MOTION_TYPE || state.motionType == FOLLOW_MOTION_TYPE;
+    bool const hadMovementSignal = player->isMoving() ||
+        player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
+        player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
+        (player->movespline && player->movespline->Initialized() && !player->movespline->Finalized());
+
+    uint32 const nowMs = GameTime::GetGameTimeMS();
+    auto orderItr = g_TargetRelativeMoveOrderByGuid.find(player->GetGUID().GetRawValue());
+    if (orderItr != g_TargetRelativeMoveOrderByGuid.end())
+    {
+        TargetRelativeMoveOrderState const& order = orderItr->second;
+        uint32 const orderAgeMs = order.lastIssueMs != 0 && nowMs >= order.lastIssueMs ? nowMs - order.lastIssueMs : 0;
+        if (!order.targetGuid.IsEmpty() && orderAgeMs <= 6000)
+        {
+            state.targetGuid = order.targetGuid;
+            state.desiredRange = order.issuedRange > 0.0f ? order.issuedRange : 1.5f;
+            state.mode = order.mode ? order.mode : 1;
+            state.shouldResume = targetRelativeMotion || hadMovementSignal || orderAgeMs <= 2500;
+            return state;
+        }
+    }
+
+    Unit* target = !context.targetGuid.IsEmpty() ? ObjectAccessor::GetUnit(*player, context.targetGuid) : nullptr;
+    if (!target || !target->IsAlive())
+        target = player->GetVictim();
+    if (!target || !target->IsAlive())
+        target = player->GetSelectedUnit();
+
+    if (!target || !target->IsAlive() || target == player)
+        return state;
+
+    state.targetGuid = target->GetGUID();
+    state.desiredRange = player->IsValidAttackTarget(target) ? 0.5f : 1.5f;
+    state.mode = player->IsValidAttackTarget(target) ? 1 : 2;
+    state.shouldResume = targetRelativeMotion;
+    return state;
+}
+
+void ResumeDruidShapeshiftMovement(Player* player, DruidShapeshiftMovementResumeState const& state, uint32 spellId)
+{
+    if (!player || !state.shouldResume || state.targetGuid.IsEmpty() || !CanIssueFollowCommands(player))
+        return;
+
+    Unit* target = ObjectAccessor::GetUnit(*player, state.targetGuid);
+    if (!target || !target->IsAlive() || target == player || player->GetMapId() != target->GetMapId())
+        return;
+
+    MotionMaster* motionMaster = player->GetMotionMaster();
+    if (!motionMaster)
+        return;
+
+    bool const hostileTarget = player->IsValidAttackTarget(target);
+    if (hostileTarget)
+    {
+        player->SetSelection(target->GetGUID());
+        if (player->GetVictim() != target || !player->IsInCombat())
+            player->Attack(target, false);
+    }
+
+    motionMaster->Clear(MOTION_SLOT_ACTIVE);
+    bool const preparedMotionMaster = PrepareMotionMasterForExplicitBotMovement(player);
+    if (hostileTarget && state.mode != 2)
+    {
+        motionMaster->MoveChase(target);
+        RecordTargetRelativeMovementOrder(player, target, 0.5f, 1);
+    }
+    else
+    {
+        float const followRange = std::max(0.5f, state.desiredRange);
+        motionMaster->MoveFollow(target, followRange, player->GetFollowAngle());
+        RecordTargetRelativeMovementOrder(player, target, followRange, 2);
+    }
+
+    MotionPrimeResult primeResult = PrimeTargetRelativeMotion(player);
+    MarkTargetRelativeMovementLaunch(player);
+    primeResult.addToWorldCalled = preparedMotionMaster;
+
+    std::ostringstream diag;
+    diag << "druid_shapeshift_movement_resumed"
+         << " spell=" << spellId
+         << " target=" << target->GetGUID().ToString()
+         << " hostile=" << (hostileTarget ? "yes" : "no")
+         << " previous_motion=" << uint32(state.motionType)
+         << " mode=" << uint32(state.mode)
+         << " desired_range=" << state.desiredRange
+         << " motion_after=" << uint32(motionMaster->GetCurrentMovementGeneratorType())
+         << " moving_after=" << (player->isMoving() ? "yes" : "no")
+         << " chase_move=" << (player->HasUnitState(UNIT_STATE_CHASE_MOVE) ? "yes" : "no")
+         << " follow_move=" << (player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ? "yes" : "no");
+    AppendMotionPrimeDiag(diag, primeResult);
+    SetLastMovementDebugStatus(player, diag.str());
+}
+
+
 bool ShouldDeferStationaryCastForActiveMovement(Player* player, Unit* castTarget, SpellInfo const* spellInfo,
     playerbot::PvpClassSpellContext const& context, bool isFoodOrDrinkSpell, std::string* diagOut)
 {
@@ -2779,6 +2893,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "cooldown_or_casting";
         return false;
     }
+
+    DruidShapeshiftMovementResumeState const shapeshiftMovementResume = CaptureDruidShapeshiftMovementResume(player, context, spellInfo);
 
     bool const isTemporaryWeaponImbue = [&spellInfo]()
     {
@@ -3178,6 +3294,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel())
         StopPlayerbotForStationaryCast(player);
+
+    ResumeDruidShapeshiftMovement(player, shapeshiftMovementResume, resolvedSpellId);
 
     // Hunter PvP trap setup: when Feign Death succeeds against a nearby melee
     // threat, pause movement, clear explicit target selection for visual parity,

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3184,7 +3184,7 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target, Classic
         AddDecisionCandidate(feralCandidates, !inCat && !inBear && IsSpellReady(player, 768), 60.0f,
             { "druid cat form", "prefer cat form for feral pressure", 768, playerbot::PvpClassSpellContext::TargetMode::Self });
         AddDecisionCandidate(feralCandidates, inCat && IsRootedOrSnared(player) && !player->IsWithinMeleeRange(target) && IsSpellReady(player, 768), 59.0f,
-            { "druid cat form", "powershift root or snare", 768, playerbot::PvpClassSpellContext::TargetMode::Self });
+            { "druid cat form", "powershift root or snare", 768, playerbot::PvpClassSpellContext::TargetMode::Self, target ? target->GetGUID() : ObjectGuid::Empty });
         AddDecisionCandidate(feralCandidates, inCat && !player->IsWithinMeleeRange(target) && IsSpellReady(player, 9821), 58.0f,
             { "druid dash", "catch target in cat form", 9821, playerbot::PvpClassSpellContext::TargetMode::Self });
         AddDecisionCandidate(feralCandidates, inCat && !player->IsWithinMeleeRange(target) && IsSpellReady(player, 49376), 57.0f,


### PR DESCRIPTION
### Motivation

- Prevent bots from losing pending chase/follow movement when a Druid cancels shapeshift to cast a non-shapeshiftable spell by capturing and later resuming prior movement intent.

### Description

- Add `DruidShapeshiftMovementResumeState` and two helpers `CaptureDruidShapeshiftMovementResume` and `ResumeDruidShapeshiftMovement` to capture the bot's pre-shapeshift movement state and reissue chase/follow orders after the shapeshift is removed.
- Integrate resume logic into `CastDirectSpell` by calling `CaptureDruidShapeshiftMovementResume` before shapeshift removal and `ResumeDruidShapeshiftMovement` afterwards to restore movement when appropriate.
- Preserve and reapply selection/attack state for hostile targets and record/prime target-relative motion via existing motion helper calls.
- Fix a decision candidate in `SelectDruidSpell` to include the target GUID for the cat-form powershift case by passing `target ? target->GetGUID() : ObjectGuid::Empty`.

### Testing

- Built the server with the changes and verified compilation succeeded.
- Ran the Playerbot PvP unit tests and a lightweight PvP bot integration smoke test; all automated tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a04c24e0c83279787b63057c117fe)