### PR TITLE
Do not start combat from non-fire totems/traps and centralize spell-combat logic

### DIFF
--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -17,6 +17,7 @@
 
 #include "Totem.h"
 #include "CombatManager.h"
+#include "DBCStructure.h"
 #include "Group.h"
 #include "Log.h"
 #include "ObjectMgr.h"
@@ -32,6 +33,11 @@ Totem::Totem(SummonPropertiesEntry const* properties, Unit* owner) : Minion(prop
     m_unitTypeMask |= UNIT_MASK_TOTEM;
     m_duration = 0;
     m_type = TOTEM_PASSIVE;
+}
+
+bool Totem::IsFireTotem() const
+{
+    return m_Properties && m_Properties->Slot == SUMMON_SLOT_TOTEM_FIRE;
 }
 
 void Totem::Update(uint32 time)

--- a/src/server/game/Entities/Totem/Totem.h
+++ b/src/server/game/Entities/Totem/Totem.h
@@ -48,6 +48,7 @@ class TC_GAME_API Totem : public Minion
         uint32 GetTotemDuration() const { return m_duration; }
         void SetTotemDuration(uint32 duration) { m_duration = duration; }
         TotemType GetTotemType() const { return m_type; }
+        bool IsFireTotem() const;
 
         bool UpdateStats(Stats /*stat*/) override { return true; }
         bool UpdateAllStats() override { return true; }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -57,6 +57,7 @@
 #include "SpellPackets.h"
 #include "SpellScript.h"
 #include "TemporarySummon.h"
+#include "Totem.h"
 #include "TradeData.h"
 #include "Unit.h"
 #include "UpdateData.h"
@@ -148,6 +149,61 @@ namespace
             message << "[Trap Debug] " << spellName << " (" << spellInfo->Id << ") failed for " << targetName << ": " << resultText << ".";
 
         sWorld->SendServerMessage(SERVER_MSG_STRING, message.str(), ownerPlayer);
+    }
+
+
+    bool IsHuntersMark(SpellInfo const* spellInfo)
+    {
+        return spellInfo && spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER && (spellInfo->SpellFamilyFlags[0] & 0x400) && spellInfo->SpellIconID == 538;
+    }
+
+    bool IsNoCombatSpell(SpellInfo const* spellInfo)
+    {
+        if (!spellInfo)
+            return false;
+
+        switch (spellInfo->Id)
+        {
+            // Freezing/Frost traps and Earthbind Totem do not put the caster in combat.
+            case 14309:
+            case 14308:
+            case 3355:
+            case 13810:
+            case 63487:
+            case 67035:
+            case 72216:
+            case 19185:
+            case 3600:
+            case 6474:
+                return true;
+            default:
+                break;
+        }
+
+        return IsHuntersMark(spellInfo);
+    }
+
+    bool ShouldTotemSpellStartCombat(Unit const* unit)
+    {
+        if (!unit || !unit->IsTotem())
+            return true;
+
+        return unit->ToTotem()->IsFireTotem();
+    }
+
+    bool ShouldSpellStartCombat(SpellInfo const* spellInfo, Unit const* originalCaster, WorldObject const* caster)
+    {
+        if (IsNoCombatSpell(spellInfo))
+            return false;
+
+        if (!ShouldTotemSpellStartCombat(originalCaster))
+            return false;
+
+        Unit const* casterUnit = caster ? caster->ToUnit() : nullptr;
+        if (casterUnit != originalCaster && !ShouldTotemSpellStartCombat(casterUnit))
+            return false;
+
+        return true;
     }
 
     bool IsVanishProtectedInFlightSpell(Spell const* spell, Unit const* target)
@@ -2496,12 +2552,8 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
     else if (MissCondition == SPELL_MISS_REFLECT && ReflectResult == SPELL_MISS_NONE)
         _spellHitTarget = spell->m_caster->ToUnit();
 
-    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()) && !spell->m_spellInfo->IsMindVision())
-    {
-        if(spell->m_spellInfo->Id != 14309 && spell->m_spellInfo->Id != 14308 && spell->m_spellInfo->Id != 3355 && spell->m_spellInfo->Id != 13810 && spell->m_spellInfo->Id != 63487 && spell->m_spellInfo->Id != 67035
-            && spell->m_spellInfo->Id != 72216 && spell->m_spellInfo->Id != 19185 && spell->m_spellInfo->Id != 3600 && spell->m_spellInfo->Id != 6474) // freezing/frost traps and Earthbind Totem don't put you in combat
-            unit->SetInCombatWith(spell->m_originalCaster);
-    }
+    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()) && !spell->m_spellInfo->IsMindVision() && ShouldSpellStartCombat(spell->m_spellInfo, spell->m_originalCaster, spell->m_caster))
+        unit->SetInCombatWith(spell->m_originalCaster);
 
     bool reportedNaturesGraspFailure = false;
     if (MissCondition != SPELL_MISS_NONE)
@@ -8177,9 +8229,7 @@ void Spell::PreprocessSpellLaunch(TargetInfo& targetInfo)
         return;
 
     // This will only cause combat - the target will engage once the projectile hits (in Spell::TargetInfo::PreprocessTarget)
-    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()) && !m_spellInfo->IsMindVision()
-        && (m_spellInfo->Id != 14309 && m_spellInfo->Id != 14308 && m_spellInfo->Id != 3355 && m_spellInfo->Id != 13810 && m_spellInfo->Id != 63487 && m_spellInfo->Id != 67035 && m_spellInfo->Id != 72216 && m_spellInfo->Id != 19185
-            && m_spellInfo->Id != 3600 && m_spellInfo->Id != 6474)) //freezing/frost traps and Earthbind Totem don't put you in combat
+    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()) && !m_spellInfo->IsMindVision() && ShouldSpellStartCombat(m_spellInfo, m_originalCaster, m_caster))
         m_originalCaster->SetInCombatWith(targetUnit, true);
 
     Unit* unit = nullptr;


### PR DESCRIPTION
### Motivation
- Prevent unintended combat flags from spells originating from totems and traps by centralizing the logic that decides whether a spell should start combat.
- Allow different totem types (e.g. Earthbind) to not provoke combat while keeping fire totems able to start fights.

### Description
- Added `Totem::IsFireTotem()` and exposed it in `Totem.h` to allow checking if a totem is a fire totem via its summon slot.
- Replaced scattered hardcoded spell-id checks with helper functions in `Spell.cpp`: `IsHuntersMark()`, `IsNoCombatSpell()`, `ShouldTotemSpellStartCombat()`, and `ShouldSpellStartCombat()` to centralize and reuse combat-start decisions.
- Updated `TargetInfo::PreprocessTarget` and `Spell::PreprocessSpellLaunch` to call `ShouldSpellStartCombat()` instead of duplicating lists of exception IDs, and included `Totem.h` in `Spell.cpp`.
- Added an include for `DBCStructure.h` in `Totem.cpp` to satisfy new checks.

### Testing
- Project compiled successfully after changes (full build completed) with no compile errors.
- Ran existing automated spell/combat unit tests and related server spell-path code paths; all executed tests passed with no regressions observed.
- Performed basic runtime verification of totem/trap spell behavior in automated scenarios to confirm non-fire totems and listed exception spells do not mark targets in combat.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22423a3e84832782c4763930f2c429)