### PR TITLE
Playerbot: pick castable distant targets for Shaman Rehgar's Fury and Druid Feral Charge

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1649,6 +1649,55 @@ Unit const* SelectNearbyEnemyTarget(Player const* player, Unit const* preferredT
     return best;
 }
 
+Unit const* SelectEnemyTargetInSpellRange(Player const* player, Unit const* preferredTarget, uint32 spellId)
+{
+    if (!player || !player->FindMap())
+        return nullptr;
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!spellInfo)
+        return nullptr;
+
+    float const minRange = spellInfo->GetMinRange(false);
+    float const maxRange = spellInfo->GetMaxRange(false);
+
+    auto isCandidateUsable = [&](Unit const* candidate)
+    {
+        if (!HasHostileTarget(player, candidate) || IsTargetInvalidByImmunity(player, candidate))
+            return false;
+        if (!player->IsWithinLOSInMap(candidate))
+            return false;
+        if (minRange > 0.0f && player->IsWithinDistInMap(candidate, minRange))
+            return false;
+        if (maxRange > 0.0f && !player->IsWithinDistInMap(candidate, maxRange))
+            return false;
+
+        return player->IsValidAttackTarget(candidate, spellInfo);
+    };
+
+    if (isCandidateUsable(preferredTarget))
+        return preferredTarget;
+
+    Unit const* best = nullptr;
+    float bestDistance = std::numeric_limits<float>::max();
+    Map::PlayerList const& mapPlayers = player->FindMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!isCandidateUsable(candidate))
+            continue;
+
+        float const distance = player->GetDistance(candidate);
+        if (distance < bestDistance)
+        {
+            best = candidate;
+            bestDistance = distance;
+        }
+    }
+
+    return best;
+}
+
 Unit const* SelectNearbyEnemyManaTarget(Player const* player, Unit const* preferredTarget, float maxDistance, float minManaPct)
 {
     if (!player || !player->FindMap())
@@ -3146,6 +3195,8 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target, Classic
         bool const isProwling = HasAuraFromSpellChain(player, 9913);
         Unit const* lowAlly = SelectFriendlyHealthTarget(player, 40.0f, 80.0f);
         Unit const* rootTarget = SelectPredatorsSwiftnessRootTarget(player, target, 30.0f);
+        Unit const* feralChargeBearTarget = IsSpellReady(player, 16979) ? SelectEnemyTargetInSpellRange(player, target, 16979) : nullptr;
+        Unit const* feralChargeCatTarget = IsSpellReady(player, 49376) ? SelectEnemyTargetInSpellRange(player, target, 49376) : nullptr;
         bool const safeAgain = !player->HealthBelowPct(60) || !heavyMeleePressure;
 
         std::vector<PrioritizedSpellDecision> feralCandidates;
@@ -3169,8 +3220,8 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target, Classic
             { "druid bear form", "swap bear under heavy melee pressure", 5487, playerbot::PvpClassSpellContext::TargetMode::Self, meleeThreat ? meleeThreat->GetGUID() : ObjectGuid::Empty });
         AddDecisionCandidate(feralCandidates, inBear && player->GetComboPoints() >= 5 && player->GetPowerPct(POWER_MANA) < 50.0f && !player->HasAura(89758) && IsSpellReady(player, 89758), 67.0f,
             { "druid thinnervate", "bear combo point thinnervate", 89758, playerbot::PvpClassSpellContext::TargetMode::Enemy });
-        AddDecisionCandidate(feralCandidates, inBear && IsSpellReady(player, 16979), 66.0f,
-            { "druid feral charge bear", "escape by charging a distant target", 16979, playerbot::PvpClassSpellContext::TargetMode::Enemy });
+        AddDecisionCandidate(feralCandidates, inBear && feralChargeBearTarget, 66.0f,
+            { "druid feral charge bear", "escape by charging a distant target", 16979, playerbot::PvpClassSpellContext::TargetMode::Enemy, feralChargeBearTarget ? feralChargeBearTarget->GetGUID() : ObjectGuid::Empty });
         AddDecisionCandidate(feralCandidates, inBear && IsSpellReady(player, 22842), 65.0f,
             { "druid frenzied regeneration", "bear survival recovery", 22842, playerbot::PvpClassSpellContext::TargetMode::Self });
         AddDecisionCandidate(feralCandidates, inBear && IsSpellReady(player, 5229), 64.0f,
@@ -3185,10 +3236,10 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target, Classic
             { "druid cat form", "prefer cat form for feral pressure", 768, playerbot::PvpClassSpellContext::TargetMode::Self });
         AddDecisionCandidate(feralCandidates, inCat && IsRootedOrSnared(player) && !player->IsWithinMeleeRange(target) && IsSpellReady(player, 768), 59.0f,
             { "druid cat form", "powershift root or snare", 768, playerbot::PvpClassSpellContext::TargetMode::Self, target ? target->GetGUID() : ObjectGuid::Empty });
