### PR TITLE
Do not let instance template override mount allowance for arenas/battlegrounds

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -254,8 +254,9 @@ void WorldSession::HandleMoveWorldportAck()
         if (!player->CheckInstanceValidity(false))
             player->m_InstanceValid = false;
 
-        // instance mounting is handled in InstanceTemplate
-        allowMount = mInstance->AllowMount;
+        // instance mounting is handled in InstanceTemplate, except arenas are governed by arena/battleground rules
+        if (!mEntry->IsBattleArena())
+            allowMount = mInstance->AllowMount;
     }
 
     // mount allow check

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6418,10 +6418,14 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                     return SPELL_FAILED_ONLY_ABOVEWATER;
 
                 // Ignore map check if spell have AreaId. AreaId already checked and this prevent special mount spells
-                bool allowMount = !unitCaster->GetMap()->IsDungeon() || unitCaster->GetMap()->IsBattlegroundOrArena();
-                InstanceTemplate const* it = sObjectMgr->GetInstanceTemplate(unitCaster->GetMapId());
-                if (it)
-                    allowMount = it->AllowMount;
+                Map const* map = unitCaster->GetMap();
+                bool allowMount = !map->IsDungeon() || map->IsBattlegroundOrArena();
+                if (!map->IsBattleArena())
+                {
+                    if (InstanceTemplate const* it = sObjectMgr->GetInstanceTemplate(unitCaster->GetMapId()))
+                        allowMount = it->AllowMount;
+                }
+
                 if (unitCaster->GetTypeId() == TYPEID_PLAYER && !allowMount && !m_spellInfo->AreaGroupId)
                     return SPELL_FAILED_NO_MOUNTS_ALLOWED;
 


### PR DESCRIPTION
### Motivation
- Ensure arena and battleground maps keep their specific mount rules instead of being overridden by instance templates.
- Unify mount-allow logic between teleport/instance handling and spell mount checks to avoid inconsistent behavior when entering arenas.

### Description
- In `WorldSession::HandleMoveWorldportAck` avoid using the instance template's `AllowMount` value for maps classified as battle arenas, leaving arena/battleground rules to apply. 
- In `Spell::CheckCast` for `SPELL_AURA_MOUNTED` compute `allowMount` from the `Map` and only consult the `InstanceTemplate`'s `AllowMount` when the map is not a battle arena, and use a local `map` pointer for clarity. 
- Updated comments to reflect that instance mounting is handled in `InstanceTemplate` except for arenas which follow arena/battleground rules.

### Testing
- Built the project with `make` and the build completed successfully. 
- Ran automated unit tests via `ctest` and all tests passed. 
- Executed automated integration/smoke tests covering mount spells and instance/arena transitions and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2059f3944c8327a9197a3e0dd5173e)