### PR TITLE
Fix playerbot totem refresh fallback constant

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -69,6 +69,7 @@ constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
 constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 constexpr uint32 kDruidCasterFaerieFireSpellId = 9907;
 constexpr uint32 kPriestWeakenedSoulSpellId = 6788;
+constexpr float kPlayerbotTotemRefreshDistance = 30.0f;
 std::unordered_map<ObjectGuid, bool> g_HunterRangedModeByBot;
 std::mutex g_HunterRangedModeByBotLock;
 std::unordered_map<ObjectGuid, uint8> g_CombatNoTargetTicksByBot;


### PR DESCRIPTION
### Motivation
- Code was failing to compile due to an undefined identifier used as a fallback in totem range checks; the function `GetPlayerbotTotemRefreshDistance` expects a fallback constant when the totem is invalid or has no radius.

### Description
- Add the missing fallback constant `constexpr float kPlayerbotTotemRefreshDistance = 30.0f;` to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` so `GetPlayerbotTotemRefreshDistance` can return a valid distance.

### Testing
- Ran `git diff --check` with no issues reported. 
- Started `ninja -C build scripts` to validate the build but the local build triggered a full multi-hundred-step rebuild and was interrupted, so a full compile of the tree was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20c3c3d220832793b9ed65c6ad9b51)