### PR TITLE
Deathmatch (BRT/SCM): award point on human leave and requeue reported playerbots

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBRT.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBRT.cpp
@@ -45,6 +45,7 @@ void BattlegroundBRT::AddPlayer(Player* player)
 
 void BattlegroundBRT::RemovePlayer(Player* player, ObjectGuid /*guid*/, uint32 team)
 {
+    AwardLeavePointIfNeeded(player, team);
     TrackHumanParticipantRemoved(player, team);
 }
 
@@ -360,6 +361,55 @@ void BattlegroundBRT::UpdateTeamScoreWorldStates()
     UpdateWorldState(BG_BRT_WORLDSTATE_MAX_KILLS_UI, BG_BRT_KILL_LIMIT);
 }
 
+void BattlegroundBRT::AwardPointToTeam(uint32 team)
+{
+    if (GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    if (team == ALLIANCE)
+    {
+        ++_allianceKills;
+        m_TeamScores[TEAM_ALLIANCE] = _allianceKills;
+
+        if ((_allianceKills % 10) == 0)
+            RewardHonorToTeam(GetHonorRewardForTeam(), ALLIANCE);
+    }
+    else if (team == HORDE)
+    {
+        ++_hordeKills;
+        m_TeamScores[TEAM_HORDE] = _hordeKills;
+
+        if ((_hordeKills % 10) == 0)
+            RewardHonorToTeam(GetHonorRewardForTeam(), HORDE);
+    }
+    else
+        return;
+
+    UpdateTeamScoreWorldStates();
+
+    if (_allianceKills >= BG_BRT_KILL_LIMIT)
+        EndBattleground(ALLIANCE);
+    else if (_hordeKills >= BG_BRT_KILL_LIMIT)
+        EndBattleground(HORDE);
+}
+
+void BattlegroundBRT::AwardLeavePointIfNeeded(Player const* player, uint32 team)
+{
+    if (GetStatus() != STATUS_IN_PROGRESS || !player || (team != ALLIANCE && team != HORDE))
+        return;
+
+    WorldSession const* session = player->GetSession();
+    if (!session)
+        return;
+
+    bool const isHumanLeave = !session->IsVirtualSession();
+    bool const isReportedBotLeave = session->IsVirtualSession() && (player->HasAura(43680) || player->HasAura(SPELL_AURA_PLAYER_INACTIVE));
+    if (!isHumanLeave && !isReportedBotLeave)
+        return;
+
+    AwardPointToTeam(team == ALLIANCE ? HORDE : ALLIANCE);
+}
+
 void BattlegroundBRT::HandleKillPlayer(Player* victim, Player* killer)
 {
     Battleground::HandleKillPlayer(victim, killer);
@@ -373,29 +423,7 @@ void BattlegroundBRT::HandleKillPlayer(Player* victim, Player* killer)
     if (!killerTeam || !victimTeam || killerTeam == victimTeam)
         return;
 
-    if (killerTeam == ALLIANCE)
-    {
-        ++_allianceKills;
-        m_TeamScores[TEAM_ALLIANCE] = _allianceKills;
-
-        if ((_allianceKills % 10) == 0)
-            RewardHonorToTeam(GetHonorRewardForTeam(), ALLIANCE);
-    }
-    else if (killerTeam == HORDE)
-    {
-        ++_hordeKills;
-        m_TeamScores[TEAM_HORDE] = _hordeKills;
-
-        if ((_hordeKills % 10) == 0)
-            RewardHonorToTeam(GetHonorRewardForTeam(), HORDE);
-    }
-
-    UpdateTeamScoreWorldStates();
-
-    if (_allianceKills >= BG_BRT_KILL_LIMIT)
-        EndBattleground(ALLIANCE);
-    else if (_hordeKills >= BG_BRT_KILL_LIMIT)
-        EndBattleground(HORDE);
+    AwardPointToTeam(killerTeam);
 }
 
 void BattlegroundBRT::FillInitialWorldStates(WorldPackets::WorldState::InitWorldStates& packet)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundBRT.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBRT.h
@@ -131,6 +131,8 @@ public:
 private:
     WorldSafeLocsEntry const* GetCurrentTeamGraveyard(TeamId teamId) const;
     void UpdateTeamScoreWorldStates();
+    void AwardPointToTeam(uint32 team);
+    void AwardLeavePointIfNeeded(Player const* player, uint32 team);
     uint32 GetHonorRewardForTeam() const;
     void ModifyEndOfMatchHonorRewards(uint32 winner, uint32 team, uint32& winnerHonor, uint32& loserHonor) const override;
     void TrackHumanParticipantAdded(Player const* player, bool isInBattleground);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.cpp
@@ -45,6 +45,7 @@ void BattlegroundSCM::AddPlayer(Player* player)
 
 void BattlegroundSCM::RemovePlayer(Player* player, ObjectGuid /*guid*/, uint32 team)
 {
+    AwardLeavePointIfNeeded(player, team);
     TrackHumanParticipantRemoved(player, team);
 }
 
@@ -357,6 +358,55 @@ void BattlegroundSCM::UpdateTeamScoreWorldStates()
     UpdateWorldState(BG_SCM_WORLDSTATE_MAX_KILLS_UI, BG_SCM_KILL_LIMIT);
 }
 
