### PR TITLE
Improve playerbot mount/prepare logic and add stealth/pet/spell safeguards

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -3951,11 +3951,11 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
         failureReason = "controlled_cannot_mount";
         return false;
     }
-    if (isMountSpell && !IsStrictlyOutdoorsForMount(player))
+    if (isMountSpell && spellInfo->HasAttribute(SPELL_ATTR0_OUTDOORS_ONLY) && !player->IsOutdoors())
     {
-        // Enforce indoor mount denial server-side for virtual bot casters.
-        // Mount selection already prefers outdoors, but execution must also
-        // gate this so stale context cannot cast mounts while indoors.
+        // Match Spell::CheckCast's outdoors-only rule without adding extra
+        // terrain-status restrictions that can falsely block custom/playerbot
+        // mounts in battleground prep rooms where mounting is otherwise legal.
         failureReason = "indoors_cannot_mount";
         return false;
     }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -78,6 +78,8 @@ constexpr uint32 kWandShootSpellId = 5019;
 constexpr uint32 kPlayerbotDispelCooldownToken = 900004;
 constexpr uint32 kPlayerbotHandOfSacrificeCooldownToken = 900005;
 constexpr uint32 kDruidCasterFaerieFireSpellId = 9907;
+constexpr uint32 kDruidThornsSpellId = 9910;
+constexpr uint32 kDruidMassThornsSpellId = 89762;
 constexpr uint32 kPriestWeakenedSoulSpellId = 6788;
 constexpr uint32 kPriestShadowWordPainSpellId = 589;
 constexpr uint32 kMageManaRubyUseSpellId = 22044;
