### PR TITLE
Fix Playerbot stationary-cast stop state and Gurubashi compile errors

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -865,7 +865,7 @@ public:
 
             if (tracked.HasPosition)
             {
-                float const distance2d = tracked.Position.GetExactDist2d(currentPosition);
+                float const distance2d = tracked.LastPosition.GetExactDist2d(currentPosition);
                 bool const isTeleportTransition = player->IsBeingTeleported() || tracked.MapId != player->GetMapId() || distance2d > 45.0f;
                 bool const crossedBattleRingBoundary =
                     tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing;
@@ -882,7 +882,7 @@ public:
             }
 
             tracked.AreaState = currentState;
-            tracked.Position = currentPosition;
+            tracked.LastPosition = currentPosition;
             tracked.MapId = player->GetMapId();
             tracked.HasPosition = true;
         }
@@ -898,7 +898,7 @@ private:
     struct TrackedState
     {
         GurubashiAreaState AreaState = GurubashiAreaState::Outside;
-        Position Position;
+        Position LastPosition;
         uint32 MapId = 0;
         bool HasPosition = false;
     };

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -509,6 +509,15 @@ struct TargetRelativeMoveOrderState
 
 std::unordered_map<uint64, TargetRelativeMoveOrderState> g_TargetRelativeMoveOrderByGuid;
 
+struct StationaryCastStopState
+{
+    ObjectGuid targetGuid = ObjectGuid::Empty;
+    uint32 spellId = 0;
+    uint32 stopMs = 0;
+};
+
+std::unordered_map<uint64, StationaryCastStopState> g_StationaryCastStopByGuid;
+
 void RecordTargetRelativeMovementOrder(Player const* player, Unit const* target, float issuedRange, uint8 mode)
 {
     if (!player || !target)
@@ -3242,6 +3251,8 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
             failureReason = "stationary_cast_deferred_for_active_movement";
             return false;
         }
+
+        bool const hadActiveMovement = HasActiveMovementForStationaryCast(player);
 
         // Force the bot into a fully stopped server-side state and attempt the
         // stationary spell in the same decision tick. Non-move-allowed channels


### PR DESCRIPTION
### Motivation
- Restore the stationary-cast stop tracking used by playerbot spell casting so the delayed-stopping logic can compile and behave correctly. 
- Capture whether a bot had active movement before forcing a stop so the existing delay/retry logic still works after `StopPlayerbotForStationaryCast` is called. 
- Resolve a compile-time name collision in the Gurubashi arena script where a struct member named `Position` conflicted with the `Position` type under newer compiler diagnostics. 

### Description
- Add `struct StationaryCastStopState` and the global map `g_StationaryCastStopByGuid` to restore the stationary-cast stop tracking state used by the playerbot cast flow. 
- Record `bool const hadActiveMovement = HasActiveMovementForStationaryCast(player);` before calling `StopPlayerbotForStationaryCast(player)` so the code can make decisions based on pre-stop motion. 
- Rename `TrackedState::Position` to `TrackedState::LastPosition` in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` and update all uses to avoid the identifier/type collision while preserving behavior. 

### Testing
- Ran `git diff --check` to verify there were no obvious diff issues, which passed. 
- Compiled the Gurubashi script object with `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Custom/custom_gurubashi_arena.cpp.o`, which completed successfully. 
- Configured a Playerbot-enabled build and compiled the Playerbot and Gurubashi object files with `ninja -C build-playerbot-ninja src/server/scripts/CMakeFiles/scripts.dir/Playerbot/Pvp/PlayerbotPvpClassActions.cpp.o src/server/scripts/CMakeFiles/scripts.dir/Custom/custom_gurubashi_arena.cpp.o`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2189b50d248327b7d0902577f85330)