### PR TITLE
Fix paladin judgement aura iteration crash

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1471,46 +1471,58 @@ private:
 
     void HandleScriptEffect(SpellEffIndex /*effIndex*/)
     {
+        Unit* caster = GetCaster();
+        if (!caster)
+            return;
+
+        Unit* hitUnit = GetHitUnit();
         uint32 spellId2 = SPELL_PALADIN_JUDGEMENT_DAMAGE;
-        // some seals have SPELL_AURA_DUMMY in EFFECT_2
-        Unit::AuraEffectList const& auras = GetCaster()->GetAuraEffectsByType(SPELL_AURA_DUMMY);
+        uint32 sealManaRefund = 0;
+
+        // Some seals have SPELL_AURA_DUMMY in EFFECT_2.  Do not cast or remove
+        // auras while iterating this list: triggered Judgement effects can alter
+        // the caster's seal auras and invalidate the AuraEffectList iterator.
+        Unit::AuraEffectList const& auras = caster->GetAuraEffectsByType(SPELL_AURA_DUMMY);
         for (Unit::AuraEffectList::const_iterator i = auras.begin(); i != auras.end(); ++i)
         {
-            if ((*i)->GetSpellInfo()->GetSpellSpecific() == SPELL_SPECIFIC_SEAL || (*i)->GetSpellInfo()->Id == 20164)
-            {
-                if ((*i)->GetEffIndex() == EFFECT_2)
-                {
-                    if (sSpellMgr->GetSpellInfo((*i)->GetAmount()))
-                    {
-                        spellId2 = (*i)->GetAmount();
-                        Aura* sanctifiedSeals = GetCaster()->GetAuraOfRankedSpell(SPELL_PALADIN_SANCTIFIED_SEALS);
-                        if (sanctifiedSeals && sanctifiedSeals->GetSpellInfo())
-                        {
-                            if (true)
-                            {
-                                //refund mana of original seal
-                                const SpellInfo* originalSpell = (*i)->GetSpellInfo();
-                                uint32 mana = originalSpell->ManaCost;
-                                uint32 bp = (uint32)(mana * 0.8);
-                                CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
-                                args.AddSpellBP0(bp);
-                                GetCaster()->CastSpell(GetCaster(), SPELL_PALADIN_ILLUMINATION_ENERGIZE, args);
-                            }
-                        }
-                        //found seal remove and break
-                        //GetCaster()->RemoveAurasDueToSpell((*i)->GetSpellInfo()->Id);
-                        GetCaster()->CastSpell(GetHitUnit(), spellId2, true);
-                    }
-                }
-            }
-        }
-        //remove all seal spells.
-        GetCaster()->RemoveAurasDueToSpell(20164);
+            AuraEffect const* auraEffect = *i;
+            if (!auraEffect)
+                continue;
 
-        auto removeRankedSeal = [this](uint32 spellId)
+            SpellInfo const* auraSpellInfo = auraEffect->GetSpellInfo();
+            if (!auraSpellInfo)
+                continue;
+
+            if ((auraSpellInfo->GetSpellSpecific() != SPELL_SPECIFIC_SEAL && auraSpellInfo->Id != 20164) ||
+                auraEffect->GetEffIndex() != EFFECT_2 || !sSpellMgr->GetSpellInfo(auraEffect->GetAmount()))
+                continue;
+
+            spellId2 = auraEffect->GetAmount();
+
+            if (Aura* sanctifiedSeals = caster->GetAuraOfRankedSpell(SPELL_PALADIN_SANCTIFIED_SEALS))
+                if (sanctifiedSeals->GetSpellInfo())
+                    sealManaRefund = auraSpellInfo->ManaCost * 8 / 10;
+
+            break;
+        }
+
+        if (sealManaRefund)
         {
-            if (AuraApplication* seal = GetCaster()->GetAuraApplicationOfRankedSpell(spellId))
-                GetCaster()->RemoveAurasDueToSpell(seal->GetBase()->GetId());
+            CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
+            args.AddSpellBP0(sealManaRefund);
+            caster->CastSpell(caster, SPELL_PALADIN_ILLUMINATION_ENERGIZE, args);
+        }
+
+        if (hitUnit)
+            caster->CastSpell(hitUnit, spellId2, true);
+
+        // Remove all seal spells.
+        caster->RemoveAurasDueToSpell(20164);
+
+        auto removeRankedSeal = [caster](uint32 spellId)
+        {
+            if (AuraApplication* seal = caster->GetAuraApplicationOfRankedSpell(spellId))
+                caster->RemoveAurasDueToSpell(seal->GetBase()->GetId());
         };
 
         removeRankedSeal(20154); // Seal of Righteousness


### PR DESCRIPTION
### Motivation
- The Judgement script iterated the caster's SPELL_AURA_DUMMY effects while performing triggered casts and aura removals inside the loop, which could modify the aura list and cause a crash (SIGSEGV). 

### Description
- Cache `GetCaster()` and `GetHitUnit()` before inspecting auras and return early if the caster is missing to avoid dereferencing null. 
- Replace in-loop casting/removal with a safe two-phase approach that scans `AuraEffectList` to resolve the triggered Judgement spell and mana refund, then breaks; actual casts and aura removals are performed after the iteration to avoid invalidating the iterator. 
- Guard intermediate pointers (`AuraEffect`, `SpellInfo`) and compute the mana refund using integer arithmetic. 
- Changes confined to `src/server/scripts/Spells/spell_paladin.cpp` in `spell_pal_judgement::HandleScriptEffect`. 

### Testing
- Compiled the updated translation unit with `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Spells/spell_paladin.cpp.o`, which completed successfully. 
- Started a full build with `cmake --build build --target worldserver -j2`; the build ran and produced object compilation output but was interrupted manually before completion (targeted object had already been built).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2386e8e7d483279e127c3733b25743)