### PR TITLE
Improve arena replay capture/playback, add diagnostics and world pumping

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -16,8 +16,13 @@
 #include "ScriptedGossip.h"
 #include "GameEventMgr.h"
 #include "Player.h"
+#include "Timer.h"
 #include "WorldSession.h"
 #include <DBCStores.h>
+#include <algorithm>
+#include <deque>
+#include <sstream>
+#include <vector>
 
 
 std::vector<Opcodes> watchList = {
@@ -73,9 +78,202 @@ std::vector<Opcodes> watchList = {
 
 
 struct PacketRecord { uint32 timestamp; WorldPacket packet; };
-struct MatchRecord { BattlegroundTypeId typeId; uint8 arenaTypeId; uint32 mapId; std::deque<PacketRecord> packets; };
+struct MatchRecord
+{
+    BattlegroundTypeId typeId;
+    uint8 arenaTypeId;
+    uint32 mapId;
+    std::deque<PacketRecord> packets;
+    uint32 captureStartMs = 0;
+    uint32 playbackStartMs = 0;
+    uint32 lastDebugMs = 0;
+};
 std::unordered_map<uint32, MatchRecord> records;
-std::unordered_map<uint64, MatchRecord> loadedReplays;
+std::unordered_map<uint32, MatchRecord> loadedReplays;
+
+namespace
+{
+    constexpr uint32 ReplayCountdownMs = 5000;
+
+    uint32 GetPlayerLowGuid(Player const* player)
+    {
+        return player->GetGUID().GetCounter();
+    }
+
+    bool IsWatchedReplayPacket(uint16 opcode)
+    {
+        return std::find(watchList.begin(), watchList.end(), opcode) != watchList.end();
+    }
+
+
+    char const* ReplayStatusName(BattlegroundStatus status)
+    {
+        switch (status)
+        {
+            case STATUS_WAIT_QUEUE:
+                return "WAIT_QUEUE";
+            case STATUS_WAIT_JOIN:
+                return "WAIT_JOIN";
+            case STATUS_IN_PROGRESS:
+                return "IN_PROGRESS";
+            case STATUS_WAIT_LEAVE:
+                return "WAIT_LEAVE";
+            default:
+                return "UNKNOWN";
+        }
+    }
+
+    void WhisperReplayDebug(Player* player, std::string_view message)
+    {
+        if (!player)
+            return;
+
+        ObjectGuid replayGuid = ObjectGuid::Create<HighGuid::Player>(1);
+        WorldPacket data;
+        ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER_FOREIGN, LANG_UNIVERSAL, replayGuid, player->GetGUID(), message, 0, "ReplayDebug");
+        player->SendDirectMessage(&data);
+    }
+
+    bool ShouldSendReplayDebug(MatchRecord& match, uint32 intervalMs = 5000)
+    {
+        uint32 const now = getMSTime();
+        if (match.lastDebugMs && getMSTimeDiff(match.lastDebugMs, now) < intervalMs)
+            return false;
+
+        match.lastDebugMs = now;
+        return true;
+    }
+
+    void WhisperReplayState(Player* player, MatchRecord& match, Battleground const* bg, char const* reason)
+    {
+        if (!ShouldSendReplayDebug(match))
+            return;
+
+        std::ostringstream ss;
+        ss << "[" << reason << "]";
+        ss << " status=" << (bg ? ReplayStatusName(bg->GetStatus()) : "NO_BG");
+        if (bg)
+        {
+            ss << " startDelay=" << bg->GetStartDelayTime();
+            ss << " startTime=" << bg->GetStartTime();
+            ss << " players=" << bg->GetPlayersSize();
+            ss << " replayId=" << bg->GetReplayId();
+        }
+
+        ss << " packets=" << match.packets.size();
+        if (!match.packets.empty())
+            ss << " nextTs=" << match.packets.front().timestamp;
+        ss << " playbackStart=" << match.playbackStartMs;
+
+        if (player)
+        {
+            ss << " pInWorld=" << player->IsInWorld();
+            ss << " pTeleport=" << player->IsBeingTeleported();
+            ss << " pBgId=" << player->GetBattlegroundId();
+            ss << " pMap=" << player->GetMapId();
+            ss << " pHasMap=" << (player->FindMap() ? 1 : 0);
+            ss << " pBattleArena=" << (player->FindMap() && player->FindMap()->IsBattleArena() ? 1 : 0);
+        }
+
+        WhisperReplayDebug(player, ss.str());
+    }
+
+    bool IsSpectatorReadyForReplay(Player const* player, Battleground const* bg)
+    {
+        return player
+            && bg
+            && player->IsInWorld()
+            && !player->IsBeingTeleported()
+            && player->GetBattlegroundId() == bg->GetInstanceID()
+            && player->GetMapId() == bg->GetMapId()
+            && player->FindMap()
+            && player->FindMap()->IsBattleArena();
+    }
+
+    void EndReplayForSpectator(uint32 spectatorLowGuid, Battleground* bg)
+    {
+        if (!bg)
+            return;
+
+        bg->EndNow();
+        bg->toggleReplay(0);
+
+        if (Player* player = ObjectAccessor::FindPlayerByLowGUID(spectatorLowGuid))
+            player->LeaveBattleground(bg);
+    }
+
+    bool PumpReplayPackets(uint32 spectatorLowGuid, Battleground* bg)
+    {
+        auto it = loadedReplays.find(spectatorLowGuid);
+        if (it == loadedReplays.end())
+            return false;
+
+        MatchRecord& match = it->second;
+        if (match.packets.empty() || !bg)
+        {
+            if (Player* player = ObjectAccessor::FindPlayerByLowGUID(spectatorLowGuid))
+                WhisperReplayState(player, match, bg, match.packets.empty() ? "ending-empty-packets" : "ending-no-bg");
+            EndReplayForSpectator(spectatorLowGuid, bg);
+            return true;
+        }
+
+        Player* player = ObjectAccessor::FindPlayerByLowGUID(spectatorLowGuid);
+        if (!player)
+        {
+            EndReplayForSpectator(spectatorLowGuid, bg);
+            return true;
+        }
+
+        if (!IsSpectatorReadyForReplay(player, bg))
+        {
+            WhisperReplayState(player, match, bg, "waiting-spectator-ready");
+            return false;
+        }
+
+        uint32 elapsed = 0;
+        bool const replayGatesOpen = bg->GetStatus() == BattlegroundStatus::STATUS_IN_PROGRESS || bg->GetStartDelayTime() <= 0;
+        if (replayGatesOpen)
+        {
+            if (!match.playbackStartMs)
+                match.playbackStartMs = getMSTime();
+
+            elapsed = getMSTimeDiff(match.playbackStartMs, getMSTime());
+        }
+        else if (bg->GetStatus() != BattlegroundStatus::STATUS_WAIT_JOIN)
+        {
+            WhisperReplayState(player, match, bg, "waiting-status");
+            return false;
+        }
+
+        WhisperReplayState(player, match, bg, replayGatesOpen ? "pumping" : "waiting-gates");
+
+        uint32 sentPackets = 0;
+        while (!match.packets.empty() && match.packets.front().timestamp <= elapsed)
+        {
+            player->GetSession()->SendPacket(&match.packets.front().packet);
+            match.packets.pop_front();
+            ++sentPackets;
+        }
+
+        if (sentPackets)
+        {
+            std::ostringstream ss;
+            ss << "[sent] count=" << sentPackets << " remaining=" << match.packets.size();
+            if (!match.packets.empty())
+                ss << " nextTs=" << match.packets.front().timestamp << " elapsed=" << elapsed;
+            WhisperReplayDebug(player, ss.str());
+        }
+
+        if (match.packets.empty())
+        {
+            WhisperReplayDebug(player, "[finished] no replay packets remain; ending replay");
+            EndReplayForSpectator(spectatorLowGuid, bg);
+            return true;
+        }
+
+        return false;
+    }
+}
 
 class BGReplayServerScript : public ServerScript {
 public:
@@ -90,27 +288,35 @@ public:
         if (bg == nullptr || bg->IsReplay()) return;
         if (!bg->isArena())
             return;
-        //ignore packets until arena started
-        if (bg->GetStatus() != BattlegroundStatus::STATUS_IN_PROGRESS) return;
+        // Record setup packets during the join countdown as well as live arena packets.
+        // Initial object-create/update packets are sent before STATUS_IN_PROGRESS;
+        // without them replay viewers enter an empty arena when the gates open.
+        if (bg->GetStatus() != BattlegroundStatus::STATUS_WAIT_JOIN && bg->GetStatus() != BattlegroundStatus::STATUS_IN_PROGRESS) return;
         //record packets from 1 player of each team
         //iterate just in case a player leaves and used as reference
         for (auto it : bg->GetPlayers()) {
             if (it.second.Team == session->GetPlayer()->GetBGTeam()) {
-                if (it.first.GetRawValue() != session->GetPlayer()->GetGUID())
+                if (it.first.GetCounter() != GetPlayerLowGuid(session->GetPlayer()))
                     return; else break;
             }
         }
         //ignore packets not in watch list
-        if (std::find(watchList.begin(), watchList.end(), packet.GetOpcode()) == watchList.end())
-        {
+        if (!IsWatchedReplayPacket(packet.GetOpcode()))
             return;
-        }
 
         if (records.find(bg->GetInstanceID()) == records.end())
             records[bg->GetInstanceID()].packets.clear();
         MatchRecord& record = records[bg->GetInstanceID()];
 
-        uint32 timestamp = bg->GetStartTime();
+        uint32 timestamp = 0;
+        if (bg->GetStatus() == BattlegroundStatus::STATUS_IN_PROGRESS)
+        {
+            if (!record.captureStartMs)
+                record.captureStartMs = getMSTime();
+
+            timestamp = getMSTimeDiff(record.captureStartMs, getMSTime());
+        }
+
         record.typeId = bg->GetTypeID(false);
         if (record.typeId == BATTLEGROUND_AA)
         {
@@ -124,6 +330,44 @@ public:
     }
 };
 
+
+class BGReplayWorldScript : public WorldScript
+{
+public:
+    BGReplayWorldScript() : WorldScript("BGReplayWorldScript") { }
+
+    void OnUpdate(uint32 /*diff*/) override
+    {
+        for (auto it = loadedReplays.begin(); it != loadedReplays.end();)
+        {
+            uint32 const spectatorLowGuid = it->first;
+            Player* player = ObjectAccessor::FindPlayerByLowGUID(spectatorLowGuid);
+            if (!player)
+            {
+                it = loadedReplays.erase(it);
+                continue;
+            }
+
+            Battleground* bg = player->GetBattleground();
+            if (!bg)
+            {
+                ++it;
+                continue;
+            }
+
+            if (!bg->IsReplay() || bg->GetReplayId() != spectatorLowGuid)
+            {
+                it = loadedReplays.erase(it);
+                continue;
+            }
+
+            if (PumpReplayPackets(spectatorLowGuid, bg))
+                it = loadedReplays.erase(it);
+            else
+                ++it;
+        }
+    }
+};
 
 class BGReplayBGScript : public BattlegroundScript {
 public:
@@ -142,51 +386,22 @@ public:
         }
     }
 
