### PR TITLE
Fix Unit water aura battleground compile error

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3528,9 +3528,8 @@ void Unit::ProcessTerrainStatusUpdate(ZLiquidStatus /*oldLiquidStatus*/, Optiona
         // Scarlet Chapel and Ruins of Lordaeron's shallow water are part of
         // intended PvP pathing and should not force players out of mounts or
         // Travel Form when they cross it.
-        if (!battleground || (battleground->GetTypeID(true) != BATTLEGROUND_SCM && battleground->GetTypeID(true) != BATTLEGROUND_RL))
+        if (!ShouldPreserveMountInWaterForBattleground(player))
             RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_ABOVEWATER);
-        }
     }
     else
         RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_UNDERWATER);


### PR DESCRIPTION
### Motivation
- The build was failing due to an undeclared `battleground` variable used in `Unit::ProcessTerrainStatusUpdate`, and an extra closing brace caused the `else` and liquid-handling logic to be parsed outside the function.

### Description
- Replace the invalid `battleground` reference with the existing helper `ShouldPreserveMountInWaterForBattleground(player)` in `src/server/game/Entities/Unit/Unit.cpp`.
- Remove the stray closing brace that prematurely closed the function so the `else` branch and liquid-handling code remain inside `Unit::ProcessTerrainStatusUpdate`.

### Testing
- Running `ninja -C build src/server/game/Entities/Unit/Unit.cpp.o` failed because that object target name does not exist in this build configuration.
- Building the correct target with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/Unit/Unit.cpp.o` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204e61fc808327b3f908659e4f5630)