### PR TITLE
Disable playerbot direct-drop in Scarlet Chapel

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -409,6 +409,12 @@ namespace
         return battleground && battleground->GetMapId() == 489;
     }
 
+    bool IsScarletChapel(Player const* player)
+    {
+        Battleground const* battleground = player ? player->GetBattleground() : nullptr;
+        return battleground && battleground->GetTypeID(true) == BATTLEGROUND_SCM;
+    }
+
     TeamId ResolveTeamId(uint32 teamValue)
     {
         if (teamValue == TEAM_ALLIANCE || teamValue == ALLIANCE)
@@ -1020,7 +1026,11 @@ namespace
 
         if (generatePath && player->InBattleground())
         {
-            if (directDropState.pending &&
+            bool const allowDirectDrop = !IsScarletChapel(player);
+            if (!allowDirectDrop)
+                directDropState.pending = false;
+
+            if (allowDirectDrop && directDropState.pending &&
                 nowMs > directDropState.issueMs + 1200 &&
                 !player->isMoving())
             {
@@ -1046,7 +1056,7 @@ namespace
                 }
             }
 
-            if (nowMs >= directDropState.suppressUntilMs && ShouldPreferDirectDropShortcut(player, safeDestination))
+            if (allowDirectDrop && nowMs >= directDropState.suppressUntilMs && ShouldPreferDirectDropShortcut(player, safeDestination))
             {
                 Position const shortcutDestination = BuildDownhillEscapeDestination(player, safeDestination);
                 motionMaster->MovePoint(0, shortcutDestination, false);
@@ -1070,6 +1080,18 @@ namespace
             PathType pathType = PathType(0);
             if (!TryBuildBattlegroundSegmentDestination(player, safeDestination, segmentDestination, &pathType))
             {
+                if (!allowDirectDrop)
+                {
+                    motionMaster->MovePoint(0, safeDestination, true);
+                    EmitBattlegroundGmDebug(player,
+                        "movepoint=blocked-no-nav fallback=full-path directDrop=disabled-scarlet-chapel destDist=" +
+                        std::to_string(int32(player->GetDistance(safeDestination))), 0);
+
+                    state.lastDestination = destination;
+                    state.lastIssueMs = nowMs;
+                    return true;
+                }
+
                 // Recovery path for segmented-nav failures (for example, after a
                 // partial drop where local nav probing can't find a legal segment):
                 // issue a direct movement order so the bot keeps progressing

--- a/tests/game/ScarletChapelQueue.cpp
+++ b/tests/game/ScarletChapelQueue.cpp
@@ -26,3 +26,12 @@ TEST_CASE("Scarlet Chapel forced queue side is preserved during active battlegro
     CHECK(npcSource.find("ACTION_QUEUE_ALLIANCE") != std::string::npos);
     CHECK(npcSource.find("ACTION_QUEUE_HORDE") != std::string::npos);
 }
+
+TEST_CASE("Playerbot direct drop movement is disabled in Scarlet Chapel", "[scarlet][playerbot][movement]")
+{
+    std::string const lifecycleSource = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp");
+
+    CHECK(lifecycleSource.find("bool const allowDirectDrop = !IsScarletChapel(player)") != std::string::npos);
+    CHECK(lifecycleSource.find("allowDirectDrop && nowMs >= directDropState.suppressUntilMs") != std::string::npos);
+    CHECK(lifecycleSource.find("directDrop=disabled-scarlet-chapel") != std::string::npos);
+}


### PR DESCRIPTION
### Motivation

- Prevent playerbot direct-drop/dropoff movement inside the Scarlet Chapel battleground to avoid bots using downhill/direct-drop shortcuts that can stall or produce invalid movement in that map.
- Keep generic battleground movement logic unchanged so direct-drop behavior still applies elsewhere where it is safe.

### Description

- Added a helper `IsScarletChapel(Player const*)` and a local guard `allowDirectDrop = !IsScarletChapel(player)` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to detect Scarlet Chapel and gate direct-drop behavior.
- When `allowDirectDrop` is false the code clears any pending direct-drop state and disables the direct-drop shortcut and stalled direct-drop recovery code paths.
- Changed the no-nav fallback for Scarlet Chapel so bots issue a full path-generated move (`motionMaster->MovePoint(0, safeDestination, true)`) instead of the downhill/direct-drop fallback used elsewhere.
- Added a source-level regression check in `tests/game/ScarletChapelQueue.cpp` that verifies the new Scarlet Chapel guard strings exist in the lifecycle source.

### Testing

- Ran a Python assertion script that verifies the lifecycle source contains `bool const allowDirectDrop = !IsScarletChapel(player)` and related guard strings, and this check succeeded.
- Ran `git diff --check` to verify there are no whitespace/diff issues and it returned clean.
- Started a `cmake --build build --target worldserver` build to validate compilation; the build progressed for a long-running compile and no compile errors were observed before the job was terminated in this environment.
- Note: the new test is a source-level check added to the tests tree but the full unit-test harness was not executed in this environment (unit tests were not enabled in the active CMake configuration).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d6a1f8c7883279c7d7d51046a0eec)