### PR TITLE
Prevent Hunter's Mark and non-fire totems from starting combat

### DIFF
--- a/src/server/game/Entities/Totem/Totem.h
+++ b/src/server/game/Entities/Totem/Totem.h
@@ -48,6 +48,7 @@ class TC_GAME_API Totem : public Minion
         uint32 GetTotemDuration() const { return m_duration; }
         void SetTotemDuration(uint32 duration) { m_duration = duration; }
         TotemType GetTotemType() const { return m_type; }
+        bool IsFireTotem() const { return m_Properties && m_Properties->Slot == SUMMON_SLOT_TOTEM_FIRE; }
 
         bool UpdateStats(Stats /*stat*/) override { return true; }
         bool UpdateAllStats() override { return true; }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -57,6 +57,7 @@
 #include "SpellPackets.h"
 #include "SpellScript.h"
 #include "TemporarySummon.h"
+#include "Totem.h"
 #include "TradeData.h"
 #include "Unit.h"
 #include "UpdateData.h"
@@ -148,6 +149,61 @@ namespace
             message << "[Trap Debug] " << spellName << " (" << spellInfo->Id << ") failed for " << targetName << ": " << resultText << ".";
 
         sWorld->SendServerMessage(SERVER_MSG_STRING, message.str(), ownerPlayer);
+    }
+
+
+    bool IsHuntersMark(SpellInfo const* spellInfo)
+    {
+        return spellInfo && spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER && (spellInfo->SpellFamilyFlags[0] & 0x400) && spellInfo->SpellIconID == 538;
+    }
+
+    bool IsNoCombatSpell(SpellInfo const* spellInfo)
+    {
+        if (!spellInfo)
+            return false;
+
+        switch (spellInfo->Id)
+        {
+            // Freezing/Frost traps and Earthbind Totem do not put the caster in combat.
+            case 14309:
+            case 14308:
+            case 3355:
+            case 13810:
+            case 63487:
+            case 67035:
+            case 72216:
+            case 19185:
+            case 3600:
+            case 6474:
+                return true;
+            default:
+                break;
+        }
+
+        return IsHuntersMark(spellInfo);
+    }
+
+    bool ShouldTotemSpellStartCombat(Unit const* unit)
+    {
+        if (!unit || !unit->IsTotem())
+            return true;
+
+        return unit->ToTotem()->IsFireTotem();
+    }
+
+    bool ShouldSpellStartCombat(SpellInfo const* spellInfo, Unit const* originalCaster, WorldObject const* caster)
+    {
+        if (IsNoCombatSpell(spellInfo))
+            return false;
+
+        if (!ShouldTotemSpellStartCombat(originalCaster))
+            return false;
+
+        Unit const* casterUnit = caster ? caster->ToUnit() : nullptr;
+        if (casterUnit != originalCaster && !ShouldTotemSpellStartCombat(casterUnit))
+            return false;
+
+        return true;
     }
 
     bool IsVanishProtectedInFlightSpell(Spell const* spell, Unit const* target)
@@ -2496,12 +2552,8 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
     else if (MissCondition == SPELL_MISS_REFLECT && ReflectResult == SPELL_MISS_NONE)
         _spellHitTarget = spell->m_caster->ToUnit();
 
-    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()) && !spell->m_spellInfo->IsMindVision())
-    {
-        if(spell->m_spellInfo->Id != 14309 && spell->m_spellInfo->Id != 14308 && spell->m_spellInfo->Id != 3355 && spell->m_spellInfo->Id != 13810 && spell->m_spellInfo->Id != 63487 && spell->m_spellInfo->Id != 67035
-            && spell->m_spellInfo->Id != 72216 && spell->m_spellInfo->Id != 19185 && spell->m_spellInfo->Id != 3600 && spell->m_spellInfo->Id != 6474) // freezing/frost traps and Earthbind Totem don't put you in combat
-            unit->SetInCombatWith(spell->m_originalCaster);
-    }
+    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()) && !spell->m_spellInfo->IsMindVision() && ShouldSpellStartCombat(spell->m_spellInfo, spell->m_originalCaster, spell->m_caster))
+        unit->SetInCombatWith(spell->m_originalCaster);
 
     bool reportedNaturesGraspFailure = false;
     if (MissCondition != SPELL_MISS_NONE)
@@ -8177,9 +8229,7 @@ void Spell::PreprocessSpellLaunch(TargetInfo& targetInfo)
         return;
 
     // This will only cause combat - the target will engage once the projectile hits (in Spell::TargetInfo::PreprocessTarget)
-    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()) && !m_spellInfo->IsMindVision()
-        && (m_spellInfo->Id != 14309 && m_spellInfo->Id != 14308 && m_spellInfo->Id != 3355 && m_spellInfo->Id != 13810 && m_spellInfo->Id != 63487 && m_spellInfo->Id != 67035 && m_spellInfo->Id != 72216 && m_spellInfo->Id != 19185
-            && m_spellInfo->Id != 3600 && m_spellInfo->Id != 6474)) //freezing/frost traps and Earthbind Totem don't put you in combat
+    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()) && !m_spellInfo->IsMindVision() && ShouldSpellStartCombat(m_spellInfo, m_originalCaster, m_caster))
         m_originalCaster->SetInCombatWith(targetUnit, true);
 
     Unit* unit = nullptr;


### PR DESCRIPTION
### Motivation
- Hunters' mark and many shaman totem spells were placing players or owners into combat via the spell combat-start path when they should not. 
- The goal is to preserve fire totem (searing/magma/fire nova) and explicit totem kill behavior while blocking non-combat auras/marks from triggering combat.

### Description
- Added `bool IsFireTotem() const` to `Totem` in `src/server/game/Entities/Totem/Totem.h` to identify fire totems at runtime.
- Introduced centralized helpers in `src/server/game/Spells/Spell.cpp`: `IsHuntersMark`, `IsNoCombatSpell`, `ShouldTotemSpellStartCombat`, and `ShouldSpellStartCombat` to encapsulate the combat-start exceptions and totem logic. 
- Replaced scattered ad-hoc spell-ID checks with `ShouldSpellStartCombat(...)` in both `Spell::TargetInfo::PreprocessTarget` and `Spell::PreprocessSpellLaunch` so Hunter's Mark and non-fire totem spells no longer set combat state, while fire totems and existing trap/Earthbind exceptions remain allowed.
- Added `#include "Totem.h"` to `Spell.cpp` and adjusted the logic to validate both `m_originalCaster` and the actual `caster` when deciding whether a spell should start combat.

### Testing
- Ran `git diff --check` which produced no whitespace or trivial diff warnings and reported the changes; it succeeded.
- Built the game target with `cmake --build build --target game -- -j2`, which completed successfully and produced `libgame.a` (full build logs captured); the build succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22423a3e84832782c4763930f2c429)