### PR TITLE
Prevent duplicate reentrant aura effect application

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3716,6 +3716,13 @@ void Unit::_ApplyAuraEffect(Aura* aura, uint8 effIndex)
     ASSERT(aura->HasEffect(effIndex));
     AuraApplication * aurApp = aura->GetApplicationOfTarget(GetGUID());
     ASSERT(aurApp);
+
+    // Aura application can be re-entered by scripts/procs/target-map updates while
+    // another effect from the same aura is being applied. If that already applied
+    // this effect, do not try to handle it a second time.
+    if (aurApp->HasEffect(effIndex))
+        return;
+
     if (!aurApp->GetEffectMask())
         _ApplyAura(aurApp, 1 << effIndex);
     else

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -783,8 +783,14 @@ void Aura::_ApplyEffectForTargets(uint8 effIndex)
     // apply effect to targets
     for (UnitList::iterator itr = targetList.begin(); itr != targetList.end(); ++itr)
     {
-        if (GetApplicationOfTarget((*itr)->GetGUID()))
+        if (AuraApplication* aurApp = GetApplicationOfTarget((*itr)->GetGUID()))
         {
+            // Side effects while applying an aura to an earlier target can update this
+            // application too. Re-check the effect state before asking Unit to apply it
+            // so a re-entrant target update cannot apply the same effect twice.
+            if (aurApp->HasEffect(effIndex))
+                continue;
+
             // owner has to be in world, or effect has to be applied to self
             ASSERT((!GetOwner()->IsInWorld() && GetOwner() == *itr) || GetOwner()->IsInMap(*itr));
             (*itr)->_ApplyAuraEffect(this, effIndex);


### PR DESCRIPTION
### Motivation
- Avoid a crash/assertion caused by re-entrant application of the same aura effect when scripts/procs/target-map updates trigger side-effects during effect application.
- Ensure an aura effect already applied by a nested call is not handled a second time, preventing `_HandleEffect(..., true)` from violating effect state invariants.

### Description
- Add a re-entrancy guard in `Unit::_ApplyAuraEffect` that returns early if the `AuraApplication` already reports the requested effect via `aurApp->HasEffect(effIndex)`. (file: `src/server/game/Entities/Unit/Unit.cpp`)
- Re-check the application state in `Aura::_ApplyEffectForTargets` before invoking `Unit::_ApplyAuraEffect` by fetching the `AuraApplication*` and skipping the target if `aurApp->HasEffect(effIndex)` is true, preventing double-application from target-map / side-effect races. (file: `src/server/game/Spells/Auras/SpellAuras.cpp`)
- Add clarifying comments describing the re-entrancy rationale and keep existing behavior otherwise unchanged.

### Testing
- Ran `git diff --check` with no problems reported for the modified files (succeeded). 
- Compiled the affected objects with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/Unit/Unit.cpp.o src/server/game/CMakeFiles/game.dir/Spells/Auras/SpellAuras.cpp.o` and the two changed translation units compiled successfully. 
- Attempted a full build via `cmake --build build --target worldserver -j2`; the build progressed but ultimately failed on an unrelated pre-existing compile error in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` (`Position Position` redeclaration), indicating the changes themselves did not introduce that failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f681c7f9c83279c3202585d7dfd34)