### PR TITLE
Fix stationary playerbot channel casts

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2432,11 +2432,17 @@ void StopPlayerbotForStationaryCast(Player* player)
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
 
-    if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
-    {
-        player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
-        player->SendMovementFlagUpdate();
-    }
+    // Unit::StopMoving() only strips the spline forward flag when an active
+    // server spline exists. Playerbots can also carry stale client-style
+    // movement flags (strafe/back/fall/spline elevation) after chase/follow
+    // movement was cleared, and Spell::CheckCast rejects stationary channeled
+    // spells such as Drain Life while any MOVEMENTFLAG_MASK_MOVING bit remains.
+    // Clear the full moving mask for bot-controlled stationary casts so the
+    // immediate cast attempt observes the same stopped state that a real client
+    // would send before casting.
+    player->ClearUnitState(UNIT_STATE_MOVING | UNIT_STATE_MOVE);
+    player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+    player->SendMovementFlagUpdate();
 }
 
 bool CanIssueFollowCommands(Player const* player)


### PR DESCRIPTION
### Motivation
- Playerbots could fail to start non-move-allowed channeled spells (e.g. Warlock `Drain Life`) because stale movement flags/state remained after stopping chase/follow movement, causing `SPELL_FAILED_MOVING` in `Spell::CheckCast`.

### Description
- In `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` updated `StopPlayerbotForStationaryCast` to clear residual movement state and flags by calling `player->ClearUnitState(UNIT_STATE_MOVING | UNIT_STATE_MOVE)`, `player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING)`, and `player->SendMovementFlagUpdate()` before attempting stationary casts.
- Removed the previous conditional that only removed movement flags for virtual sessions so the stop-path now enforces a consistent stopped state for bot-controlled casts.
- Added a comment explaining why the extra clearing is required to mirror the client-side stopped state expected by the spell-check path.

### Testing
- Built the game target with `cmake --build build --target game -- -j2`, which completed successfully (full project build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20afb284d48327a505760dca719676)