-    void OnBattlegroundUpdate(Battleground* bg, uint32 diff) override {
+    void OnBattlegroundUpdate(Battleground* bg, uint32 /*diff*/) override {
 
         if (!bg->isArena())
             return;
 
         if (!bg->IsReplay()) return;
         int32 startDelayTime = bg->GetStartDelayTime();
-        if (startDelayTime > 5000)
+        if (startDelayTime > int32(ReplayCountdownMs))
         {
-            bg->SetStartDelayTime(5000);
-            bg->SetStartTime(bg->GetStartTime() + (startDelayTime - 5000));
-        }
-        if (bg->GetStatus() != BattlegroundStatus::STATUS_IN_PROGRESS) return;
-
-        //retrieve replay data
-        auto it = loadedReplays.find(bg->GetReplayId());
-        if (it == loadedReplays.end()) return;
-        MatchRecord& match = it->second;
-
-        //if replay ends or spectator left > free replay data and/or kick player
-        if (match.packets.empty() || bg->GetPlayers().empty()) {
-            loadedReplays.erase(it);
-
-            if (!bg->GetPlayers().empty())
-            {
-                uint32 playerGUID = bg->GetReplayId();
-                bg->EndNow();
-                bg->toggleReplay(0);
-                Player* player = ObjectAccessor::FindPlayerByLowGUID(playerGUID);
-                player->LeaveBattleground(bg);
-            }
-            return;
+            bg->SetStartDelayTime(ReplayCountdownMs);
+            bg->SetStartTime(bg->GetStartTime() + (startDelayTime - ReplayCountdownMs));
         }
 
-        //send replay data to spectator
-        while (!match.packets.empty() && match.packets.front().timestamp <= bg->GetStartTime()) {
-            if (bg->GetPlayers().empty())
-                break;
-            uint32 playerGUID = bg->GetReplayId();
-            Player* player = ObjectAccessor::FindPlayerByLowGUID(playerGUID);
-            if (!player)
-                break;
-            player->GetSession()->SendPacket(&match.packets.front().packet);
-            match.packets.pop_front();
-        }
+        uint32 const spectatorLowGuid = bg->GetReplayId();
+        if (PumpReplayPackets(spectatorLowGuid, bg))
+            loadedReplays.erase(spectatorLowGuid);
     }
 
     void saveReplay(Battleground* bg) {
@@ -194,6 +409,11 @@ public:
         auto it = records.find(bg->GetInstanceID());
         if (it == records.end()) return;
         MatchRecord& match = it->second;
+        if (match.packets.empty())
+        {
+            records.erase(it);
+            return;
+        }
 
         //serialize arena replay data
         ByteBuffer buffer;
@@ -249,20 +469,34 @@ public:
         bool StartReplay(Player* player, uint32 replayId) {
             auto handler = ChatHandler(player->GetSession());
 
+            WhisperReplayDebug(player, "[start] loading replay " + std::to_string(replayId));
             if (!loadReplayDataForPlayer(player, replayId))
                 return false;
 
-            MatchRecord record = loadedReplays[player->GetGUID()];
+            MatchRecord record = loadedReplays[GetPlayerLowGuid(player)];
+            {
+                std::ostringstream ss;
+                ss << "[start] loaded packets=" << record.packets.size() << " type=" << uint32(record.typeId) << " arenaType=" << uint32(record.arenaTypeId) << " map=" << record.mapId;
+                if (!record.packets.empty())
+                    ss << " firstTs=" << record.packets.front().timestamp << " lastTs=" << record.packets.back().timestamp;
+                WhisperReplayDebug(player, ss.str());
+            }
             Battleground* bg = sBattlegroundMgr->CreateNewBattleground(record.typeId, GetBattlegroundBracketByLevel(record.mapId, 60), record.arenaTypeId, false);
             if (!bg) {
+                loadedReplays.erase(GetPlayerLowGuid(player));
                 handler.PSendSysMessage("Couldn't create arena map!");
                 handler.SetSentErrorMessage(true);
                 return false;
             }
             player->SetIsSpectator(true);
-            bg->toggleReplay(player->GetGUID());
+            bg->toggleReplay(GetPlayerLowGuid(player));
             player->SetPendingSpectatorForBG(bg->GetInstanceID());
             bg->StartBattleground();
+            {
+                std::ostringstream ss;
+                ss << "[start] created bg instance=" << bg->GetInstanceID() << " type=" << uint32(bg->GetTypeID()) << " map=" << bg->GetMapId() << " status=" << ReplayStatusName(bg->GetStatus()) << " startDelay=" << bg->GetStartDelayTime();
+                WhisperReplayDebug(player, ss.str());
+            }
 
             BattlegroundTypeId bgTypeId = bg->GetTypeID();
 
@@ -276,6 +510,7 @@ public:
             player->GetSession()->SendPacket(&data);
 
             handler.PSendSysMessage("Replay begins.");
+            WhisperReplayDebug(player, "[start] teleport sent; diagnostics will continue every 5 seconds while waiting/pumping");
             return true;
         }
 
@@ -296,8 +531,15 @@ public:
             }
             MatchRecord record;
             deserializeMatchData(record, fields);
+            {
+                std::ostringstream ss;
+                ss << "[load] db replay=" << matchId << " packets=" << record.packets.size() << " contentSize=" << fields[3].GetUInt32() << " blobBytes=" << fields[4].GetBinary().size();
+                if (!record.packets.empty())
+                    ss << " firstTs=" << record.packets.front().timestamp << " lastTs=" << record.packets.back().timestamp;
+                WhisperReplayDebug(p, ss.str());
+            }
 
-            loadedReplays[p->GetGUID()] = std::move(record);
+            loadedReplays[GetPlayerLowGuid(p)] = std::move(record);
             return true;
         }
 
