### PR TITLE
fix(priest): let Shadowguard proc Blackout

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -91,6 +91,8 @@ enum PriestSpells
     SPELL_PRIEST_SPIRITUAL_HEALING_R1               = 14898,
     SPELL_PRIEST_DIVINE_PROVIDENCE_R1               = 47562,
     SPELL_PRIEST_SHADOW_GUARD_DAMAGE_R1             = 28377,
+    SPELL_PRIEST_BLACKOUT_R1                        = 15268,
+    SPELL_PRIEST_BLACKOUT_STUN                      = 15269,
     SPELL_PRIEST_SPIRIT_DURATION_INCREASE_R1        = 81322,
     SPELL_PRIEST_SPIRIT_DURATION_INCREASE_R2        = 81323,
     SPELL_PRIEST_SPIRIT_OF_REDEMPTION               = 27827,
@@ -1363,9 +1365,16 @@ class spell_pri_shadow_guard : public AuraScript
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
+
+        Unit* caster = eventInfo.GetActionTarget();
+        Unit* target = eventInfo.GetActor();
         uint32 triggerSpell = sSpellMgr->GetSpellWithRank(SPELL_PRIEST_SHADOW_GUARD_DAMAGE_R1, aurEff->GetSpellInfo()->GetRank());
 
-        eventInfo.GetActionTarget()->CastSpell(eventInfo.GetActor(), triggerSpell, aurEff);
+        caster->CastSpell(target, triggerSpell, aurEff);
+
+        if (Aura const* blackout = caster->GetAuraOfRankedSpell(SPELL_PRIEST_BLACKOUT_R1))
+            if (roll_chance_i(blackout->GetSpellInfo()->GetRank() * 2))
+                caster->CastSpell(target, SPELL_PRIEST_BLACKOUT_STUN, true);
     }
 
     void Register() override


### PR DESCRIPTION
### Motivation
- Shadowguard's triggered damage did not apply the legacy Blackout stun when the priest had the Blackout talent/aura, so hardcode a simple proc path to ensure Shadowguard can trigger Blackout.

### Description
- Add `SPELL_PRIEST_BLACKOUT_R1` and `SPELL_PRIEST_BLACKOUT_STUN` constants to `src/server/scripts/Spells/spell_priest.cpp`.
- Adjust `spell_pri_shadow_guard::HandleProc` to obtain `caster` and `target`, cast the ranked Shadowguard damage with `caster->CastSpell(target, triggerSpell, aurEff);`, then check for the caster's Blackout aura and roll a `rank * 2` percent chance to cast the Blackout stun (`SPELL_PRIEST_BLACKOUT_STUN`).
- Keep the original Shadowguard damage trigger behavior while adding the additional Blackout stun branch.

### Testing
- Ran `git diff --check` to validate no obvious whitespace/errors in the diff and it passed.
- Built the modified script object with `ninja -C build src/server/scripts/CMakeFiles/scripts.dir/Spells/spell_priest.cpp.o` which completed successfully.
- Started a full `ninja -C build worldserver` rebuild; it was interrupted due to time, but no errors appeared prior to interruption (only existing compiler warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a010167883278f5faa919badad36)