### PR TITLE
Handle Holy Priest Spirit of Redemption off-GCD via lifecycle fast-path

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3124,8 +3124,6 @@ SpellDecision SelectPriestSpell(Player const* player, Unit const* target, Unit c
     Unit const* fearWardTarget = (player->GetRace() == RACE_DWARF && IsSpellReady(player, 6346)) ? SelectFriendlyMissingBuffTarget(player, 6346, 40.0f) : nullptr;
 
     std::vector<PrioritizedSpellDecision> candidates;
-    AddDecisionCandidate(candidates, isHolyPriest && player->HealthBelowPct(50) && IsSpellReady(player, 81321), 61.0f,
-        { "priest spirit of redemption", "enter spirit of redemption below half health", 81321, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, spiritHealTarget, 60.5f,
         { "priest flash heal", "spam flash heal during spirit of redemption", 10917, spiritHealTarget == player ? playerbot::PvpClassSpellContext::TargetMode::Self : playerbot::PvpClassSpellContext::TargetMode::Ally, spiritHealTarget ? spiritHealTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, fearWardTarget, 60.2f,
@@ -4641,10 +4639,11 @@ PvpClassSpellContext PvpCore::BuildClassSpellContext(Player const* player, PvpVa
         }
     }
 
-    // PvP insignia/class-trinket crowd-control breaks are handled by the
-    // per-player fast path in RandomBotParticipationManager::ProcessPlayerLifecycle.
-    // Keep them out of the normal class-spell decision graph so they are not
-    // throttled by decision cadence and do not consume the class action tick/GCD.
+    // PvP insignia/class-trinket crowd-control breaks and holy-priest Spirit
+    // of Redemption are handled by per-player fast paths in
+    // RandomBotParticipationManager::ProcessPlayerLifecycle. Keep them out of
+    // the normal class-spell decision graph so they are not throttled by
+    // decision cadence and do not consume the class action tick/GCD.
 
     context.shouldExecute = context.shouldExecute || context.spellId != 0;
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -117,6 +117,8 @@ using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 
 constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(1500);
 constexpr std::chrono::milliseconds PlayerbotInsigniaCheckInterval(500);
+constexpr uint32 kPriestSpiritOfRedemptionSpellId = 81321;
+constexpr uint32 kHolyPriestProfileTalentSpellId = 724;
 
 std::unordered_map<uint64, LifecycleCadenceTimePoint> g_NextRandomBotLifecycleProcessTimeByGuid;
 std::mutex g_RandomBotLifecycleCadenceLock;
@@ -248,6 +250,69 @@ uint32 GetFirstOnUseItemSpell(ItemTemplate const* itemTemplate)
     }
 
     return 0;
+}
+
+uint32 ResolveKnownPlayerSpellInChain(Player const* player, uint32 spellId)
+{
+    if (!player || !spellId)
+        return 0;
+
+    SpellInfo const* baseSpellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!baseSpellInfo || !baseSpellInfo->GetFirstRankSpell())
+        return 0;
+
+    uint32 resolvedSpellId = 0;
+    for (uint32 chainSpellId = baseSpellInfo->GetFirstRankSpell()->Id; chainSpellId != 0; chainSpellId = sSpellMgr->GetNextSpellInChain(chainSpellId))
+    {
+        if (player->HasSpell(chainSpellId))
+            resolvedSpellId = chainSpellId;
+    }
+
+    return resolvedSpellId;
+}
+
+bool TryCastPriestSpiritOfRedemption(Player* player)
+{
+    if (!player)
+        return false;
+
+    playerbot::PvpCoreConfig const& config = playerbot::PvpCore::GetConfig();
+    if (!config.moduleEnabled || !config.pvpCoreEnabled || !config.pvpClassSpellsEnabled)
+        return false;
+
+    if (!playerbot::IsManagedRandomBot(player) || !player->IsInWorld() || !player->IsAlive())
+        return false;
+
+    bool const inActiveBattleground = player->InBattleground() &&
+        player->GetBattleground() &&
+        player->GetBattleground()->GetStatus() == STATUS_IN_PROGRESS;
+    bool const inActiveDuel = player->duel && player->duel->State == DUEL_STATE_IN_PROGRESS;
+    if (!inActiveBattleground && !inActiveDuel)
+        return false;
+
+    if (player->GetClass() != CLASS_PRIEST || !player->HealthBelowPct(50))
+        return false;
+
+    if (player->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION))
+        return false;
+
+    uint8 const activeSpec = player->GetActiveSpec();
+    if (!player->HasTalent(kHolyPriestProfileTalentSpellId, activeSpec))
+        return false;
+
+    if (player->IsBeingTeleportedFar() || player->IsBeingTeleportedNear())
+        return false;
+
+    uint32 const spellId = ResolveKnownPlayerSpellInChain(player, kPriestSpiritOfRedemptionSpellId);
+    SpellInfo const* spellInfo = spellId ? sSpellMgr->GetSpellInfo(spellId) : nullptr;
+    if (!spellInfo || player->GetSpellHistory()->HasCooldown(spellId))
+        return false;
+
+    SpellCastResult const castResult = player->CastSpell(player, spellId, CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS)));
+    TC_LOG_DEBUG("playerbots.pvp.class",
+        "Playerbot PvP spirit of redemption fast-path attempt: guid={} spell={} result={}.",
+        player->GetGUID().ToString(), spellId, uint32(castResult));
+    return castResult == SPELL_CAST_OK;
 }
 
 bool TryUseEquippedInsigniaTrinket(Player* player)
@@ -1465,6 +1530,7 @@ void RandomBotParticipationManager::ProcessPlayerLifecycle(Player* player)
     TryReviveManagedBotAfterStartup(player);
     TryFinalizePendingManagedBotTeleport(player);
     TryUsePlayerbotInsigniaBreaker(player);
+    TryCastPriestSpiritOfRedemption(player);
     ProcessActiveBattlegroundTacticalTick(player);
 
     if (!CanProcessPlayerLifecycle(player))


### PR DESCRIPTION
### Motivation
- Prevent Holy priest `Spirit of Redemption` from being subject to PvP decision cadence and global cooldown consumption by moving it out of the regular class-spell decision graph.

### Description
- Remove the Spirit of Redemption candidate from `SelectPriestSpell` in `PlayerbotPvpCore.cpp` so it is no longer selected via the normal decision cadence.
- Add an off-cadence fast-path in `RandomBotParticipationManager::ProcessPlayerLifecycle` by introducing `TryCastPriestSpiritOfRedemption`, constants for the spell and required holy profile talent, and `ResolveKnownPlayerSpellInChain` helper in `PlayerbotRandomBotParticipation.cpp` to resolve ranks and cooldowns before casting with `TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS`.
- Update comments to note that Spirit of Redemption is handled by the per-player lifecycle fast-path (similar to insignia/trinket handling) to avoid throttling and GCD use.

### Testing
- Project full build executed with CMake (`cmake --build build --target game`), compilation completed successfully (warnings only) and no compile errors were introduced.
- `git diff --check` was run and reported no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21793cbfbc8327bb587e698897a4d2)