### PR TITLE
Fix playerbot lifecycle barrier declarations

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -517,6 +517,8 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
     bool BreakExpiredHunterFeignDeath(Player* player);
     bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000);
     bool TryGetObjectivePosition(Battleground* battleground, Player* player, Position& destination);
+    bool PositionTouchesBrtMovementBarrier(Player const* player, Position const& position, float clearance);
+    bool SegmentTouchesBrtMovementBarrier(Player const* player, Position const& from, Position const& to, float clearance);
 
     float GetMovementProbeZ(Player const* player, Position const& position)
     {


### PR DESCRIPTION
### Motivation
- Build failed with "use of undeclared identifier" errors because Blackrock Throne barrier helpers were referenced before their declarations in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`.

### Description
- Add forward declarations for `PositionTouchesBrtMovementBarrier` and `SegmentTouchesBrtMovementBarrier` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` before movement-check helpers, with no gameplay behavior changes.

### Testing
- Ran `git diff --check` which produced no check failures; succeeded.
- Configured the Playerbot-enabled build with `cmake -S . -B build-playerbot -DPLAYERBOT=ON -DSCRIPTS=static -DCMAKE_BUILD_TYPE=RelWithDebInfo` which completed successfully.
- Built the `PlayerbotPvpLifecycleActions.cpp` object via the generated build files (`make`/CMake) and the compile step for that translation unit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27635b62188327b5610af580a7f643)