### PR TITLE
Restrict combat warlock pet summons

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -67,6 +67,7 @@ constexpr uint32 kHunterAutoShotSpellId = 75;
 constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
 constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 constexpr uint32 kDruidCasterFaerieFireSpellId = 9907;
+constexpr uint32 kWarlockFelDominationSpellId = 18708;
 std::unordered_map<ObjectGuid, bool> g_HunterRangedModeByBot;
 std::mutex g_HunterRangedModeByBotLock;
 std::unordered_map<ObjectGuid, uint8> g_CombatNoTargetTicksByBot;
@@ -3360,10 +3361,10 @@ SpellDecision SelectWarlockSpell(Player const* player, Unit const* target, Class
         { "warlock devour magic enemy", "felhunter dispels enemy magic buffs", 19736, playerbot::PvpClassSpellContext::TargetMode::Enemy, devourEnemyTarget ? devourEnemyTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, fearTarget, 53.0f,
         { "warlock fear", "prioritize fear control on paladin/priest targets in range", 6215, playerbot::PvpClassSpellContext::TargetMode::Enemy, fearTarget ? fearTarget->GetGUID() : ObjectGuid::Empty });
-    AddDecisionCandidate(candidates, !isAfflictionWarlock && player->IsInCombat() && needsPetSummon && !player->HasAura(18708) && IsSpellReady(player, 18708), 52.0f,
-        { "warlock fel domination", "prepare instant pet recovery before voidwalker summon", 18708, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, needsPetSummon && IsSpellReady(player, summonPetSpell), 51.0f,
-        { isAfflictionWarlock ? "warlock summon felhunter" : "warlock summon voidwalker", isAfflictionWarlock ? "recover felhunter in combat when absent" : "recover voidwalker in combat when absent", summonPetSpell, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, !isAfflictionWarlock && player->IsInCombat() && needsPetSummon && !player->HasAura(kWarlockFelDominationSpellId) && IsSpellReady(player, kWarlockFelDominationSpellId), 52.0f,
+        { "warlock fel domination", "prepare instant pet recovery before voidwalker summon", kWarlockFelDominationSpellId, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, needsPetSummon && (!player->IsInCombat() || player->HasAura(kWarlockFelDominationSpellId)) && IsSpellReady(player, summonPetSpell), 51.0f,
+        { isAfflictionWarlock ? "warlock summon felhunter" : "warlock summon voidwalker", isAfflictionWarlock ? "recover felhunter when absent and safe to summon" : "recover voidwalker when absent and safe to summon", summonPetSpell, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, !isAfflictionWarlock && !player->HasAura(25228) && IsSpellReady(player, 19028), 45.0f,
         { "warlock soul link", "maintain soul link when pet is available", 19028, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, target->GetPowerType() == POWER_MANA && ShouldUseCurseOfTongues(target) && !HasAuraFromSpellChain(target, 11719) &&


### PR DESCRIPTION
### Motivation
- Prevent warlock playerbots from attempting to summon/replace pets while in combat unless the Fel Domination cooldown is active, leaving out-of-combat pet maintenance unchanged.

### Description
- Introduced `kWarlockFelDominationSpellId` constant and used it in PvP playerbot decision logic in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`.
- Updated warlock spell decision ordering so that the in-combat summon candidate is gated by the presence/availability of Fel Domination, while out-of-combat summon decisions remain allowed.
- Adjusted decision text to reflect the safer/conditional summon behavior.

### Testing
- Ran `git diff --check` with no issues.
- Performed a full `cmake --build build --target game -- -j2` build; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa555abe08327a3b9926995379913)