+void BattlegroundSCM::AwardPointToTeam(uint32 team)
+{
+    if (GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    if (team == ALLIANCE)
+    {
+        ++_allianceKills;
+        m_TeamScores[TEAM_ALLIANCE] = _allianceKills;
+
+        if ((_allianceKills % 10) == 0)
+            RewardHonorToTeam(GetHonorRewardForTeam(), ALLIANCE);
+    }
+    else if (team == HORDE)
+    {
+        ++_hordeKills;
+        m_TeamScores[TEAM_HORDE] = _hordeKills;
+
+        if ((_hordeKills % 10) == 0)
+            RewardHonorToTeam(GetHonorRewardForTeam(), HORDE);
+    }
+    else
+        return;
+
+    UpdateTeamScoreWorldStates();
+
+    if (_allianceKills >= BG_SCM_KILL_LIMIT)
+        EndBattleground(ALLIANCE);
+    else if (_hordeKills >= BG_SCM_KILL_LIMIT)
+        EndBattleground(HORDE);
+}
+
+void BattlegroundSCM::AwardLeavePointIfNeeded(Player const* player, uint32 team)
+{
+    if (GetStatus() != STATUS_IN_PROGRESS || !player || (team != ALLIANCE && team != HORDE))
+        return;
+
+    WorldSession const* session = player->GetSession();
+    if (!session)
+        return;
+
+    bool const isHumanLeave = !session->IsVirtualSession();
+    bool const isReportedBotLeave = session->IsVirtualSession() && (player->HasAura(43680) || player->HasAura(SPELL_AURA_PLAYER_INACTIVE));
+    if (!isHumanLeave && !isReportedBotLeave)
+        return;
+
+    AwardPointToTeam(team == ALLIANCE ? HORDE : ALLIANCE);
+}
+
 void BattlegroundSCM::HandleKillPlayer(Player* victim, Player* killer)
 {
     Battleground::HandleKillPlayer(victim, killer);
@@ -370,29 +420,7 @@ void BattlegroundSCM::HandleKillPlayer(Player* victim, Player* killer)
     if (!killerTeam || !victimTeam || killerTeam == victimTeam)
         return;
 
-    if (killerTeam == ALLIANCE)
-    {
-        ++_allianceKills;
-        m_TeamScores[TEAM_ALLIANCE] = _allianceKills;
-
-        if ((_allianceKills % 10) == 0)
-            RewardHonorToTeam(GetHonorRewardForTeam(), ALLIANCE);
-    }
-    else if (killerTeam == HORDE)
-    {
-        ++_hordeKills;
-        m_TeamScores[TEAM_HORDE] = _hordeKills;
-
-        if ((_hordeKills % 10) == 0)
-            RewardHonorToTeam(GetHonorRewardForTeam(), HORDE);
-    }
-
-    UpdateTeamScoreWorldStates();
-
-    if (_allianceKills >= BG_SCM_KILL_LIMIT)
-        EndBattleground(ALLIANCE);
-    else if (_hordeKills >= BG_SCM_KILL_LIMIT)
-        EndBattleground(HORDE);
+    AwardPointToTeam(killerTeam);
 }
 
 void BattlegroundSCM::FillInitialWorldStates(WorldPackets::WorldState::InitWorldStates& packet)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSCM.h
@@ -133,6 +133,8 @@ public:
 private:
     WorldSafeLocsEntry const* GetCurrentTeamGraveyard(TeamId teamId) const;
     void UpdateTeamScoreWorldStates();
+    void AwardPointToTeam(uint32 team);
+    void AwardLeavePointIfNeeded(Player const* player, uint32 team);
     void ApplyNonInteractableObjectFlags();
     void SpawnRandomBuffSet(uint32 speedTypeIndex);
     uint32 GetHonorRewardForTeam() const;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -28,6 +28,7 @@
 #include "BattlefieldMgr.h"
 #include "Battleground.h"
 #include "BattlegroundMgr.h"
+#include "BattlegroundQueue.h"
 #include "BattlegroundScore.h"
 #include "CellImpl.h"
 #include "Channel.h"
@@ -23132,23 +23133,110 @@ bool Player::CanReportAfkDueToLimit()
     return true;
 }
 
