### PR TITLE
Set playerbot spell decision cadence to one second

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -115,7 +115,7 @@ bool IsLifecycleGateEnabled()
 using LifecycleCadenceClock = std::chrono::steady_clock;
 using LifecycleCadenceTimePoint = LifecycleCadenceClock::time_point;
 
-constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(1500);
+constexpr std::chrono::milliseconds RandomBotLifecycleCadenceInterval(1000);
 constexpr std::chrono::milliseconds PlayerbotInsigniaCheckInterval(500);
 constexpr uint32 kPriestSpiritOfRedemptionSpellId = 81321;
 constexpr uint32 kHolyPriestProfileTalentSpellId = 724;

--- a/tests/game/PlayerbotRandomPopulation.cpp
+++ b/tests/game/PlayerbotRandomPopulation.cpp
@@ -74,6 +74,14 @@ TEST_CASE("Playerbot battleground queue target remains Warsong", "[playerbot][po
     CHECK(source.find("BATTLEGROUND_WS") != std::string::npos);
 }
 
+TEST_CASE("Playerbot class spell decision cadence is once per second", "[playerbot][pvp]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp");
+    CHECK(source.find("RandomBotLifecycleCadenceInterval(1000)") != std::string::npos);
+    CHECK(source.find("PvpClassSpellContext const classSpellContext = PvpCore::BuildClassSpellContext(player, values)") != std::string::npos);
+    CHECK(source.find("bool const didExecuteClassSpell = PvpClassActions::Execute(player, classSpellContext)") != std::string::npos);
+}
+
 TEST_CASE("Playerbot class spell fallback skips player spell cooldowns during selection", "[playerbot][pvp]")
 {
     std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp");


### PR DESCRIPTION
### Motivation
- Reduce the managed playerbot class-spell decision cadence so spell decisions are evaluated once per second to match the desired faster decision cadence.

### Description
- Change the lifecycle cadence constant `RandomBotLifecycleCadenceInterval` from `1500`ms to `1000`ms in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`.
- Add a source-level regression check in `tests/game/PlayerbotRandomPopulation.cpp` that asserts the cadence constant and verifies the class spell decision execution path is present.

### Testing
- Ran a `python3` assertion script that verifies the updated `RandomBotLifecycleCadenceInterval(1000)` and the presence of the class spell decision execution lines, and it passed.
- Ran `git diff --check` to validate there are no whitespace/errors in the diff and it passed; an attempted full `cmake --build` was started but intentionally stopped due to a large rebuild in the existing build tree, so full binary/unit test execution was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a9329f4883278f3cd5ac145e8958)