### PR TITLE
Fix spell autocast for summoned guardians

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -31,14 +31,33 @@
 #include "SpellMgr.h"
 #include "Util.h"
 
+namespace
+{
+    bool HasCreatureSpells(Creature const* creature)
+    {
+        for (uint32 spellId : creature->m_spells)
+            if (spellId)
+                return true;
+
+        return false;
+    }
+}
+
 int32 PetAI::Permissible(Creature const* creature)
 {
     if (creature->HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))
     {
-        if (reinterpret_cast<Guardian const*>(creature)->GetOwner()->GetTypeId() == TYPEID_PLAYER)
-            return PERMIT_BASE_PROACTIVE;
+        if (Unit const* owner = reinterpret_cast<Guardian const*>(creature)->GetOwner())
+            if (owner->GetTypeId() == TYPEID_PLAYER)
+                return PERMIT_BASE_PROACTIVE;
+
         return PERMIT_BASE_REACTIVE;
     }
+
+    if (creature->IsGuardian() && const_cast<Creature*>(creature)->GetCharmInfo() && HasCreatureSpells(creature))
+        if (Unit const* owner = reinterpret_cast<Guardian const*>(creature)->GetOwner())
+            if (owner->GetTypeId() == TYPEID_PLAYER)
+                return PERMIT_BASE_PROACTIVE;
 
     return PERMIT_BASE_NO;
 }

--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -391,8 +391,21 @@ void Guardian::InitStats(uint32 duration)
 
     InitStatsForLevel(GetOwner()->GetLevel());
 
-    if (GetOwner()->GetTypeId() == TYPEID_PLAYER && HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))
-        m_charmInfo->InitCharmCreateSpells();
+    if (GetOwner()->GetTypeId() == TYPEID_PLAYER)
+    {
+        bool hasCreatureSpells = false;
+        for (uint32 spellId : m_spells)
+        {
+            if (spellId)
+            {
+                hasCreatureSpells = true;
+                break;
+            }
+        }
+
+        if (HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN) || hasCreatureSpells)
+            InitCharmInfo()->InitCharmCreateSpells();
+    }
 
     SetReactState(REACT_AGGRESSIVE);
 }


### PR DESCRIPTION
### Motivation
- Player-owned summoned guardians (eg. Timbermaw Defender) that have spells defined in their creature template were not initializing charm/autocast state and therefore didn't cast their spells.

### Description
- Allow summons with creature-template spells to behave like pets for autocast: added a helper `HasCreatureSpells` and extended `PetAI::Permissible` to return `PERMIT_BASE_PROACTIVE` for player-owned guardians that have charm data and non-empty `m_spells` so they will use `PetAI` autocast logic (`src/server/game/AI/CoreAI/PetAI.cpp`).
- Initialize charm spell/action state for summoned guardians that are owned by players even when they are not full `UNIT_MASK_CONTROLABLE_GUARDIAN` pets by detecting template spells and calling the charm initialization path in `Guardian::InitStats` (`src/server/game/Entities/Creature/TemporarySummon.cpp`).

### Testing
- Ran `git diff --check` to verify no whitespace/errors and it passed.
- Built the game target with `cmake --build build --target game -- -j2` and the build completed successfully (no compilation errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a275741ddf483279e231f2a37efdead)