### PR TITLE
Playerbot: avoid Power Word: Shielding units with Weakened Soul (6788)

### DIFF
--- a/src/server/game/AI/PlayerAI/PlayerAI.cpp
+++ b/src/server/game/AI/PlayerAI/PlayerAI.cpp
@@ -191,6 +191,7 @@ enum Spells
     SPELL_PAIN_SUPPRESSION    = 33206,
     SPELL_INNER_FOCUS         = 14751,
     SPELL_POWER_WORD_SHIELD   = 48066,
+    SPELL_WEAKENED_SOUL       =  6788,
 
     /* Priest - Holy */
     PASSIVE_SPIRIT_REDEMPTION = 20711,
@@ -834,7 +835,9 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             switch (GetSpec())
             {
                 case SPEC_PRIEST_DISCIPLINE:
-                    VerifyAndPushSpellCast(spells, SPELL_POWER_WORD_SHIELD, TARGET_CHARMER, 3);
+                    if (Unit* charmer = me->GetCharmer())
+                        if (!charmer->HasAura(SPELL_WEAKENED_SOUL))
+                            VerifyAndPushSpellCast(spells, SPELL_POWER_WORD_SHIELD, charmer, 3);
                     VerifyAndPushSpellCast(spells, SPELL_INNER_FOCUS, TARGET_NONE, 3);
                     VerifyAndPushSpellCast(spells, SPELL_PAIN_SUPPRESSION, TARGET_CHARMER, 15);
                     VerifyAndPushSpellCast(spells, SPELL_POWER_INFUSION, TARGET_CHARMER, 10);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -67,6 +67,7 @@ constexpr uint32 kHunterAutoShotSpellId = 75;
 constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
 constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 constexpr uint32 kDruidCasterFaerieFireSpellId = 9907;
+constexpr uint32 kPriestWeakenedSoulSpellId = 6788;
 std::unordered_map<ObjectGuid, bool> g_HunterRangedModeByBot;
 std::mutex g_HunterRangedModeByBotLock;
 std::unordered_map<ObjectGuid, uint8> g_CombatNoTargetTicksByBot;
@@ -2204,7 +2205,7 @@ Unit const* SelectEnemyClassTarget(Player const* player, uint8 classId, float ma
     return best;
 }
 
-Unit const* SelectFriendlyHealthTarget(Player const* player, float maxDistance, float maxHealthPct)
+Unit const* SelectFriendlyHealthTarget(Player const* player, float maxDistance, float maxHealthPct, uint32 excludedAuraId = 0)
 {
     if (!player || !player->FindMap())
         return nullptr;
@@ -2219,6 +2220,8 @@ Unit const* SelectFriendlyHealthTarget(Player const* player, float maxDistance, 
         if (!candidate || !candidate->IsAlive())
             return;
         if (!IsFriendlySupportTarget(player, candidate))
+            return;
+        if (excludedAuraId && candidate->HasAura(excludedAuraId))
             return;
         if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, maxDistance))
             return;
@@ -3032,7 +3035,7 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
     bool const dispelThrottleActive = playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, kPlayerbotDispelCooldownToken);
     Unit const* debuffedAlly = (!dispelThrottleActive && IsSpellReady(player, 988)) ? SelectFriendlyDispelTarget(player, DISPEL_MAGIC, GetConfiguredHealRange()) : nullptr;
     Unit const* enemyBuffedTarget = (!dispelThrottleActive && IsSpellReady(player, 988) && hasHostileTarget) ? SelectEnemyDispelTarget(player, DISPEL_MAGIC, target, GetConfiguredSpellRange()) : nullptr;
-    Unit const* shieldTarget = IsSpellReady(player, 10901) ? SelectFriendlyHealthTarget(player, GetConfiguredHealRange(), 50.0f) : nullptr;
+    Unit const* shieldTarget = IsSpellReady(player, 10901) ? SelectFriendlyHealthTarget(player, GetConfiguredHealRange(), 50.0f, kPriestWeakenedSoulSpellId) : nullptr;
     Unit const* renewTarget = IsSpellReady(player, 10929) ? SelectFriendlyHealthTarget(player, GetConfiguredHealRange(), 80.0f) : nullptr;
     Unit const* healTarget = IsSpellReady(player, 10917) ? SelectFriendlyHealthTarget(player, GetConfiguredHealRange(), 85.0f) : nullptr;
     Unit const* emergencyLowAlly = IsSpellReady(player, 10917) ? SelectFriendlyHealthTarget(player, 15.0f, 25.0f) : nullptr;


### PR DESCRIPTION
### Motivation
- Prevent priest playerbots from attempting to cast Power Word: Shield on allies that already have the Weakened Soul aura (spell id `6788`), which makes shielding them ineffective.

### Description
- Added `SPELL_WEAKENED_SOUL` (6788) to `PlayerAI` and guarded discipline priest charmer-shield selection so `Power Word: Shield` is only offered if the charmer does not have `SPELL_WEAKENED_SOUL` in `PlayerAI::SelectAppropriateCastForSpec`.
- Extended `SelectFriendlyHealthTarget` in `playerbot` PvP core to accept an optional `excludedAuraId` parameter and skip candidates that have that aura when choosing heal/shield targets.
- Introduced `kPriestWeakenedSoulSpellId` constant and passed it into the shield-target selection so `SelectPriestSpell` will not choose `Power Word: Shield` for targets with `Weakened Soul`.

### Testing
- Performed a full build of the worldserver target with `cmake --build build --target worldserver -j2`, which compiled successfully (warnings only) after the changes.
- Performed code searches and inspections to ensure the excluded-aura logic is only applied to playerbot target selection for healing/shielding; no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20af38c8a48327b39b5422f7c5d091)