### PR TITLE
Fix BGReplay compile errors

### DIFF
--- a/src/server/scripts/Custom/BGReplay.cpp
+++ b/src/server/scripts/Custom/BGReplay.cpp
@@ -1071,7 +1071,7 @@ namespace
         // Make sure the actor is not explicitly non-attackable/passive in the client value fields.
         uint32 flags = originalFlags;
         flags &= ~UNIT_FLAG_NON_ATTACKABLE;
-        flags &= ~UNIT_FLAG_NOT_SELECTABLE;
+        flags &= ~UNIT_FLAG_UNINTERACTIBLE;
         flags &= ~UNIT_FLAG_PACIFIED;
         flags &= ~UNIT_FLAG_IMMUNE_TO_PC;
         return flags;
@@ -1158,13 +1158,11 @@ namespace
                     }
                     else if (fieldIndex == UNIT_FIELD_FLAGS)
                     {
-                        uint32 originalFlags = ReadUInt32(payload, pos);
-                        WriteUInt32(payload, pos, ReplayRedNameUnitFlagsForActor(*actor, originalFlags));
+                        WriteUInt32(payload, pos, ReplayRedNameUnitFlagsForActor(*actor, value));
                     }
                     else if (fieldIndex == PLAYER_FLAGS)
                     {
-                        uint32 originalFlags = ReadUInt32(payload, pos);
-                        WriteUInt32(payload, pos, ReplayRedNamePlayerFlagsForActor(*actor, originalFlags));
+                        WriteUInt32(payload, pos, ReplayRedNamePlayerFlagsForActor(*actor, value));
                     }
 
                     // Record target pair positions, but don't write until both low/high halves are known.


### PR DESCRIPTION
### Motivation
- Fix compilation failures in the arena/battleground replay script caused by an undefined unit flag constant and incorrect use of the update-field reader while patching update packets.

### Description
- Replace the unavailable `UNIT_FLAG_NOT_SELECTABLE` with the repository's `UNIT_FLAG_UNINTERACTIBLE` in `ReplayRedNameUnitFlagsForActor` to use the active unit flag constant.
- Use the already-decoded `value` when rewriting `UNIT_FIELD_FLAGS` and `PLAYER_FLAGS` in `PatchUpdateValuesBlock` instead of calling the wrong `ReadUInt32` overload that would advance `pos`.

### Testing
- Ran `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Custom/BGReplay.cpp.o`, which completed successfully.
- Ran `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Custom/custom_script_loader.cpp.o`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204f9d0fd08327979fe0e481bbd2b2)