### PR TITLE
Refresh playerbot shaman totems when out of range

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -38,6 +38,7 @@
 #include "SpellAuraEffects.h"
 #include "SpellMgr.h"
 #include "SpellHistory.h"
+#include "Totem.h"
 #include "Unit.h"
 #include "Util.h"
 
@@ -67,6 +68,7 @@ constexpr uint32 kHunterAutoShotSpellId = 75;
 constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
 constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 constexpr uint32 kDruidCasterFaerieFireSpellId = 9907;
+constexpr float kPlayerbotTotemRefreshDistance = 20.0f;
 std::unordered_map<ObjectGuid, bool> g_HunterRangedModeByBot;
 std::mutex g_HunterRangedModeByBotLock;
 std::unordered_map<ObjectGuid, uint8> g_CombatNoTargetTicksByBot;
@@ -842,6 +844,27 @@ bool IsDruidCasterForm(Player const* player)
     return player && player->GetClass() == CLASS_DRUID && player->GetShapeshiftForm() == FORM_NONE;
 }
 
+float GetPlayerbotTotemRefreshDistance(Creature const* totem)
+{
+    if (!totem || !totem->IsTotem())
+        return kPlayerbotTotemRefreshDistance;
+
+    float maxRadius = 0.0f;
+    Totem const* totemUnit = totem->ToTotem();
+    for (uint8 spellSlot = 0; spellSlot < MAX_CREATURE_SPELLS; ++spellSlot)
+    {
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(totemUnit->GetSpell(spellSlot));
+        if (!spellInfo)
+            continue;
+
+        for (SpellEffectInfo const& spellEffectInfo : spellInfo->GetEffects())
+            if (spellEffectInfo.IsEffect() && spellEffectInfo.HasRadius())
+                maxRadius = std::max(maxRadius, spellEffectInfo.CalcRadius(const_cast<Creature*>(totem)));
+    }
+
+    return maxRadius > 0.0f ? maxRadius : kPlayerbotTotemRefreshDistance;
+}
+
 bool HasActiveTotemInSlot(Player const* player, uint8 slot)
 {
     if (!player || slot >= MAX_SUMMON_SLOT)
@@ -852,7 +875,10 @@ bool HasActiveTotemInSlot(Player const* player, uint8 slot)
         return false;
 
     Creature* totem = ObjectAccessor::GetCreature(*player, summonGuid);
-    return totem && totem->IsAlive();
+    if (!totem || !totem->IsAlive())
+        return false;
+
+    return player->IsWithinDistInMap(totem, GetPlayerbotTotemRefreshDistance(totem));
 }
 
 bool HasActiveEarthTotem(Player const* player)
@@ -3600,18 +3626,18 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target, Unit c
     AddDecisionCandidate(candidates, hasHostileTarget && IsMeleeClass(target) && player->IsWithinDistInMap(target, 20.0f) && IsSpellReady(player, 10473), 55.0f,
         { "shaman frost shock", "snare medium-range melee threats", 10473, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     Unit const* poisonedAllyInTotemRange = IsSpellReady(player, 8170) ? SelectFriendlyDispelTarget(player, DISPEL_POISON, 20.0f) : nullptr;
-    AddDecisionCandidate(candidates, poisonedAllyInTotemRange && !HasActiveWaterTotem(player) && !HasAuraFromSpellChain(player, 8170), 54.0f,
-        { "shaman poison cleansing totem", "answer rogue poison pressure", 8170, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, poisonedAllyInTotemRange && !HasActiveWaterTotem(player), 54.0f,
+        { "shaman poison cleansing totem", "answer rogue poison pressure with a nearby water totem", 8170, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, hasHostileTarget && (target->GetClass() == CLASS_PRIEST || target->GetClass() == CLASS_WARLOCK) && player->IsWithinDistInMap(target, 20.0f) && !HasActiveEarthTotem(player) && IsSpellReady(player, 8143), 53.0f,
         { "shaman tremor totem", "mitigate fear pressure from priest/warlock", 8143, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, isRestoShaman && player->GetPowerPct(POWER_MANA) < 50.0f && !HasActiveWaterTotem(player) && IsSpellReady(player, 16190), 52.8f,
         { "shaman mana tide totem", "restore mana below half", 16190, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, isRestoShaman && !HasActiveEarthTotem(player) && !HasAuraFromSpellChain(player, 81476) && IsSpellReady(player, 81476), 52.7f,
-        { "shaman tremor totem", "maintain tremor totem", 81476, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, isRestoShaman && !HasActiveWaterTotem(player) && !HasAuraFromSpellChain(player, 81477) && IsSpellReady(player, 81477), 52.6f,
-        { "shaman poison cleansing totem", "maintain poison cleansing totem", 81477, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, isRestoShaman && !HasActiveAirTotem(player) && !HasAuraFromSpellChain(player, 81478) && IsSpellReady(player, 81478), 52.5f,
-        { "shaman grounding totem", "maintain grounding totem", 81478, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, isRestoShaman && !HasActiveEarthTotem(player) && IsSpellReady(player, 81476), 52.7f,
+        { "shaman tremor totem", "maintain a nearby tremor totem", 81476, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, isRestoShaman && !HasActiveWaterTotem(player) && IsSpellReady(player, 81477), 52.6f,
+        { "shaman poison cleansing totem", "maintain a nearby poison cleansing totem", 81477, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, isRestoShaman && !HasActiveAirTotem(player) && IsSpellReady(player, 81478), 52.5f,
+        { "shaman grounding totem", "maintain a nearby grounding totem", 81478, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, isRestoShaman && SelectNearbyMeleeTarget(player, target, 8.0f) && player->HealthBelowPct(50) && IsSpellReady(player, 2645), 52.4f,
         { "shaman ghost wolf", "escape melee pressure while endangered", 2645, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, isRestoShaman && distantEscapeTarget && player->HasAura(2645) && IsSpellReady(player, 82419), 52.3f,


### PR DESCRIPTION
### Motivation
- Playerbot restoration shamans were blocked from recasting utility totems (tremor, poison cleansing, grounding) when their existing totem object still existed but the bot had moved out of its effect radius.  
- The change ensures playerbots will refresh totems when they are effectively out of range of the totem effect so defensive/dispelling support remains available.

### Description
- Added `#include "Totem.h"` and a new constant `kPlayerbotTotemRefreshDistance` and helper `GetPlayerbotTotemRefreshDistance` that computes a totem's effective radius by inspecting its `SpellEffectInfo::CalcRadius` values and falls back to a 20-yard default.  
- Reworked `HasActiveTotemInSlot` to treat a totem as active only if the player is still within the totem's effect radius (via `GetPlayerbotTotemRefreshDistance`) and the totem is alive.  
- Relaxed restoration-maintenance decision checks so maintenance casts for tremor/poison-cleansing/grounding totems are allowed to replace missing or out-of-range totems (removed blocking `HasAuraFromSpellChain` checks).  
- Adjusted poison-response logic so Poison Cleansing Totem is considered for recast when no nearby water totem is effectively active and updated the decision descriptions accordingly.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems.  
- Built the modified script object with `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpCore.cpp.o` after enabling Playerbot scripts, and the file compiled successfully.  
- Configured and generated the build with `cmake -S . -B build -DPLAYERBOT=ON -DSCRIPTS_PLAYERBOT=static` and script-targets were produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ae3756688327a18f9d681b9dea4e)