### PR TITLE
Preserve mounts in shallow water; only dismount on full submersion

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3520,16 +3520,24 @@ void Unit::ProcessTerrainStatusUpdate(ZLiquidStatus /*oldLiquidStatus*/, Optiona
         if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
             SetSwim(CanSwim() && IsInWater());
 
-    // remove appropriate auras if we are swimming/not swimming respectively
+    // Remove appropriate auras if we are swimming/not swimming respectively.
     if (IsInWater())
     {
         Player* player = ToPlayer();
 
-        // Scarlet Chapel and Ruins of Lordaeron's shallow water are part of
-        // intended PvP pathing and should not force players out of mounts or
-        // Travel Form when they cross it.
+        // Scarlet Chapel and Ruins of Lordaeron's water are part of intended
+        // PvP pathing and should never force players out of mounts or Travel
+        // Form. Everywhere else, mounts are handled explicitly on full
+        // submersion so shallow water does not dismount players before they
+        // transition from walking to swimming.
         if (!ShouldPreserveMountInWaterForBattleground(player))
-            RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_ABOVEWATER);
+        {
+            bool const underwater = IsUnderWater();
+            if (underwater)
+                RemoveAurasByType(SPELL_AURA_MOUNTED);
+
+            RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_ABOVEWATER, 0, !underwater);
+        }
     }
     else
         RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_UNDERWATER);
@@ -4382,7 +4390,7 @@ void Unit::RemoveNotOwnSingleTargetAuras(uint32 newPhase)
     }
 }
 
-void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
+void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except, bool skipMountedAuras)
 {
     if (!(m_interruptMask & flag))
         return;
@@ -4394,6 +4402,9 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
         ++iter;
         if ((aura->GetSpellInfo()->AuraInterruptFlags & flag) && (!except || aura->GetId() != except))
         {
+            if (skipMountedAuras && aura->HasEffectType(SPELL_AURA_MOUNTED))
+                continue;
+
             if ((HasAura(81439) || HasAura(89783)) && aura->HasEffectType(SPELL_AURA_MOD_STEALTH))
             {
                 uint32 const protectedFlags = AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE |

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1374,7 +1374,7 @@ class TC_GAME_API Unit : public WorldObject
         void RemoveAurasDueToItemSpell(uint32 spellId, ObjectGuid castItemGuid);
         void RemoveAurasByType(AuraType auraType, ObjectGuid casterGUID = ObjectGuid::Empty, Aura* except = nullptr, bool negative = true, bool positive = true);
         void RemoveNotOwnSingleTargetAuras(uint32 newPhase = 0x0);
-        void RemoveAurasWithInterruptFlags(uint32 flag, uint32 except = 0);
+        void RemoveAurasWithInterruptFlags(uint32 flag, uint32 except = 0, bool skipMountedAuras = false);
         void RemoveAurasWithAttribute(uint32 flags);
         void RemoveAurasWithFamily(SpellFamilyNames family, uint32 familyFlag1, uint32 familyFlag2, uint32 familyFlag3, ObjectGuid casterGUID);
         void RemoveAurasWithMechanic(uint32 mechanicMaskToRemove, AuraRemoveMode removeMode = AURA_REMOVE_BY_DEFAULT, uint32 exceptSpellId = 0, bool withEffectMechanics = false);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -5073,10 +5073,10 @@ void SpellMgr::LoadSpellInfoCorrections()
         if (!spellInfo)
             continue;
 
-        // Mounts should end when the caster enters water; battleground
-        // exceptions are handled where the not-above-water interrupt fires.
-        if (spellInfo->HasAura(SPELL_AURA_MOUNTED))
-            spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_NOT_ABOVEWATER;
+        // Mounts dismount on full submersion in Unit::ProcessTerrainStatusUpdate.
+        // Do not tag them with AURA_INTERRUPT_FLAG_NOT_ABOVEWATER here, because
+        // that interrupt fires as soon as a player touches shallow water. Mount
+        // auras that already carry the flag are skipped until submersion there.
 
         // Fix range for trajectory triggered spell
         for (SpellEffectInfo const& spellEffectInfo : spellInfo->GetEffects())


### PR DESCRIPTION
### Motivation

- Prevent players from being forced off mounts/Travel Form when they touch shallow water while preserving intended battleground pathing exceptions.
- Ensure mount auras are removed only when the unit is fully submerged rather than on first contact with water.

### Description

- Adjusted `Unit::ProcessTerrainStatusUpdate` to avoid applying `AURA_INTERRUPT_FLAG_NOT_ABOVEWATER` behavior on shallow water and to only remove `SPELL_AURA_MOUNTED` when `IsUnderWater()` is true, while preserving exceptions for specified battlegrounds via `ShouldPreserveMountInWaterForBattleground`.
- Added a `skipMountedAuras` boolean parameter to `Unit::RemoveAurasWithInterruptFlags` and updated its implementation to skip removing auras that have `SPELL_AURA_MOUNTED` when requested.
- Updated `Unit` header to add the new `skipMountedAuras` parameter with a default value and adjusted calls accordingly.
- Removed the blanket addition of `AURA_INTERRUPT_FLAG_NOT_ABOVEWATER` to mount spells in `SpellMgr::LoadSpellInfoCorrections` and added a comment noting mounts are handled on full submersion in `Unit::ProcessTerrainStatusUpdate` and existing mount auras that already have the flag remain unchanged.

### Testing

- Project compiled successfully after the changes (`make`/build completed without errors).
- Existing automated unit/test-suite run succeeded with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2059c24e5c832796a530b548405963)