@@ -323,11 +565,14 @@ public:
         void deserializeMatchData(MatchRecord& record, Field* fields) {
             record.arenaTypeId = uint8(fields[1].GetUInt32());
             record.typeId = BattlegroundTypeId(fields[2].GetUInt32());
-            int size = uint32(fields[3].GetUInt32());
+            uint32 const size = fields[3].GetUInt32();
             std::vector<uint8> data = fields[4].GetBinary();
             record.mapId = uint32(fields[5].GetUInt32());
+            if (!size || data.empty())
+                return;
+
             ByteBuffer buffer;
-            buffer.append(&data[0], data.size());
+            buffer.append(data.data(), std::min<size_t>(size, data.size()));
 
             /** deserialize replay binary data **/
             uint32 packetSize;
@@ -348,6 +593,14 @@ public:
 
                 record.packets.push_back({ packetTimestamp, packet });
             }
+
+            if (!record.packets.empty())
+            {
+                uint32 const replayStartTimestamp = record.packets.front().timestamp;
+                if (replayStartTimestamp)
+                    for (PacketRecord& packetRecord : record.packets)
+                        packetRecord.timestamp -= replayStartTimestamp;
+            }
         }
     };
     CreatureAI* GetAI(Creature* creature) const override
@@ -358,6 +611,7 @@ public:
 
 void AddBGReplayScripts() {
     new BGReplayServerScript();
+    new BGReplayWorldScript();
     new BGReplayBGScript();
     new ReplayGossip();
 }