@@ -932,6 +934,12 @@ SpellDecision SelectRacialSpell(Player const* player, Unit const* target, Unit c
     if (!player || !player->IsAlive())
         return {};
 
+    // Avoid breaking rogue/druid stealth openers or Shadowmeld recovery windows
+    // with racial utility. Stealthed bots should commit to their opener instead
+    // of spending a racial before they engage.
+    if (player->HasStealthAura())
+        return {};
+
     switch (player->GetRace())
     {
         case RACE_ORC:
@@ -1603,6 +1611,17 @@ bool CanAttemptMount(Player const* player, SpellInfo const* mountSpellInfo)
     return allowMount || mountSpellInfo->AreaGroupId;
 }
 
+bool CanCastMountSpellAtCurrentLocation(Player const* player, SpellInfo const* mountSpellInfo)
+{
+    if (!CanAttemptMount(player, mountSpellInfo))
+        return false;
+
+    // Let custom/playerbot mount spells that do not carry the outdoors-only
+    // attribute work in battleground prep rooms where the map permits mounting.
+    // Regular mounts still honor Spell::CheckCast's outdoors-only requirement.
+    return !mountSpellInfo->HasAttribute(SPELL_ATTR0_OUTDOORS_ONLY) || player->IsOutdoors();
+}
+
 bool IsHardControlled(Player const* player)
 {
     if (!player)
@@ -1633,13 +1652,33 @@ uint32 SelectReadyKnownMountSpell(Player const* player)
             continue;
         if (!IsSpellReady(player, spellId))
             continue;
-        if (!CanAttemptMount(player, spellInfo))
+        if (!CanCastMountSpellAtCurrentLocation(player, spellInfo))
             continue;
 
         return spellId;
     }
 
     return 0;
+}
+
+SpellDecision SelectMountSpell(Player const* player, char const* reason)
+{
+    SpellDecision decision;
+    if (!player || !player->IsAlive() || player->IsInCombat() || player->IsMounted())
+        return decision;
+
+    if (IsHardControlled(player))
+        return decision;
+
+    if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
+        if (SpellInfo const* defaultMountInfo = sSpellMgr->GetSpellInfo(SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
+            if (CanCastMountSpellAtCurrentLocation(player, defaultMountInfo))
+                return { "mount", reason, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
+
+    if (uint32 const knownMountSpellId = SelectReadyKnownMountSpell(player))
+        return { "mount", reason, knownMountSpellId, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
+
+    return decision;
 }
 
 SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
@@ -1750,26 +1789,19 @@ SpellDecision SelectOutOfCombatEatDrinkOrMountSpell(Player const* player)
     if (inArenaMap || inActiveDuel)
         return decision;
 
-    if (inBattlegroundPreparation)
+    // During battleground preparation this selector only runs after
+    // SelectPreparationBuffSpell() has no pet/buff actions left. At that point,
+    // mount if the current spot is legal for the selected mount spell so bots
+    // are ready to move as soon as the gates open.
+    char const* mountReason = inBattlegroundPreparation ? "mount during preparation after prep actions" : "mount while out of combat";
+
+    // Keep pressure logic responsive outside the prep phase: don't choose an
+    // out-of-combat mount action while hostile players are already within
+    // practical engage range.
+    if (!inBattlegroundPreparation && !player->InBattleground() && HasNearbyAttackableEnemyPlayer(player, 45.0f))
         return decision;
 
-    if (!IsStrictlyOutdoorsForMount(player))
-        return decision;
-
-    // Keep pressure logic responsive: don't choose an out-of-combat mount
-    // action while hostile players are already within practical engage range.
-    if (!player->InBattleground() && HasNearbyAttackableEnemyPlayer(player, 45.0f))
-        return decision;
-
-    if (IsSpellReady(player, SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
-        if (SpellInfo const* defaultMountInfo = sSpellMgr->GetSpellInfo(SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT))
-            if (CanAttemptMount(player, defaultMountInfo))
-                return { "mount", "mount while outside and out of combat", SPELL_PLAYERBOT_OUT_OF_COMBAT_MOUNT, playerbot::PvpClassSpellContext::TargetMode::Self };
-
-    if (uint32 const knownMountSpellId = SelectReadyKnownMountSpell(player))
-        return { "mount", "mount while outside and out of combat", knownMountSpellId, playerbot::PvpClassSpellContext::TargetMode::Self };
-
-    return decision;
+    return SelectMountSpell(player, mountReason);
 }
 
 bool HasHostileTarget(Player const* player, Unit const* target)
@@ -1877,6 +1909,15 @@ bool HasAuraFromSpellChain(Unit const* unit, uint32 baseSpellId, ObjectGuid cast
     return false;
 }
 
+bool HasAnyAuraFromSpellChain(Unit const* unit, std::initializer_list<uint32> baseSpellIds)
+{
+    for (uint32 baseSpellId : baseSpellIds)
+        if (HasAuraFromSpellChain(unit, baseSpellId))
+            return true;
+
+    return false;
+}
+
 bool HasHunterStingFromCaster(Unit const* unit, ObjectGuid casterGuid)
 {
     return HasAuraFromSpellChain(unit, 25295, casterGuid) || // Serpent Sting
@@ -1947,6 +1988,48 @@ ObjectGuid SelectFriendlyWithoutAuraFromSpellChain(Player const* player, uint32 
     return bestTarget ? bestTarget->GetGUID() : ObjectGuid::Empty;
 }
 
+ObjectGuid SelectFriendlyWithoutAnyAuraFromSpellChain(Player const* player, std::initializer_list<uint32> baseSpellIds, float maxDistance, bool includeSelf)
+{
+    if (!player || !player->FindMap() || baseSpellIds.size() == 0)
+        return ObjectGuid::Empty;
+
+    auto isEligible = [&](Player* candidate)
+    {
+        if (!candidate || !candidate->IsAlive())
+            return false;
+        if (!IsFriendlySupportTarget(player, candidate))
+            return false;
+        if (!player->IsWithinLOSInMap(candidate) || !player->IsWithinDistInMap(candidate, maxDistance))
+            return false;
+        if (HasAnyAuraFromSpellChain(candidate, baseSpellIds))
+            return false;
+
+        return true;
+    };
+
+    if (includeSelf && isEligible(const_cast<Player*>(player)))
+        return player->GetGUID();
+
+    Player* bestTarget = nullptr;
+    float bestDistance = std::numeric_limits<float>::max();
+    Map::PlayerList const& mapPlayers = player->FindMap()->GetPlayers();
+    for (Map::PlayerList::const_iterator itr = mapPlayers.begin(); itr != mapPlayers.end(); ++itr)
+    {
+        Player* candidate = itr->GetSource();
+        if (!isEligible(candidate))
+            continue;
+
+        float const distance = player->GetDistance(candidate);
+        if (distance < bestDistance)
+        {
+            bestDistance = distance;
+            bestTarget = candidate;
+        }
+    }
+
+    return bestTarget ? bestTarget->GetGUID() : ObjectGuid::Empty;
+}
+
 SpellDecision SelectPreparationBuffSpell(Player const* player)
 {
     SpellDecision decision;
@@ -1985,15 +2068,31 @@ SpellDecision SelectPreparationBuffSpell(Player const* player)
 
             break;
         }
+        case CLASS_HUNTER:
+        {
+            HunterPetDecisionState const petState = GetHunterPetDecisionState(player);
+            bool const hasDeadPet = petState.hasDeadPet || petState.shouldRevivePet;
+            if (hasDeadPet &&
+                !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, kHunterRevivePetSpellId) &&
+                IsSpellReady(player, kHunterRevivePetSpellId))
+                return { "hunter revive pet prep", "revive dead hunter pet before gates open", kHunterRevivePetSpellId, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
+
+            if (!petState.hasLivingPet && !hasDeadPet && petState.canCallPet &&
+                !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, kHunterCallPetSpellId) &&
+                IsSpellReady(player, kHunterCallPetSpellId))
+                return { "hunter call pet prep", "call active stable pet before gates open", kHunterCallPetSpellId, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
+
+            break;
+        }
         case CLASS_DRUID:
         {
             if (IsSpellReady(player, 21850) && !HasAuraFromSpellChain(player, 21850))
                 return { "druid gift of the wild prep", "apply raid-wide stat buff before gates open", 21850, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
 
-            if (IsSpellReady(player, 9910))
+            if (IsSpellReady(player, kDruidMassThornsSpellId))
             {
-                if (ObjectGuid targetGuid = SelectFriendlyWithoutAuraFromSpellChain(player, 9910, 45.0f, true); !targetGuid.IsEmpty())
-                    return { "druid thorns prep", "apply thorns to nearby allies before gates open", 9910, playerbot::PvpClassSpellContext::TargetMode::Ally, targetGuid };
+                if (ObjectGuid targetGuid = SelectFriendlyWithoutAnyAuraFromSpellChain(player, { kDruidThornsSpellId, kDruidMassThornsSpellId }, 45.0f, true); !targetGuid.IsEmpty())
+                    return { "druid mass thorns prep", "apply mass thorns to nearby allies before gates open", kDruidMassThornsSpellId, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
             }
 
             break;
@@ -2034,9 +2133,26 @@ SpellDecision SelectPreparationBuffSpell(Player const* player)
 
             break;
         }
+        case CLASS_WARLOCK:
+        {
+            Pet const* pet = player->GetPet();
+            if (pet && pet->IsAlive())
+                break;
+
+            ClassicProfileSelection const profileSelection = DetectClassicClassProfile(player);
+            bool const isAfflictionWarlock = profileSelection.profile == ClassicClassProfile::PrimaryClassic;
+            uint32 const summonPetSpell = isAfflictionWarlock ? 691 : 697;
+            if (IsSpellReady(player, summonPetSpell))
+                return { isAfflictionWarlock ? "warlock summon felhunter prep" : "warlock summon voidwalker prep", isAfflictionWarlock ? "summon felhunter before gates open" : "summon voidwalker before gates open", summonPetSpell, playerbot::PvpClassSpellContext::TargetMode::Self, player->GetGUID() };
+
+            break;
+        }
         default:
             break;
     }
+
+    if (SpellDecision const mountDecision = SelectMountSpell(player, "mount during preparation after prep actions"); mountDecision.spellId)
+        return mountDecision;
 
     return decision;
 }

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -247,6 +247,9 @@ bool TryCastHumanInsigniaRacial(Player* player)
     if (!spellId || !player->HasSpell(spellId))
         return false;
 
+    if (player->HasStealthAura())
+        return false;
+
     SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
     if (!spellInfo || player->GetSpellHistory()->HasCooldown(spellId))
         return false;


### PR DESCRIPTION
### Motivation

- Prevent incorrect blocking of mount spells that are allowed by map/instance rules while still enforcing the server `outdoors-only` attribute for normal mounts, and avoid breaking stealth openers or utility windows with automated racial/insignia usage. 
- Make preparation buff selection more complete and robust by handling hunter pet revive/call, druid thorns, and warlock summon choices, and reduce false positives for aura checks when choosing targets.

### Description

- Replace the strict outdoors check in the cast path with an attribute-aware condition that checks `SPELL_ATTR0_OUTDOORS_ONLY` and `player->IsOutdoors()` in `CastDirectSpell` so custom mounts without the outdoors attribute can mount when the map allows it.
- Add `CanCastMountSpellAtCurrentLocation` and `SelectMountSpell` and update `SelectReadyKnownMountSpell` and `SelectOutOfCombatEatDrinkOrMountSpell` to use them so mount selection respects per-spell outdoors attributes and battleground-prep allowances.
- Introduce `HasAnyAuraFromSpellChain` and `SelectFriendlyWithoutAnyAuraFromSpellChain` and use them to select `kDruidMassThornsSpellId` for druid prep, replacing the single-id logic.
- Extend `SelectPreparationBuffSpell` to handle hunter pet revive/call and warlock summon choices during preparation and attempt a mount after prep actions using the new mount selection routine.
- Prevent racial and insignia usage from breaking stealth by returning early from `SelectRacialSpell` and `TryCastHumanInsigniaRacial` when `player->HasStealthAura()` is active, and add small related comments and tidy ups.

### Testing

- Project compiled successfully with the changes applied (`build` completed without errors).
- Ran playerbot PvP unit tests and automated playerbot PvP-related smoke tests covering battleground preparation, mount selection, and preparation spell selection, and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232e0fe39c832798941f12f8053ae5)