### PR TITLE
Handle player-owned spell-only guardians and safe owner checks; enable creature-spell autocast

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -31,14 +31,40 @@
 #include "SpellMgr.h"
 #include "Util.h"
 
+namespace
+{
+    bool HasCreatureSpells(Creature const* creature)
+    {
+        for (uint32 spellId : creature->m_spells)
+            if (spellId)
+                return true;
+
+        return false;
+    }
+
+    bool IsPlayerOwnedSpellGuardian(Creature const* creature)
+    {
+        if (!creature->IsGuardian() || creature->HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN) || !HasCreatureSpells(creature))
+            return false;
+
+        Unit* owner = reinterpret_cast<Guardian const*>(creature)->GetOwner();
+        return owner && owner->GetTypeId() == TYPEID_PLAYER;
+    }
+}
+
 int32 PetAI::Permissible(Creature const* creature)
 {
     if (creature->HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))
     {
-        if (reinterpret_cast<Guardian const*>(creature)->GetOwner()->GetTypeId() == TYPEID_PLAYER)
-            return PERMIT_BASE_PROACTIVE;
+        if (Unit const* owner = reinterpret_cast<Guardian const*>(creature)->GetOwner())
+            if (owner->GetTypeId() == TYPEID_PLAYER)
+                return PERMIT_BASE_PROACTIVE;
+
         return PERMIT_BASE_REACTIVE;
     }
+
+    if (IsPlayerOwnedSpellGuardian(creature))
+        return PERMIT_BASE_PROACTIVE;
 
     return PERMIT_BASE_NO;
 }
@@ -203,14 +229,17 @@ void PetAI::UpdateAI(uint32 diff)
     {
         TargetSpellList targetSpellStore;
 
-        for (uint8 i = 0; i < me->GetPetAutoSpellSize(); ++i)
+        bool const useCreatureSpells = IsPlayerOwnedSpellGuardian(me);
+        uint8 const spellCount = useCreatureSpells ? MAX_CREATURE_SPELLS : me->GetPetAutoSpellSize();
+
+        for (uint8 i = 0; i < spellCount; ++i)
         {
-            uint32 spellID = me->GetPetAutoSpellOnPos(i);
+            uint32 spellID = useCreatureSpells ? me->m_spells[i] : me->GetPetAutoSpellOnPos(i);
             if (!spellID)
                 continue;
 
             SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellID);
-            if (!spellInfo)
+            if (!spellInfo || spellInfo->IsPassive())
                 continue;
 
             if (me->GetSpellHistory()->HasGlobalCooldown(spellInfo))
@@ -225,7 +254,7 @@ void PetAI::UpdateAI(uint32 diff)
                 if (spellInfo->CanBeUsedInCombat())
                 {
                     // Check if we're in combat or commanded to attack
-                    if (!me->IsInCombat() && !me->GetCharmInfo()->IsCommandAttack())
+                    if (!useCreatureSpells && !me->IsInCombat() && !me->GetCharmInfo()->IsCommandAttack())
                         continue;
                 }
 

--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -391,8 +391,21 @@ void Guardian::InitStats(uint32 duration)
 
     InitStatsForLevel(GetOwner()->GetLevel());
 
-    if (GetOwner()->GetTypeId() == TYPEID_PLAYER && HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))
-        m_charmInfo->InitCharmCreateSpells();
+    if (GetOwner()->GetTypeId() == TYPEID_PLAYER)
+    {
+        bool hasCreatureSpells = false;
+        for (uint32 spellId : m_spells)
+        {
+            if (spellId)
+            {
+                hasCreatureSpells = true;
+                break;
+            }
+        }
+
+        if (HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN) || hasCreatureSpells)
+            InitCharmInfo()->InitCharmCreateSpells();
+    }
 
     SetReactState(REACT_AGGRESSIVE);
 }


### PR DESCRIPTION
### Motivation
- Allow player-owned guardians that are not controlable but have creature spell entries to be treated proactively for AI and spell initialization.
- Prevent potential null-deref by making owner checks in `Permissible` safe.
- Ensure charm/spell initialization occurs for guardians that define creature spells even when they aren't marked as controlable.

### Description
- Added `HasCreatureSpells` and `IsPlayerOwnedSpellGuardian` helper functions in `PetAI.cpp` to detect guardians with creature spell lists.
- Made `Permissible` safely obtain the owner pointer and return `PERMIT_BASE_PROACTIVE` for player-owned spell guardians.
- Updated `PetAI::UpdateAI` to support autocasting from `me->m_spells` when the creature is a player-owned spell guardian by using `MAX_CREATURE_SPELLS` and relaxing the combat-only restriction for those spells.
- Modified `Guardian::InitStats` in `TemporarySummon.cpp` to call `InitCharmInfo()->InitCharmCreateSpells()` when the owner is a player and the guardian either is controlable or has creature spells.

### Testing
- Built the project with the normal build (`make`/`cmake --build`) and the build completed successfully.
- Executed the automated test suite via `make test` and all tests passed.
- Ran automated integration scenarios exercising pet/guardian spell casting and initialization and observed no crashes or regressions in those runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a275741ddf483279e231f2a37efdead)