### PR TITLE
Fix shared vision cleanup on unit despawn

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7063,6 +7063,26 @@ void Unit::RemovePlayerFromVision(Player* player)
     }
 }
 
+void Unit::RemoveAllPlayersFromVision()
+{
+    while (!m_sharedVision.empty())
+    {
+        Player* player = m_sharedVision.front();
+
+        if (player && player->GetViewpoint() == this)
+            player->SetViewpoint(this, false);
+
+        // SetViewpoint(false) normally removes the player through
+        // RemovePlayerFromVision. If the farsight update is already
+        // inconsistent, remove the stale entry here so despawning units cannot
+        // reach the destructor with shared vision still attached.
+        m_sharedVision.remove(player);
+    }
+
+    setActive(false);
+    SetWorldObject(false);
+}
+
 void Unit::RemoveBindSightAuras()
 {
     RemoveAurasByType(SPELL_AURA_BIND_SIGHT);
@@ -10361,6 +10381,7 @@ void Unit::RemoveFromWorld()
 
         RemoveCharmAuras();
         RemoveBindSightAuras();
+        RemoveAllPlayersFromVision();
         RemoveNotOwnSingleTargetAuras();
 
         RemoveAllGameObjects();

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1319,6 +1319,7 @@ class TC_GAME_API Unit : public WorldObject
         SharedVisionList const& GetSharedVisionList() { return m_sharedVision; }
         void AddPlayerToVision(Player* player);
         void RemovePlayerFromVision(Player* player);
+        void RemoveAllPlayersFromVision();
         bool HasSharedVision() const { return !m_sharedVision.empty(); }
         void RemoveBindSightAuras();
         void RemoveCharmAuras();


### PR DESCRIPTION
### Motivation
- Prevent unit destructor assertion `ASSERT(m_sharedVision.empty())` and crashes caused by lingering shared-vision entries when a unit is despawned.
- Ensure players that have an active farsight/viewpoint to a despawning unit are returned to their normal viewpoint so the farsight state stays consistent.

### Description
- Add `Unit::RemoveAllPlayersFromVision()` which iterates `m_sharedVision`, calls `player->SetViewpoint(this, false)` for active viewpoints, defensively removes stale entries, and clears the unit's active/worldobject flags.
- Declare the new `RemoveAllPlayersFromVision()` in `Unit.h` next to the existing shared-vision methods.
- Invoke `RemoveAllPlayersFromVision()` from `Unit::RemoveFromWorld()` after `RemoveCharmAuras()`/`RemoveBindSightAuras()` so shared vision is cleaned before unit destruction.

### Testing
- Built the server binary with `cmake --build build --target worldserver -j2` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2783f3a2c0832785e0fcbcf6540778)