### PR DESCRIPTION
### Motivation
- Make arena replay capture and playback reliable by recording pre-start setup packets and playing packets to spectators in real time rather than relying on absolute start timestamps. 
- Improve robustness around spectator lifecycle and BG state so replays don't leave viewers in empty maps or hang when the spectator disconnects or isn't ready. 
- Add lightweight runtime diagnostics to help troubleshoot replay state and delivery timing.

### Description
- Extend `MatchRecord` with `captureStartMs`, `playbackStartMs`, and `lastDebugMs` and switch `loadedReplays` key type to spectator low GUID (`uint32`) for simpler lookup. 
- Record packets relative to `captureStartMs` during `OnPacketSend` so setup packets sent during `STATUS_WAIT_JOIN` are captured; use `IsWatchedReplayPacket` helper for opcode filtering. 
- Normalize stored replay timestamps on deserialization by subtracting the first packet timestamp and safely bound the DB blob copy with `std::min`. 
- Introduce helpers in an anonymous namespace: `GetPlayerLowGuid`, `ReplayStatusName`, `WhisperReplayDebug`, `WhisperReplayState`, `IsSpectatorReadyForReplay`, `EndReplayForSpectator`, and `PumpReplayPackets` to centralize replay logic and diagnostics. 
- Add `BGReplayWorldScript` to pump replay packets per world update and clean up `loadedReplays` when spectators disconnect or replay ends. 
- Simplify `OnBattlegroundUpdate` to clamp replay countdown (`ReplayCountdownMs = 5000`) and delegate packet pumping to `PumpReplayPackets`. 
- Update gossip/replay UI logic to use low GUID keys, create the battleground, toggle replay with low GUID, send diagnostic whispers at load/start, and warn on missing data. 
- Ensure empty replay blobs are skipped and `records` entries are removed when nothing to save.

### Testing
- Project was built successfully after the changes with no compiler errors. 
- No automated unit tests were added for this script; existing automated test suites were not modified. 
- Runtime behavior was exercised in an integration-style run (script-level exercise) to verify replay load, BG creation, and packet pumping logic (no automated result recorded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e16396a188327bb7683d92a9f9081)