### PR TITLE
Add Interloped proc diagnostics

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10798,6 +10798,12 @@ void Unit::GetProcAurasTriggeredOnEvent(AuraApplicationProcContainer& aurasTrigg
 
 void Unit::TriggerAurasProcOnEvent(Unit* actionTarget, uint32 typeMaskActor, uint32 typeMaskActionTarget, uint32 spellTypeMask, uint32 spellPhaseMask, uint32 hitMask, Spell* spell, DamageInfo* damageInfo, HealInfo* healInfo)
 {
+    if (spell && spell->GetSpellInfo() && spell->GetSpellInfo()->Id == 20904 && HasAura(81388))
+        if (Player* player = ToPlayer())
+            if (WorldSession* session = player->GetSession())
+                ChatHandler(session).PSendSysMessage("[Interloped proc debug] received Aimed Shot 20904 proc event while aura 81388 is present: typeMaskActor=0x%08X typeMaskActionTarget=0x%08X spellTypeMask=0x%08X phaseMask=0x%08X hitMask=0x%08X damageInfo=%s healInfo=%s",
+                    typeMaskActor, typeMaskActionTarget, spellTypeMask, spellPhaseMask, hitMask, damageInfo ? "yes" : "no", healInfo ? "yes" : "no");
+
     // prepare data for self trigger
     ProcEventInfo myProcEventInfo(this, actionTarget, actionTarget, typeMaskActor, spellTypeMask, spellPhaseMask, hitMask, spell, damageInfo, healInfo);
     if (typeMaskActor)

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -20,6 +20,7 @@
 #include "BattlefieldMgr.h"
 #include "Battleground.h"
 #include "CellImpl.h"
+#include "Chat.h"
 #include "Common.h"
 #include "DBCStores.h"
 #include "GridNotifiersImpl.h"
@@ -48,6 +49,41 @@
 #include <numeric>
 namespace
 {
+    uint32 constexpr INTERLOPED_AURA_ID = 81388;
+    uint32 constexpr INTERLOPED_PROC_ID = 81391;
+    uint32 constexpr AIMED_SHOT_ID = 20904;
+
+    bool IsInterlopedTriggeredSpellDebug(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
+    {
+        SpellInfo const* eventSpellInfo = eventInfo.GetSpellInfo();
+        return aurEff && aurEff->GetId() == INTERLOPED_AURA_ID && aurEff->GetSpellEffectInfo().TriggerSpell == INTERLOPED_PROC_ID && eventSpellInfo && eventSpellInfo->Id == AIMED_SHOT_ID;
+    }
+
+    Player* GetInterlopedDebugPlayer(AuraApplication const* aurApp, ProcEventInfo& eventInfo)
+    {
+        if (aurApp)
+            if (Player* player = aurApp->GetTarget()->ToPlayer())
+                return player;
+
+        if (Unit* actor = eventInfo.GetActor())
+        {
+            if (Player* player = actor->ToPlayer())
+                return player;
+
+            if (Player* owner = actor->GetSpellModOwner())
+                return owner;
+        }
+
+        return nullptr;
+    }
+
+    void SendInterlopedProcDebug(AuraApplication const* aurApp, ProcEventInfo& eventInfo, char const* reason)
+    {
+        if (Player* player = GetInterlopedDebugPlayer(aurApp, eventInfo))
+            if (WorldSession* session = player->GetSession())
+                ChatHandler(session).PSendSysMessage("[Interloped proc debug] %s", reason);
+    }
+
     bool IsFollowFearSpell(SpellInfo const* spellInfo)
     {
         if (!spellInfo)
@@ -1050,7 +1086,11 @@ void AuraEffect::HandleProc(AuraApplication* aurApp, ProcEventInfo& eventInfo)
 {
     bool prevented = GetBase()->CallScriptEffectProcHandlers(this, aurApp, eventInfo);
     if (prevented)
+    {
+        if (IsInterlopedTriggeredSpellDebug(this, eventInfo))
+            SendInterlopedProcDebug(aurApp, eventInfo, "blocked: AuraScript OnEffectProc handler prevented Interloped 81391 from being cast");
         return;
+    }
 
     switch (GetAuraType())
     {
@@ -5867,9 +5907,12 @@ void AuraEffect::HandleProcTriggerSpellAuraProc(AuraApplication* aurApp, ProcEve
     Unit* triggerTarget = eventInfo.GetProcTarget();
 
     uint32 triggerSpellId = GetSpellEffectInfo().TriggerSpell;
+    bool const interlopedDebug = IsInterlopedTriggeredSpellDebug(this, eventInfo);
     if (triggerSpellId == 0)
     {
         TC_LOG_WARN("spells.aura.effect.nospell", "AuraEffect::HandleProcTriggerSpellAuraProc: Spell {} [EffectIndex: {}] does not have triggered spell.", GetId(), GetEffIndex());
+        if (interlopedDebug)
+            SendInterlopedProcDebug(aurApp, eventInfo, "blocked: aura 81388 effect has no trigger spell configured, so Interloped 81391 cannot be cast");
         return;
     }
 
@@ -5877,6 +5920,16 @@ void AuraEffect::HandleProcTriggerSpellAuraProc(AuraApplication* aurApp, ProcEve
     {
         TC_LOG_DEBUG("spells.aura.effect", "AuraEffect::HandleProcTriggerSpellAuraProc: Triggering spell {} from aura {} proc", triggeredSpellInfo->Id, GetId());
         SpellCastResult const castResult = triggerCaster->CastSpell(triggerTarget, triggeredSpellInfo->Id, this);
+        if (interlopedDebug)
+        {
+            if (Player* player = GetInterlopedDebugPlayer(aurApp, eventInfo))
+                if (WorldSession* session = player->GetSession())
+                {
+                    EnumText const reasonText = EnumUtils::ToString(castResult);
+                    ChatHandler(session).PSendSysMessage("[Interloped proc debug] CastSpell for Interloped 81391 returned %s (%u); caster=%s target=%s",
+                        reasonText.Title, uint32(castResult), triggerCaster ? triggerCaster->GetName().c_str() : "<none>", triggerTarget ? triggerTarget->GetName().c_str() : "<none>");
+                }
+        }
 
         if (castResult != SPELL_CAST_OK && IsNaturesGraspAura(GetId()))
         {
@@ -5891,7 +5944,11 @@ void AuraEffect::HandleProcTriggerSpellAuraProc(AuraApplication* aurApp, ProcEve
         }
     }
     else
+    {
         TC_LOG_ERROR("spells.aura.effect.nospell","AuraEffect::HandleProcTriggerSpellAuraProc: Spell {} has non-existent spell {} in EffectTriggered[{}] and is therefore not triggered.", GetId(), triggerSpellId, GetEffIndex());
+        if (interlopedDebug)
+            SendInterlopedProcDebug(aurApp, eventInfo, "blocked: Interloped trigger spell 81391 does not exist in Spell.dbc/SpellInfo");
+    }
 }
 
 void AuraEffect::HandleProcTriggerSpellWithValueAuraProc(AuraApplication* aurApp, ProcEventInfo& eventInfo)

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2207,6 +2207,112 @@ void Aura::ResetProcCooldown()
     m_procCooldown = std::chrono::steady_clock::now();
 }
 
+
+namespace
+{
+uint32 constexpr INTERLOPED_AURA_ID = 81388;
+uint32 constexpr INTERLOPED_PROC_ID = 81391;
+uint32 constexpr AIMED_SHOT_ID = 20904;
+
+bool IsInterlopedAimedShotProcDebug(Aura const* aura, ProcEventInfo& eventInfo)
+{
+    SpellInfo const* eventSpellInfo = eventInfo.GetSpellInfo();
+    return aura && aura->GetId() == INTERLOPED_AURA_ID && eventSpellInfo && eventSpellInfo->Id == AIMED_SHOT_ID;
+}
+
+Player* GetInterlopedDebugPlayer(AuraApplication const* aurApp, ProcEventInfo& eventInfo)
+{
+    if (aurApp)
+        if (Player* player = aurApp->GetTarget()->ToPlayer())
+            return player;
+
+    if (Unit* actor = eventInfo.GetActor())
+    {
+        if (Player* player = actor->ToPlayer())
+            return player;
+
+        if (Player* owner = actor->GetSpellModOwner())
+            return owner;
+    }
+
+    return nullptr;
+}
+
+void SendInterlopedProcDebug(AuraApplication const* aurApp, ProcEventInfo& eventInfo, char const* reason)
+{
+    if (Player* player = GetInterlopedDebugPlayer(aurApp, eventInfo))
+        if (WorldSession* session = player->GetSession())
+            ChatHandler(session).PSendSysMessage("[Interloped proc debug] %s", reason);
+}
+
+char const* GetInterlopedDbProcFailureReason(SpellProcEntry const& procEntry, ProcEventInfo& eventInfo)
+{
+    if (!(eventInfo.GetTypeMask() & procEntry.ProcFlags))
+        return "spell_proc_event ProcFlags do not match this Aimed Shot proc event type mask";
+
+    if (procEntry.AttributesMask & PROC_ATTR_REQ_EXP_OR_HONOR)
+        if (Player* actor = eventInfo.GetActor()->ToPlayer())
+            if (eventInfo.GetActionTarget() && !actor->isHonorOrXPTarget(eventInfo.GetActionTarget()))
+                return "spell_proc_event requires an honor/XP target and the Aimed Shot target does not qualify";
+
+    if (procEntry.AttributesMask & PROC_ATTR_REQ_MANA_COST)
+        if (SpellInfo const* eventSpellInfo = eventInfo.GetSpellInfo())
+            if (!eventSpellInfo->ManaCost && !eventSpellInfo->ManaCostPercentage)
+                return "spell_proc_event requires a mana cost and this Aimed Shot event reports no mana cost";
+
+    if (eventInfo.GetTypeMask() & (PROC_FLAG_KILLED | PROC_FLAG_KILL | PROC_FLAG_DEATH))
+        return "unknown spell_proc_event mismatch after kill/death checks";
+
+    if (!(procEntry.AttributesMask & PROC_ATTR_TRIGGERED_CAN_PROC) && !(eventInfo.GetTypeMask() & AUTO_ATTACK_PROC_FLAG_MASK))
+    {
+        if (Spell const* spell = eventInfo.GetProcSpell())
+        {
+            if (spell->IsTriggered())
+            {
+                SpellInfo const* spellInfo = spell->GetSpellInfo();
+                if (!spellInfo->HasAttribute(SPELL_ATTR3_TRIGGERED_CAN_TRIGGER_PROC_2) &&
+                    !spellInfo->HasAttribute(SPELL_ATTR2_TRIGGERED_CAN_TRIGGER_PROC))
+                    return "Aimed Shot was a triggered cast and spell_proc_event does not allow triggered casts to proc it";
+            }
+        }
+    }
+
+    if (procEntry.SchoolMask && !(eventInfo.GetSchoolMask() & procEntry.SchoolMask))
+        return "spell_proc_event SchoolMask does not match Aimed Shot school mask";
+
+    if (eventInfo.GetTypeMask() & SPELL_PROC_FLAG_MASK)
+    {
+        if (SpellInfo const* eventSpellInfo = eventInfo.GetSpellInfo())
+            if (!eventSpellInfo->IsAffected(procEntry.SpellFamilyName, procEntry.SpellFamilyMask))
+                return "spell_proc_event spell family name/mask does not match Aimed Shot";
+
+        if (procEntry.SpellTypeMask && !(eventInfo.GetSpellTypeMask() & procEntry.SpellTypeMask))
+            return "spell_proc_event SpellTypeMask does not match this Aimed Shot damage/heal/no-damage event";
+    }
+
+    if (eventInfo.GetTypeMask() & REQ_SPELL_PHASE_PROC_FLAG_MASK)
+        if (!(eventInfo.GetSpellPhaseMask() & procEntry.SpellPhaseMask))
+            return "spell_proc_event SpellPhaseMask does not match this Aimed Shot cast/hit/finish phase";
+
+    if ((eventInfo.GetTypeMask() & TAKEN_HIT_PROC_FLAG_MASK) || ((eventInfo.GetTypeMask() & DONE_HIT_PROC_FLAG_MASK) && !(eventInfo.GetSpellPhaseMask() & PROC_SPELL_PHASE_CAST)))
+    {
+        uint32 hitMask = procEntry.HitMask;
+        if (!hitMask)
+        {
+            if (eventInfo.GetTypeMask() & TAKEN_HIT_PROC_FLAG_MASK)
+                hitMask |= PROC_HIT_NORMAL | PROC_HIT_CRITICAL;
+            else
+                hitMask |= PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_ABSORB;
+        }
+
+        if (!(eventInfo.GetHitMask() & hitMask))
+            return "spell_proc_event HitMask does not match this Aimed Shot hit result (miss/dodge/parry/etc. will not pass a normal/crit-only proc)";
+    }
+
+    return "spell_proc_event filters failed for an unclassified reason";
+}
+}
+
 void Aura::PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInfo, TimePoint now)
 {
     bool prepare = CallScriptPrepareProcHandlers(aurApp, eventInfo);
@@ -2235,25 +2341,50 @@ void Aura::PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInf
 
 uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo, TimePoint now) const
 {
+    bool const interlopedDebug = IsInterlopedAimedShotProcDebug(this, eventInfo);
     SpellProcEntry const* procEntry = sSpellMgr->GetSpellProcEntry(GetId());
     // only auras with spell proc entry can trigger proc
     if (!procEntry)
+    {
+        if (interlopedDebug)
+            SendInterlopedProcDebug(aurApp, eventInfo, "aura 81388 has no spell_proc_event entry, so it cannot proc Interloped 81391");
         return 0;
+    }
+
+    if (interlopedDebug)
+        if (Unit* actor = eventInfo.GetActor())
+            if (Unit* target = eventInfo.GetActionTarget())
+                if (Player* player = GetInterlopedDebugPlayer(aurApp, eventInfo))
+                    if (WorldSession* session = player->GetSession())
+                        ChatHandler(session).PSendSysMessage("[Interloped proc debug] evaluating aura 81388 for Aimed Shot 20904: actor=%s target=%s typeMask=0x%08X spellTypeMask=0x%08X phaseMask=0x%08X hitMask=0x%08X procFlags=0x%08X procSpellType=0x%08X procPhase=0x%08X procHit=0x%08X chance=%.2f ppm=%.2f cooldownMs=%u charges=%u",
+                            actor->GetName().c_str(), target->GetName().c_str(), eventInfo.GetTypeMask(), eventInfo.GetSpellTypeMask(), eventInfo.GetSpellPhaseMask(), eventInfo.GetHitMask(), procEntry->ProcFlags, procEntry->SpellTypeMask, procEntry->SpellPhaseMask, procEntry->HitMask, procEntry->Chance, procEntry->ProcsPerMinute, uint32(procEntry->Cooldown.count()), procEntry->Charges);
 
     // check spell triggering us
     if (Spell const* spell = eventInfo.GetProcSpell())
     {
         // Do not allow auras to proc from effect triggered from itself
         if (spell->IsTriggeredByAura(m_spellInfo))
+        {
+            if (interlopedDebug)
+                SendInterlopedProcDebug(aurApp, eventInfo, "blocked: Aimed Shot proc spell is triggered by aura 81388 itself");
             return 0;
+        }
 
         // check if aura can proc when spell is triggered (exception for hunter auto shot & wands)
         if (spell->IsTriggered() && !(procEntry->AttributesMask & PROC_ATTR_TRIGGERED_CAN_PROC) && !(eventInfo.GetTypeMask() & AUTO_ATTACK_PROC_FLAG_MASK))
             if (!GetSpellInfo()->HasAttribute(SPELL_ATTR3_CAN_PROC_WITH_TRIGGERED))
+            {
+                if (interlopedDebug)
+                    SendInterlopedProcDebug(aurApp, eventInfo, "blocked: Aimed Shot was triggered and aura 81388 is not allowed to proc from triggered spells");
                 return 0;
+            }
 
         if (spell->m_CastItem && (procEntry->AttributesMask & PROC_ATTR_CANT_PROC_FROM_ITEM_CAST))
+        {
+            if (interlopedDebug)
+                SendInterlopedProcDebug(aurApp, eventInfo, "blocked: Aimed Shot was cast from an item and aura 81388 forbids item-cast procs");
             return 0;
+        }
     }
 
     // check don't break stealth attr present
@@ -2261,37 +2392,65 @@ uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo,
     {
         if (SpellInfo const* spellInfo = eventInfo.GetSpellInfo())
             if (spellInfo->HasAttribute(SPELL_ATTR0_CU_DONT_BREAK_STEALTH))
+            {
+                if (interlopedDebug)
+                    SendInterlopedProcDebug(aurApp, eventInfo, "blocked: aura 81388 is a stealth aura and Aimed Shot is flagged not to break stealth");
                 return 0;
+            }
     }
 
     // check if we have charges to proc with
     if (IsUsingCharges())
     {
         if (!GetCharges())
+        {
+            if (interlopedDebug)
+                SendInterlopedProcDebug(aurApp, eventInfo, "blocked: aura 81388 has no proc charges remaining");
             return 0;
+        }
 
         if (procEntry->AttributesMask & PROC_ATTR_REQ_SPELLMOD)
             if (Spell const* spell = eventInfo.GetProcSpell())
                 if (!spell->m_appliedMods.count(const_cast<Aura*>(this)))
+                {
+                    if (interlopedDebug)
+                        SendInterlopedProcDebug(aurApp, eventInfo, "blocked: aura 81388 requires a spellmod and this Aimed Shot did not apply that aura as a spellmod");
                     return 0;
+                }
     }
 
     // check proc cooldown
     if (IsProcOnCooldown(now))
+    {
+        if (interlopedDebug)
+            SendInterlopedProcDebug(aurApp, eventInfo, "blocked: aura 81388 proc is on cooldown");
         return 0;
+    }
 
     // do checks against db data
     if (!SpellMgr::CanSpellTriggerProcOnEvent(*procEntry, eventInfo))
+    {
+        if (interlopedDebug)
+            SendInterlopedProcDebug(aurApp, eventInfo, GetInterlopedDbProcFailureReason(*procEntry, eventInfo));
         return 0;
+    }
 
     // do checks using conditions table
     if (!sConditionMgr->IsObjectMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_SPELL_PROC, GetId(), eventInfo.GetActor(), eventInfo.GetActionTarget()))
+    {
+        if (interlopedDebug)
+            SendInterlopedProcDebug(aurApp, eventInfo, "blocked: conditions table entry for aura 81388 spell proc was not met");
         return 0;
+    }
 
     // AuraScript Hook
     bool check = const_cast<Aura*>(this)->CallScriptCheckProcHandlers(aurApp, eventInfo);
     if (!check)
+    {
+        if (interlopedDebug)
+            SendInterlopedProcDebug(aurApp, eventInfo, "blocked: AuraScript CheckProc handler rejected aura 81388");
         return 0;
+    }
 
     // At least one effect has to pass checks to proc aura
     uint8 procEffectMask = aurApp->GetEffectMask();
@@ -2301,7 +2460,11 @@ uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo,
                 procEffectMask &= ~(1u << i);
 
     if (!procEffectMask)
+    {
+        if (interlopedDebug)
+            SendInterlopedProcDebug(aurApp, eventInfo, "blocked: all aura 81388 effects failed DisableEffectsMask or CheckEffectProc checks");
         return 0;
+    }
 
     /// @todo
     // do allow additional requirements for procs
@@ -2320,7 +2483,11 @@ uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo,
             if (GetSpellInfo()->EquippedItemClass == ITEM_CLASS_WEAPON)
             {
                 if (target->ToPlayer()->IsInFeralForm())
+                {
+                    if (interlopedDebug)
+                        SendInterlopedProcDebug(aurApp, eventInfo, "blocked: passive aura 81388 has weapon requirements but the player is in feral form");
                     return 0;
+                }
 
                 if (DamageInfo const* damageInfo = eventInfo.GetDamageInfo())
                 {
@@ -2345,12 +2512,29 @@ uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo,
             }
 
             if (!item || item->IsBroken() || !item->IsFitToSpellRequirements(GetSpellInfo()))
+            {
+                if (interlopedDebug)
+                    SendInterlopedProcDebug(aurApp, eventInfo, "blocked: equipped item requirement for passive aura 81388 was not met or the required item is broken");
                 return 0;
+            }
         }
     }
 
-    if (roll_chance_f(CalcProcChance(*procEntry, eventInfo)))
+    float const chance = CalcProcChance(*procEntry, eventInfo);
+    double const roll = rand_chance();
+    if (chance > roll)
+    {
+        if (interlopedDebug)
+            if (Player* player = GetInterlopedDebugPlayer(aurApp, eventInfo))
+                if (WorldSession* session = player->GetSession())
+                    ChatHandler(session).PSendSysMessage("[Interloped proc debug] passed: aura 81388 will proc Interloped 81391 (effectMask=0x%02X chance=%.2f roll=%.2f)", procEffectMask, chance, roll);
         return procEffectMask;
+    }
+
+    if (interlopedDebug)
+        if (Player* player = GetInterlopedDebugPlayer(aurApp, eventInfo))
+            if (WorldSession* session = player->GetSession())
+                ChatHandler(session).PSendSysMessage("[Interloped proc debug] blocked: chance roll failed for aura 81388 (chance=%.2f roll=%.2f); Interloped 81391 will not trigger", chance, roll);
 
     return 0;
 }


### PR DESCRIPTION
### Motivation
- Investigate why aura 81388 sometimes fails to proc Interloped (81391) on Aimed Shot (20904) by providing in-game diagnostics to trace which proc checks are rejecting the proc.

### Description
- Add player-facing diagnostic helpers and predicates to identify Interloped (aura 81388 / proc 81391) interactions with Aimed Shot 20904 and a player-lookup helper to route messages to the relevant player's session.
- Instrument `Aura::GetProcEffectMask` to emit system messages for Interloped-specific failures including missing `spell_proc_event`, triggered-cast blocking, item-cast blocking, no charges, proc cooldown, DB filter mismatches, condition checks, AuraScript check failures, effect checks, equipment requirements, and chance-roll pass/fail with the computed chance and RNG roll.
- Instrument `AuraEffect::HandleProc` and `AuraEffect::HandleProcTriggerSpellAuraProc` to report when an OnEffectProc script prevents the trigger, when the trigger spell is missing, and the `CastSpell` result for the Interloped triggered cast.
- Instrument `Unit::TriggerAurasProcOnEvent` to show when an Aimed Shot proc event occurs while aura 81388 is present, logging actor/target masks and damage/heal context.

### Testing
- Ran `git diff --check` to sanity-check changes (no issues reported).
- Compiled the modified files using the repository `compile_commands.json` (targeted compilation of `Unit.cpp`, `SpellAuras.cpp`, and `SpellAuraEffects.cpp` completed successfully).
- Started a full build with `cmake --build build --target game -- -j2`; changed-file compilation progressed successfully but the full rebuild was not waited to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a217ef18850832798b7aa99150d8755)