### PR TITLE
Improve playerbot stationary-cast handling to avoid movement/cast race conditions

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -2141,6 +2141,15 @@ struct CasterSpellCooldownKeyHash
 };
 
 std::unordered_map<CasterSpellCooldownKey, std::chrono::steady_clock::time_point, CasterSpellCooldownKeyHash> g_CasterSpellCooldowns;
+
+struct StationaryCastStopState
+{
+    uint32 spellId = 0;
+    ObjectGuid targetGuid = ObjectGuid::Empty;
+    uint32 stopMs = 0;
+};
+
+std::unordered_map<uint64, StationaryCastStopState> g_StationaryCastStopByGuid;
 std::unordered_map<uint64, std::string> g_LastClassExecutionStatusByGuid;
 std::unordered_map<uint64, std::string> g_LastMovementDebugStatusByGuid;
 struct LastDirectiveState
@@ -2423,6 +2432,24 @@ bool HasActiveStationaryChannel(Player const* player)
     return spellInfo && spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel();
 }
 
+bool HasActiveMovementForStationaryCast(Player const* player)
+{
+    if (!player)
+        return false;
+
+    MotionMaster const* motionMaster = player->GetMotionMaster();
+    MovementGeneratorType const motionType = motionMaster ? motionMaster->GetCurrentMovementGeneratorType() : IDLE_MOTION_TYPE;
+    bool const activeMotion =
+        motionType == CHASE_MOTION_TYPE ||
+        motionType == FOLLOW_MOTION_TYPE ||
+        motionType == POINT_MOTION_TYPE;
+
+    return player->isMoving() ||
+        player->HasUnitState(UNIT_STATE_MOVING | UNIT_STATE_MOVE) ||
+        activeMotion ||
+        (player->movespline && player->movespline->Initialized() && !player->movespline->Finalized());
+}
+
 void StopPlayerbotForStationaryCast(Player* player)
 {
     if (!player)
@@ -2432,11 +2459,17 @@ void StopPlayerbotForStationaryCast(Player* player)
     if (MotionMaster* motionMaster = player->GetMotionMaster())
         motionMaster->Clear(MOTION_SLOT_ACTIVE);
 
-    if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
-    {
-        player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
-        player->SendMovementFlagUpdate();
-    }
+    // Unit::StopMoving() only strips the spline forward flag when an active
+    // server spline exists. Playerbots can also carry stale client-style
+    // movement flags (strafe/back/fall/spline elevation) after chase/follow
+    // movement was cleared, and Spell::CheckCast rejects stationary channeled
+    // spells such as Drain Life while any MOVEMENTFLAG_MASK_MOVING bit remains.
+    // Clear the full moving mask for bot-controlled stationary casts so the
+    // immediate cast attempt observes the same stopped state that a real client
+    // would send before casting.
+    player->ClearUnitState(UNIT_STATE_MOVING | UNIT_STATE_MOVE);
+    player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+    player->SendMovementFlagUpdate();
 }
 
 bool CanIssueFollowCommands(Player const* player)
@@ -3218,7 +3251,48 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             return false;
         }
 
+        bool const hadActiveMovement = HasActiveMovementForStationaryCast(player);
         StopPlayerbotForStationaryCast(player);
+
+        // Channeled spells such as Drain Life are checked for movement as soon
+        // as CastSpell enters the server spell pipeline. When a bot was just
+        // running a chase/follow/point generator, spend one decision tick on the
+        // stop transition before starting the stationary cast. This mirrors a
+        // real client sending a stop packet before pressing a non-movable
+        // channel and prevents same-tick movement orders from racing the cast.
+        if (!isFoodOrDrinkSpell && hadActiveMovement)
+        {
+            uint32 const nowMs = GameTime::GetGameTimeMS();
+            uint64 const botKey = player->GetGUID().GetRawValue();
+            ObjectGuid const castTargetGuid = target ? target->GetGUID() : ObjectGuid::Empty;
+            StationaryCastStopState& stopState = g_StationaryCastStopByGuid[botKey];
+            bool const alreadyStoppedForCast =
+                stopState.spellId == resolvedSpellId &&
+                stopState.targetGuid == castTargetGuid &&
+                stopState.stopMs != 0 &&
+                nowMs >= stopState.stopMs &&
+                nowMs - stopState.stopMs <= 10000;
+
+            stopState.spellId = resolvedSpellId;
+            stopState.targetGuid = castTargetGuid;
+            stopState.stopMs = nowMs;
+
+            if (!alreadyStoppedForCast)
+            {
+                std::ostringstream diag;
+                diag << "stationary_cast_waiting_for_stop"
+                     << " spell=" << resolvedSpellId
+                     << " action=" << (context.actionName ? context.actionName : "none")
+                     << " target=" << castTargetGuid.ToString()
+                     << " moving_after_stop=" << (player->isMoving() ? "yes" : "no")
+                     << " unit_moving_after_stop=" << (player->HasUnitState(UNIT_STATE_MOVING | UNIT_STATE_MOVE) ? "yes" : "no")
+                     << " flags=" << player->GetUnitMovementFlags();
+                SetLastMovementDebugStatus(player, diag.str());
+                TC_LOG_DEBUG("playerbots.pvp.classspell", "PB stationary cast delayed for stop: {}", diag.str());
+                failureReason = "stationary_cast_waiting_for_stop";
+                return false;
+            }
+        }
     }
 
     // Blink (1953) is a leap-forward spell with a destination target
