### PR TITLE
PvP: Stealth-aware racials, mount/prep logic, and pet/buff prep enhancements

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -78,6 +78,8 @@ constexpr uint32 kWandShootSpellId = 5019;
 constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
 constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 constexpr uint32 kDruidCasterFaerieFireSpellId = 9907;
+constexpr uint32 kDruidThornsSpellId = 9910;
+constexpr uint32 kDruidMassThornsSpellId = 89762;
 constexpr uint32 kPriestWeakenedSoulSpellId = 6788;
 constexpr uint32 kPriestShadowWordPainSpellId = 589;
 constexpr uint32 kMageManaRubyUseSpellId = 22044;
@@ -932,6 +934,12 @@ SpellDecision SelectRacialSpell(Player const* player, Unit const* target, Unit c
     if (!player || !player->IsAlive())
         return {};
 
+    // Avoid breaking rogue/druid stealth openers or Shadowmeld recovery windows
+    // with racial utility. Stealthed bots should commit to their opener instead
+    // of spending a racial before they engage.
+    if (player->HasStealthAura())
+        return {};
+
     switch (player->GetRace())
     {
         case RACE_ORC:
@@ -1750,24 +1758,28 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     if (inArenaMap || inActiveDuel)
         return decision;
 
-    if (inBattlegroundPreparation)
-        return decision;
-
     if (!IsStrictlyOutdoorsForMount(player))
         return decision;
 
-    // Keep pressure logic responsive: don't choose an out-of-combat mount
-    // action while hostile players are already within practical engage range.
-    if (!player->InBattleground() && HasNearbyAttackableEnemyPlayer(player, 45.0f))
+    // During battleground preparation this selector only runs after
+    // SelectPreparationBuffSpell() has no pet/buff actions left. At that point,
+    // mount if the starting area is a legal outdoor mount location so bots are
+    // ready to move as soon as the gates open.
+    char const* mountReason = inBattlegroundPreparation ? "mount during preparation after prep actions" : "mount while outside and out of combat";
+
+    // Keep pressure logic responsive outside the prep phase: don't choose an
+    // out-of-combat mount action while hostile players are already within
+    // practical engage range.
+    if (!inBattlegroundPreparation && !player->InBattleground() && HasNearbyAttackableEnemyPlayer(player, 45.0f))
         return decision;
 
     if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
         if (SpellInfo const* defaultMountInfo = sSpellMgr->GetSpellInfo(SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
             if (CanAttemptMount(player, defaultMountInfo))
-                return { "mount", "mount while outside and out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
+                return { "mount", mountReason, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
 
     if (uint32 const knownMountSpellId = SelectReadyKnownMountSpell(player))
-        return { "mount", "mount while outside and out of combat", knownMountSpellId, playerbot::PvpClassSpellContext::TargetMode::Self };
+        return { "mount", mountReason, knownMountSpellId, playerbot::PvpClassSpellContext::TargetMode::Self };
 
     return decision;
 }
@@ -1985,15 +1997,31 @@ SpellDecision SelectPreparationBuffSpell(Player const* player)
 
             break;
         }
+        case CLASS_HUNTER:
+        {
+            HunterPetDecisionState const petState = GetHunterPetDecisionState(player);
+            bool const hasDeadPet = petState.hasDeadPet || petState.shouldRevivePet;
+            if (hasDeadPet &&
+                !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, kHunterRevivePetSpellId) &&
+                IsSpellReady(player, kHunterRevivePetSpellId))
+                return { "hunter revive pet prep", "revive dead hunter pet before gates open", kHunterRevivePetSpellId, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
+
+            if (!petState.hasLivingPet && !hasDeadPet && petState.canCallPet &&
+                !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, kHunterCallPetSpellId) &&
+                IsSpellReady(player, kHunterCallPetSpellId))
+                return { "hunter call pet prep", "call active stable pet before gates open", kHunterCallPetSpellId, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
+
+            break;
+        }
         case CLASS_DRUID:
         {
             if (IsSpellReady(player, 21850) && !HasAuraFromSpellChain(player, 21850))
                 return { "druid gift of the wild prep", "apply raid-wide stat buff before gates open", 21850, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
 
-            if (IsSpellReady(player, 9910))
+            if (IsSpellReady(player, kDruidMassThornsSpellId))
             {
-                if (ObjectGuid targetGuid = SelectFriendlyWithoutAuraFromSpellChain(player, 9910, 45.0f, true); !targetGuid.IsEmpty())
-                    return { "druid thorns prep", "apply thorns to nearby allies before gates open", 9910, playerbot::PvpClassSpellContext::TargetMode::Ally, targetGuid };
+                if (ObjectGuid targetGuid = SelectFriendlyWithoutAuraFromSpellChain(player, kDruidThornsSpellId, 45.0f, true); !targetGuid.IsEmpty())
+                    return { "druid mass thorns prep", "apply mass thorns to nearby allies before gates open", kDruidMassThornsSpellId, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
             }
 
             break;
@@ -2031,6 +2059,20 @@ SpellDecision SelectPreparationBuffSpell(Player const* player)
                 if (ObjectGuid targetGuid = SelectFriendlyWithoutAuraFromSpellChain(player, 25898, 45.0f, true); !targetGuid.IsEmpty())
                     return { "paladin greater blessing of kings prep", "buff nearby team before gates open", 25898, playerbot::PvpClassSpellContext::TargetMode::Ally, targetGuid };
             }
+
+            break;
+        }
+        case CLASS_WARLOCK:
+        {
+            Pet const* pet = player->GetPet();
+            if (pet && pet->IsAlive())
+                break;
+
+            ClassicProfileSelection const profileSelection = DetectClassicClassProfile(player);
+            bool const isAfflictionWarlock = profileSelection.profile == ClassicClassProfile::PrimaryClassic;
+            uint32 const summonPetSpell = isAfflictionWarlock ? 691 : 697;
+            if (IsSpellReady(player, summonPetSpell))
+                return { isAfflictionWarlock ? "warlock summon felhunter prep" : "warlock summon voidwalker prep", isAfflictionWarlock ? "summon felhunter before gates open" : "summon voidwalker before gates open", summonPetSpell, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
 
             break;
         }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -247,6 +247,9 @@ bool TryCastHumanInsigniaRacial(Player* player)
     if (!spellId || !player->HasSpell(spellId))
         return false;
 
+    if (player->HasStealthAura())
+        return false;
+
     SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
     if (!spellInfo || player->GetSpellHistory()->HasCooldown(spellId))
         return false;


### PR DESCRIPTION
### Motivation
- Prevent racial or item usage from breaking stealth openers or Shadowmeld recovery windows. 
- Make out-of-combat mount selection respect battleground preparation and provide clearer mount reasoning. 
- Ensure class-specific preparation actions (hunter pet, warlock summon, druid mass thorns) execute before gates open to improve start-of-battle readiness.

### Description
- Added druid spell constants `kDruidThornsSpellId` and `kDruidMassThornsSpellId` and updated related prep logic to use the mass-thorns spell. 
- Avoid using racial utilities while the bot has a stealth aura by checking `player->HasStealthAura()` in `SelectRacialSpell` and `TryCastHumanInsigniaRacial`. 
- Refined out-of-combat mount selection in `SelectOutOfCombatEatDrinkOrMountSpell` to allow mounting during battleground preparation, add a descriptive `mountReason`, and keep mount pressure logic for non-prep scenarios. 
- Added hunter pre-battle actions to `SelectPreparationBuffSpell` to call or revive pets using configured spell IDs (`kHunterCallPetSpellId` / `kHunterRevivePetSpellId`) with cooldown checks. 
- Added druid pre-battle mass thorns application using the mass-thorns spell and adjusted the target selection accordingly. 
- Added warlock pre-battle summon logic to auto-summon a `felhunter` or `voidwalker` based on classic profile detection. 

### Testing
- Project compiled successfully after changes. 
- Ran the project's automated unit test suite and PvP-related tests, and they completed without failures. 
- Static analysis / CI checks were executed and reported no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232e0fe39c832798941f12f8053ae5)