### PR TITLE
Dismount when client begins swimming and refine water aura handling

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3527,17 +3527,20 @@ void Unit::ProcessTerrainStatusUpdate(ZLiquidStatus /*oldLiquidStatus*/, Optiona
 
         // Scarlet Chapel and Ruins of Lordaeron's water are part of intended
         // PvP pathing and should never force players out of mounts or Travel
-        // Form. Everywhere else, mounts are handled explicitly on full
-        // submersion so shallow water does not dismount players before they
-        // transition from walking to swimming.
-        if (!ShouldPreserveMountInWaterForBattleground(player))
+        // Form. Everywhere else, shallow water should not dismount players
+        // while they can still walk, but once the client transitions to
+        // swimming the mounted state must be cleared even if the map liquid
+        // height has not crossed the stricter underwater threshold for the
+        // current collision height.
+        bool const shouldDismount = !ShouldPreserveMountInWaterForBattleground(player) &&
+            (IsUnderWater() || HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING));
+        if (shouldDismount)
         {
-            bool const underwater = IsUnderWater();
-            if (underwater)
-                RemoveAurasByType(SPELL_AURA_MOUNTED);
-
-            RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_ABOVEWATER, 0, !underwater);
+            Dismount();
+            RemoveAurasByType(SPELL_AURA_MOUNTED);
         }
+
+        RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_ABOVEWATER, 0, !shouldDismount);
     }
     else
         RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_NOT_UNDERWATER);


### PR DESCRIPTION
### Motivation

- Ensure mounted players are correctly dismounted when the client transitions to swimming even if the map liquid height hasn't reached the stricter underwater collision threshold. 
- Preserve mount behavior for specific battlegrounds while avoiding incorrect retention of mounted state when the player is flagged as swimming.

### Description

- Added a `shouldDismount` check that dismounts when the player is either `IsUnderWater()` or has the `MOVEMENTFLAG_SWIMMING` flag, and only if the battleground exception does not apply (`ShouldPreserveMountInWaterForBattleground`).
- Call `Dismount()` before removing mount auras and then remove `SPELL_AURA_MOUNTED` to ensure the server and client states stay consistent.
- Adjusted `RemoveAurasWithInterruptFlags` to use the computed `shouldDismount` value for correct above-/underwater interrupt behavior.
- Clarified comments to explain why shallow water shouldn't dismount players during walk->swim transitions but the mounted state must be cleared when the client switches to swimming.

### Testing

- Built the server binary after the change with a full compile; the build completed successfully.
- Ran the server automated unit test suite related to movement and aura handling; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232c5c10648327b28d283af764e2e6)