@@ -3242,7 +3316,28 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
 
     if (castResult != SPELL_CAST_OK)
     {
-        if (!itemTarget && target && CanIssueFollowCommands(player))
+        if (castResult == SPELL_FAILED_MOVING && requiresStationaryCast)
+        {
+            StopPlayerbotForStationaryCast(player);
+            g_StationaryCastStopByGuid[player->GetGUID().GetRawValue()] = { resolvedSpellId, target ? target->GetGUID() : ObjectGuid::Empty, GameTime::GetGameTimeMS() };
+
+            // If an immediately preceding movement update raced this cast, the
+            // failed moving check did not consume the spell. Retry once after
+            // force-clearing the stopped state so channels do not keep reporting
+            // SPELL_FAILED_MOVING even though the bot has now stopped.
+            if (!player->isMoving())
+            {
+                if (itemTarget)
+                    castResult = player->CastSpell(CastSpellTargetArg(itemTarget), resolvedSpellId);
+                else
+                    castResult = player->CastSpell(target, resolvedSpellId, false);
+
+                if (castResult == SPELL_CAST_OK)
+                    g_StationaryCastStopByGuid.erase(player->GetGUID().GetRawValue());
+            }
+        }
+
+        if (castResult != SPELL_CAST_OK && !itemTarget && target && CanIssueFollowCommands(player))
         {
             if (castResult == SPELL_FAILED_OUT_OF_RANGE)
             {
@@ -3286,10 +3381,13 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
                 IssueBehindTargetMeleeMovement(player, target);
         }
 
-        NotifySpellCastFailureToGameMasters(player, context, castResult);
-        EnumText const reasonText = EnumUtils::ToString(castResult);
-        failureReason = reasonText.Title;
-        return false;
+        if (castResult != SPELL_CAST_OK)
+        {
+            NotifySpellCastFailureToGameMasters(player, context, castResult);
+            EnumText const reasonText = EnumUtils::ToString(castResult);
+            failureReason = reasonText.Title;
+            return false;
+        }
     }
 
     if (spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel())


### PR DESCRIPTION
### Motivation
- Prevent playerbots from failing or racing when attempting non-instant or non-move-allowed channeled spells due to stale movement flags or immediate movement updates. 
- Mirror real client behavior by ensuring a stop transition is observed before starting stationary casts to avoid `SPELL_FAILED_MOVING` races.

### Description
- Add `StationaryCastStopState` and global map `g_StationaryCastStopByGuid` to remember recent stop attempts per bot. 
- Add `HasActiveMovementForStationaryCast` to robustly detect active movement using `MotionMaster`, unit states and spline status. 
- Change `StopPlayerbotForStationaryCast` to clear the full movement mask and unit moving state and always send a movement update to remove stale client-style movement flags. 
- In `CastDirectSpell` detect when a stationary cast is required, record whether the bot had active movement, stop the bot, and defer the cast for one decision tick when appropriate by returning a specific failure reason; retry once on `SPELL_FAILED_MOVING` after force-clearing movement and update the stop state map accordingly. 
- Adjust failure handling flow to only notify and return after any cast-retry logic completes.

### Testing
- Built the server with the changes and ran the automated unit/integration test suite, which completed successfully. 
- Exercised PvP playerbot casting scenarios (automated scenarios) covering stationary channeled and cast-time spells and observed that movement-race `SPELL_FAILED_MOVING` failures were mitigated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20afb284d48327a505760dca719676)