### PR TITLE
Only dismount on full submersion; preserve mounts in specific battlegrounds

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3520,16 +3520,23 @@ void Unit::ProcessTerrainStatusUpdate(ZLiquidStatus /*oldLiquidStatus*/, Optiona
         if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
             SetSwim(CanSwim() && IsInWater());
 
-    // remove appropriate auras if we are swimming/not swimming respectively
+    // Remove appropriate auras if we are swimming/not swimming respectively.
     if (IsInWater())
     {
         Player* player = ToPlayer();
 
-        // Scarlet Chapel and Ruins of Lordaeron's shallow water are part of
-        // intended PvP pathing and should not force players out of mounts or
-        // Travel Form when they cross it.
+        // Scarlet Chapel and Ruins of Lordaeron's water are part of intended
+        // PvP pathing and should never force players out of mounts or Travel
+        // Form. Everywhere else, mounts are handled explicitly on full
+        // submersion so shallow water does not dismount players before they
+        // transition from walking to swimming.
         if (!ShouldPreserveMountInWaterForBattleground(player))
+        {
+            if (IsUnderWater())
+                RemoveAurasByType(SPELL_AURA_MOUNTED);
+
             RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_ABOVEWATER);
+        }
     }
     else
         RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_UNDERWATER);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -5073,10 +5073,9 @@ void SpellMgr::LoadSpellInfoCorrections()
         if (!spellInfo)
             continue;
 
-        // Mounts should end when the caster enters water; battleground
-        // exceptions are handled where the not-above-water interrupt fires.
-        if (spellInfo->HasAura(SPELL_AURA_MOUNTED))
-            spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_NOT_ABOVEWATER;
+        // Mounts dismount on full submersion in Unit::ProcessTerrainStatusUpdate.
+        // Do not tag them with AURA_INTERRUPT_FLAG_NOT_ABOVEWATER here, because
+        // that interrupt fires as soon as a player touches shallow water.
 
         // Fix range for trajectory triggered spell
         for (SpellEffectInfo const& spellEffectInfo : spellInfo->GetEffects())


### PR DESCRIPTION
### Motivation
- Prevent players from being dismounted as soon as they touch shallow water and ensure battleground pathing (Scarlet Chapel / Ruins of Lordaeron) does not force mounts or Travel Form to end.
- Ensure mount removal happens at full submersion instead of at first contact with water to avoid premature dismounts.

### Description
- Adjusted `Unit::ProcessTerrainStatusUpdate` to only remove `SPELL_AURA_MOUNTED` when the unit is fully underwater (`IsUnderWater()`), and to skip this for battlegrounds where mounts should be preserved by using `ShouldPreserveMountInWaterForBattleground`.
- Limited the removal of `AURA_INTERRUPT_FLAG_NOT_ABOVEWATER` effects to non-exempt battlegrounds so shallow water no longer triggers early interrupts.
- Removed the blanket addition of `AURA_INTERRUPT_FLAG_NOT_ABOVEWATER` for mount spells in `SpellMgr::LoadSpellInfoCorrections` and documented that mounts are handled on full submersion in `Unit::ProcessTerrainStatusUpdate` instead.
- Updated comments for clarity about shallow vs full submersion behavior and battleground exceptions.

### Testing
- Project was built successfully (`make`) after the changes.
- Automated unit/test suite executed and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2059c24e5c832796a530b548405963)