### PR TITLE
Prevent mage playerbots conjuring mana ruby in combat

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3015,8 +3015,8 @@ SpellDecision SelectMageSpell(Player const* player, Unit const* target, bool inM
             { "arcane intellect", "arcane intellect", 10157, playerbot::PvpClassSpellContext::TargetMode::Self } },
         { "maintain buff", !player->IsInCombat() && IsSpellReady(player, 10220) && !player->HasAura(10220), 9.0f,
             { "frost armor", "frost armor", 10220, playerbot::PvpClassSpellContext::TargetMode::Self } },
-        { "mana gem missing", IsSpellReady(player, 10054) && !player->HasItemCount(8008), 8.0f,
-            { "create mana ruby", "create mana ruby", 10054, playerbot::PvpClassSpellContext::TargetMode::Self } },
+        { "mana gem missing", !player->IsInCombat() && IsSpellReady(player, 10054) && !player->HasItemCount(8008), 8.0f,
+            { "create mana ruby", "create mana ruby outside combat", 10054, playerbot::PvpClassSpellContext::TargetMode::Self } },
         { "defensive reset", !isFireMage && !IsSpellReady(player, 11958) && IsSpellReady(player, 12472), 7.0f,
             { "mage cold snap", "reset frost defenses when ice block unavailable", 12472, playerbot::PvpClassSpellContext::TargetMode::Self } }
     });


### PR DESCRIPTION
### Motivation
- Mage playerbots should not cast `Conjure Mana Ruby` while in combat; creation is intended for out-of-combat/prep behavior to avoid wasting casts or unsafe actions during fights.

### Description
- Add `!player->IsInCombat()` to the `"mana gem missing"` decision in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` and update the decision text to `"create mana ruby outside combat"` so the conjure action is only selected when out of combat.

### Testing
- Ran `git diff --check` which produced no whitespace errors and committed the change to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a7f16110832784e7fcdc1b1fec47)