### PR TITLE
Fix group bind lookup difficulty underflow

### DIFF
--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -812,10 +812,17 @@ MapDifficulty const* GetMapDifficultyData(uint32 mapId, Difficulty difficulty)
 
 MapDifficulty const* GetDownscaledMapDifficultyData(uint32 mapId, Difficulty &difficulty)
 {
+    Difficulty const originalDifficulty = difficulty;
     uint32 tmpDiff = difficulty;
+    if (tmpDiff >= MAX_DIFFICULTY)
+        return nullptr;
+
     MapDifficulty const* mapDiff = GetMapDifficultyData(mapId, Difficulty(tmpDiff));
     if (!mapDiff)
     {
+        if (tmpDiff == REGULAR_DIFFICULTY)
+            return nullptr;
+
         if (tmpDiff > RAID_DIFFICULTY_25MAN_NORMAL) // heroic, downscale to normal
             tmpDiff -= 2;
         else
@@ -823,14 +830,18 @@ MapDifficulty const* GetDownscaledMapDifficultyData(uint32 mapId, Difficulty &di
 
         // pull new data
         mapDiff = GetMapDifficultyData(mapId, Difficulty(tmpDiff)); // we are 10 normal or 25 normal
-        if (!mapDiff)
+        if (!mapDiff && tmpDiff > REGULAR_DIFFICULTY)
         {
             tmpDiff -= 1;
             mapDiff = GetMapDifficultyData(mapId, Difficulty(tmpDiff)); // 10 normal
         }
     }
 
-    difficulty = Difficulty(tmpDiff);
+    if (mapDiff)
+        difficulty = Difficulty(tmpDiff);
+    else
+        difficulty = originalDifficulty;
+
     return mapDiff;
 }
 

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -2303,7 +2303,9 @@ InstanceGroupBind* Group::GetBoundInstance(MapEntry const* mapEntry)
 InstanceGroupBind* Group::GetBoundInstance(Difficulty difficulty, uint32 mapId)
 {
     // some instances only have one difficulty
-    GetDownscaledMapDifficultyData(mapId, difficulty);
+    MapDifficulty const* mapDiff = GetDownscaledMapDifficultyData(mapId, difficulty);
+    if (!mapDiff || difficulty >= MAX_DIFFICULTY)
+        return nullptr;
 
     BoundInstancesMap::iterator itr = m_boundInstances[difficulty].find(mapId);
     if (itr != m_boundInstances[difficulty].end())


### PR DESCRIPTION
### Motivation
- Prevent a crash during player login caused by invalid or downscaled difficulty values being used to index bound-instance arrays. 
- Ensure `GetDownscaledMapDifficultyData` and group bind lookup behave safely when map difficulty data is missing or the input difficulty is out of range.

### Description
- Guard `GetDownscaledMapDifficultyData` in `src/server/game/DataStores/DBCStores.cpp` by returning early for `tmpDiff >= MAX_DIFFICULTY` and avoiding underflow when downscaling from `REGULAR_DIFFICULTY`, and preserve the original difficulty when no valid `MapDifficulty` is found. 
- Update `Group::GetBoundInstance` in `src/server/game/Groups/Group.cpp` to use the returned `MapDifficulty` from `GetDownscaledMapDifficultyData` and return `nullptr` if downscaling fails or the resulting difficulty is invalid, avoiding unsafe indexing of `m_boundInstances`.

### Testing
- Ran `git diff --check` with no problems reported (success). 
- Built the modified translation units with `cmake --build build --target src/server/game/CMakeFiles/game.dir/DataStores/DBCStores.cpp.o src/server/game/CMakeFiles/game.dir/Groups/Group.cpp.o -j2` (succeeded). 
- Started the full `worldserver` build (`cmake --build build --target worldserver -j2`), the changed objects compiled successfully before the full build was intentionally interrupted to avoid waiting for the entire build to finish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237cc169dc8327b653278c62b84bdb)