+        AddDecisionCandidate(feralCandidates, inCat && feralChargeCatTarget, 58.5f,
+            { "druid feral charge cat", "close gap in cat form", 49376, playerbot::PvpClassSpellContext::TargetMode::Enemy, feralChargeCatTarget ? feralChargeCatTarget->GetGUID() : ObjectGuid::Empty });
         AddDecisionCandidate(feralCandidates, inCat && !player->IsWithinMeleeRange(target) && IsSpellReady(player, 9821), 58.0f,
             { "druid dash", "catch target in cat form", 9821, playerbot::PvpClassSpellContext::TargetMode::Self });
-        AddDecisionCandidate(feralCandidates, inCat && !player->IsWithinMeleeRange(target) && IsSpellReady(player, 49376), 57.0f,
-            { "druid feral charge cat", "close gap in cat form", 49376, playerbot::PvpClassSpellContext::TargetMode::Enemy });
         AddDecisionCandidate(feralCandidates, inCat && player->GetComboPoints() >= 5 && player->GetPowerPct(POWER_MANA) < 50.0f && !player->HasAura(89758) && IsSpellReady(player, 89758), 56.0f,
             { "druid thinnervate", "restore mana with combo points", 89758, playerbot::PvpClassSpellContext::TargetMode::Enemy });
         AddDecisionCandidate(feralCandidates, inCat && player->GetComboPoints() >= 5 && IsSpellReady(player, 9896), 55.0f,
@@ -3573,7 +3624,7 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target, Unit c
     Unit const* earthShieldTarget = isRestoShaman && IsSpellReady(player, 32593) && !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, 32593) ? SelectFriendlyHealthTarget(player, 40.0f, 100.0f) : nullptr;
     Unit const* purgeTarget = isRestoShaman && hasHostileTarget && IsSpellReady(player, 81325) ? SelectEnemyDispelTarget(player, DISPEL_MAGIC, target, 30.0f) : nullptr;
     Unit const* allyMagicTarget = isRestoShaman && IsSpellReady(player, 81325) ? SelectFriendlyDispelTarget(player, DISPEL_MAGIC, 40.0f) : nullptr;
-    Unit const* distantEscapeTarget = isRestoShaman && hasHostileTarget && SelectNearbyMeleeTarget(player, target, 8.0f) ? SelectNearbyEnemyTarget(player, target, 25.0f) : nullptr;
+    Unit const* distantEscapeTarget = isRestoShaman && hasHostileTarget && SelectNearbyMeleeTarget(player, target, 8.0f) && IsSpellReady(player, 81910) ? SelectEnemyTargetInSpellRange(player, target, 81910) : nullptr;
 
     std::vector<PrioritizedSpellDecision> candidates;
     // Disabled: auto-casting Windfury Weapon from PvP loop while investigating weapon-dependent aura crashes.
@@ -3614,8 +3665,8 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target, Unit c
         { "shaman grounding totem", "maintain grounding totem", 81478, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, isRestoShaman && SelectNearbyMeleeTarget(player, target, 8.0f) && player->HealthBelowPct(50) && IsSpellReady(player, 2645), 52.4f,
         { "shaman ghost wolf", "escape melee pressure while endangered", 2645, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, isRestoShaman && distantEscapeTarget && player->HasAura(2645) && IsSpellReady(player, 82419), 52.3f,
-        { "shaman rehgar's fury", "leap to distant target while escaping", 82419, playerbot::PvpClassSpellContext::TargetMode::Enemy, distantEscapeTarget ? distantEscapeTarget->GetGUID() : ObjectGuid::Empty });
+    AddDecisionCandidate(candidates, isRestoShaman && distantEscapeTarget && player->HasAura(2645), 59.5f,
+        { "shaman rehgar's fury", "leap to distant target while escaping", 81910, playerbot::PvpClassSpellContext::TargetMode::Enemy, distantEscapeTarget ? distantEscapeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, player->HealthBelowPct(50) && IsSpellReady(player, 10468), 52.0f,
         { "shaman lesser healing wave", "self-sustain while focused", 10468, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, isRestoShaman && purgeTarget, 53.5f,


### PR DESCRIPTION
### Motivation
- Playerbots were failing to cast Rehgar's Fury / Feral Charge because the target selection did not consider spell min/max range or validity, causing leap/charge abilities to be skipped even when valid targets existed.
- The intent is to choose distant enemy targets that are actually in-range and valid for the specific gap-closing spells so the bot will attempt the ability instead of ignoring it.

### Description
- Add `SelectEnemyTargetInSpellRange` to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` to pick the closest hostile player that is within a spell's min/max range, line-of-sight, and is a valid attack target for that `SpellInfo`.
- Use the new helper when evaluating feral charge options by adding `feralChargeBearTarget` and `feralChargeCatTarget` and only enqueue the feral charge decision when a valid in-range target is found (and include the explicit target GUID in the `SpellDecision`).
- Use the new helper to select a valid `distantEscapeTarget` for restoration shaman `ghost wolf` + Rehgar's Fury flow and change the decision to reference the appropriate spell id/resolved trigger when a valid distant target exists (the decision now attaches the target GUID so execution can attempt to leap/charge).
- Minor decision priority/condition adjustments to depend on the new target availability checks rather than raw `IsSpellReady` results.

### Testing
- Built the game target with `cmake --build build --target game` after the changes; the project compiled through the normal build steps with no blocking errors reported in the build output.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20b0246ed083279d36d4015b7a838b)