### PR TITLE
Keep polearm/staff inner auras synced

### DIFF
--- a/sql/updates/world/3.3.5/2026_05_12_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_05_12_00_world.sql
@@ -7,9 +7,9 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (12833, 'spell_polearm_staff_outer_aura');
 
 DELETE FROM `spell_dbc` WHERE `Id` IN (89769, 89770, 89771, 89772, 89773);
-INSERT INTO `spell_dbc` (`Id`, `DurationIndex`, `Effect1`, `EffectImplicitTargetA1`, `EffectApplyAuraName1`, `EffectBasePoints1`, `SpellName`) VALUES
-(89769, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 1'),
-(89770, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 2'),
-(89771, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 3'),
-(89772, 21, 6, 1, 4, 1, 'Polearm/Staff Inner Aura - Melee Range 1'),
-(89773, 21, 6, 1, 4, 2, 'Polearm/Staff Inner Aura - Melee Range 2');
+INSERT INTO `spell_dbc` (`Id`, `Attributes`, `AttributesEx3`, `DurationIndex`, `Effect1`, `EffectImplicitTargetA1`, `EffectApplyAuraName1`, `EffectBasePoints1`, `SpellName`) VALUES
+(89769, 64, 1048576, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 1'),
+(89770, 64, 1048576, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 2'),
+(89771, 64, 1048576, 21, 6, 1, 4, 0, 'Polearm/Staff Inner Aura 3'),
+(89772, 64, 1048576, 21, 6, 1, 4, 1, 'Polearm/Staff Inner Aura - Melee Range 1'),
+(89773, 64, 1048576, 21, 6, 1, 4, 2, 'Polearm/Staff Inner Aura - Melee Range 2');

--- a/sql/updates/world/3.3.5/2026_05_29_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_05_29_00_world.sql
@@ -1,0 +1,5 @@
+-- Keep custom polearm/staff inner auras active across death and lifecycle transitions.
+UPDATE `spell_dbc`
+SET `Attributes` = `Attributes` | 64,
+    `AttributesEx3` = `AttributesEx3` | 1048576
+WHERE `Id` IN (89769, 89770, 89771, 89772, 89773);

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -202,6 +202,24 @@ void OnKnownSpellChanged(Player* player, uint32 spellId)
     if (IsMappedOuterSpell(spellId))
         Sync(player);
 }
+
+void ScheduleSync(Player* player, Milliseconds delay)
+{
+    if (!player)
+        return;
+
+    ObjectGuid const playerGuid = player->GetGUID();
+    player->m_Events.AddEventAtOffset([playerGuid]()
+    {
+        if (Player* loadedPlayer = ObjectAccessor::FindConnectedPlayer(playerGuid))
+        {
+            TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::ScheduleSync delayed sync for player {} ({})", loadedPlayer->GetName(), loadedPlayer->GetGUID().ToString());
+            Sync(loadedPlayer);
+        }
+        else
+            TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::ScheduleSync delayed sync skipped because player {} is no longer connected", playerGuid.ToString());
+    }, delay);
+}
 }
 
 class spell_polearm_staff_outer_aura : public AuraScript
@@ -246,20 +264,24 @@ public:
 
     void OnLogin(Player* player, bool /*firstLogin*/) override
     {
-        if (!player)
-            return;
+        PolearmStaffInnerAuras::ScheduleSync(player, 1s);
+        PolearmStaffInnerAuras::ScheduleSync(player, 3s);
+    }
 
-        ObjectGuid const playerGuid = player->GetGUID();
-        player->m_Events.AddEventAtOffset([playerGuid]()
-        {
-            if (Player* loadedPlayer = ObjectAccessor::FindConnectedPlayer(playerGuid))
-            {
-                TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::OnLogin delayed sync for player {} ({})", loadedPlayer->GetName(), loadedPlayer->GetGUID().ToString());
-                PolearmStaffInnerAuras::Sync(loadedPlayer);
-            }
-            else
-                TC_LOG_DEBUG("scripts.spells", "PolearmStaffInnerAuras::OnLogin delayed sync skipped because player {} is no longer connected", playerGuid.ToString());
-        }, 1s);
+    void OnMapChanged(Player* player) override
+    {
+        PolearmStaffInnerAuras::Sync(player);
+        PolearmStaffInnerAuras::ScheduleSync(player, 1s);
+    }
+
+    void OnUpdateZone(Player* player, uint32 /*newZone*/, uint32 /*newArea*/) override
+    {
+        PolearmStaffInnerAuras::Sync(player);
+    }
+
+    void OnPlayerRepop(Player* player) override
+    {
+        PolearmStaffInnerAuras::Sync(player);
     }
 
     void OnPlayerResurrect(Player* player) override


### PR DESCRIPTION
### Motivation
- Players lose the warrior polearm/staff "inner" auras across login/death/map/zone transitions and teleports; the change aims to ensure those inner auras are reapplied when the player still qualifies (knows the outer aura and has a polearm/staff equipped).

### Description
- Add a reusable delayed sync helper `ScheduleSync(Player*, Milliseconds)` and call it to re-sync inner auras after `OnLogin` (1s and 3s delays) and on `OnMapChanged`, `OnUpdateZone`, `OnPlayerRepop`, and `OnPlayerResurrect` in `src/server/scripts/Spells/spell_warrior.cpp` so the script reapplies inner auras reliably.
- Keep existing checks that only apply inner auras when the player knows the mapped outer spell and has a polearm or staff equipped.
- Mark the custom inner aura rows as passive and death-persistent when inserting into `spell_dbc` by adding `Attributes` and `AttributesEx3` in `sql/updates/world/3.3.5/2026_05_12_00_world.sql` for fresh installs.
- Add an update script `sql/updates/world/3.3.5/2026_05_29_00_world.sql` that patches existing databases by OR-ing the passive and death-persistent flags onto the five custom inner-aura spell rows.

### Testing
- Ran `git diff --check` with no reported whitespace/patch errors.
- Built the modified script translation unit with `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Spells/spell_warrior.cpp.o` which succeeded.
- Attempted full scripts build via `cmake --build build --target scripts -- -j2`, which exercised the change but the full build failed due to an unrelated existing compile error in `custom_gurubashi_arena.cpp` that blocks the global scripts target; the targeted warrior script object still compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a095f68808327a217aa404ae252b9)