+namespace
+{
+    constexpr uint32 SPELL_BATTLEGROUND_IDLE = 43680;
+    constexpr uint32 SPELL_BATTLEGROUND_INACTIVE = 43681;
+    constexpr uint32 SPELL_BATTLEGROUND_DESERTER = 26013;
+
+    bool QueueAfkReportedPlayerbot(Player* player, BattlegroundTypeId bgTypeId, uint8 arenaType)
+    {
+        if (!player || player->InBattleground())
+            return false;
+
+        player->RemoveAurasDueToSpell(SPELL_BATTLEGROUND_DESERTER);
+        player->RemoveAurasDueToSpell(SPELL_BATTLEGROUND_IDLE);
+        player->RemoveAurasDueToSpell(SPELL_BATTLEGROUND_INACTIVE);
+
+        if (!player->IsAlive())
+            player->ResurrectPlayer(1.0f);
+
+        Battleground* bgTemplate = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
+        if (!bgTemplate || !player->GetBGAccessByLevel(bgTypeId) || !player->HasFreeBattlegroundQueueId())
+            return false;
+
+        BattlegroundQueueTypeId const bgQueueTypeId = BattlegroundMgr::BGQueueTypeId(bgTypeId, arenaType);
+        if (bgQueueTypeId == BATTLEGROUND_QUEUE_NONE)
+            return false;
+
+        if (player->GetBattlegroundQueueIndex(bgQueueTypeId) < PLAYER_MAX_BATTLEGROUND_QUEUES)
+            return false;
+
+        PvPDifficultyEntry const* bracketEntry = GetBattlegroundBracketByLevel(bgTemplate->GetMapId(), player->GetLevel());
+        if (!bracketEntry)
+            return false;
+
+        if (bgTypeId == BATTLEGROUND_SCM)
+            player->SetBGTeam(0);
+
+        BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
+        GroupQueueInfo* groupInfo = bgQueue.AddGroup(player, nullptr, bgTypeId, bracketEntry, arenaType, false, false, 0, 0);
+        if (!groupInfo)
+            return false;
+
+        player->AddBattlegroundQueueId(bgQueueTypeId);
+        sBattlegroundMgr->ScheduleQueueUpdate(groupInfo->ArenaMatchmakerRating, groupInfo->ArenaType, bgQueueTypeId, bgTypeId, bracketEntry->GetBracketId());
+        return true;
+    }
+
+    void LeaveAndRequeueAfkReportedPlayerbot(Player* player, Battleground* bg)
+    {
+        if (!player || !bg)
+            return;
+
+        BattlegroundTypeId const bgTypeId = bg->GetTypeID();
+        uint8 const arenaType = bg->GetArenaType();
+        ObjectGuid const playerGuid = player->GetGUID();
+
+        player->CastSpell(player, SPELL_BATTLEGROUND_IDLE, true);
+        player->LeaveBattleground();
+        player->RemoveAurasDueToSpell(SPELL_BATTLEGROUND_DESERTER);
+
+        player->m_Events.AddEventAtOffset([playerGuid, bgTypeId, arenaType]()
+        {
+            Player* queuedPlayer = ObjectAccessor::FindPlayer(playerGuid);
+            if (!queuedPlayer)
+                return;
+
+            QueueAfkReportedPlayerbot(queuedPlayer, bgTypeId, arenaType);
+        }, 10s);
+    }
+}
+
 ///This player has been blamed to be inactive in a battleground
 void Player::ReportedAfkBy(Player* reporter)
 {
-    Battleground* bg = GetBattleground();
-    // Battleground also must be in progress!
-    if (!bg || bg != reporter->GetBattleground() || GetTeam() != reporter->GetTeam() || bg->GetStatus() != STATUS_IN_PROGRESS)
+    if (!reporter)
         return;
 
+    Battleground* bg = GetBattleground();
+    // Battleground also must be in progress!
+    if (!bg || bg != reporter->GetBattleground() || bg->GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    uint32 const reportedBgTeam = bg->GetPlayerTeam(GetGUID());
+    uint32 const reporterBgTeam = bg->GetPlayerTeam(reporter->GetGUID());
+    if (!reportedBgTeam || reportedBgTeam != reporterBgTeam)
+        return;
+
+    WorldSession const* session = GetSession();
+    if (session && session->IsVirtualSession())
+    {
+        if (!HasAura(SPELL_BATTLEGROUND_IDLE) && !HasAura(SPELL_BATTLEGROUND_INACTIVE))
+            LeaveAndRequeueAfkReportedPlayerbot(this, bg);
+
+        return;
+    }
+
     // check if player has 'Idle' or 'Inactive' debuff
-    if (m_bgData.bgAfkReporter.find(reporter->GetGUID().GetCounter()) == m_bgData.bgAfkReporter.end() && !HasAura(43680) && !HasAura(43681) && reporter->CanReportAfkDueToLimit())
+    if (m_bgData.bgAfkReporter.find(reporter->GetGUID().GetCounter()) == m_bgData.bgAfkReporter.end() && !HasAura(SPELL_BATTLEGROUND_IDLE) && !HasAura(SPELL_BATTLEGROUND_INACTIVE) && reporter->CanReportAfkDueToLimit())
     {
         m_bgData.bgAfkReporter.insert(reporter->GetGUID().GetCounter());
         // by default 3 players have to complain to apply debuff
         if (m_bgData.bgAfkReporter.size() >= sWorld->getIntConfig(CONFIG_BATTLEGROUND_REPORT_AFK))
         {
             // cast 'Idle' spell
-            CastSpell(this, 43680, true);
+            CastSpell(this, SPELL_BATTLEGROUND_IDLE, true);
             m_bgData.bgAfkReporter.clear();
         }
     }


### PR DESCRIPTION
### Motivation
- Ensure Blackrock Throne and Scarlet Chapel (team deathmatch) treat a human leaving mid-match as a kill for the opposing team. 
- When a managed playerbot is reported AFK by teammates, make it leave and requeue after 10 seconds and award the opposing team a point when that leave happens.

### Description
- Added `AwardPointToTeam(uint32)` and `AwardLeavePointIfNeeded(Player const*, uint32)` helpers to `BattlegroundBRT` and `BattlegroundSCM`, and wired `RemovePlayer` to call `AwardLeavePointIfNeeded` so human leaves or reported playerbot leaves award a point to the other team. 
- Refactored `HandleKillPlayer` in both BRT and SCM to reuse `AwardPointToTeam` for incrementing team kills, updating worldstates and ending the battleground at the kill limit. 
- Extended `Player::ReportedAfkBy` to detect reports against virtual-session playerbots and to: mark the bot idle, make the bot leave, remove deserter aura, and schedule a requeue after 10 seconds; added helpers `QueueAfkReportedPlayerbot` and `LeaveAndRequeueAfkReportedPlayerbot` in `Player.cpp`. 
- Introduced local constants for the relevant spell IDs and included `BattlegroundQueue.h` where required; changes are limited to the active source (not the `playerbot reference/` directory) per repository agent rules.

### Testing
- Performed a full build via `cmake --build build --target worldserver -j2`; an initial compile error (missing declarations after edits) was observed and fixed, and the subsequent rebuild progressed past the previous failure (build output included warnings but no remaining declaration errors related to these changes). 
- No unit tests were added; behavior should be validated by running deathmatch matches and confirming that (1) a human leaving increments the opposing team score, and (2) a reported playerbot is removed, awards a point to the other team, and is queued again after ~10s.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20677616408327b325167fbb3c3ab7)