### PR TITLE
Fix playerbot stationary-cast stop handling and Gurubashi tracked-position compile errors

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -781,7 +781,7 @@ public:
 
             if (tracked.HasPosition)
             {
-                float const distance2d = tracked.Position.GetExactDist2d(currentPosition);
+                float const distance2d = tracked.LastPosition.GetExactDist2d(currentPosition);
                 bool const isTeleportTransition = player->IsBeingTeleported() || tracked.MapId != player->GetMapId() || distance2d > 45.0f;
                 bool const crossedBattleRingBoundary =
                     tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing;
@@ -798,7 +798,7 @@ public:
             }
 
             tracked.AreaState = currentState;
-            tracked.Position = currentPosition;
+            tracked.LastPosition = currentPosition;
             tracked.MapId = player->GetMapId();
             tracked.HasPosition = true;
         }
@@ -814,7 +814,7 @@ private:
     struct TrackedState
     {
         GurubashiAreaState AreaState = GurubashiAreaState::Outside;
-        Position Position;
+        Position LastPosition;
         uint32 MapId = 0;
         bool HasPosition = false;
     };

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -111,7 +111,14 @@ struct LastLosCastFailureState
     float requestedRecoveryRange = 0.0f;
 };
 
+struct StationaryCastStopState
+{
+    uint32 lastStopMs = 0;
+    uint32 stopCount = 0;
+};
+
 std::unordered_map<uint64, LastLosCastFailureState> g_LastLosCastFailureByGuid;
+std::unordered_map<uint64, StationaryCastStopState> g_StationaryCastStopByGuid;
 
 bool IsEffectivelyOutdoors(Player const* player)
 {
@@ -2728,7 +2735,36 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             return false;
         }
 
+        MotionMaster const* motionMaster = player->GetMotionMaster();
+        MovementGeneratorType const motionType = motionMaster ? motionMaster->GetCurrentMovementGeneratorType() : IDLE_MOTION_TYPE;
+        bool const hadActiveMovement = player->isMoving() ||
+            player->HasUnitState(UNIT_STATE_CHASE_MOVE) ||
+            player->HasUnitState(UNIT_STATE_FOLLOW_MOVE) ||
+            motionType == CHASE_MOTION_TYPE ||
+            motionType == FOLLOW_MOTION_TYPE ||
+            (player->movespline && player->movespline->Initialized() && !player->movespline->Finalized());
+
         player->StopMoving();
+
+        if (!isFoodOrDrinkSpell && hadActiveMovement)
+        {
+            uint64 const botKey = player->GetGUID().GetRawValue();
+            StationaryCastStopState& stopState = g_StationaryCastStopByGuid[botKey];
+            uint32 const nowMs = GameTime::GetGameTimeMS();
+            stopState.stopCount = stopState.lastStopMs && nowMs >= stopState.lastStopMs && nowMs - stopState.lastStopMs <= 2000
+                ? std::min<uint32>(stopState.stopCount + 1, 100)
+                : 1;
+            stopState.lastStopMs = nowMs;
+
+            std::ostringstream diag;
+            diag << "stationary_cast_stop"
+                 << " spell=" << resolvedSpellId
+                 << " motion=" << uint32(motionType)
+                 << " active_before_stop=yes"
+                 << " recent_stop_count=" << stopState.stopCount;
+            SetLastMovementDebugStatus(player, diag.str());
+        }
+
         if (WorldSession* session = player->GetSession(); session && session->IsVirtualSession())
         {
             player->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);


### PR DESCRIPTION
### Motivation
- Prevent undefined-symbol compile errors and improve diagnostics when a bot stops moving to cast by recording whether it had active movement before `StopMoving()` and retaining a small stop-history state. 
- Fix a name collision in Gurubashi arena tracking where a member named `Position` conflicted with the `Position` type and caused a compilation failure. 

### Description
- Added a `StationaryCastStopState` struct and a `g_StationaryCastStopByGuid` map to `PlayerbotPvpClassActions.cpp`, and record `hadActiveMovement` (derived from motion state) before calling `player->StopMoving()`. 
- When active movement is detected, increment a recent stop counter and emit a diagnostic string via `SetLastMovementDebugStatus()` to aid debugging of stationary-cast interruptions. 
- Renamed `TrackedState::Position` to `TrackedState::LastPosition` in `custom_gurubashi_arena.cpp` and updated all references to avoid the type/member name collision while preserving the arena exit/enforcer logic. 

### Testing
- Ran `git diff --check` to verify no whitespace/merge artifacts and it completed successfully. 
- Built the Gurubashi script object via `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Custom/custom_gurubashi_arena.cpp.o`, which completed (warnings only) after the fix. 
- Performed a syntax-only compilation of `PlayerbotPvpClassActions.cpp` using the extracted compile flags to validate the new symbols and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2186370e9c8327a876ab5785756db5)