### PR TITLE
Allow player-owned guardians to use their creature-defined autocast spells and bypass power/reagent checks

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -31,14 +31,53 @@
 #include "SpellMgr.h"
 #include "Util.h"
 
+namespace
+{
+    bool HasCreatureSpells(Creature const* creature)
+    {
+        for (uint32 spellId : creature->m_spells)
+            if (spellId)
+                return true;
+
+        return false;
+    }
+
+    bool IsPlayerOwnedSpellGuardian(Creature const* creature)
+    {
+        if (!creature->IsGuardian() || !HasCreatureSpells(creature))
+            return false;
+
+        Unit* owner = reinterpret_cast<Guardian const*>(creature)->GetOwner();
+        return owner && owner->GetTypeId() == TYPEID_PLAYER;
+    }
+
+    bool ShouldUseCreatureSpellAutocast(Creature const* creature)
+    {
+        return IsPlayerOwnedSpellGuardian(creature) && !creature->IsPet();
+    }
+
+    bool IsHealingSpell(SpellInfo const* spellInfo)
+    {
+        return std::any_of(spellInfo->GetEffects().begin(), spellInfo->GetEffects().end(), [](SpellEffectInfo const& effect)
+        {
+            return effect.IsEffect(SPELL_EFFECT_HEAL);
+        });
+    }
+}
+
 int32 PetAI::Permissible(Creature const* creature)
 {
     if (creature->HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))
     {
-        if (reinterpret_cast<Guardian const*>(creature)->GetOwner()->GetTypeId() == TYPEID_PLAYER)
-            return PERMIT_BASE_PROACTIVE;
+        if (Unit const* owner = reinterpret_cast<Guardian const*>(creature)->GetOwner())
+            if (owner->GetTypeId() == TYPEID_PLAYER)
+                return PERMIT_BASE_PROACTIVE;
+
         return PERMIT_BASE_REACTIVE;
     }
+
+    if (IsPlayerOwnedSpellGuardian(creature))
+        return PERMIT_BASE_PROACTIVE;
 
     return PERMIT_BASE_NO;
 }
@@ -203,14 +242,17 @@ void PetAI::UpdateAI(uint32 diff)
     {
         TargetSpellList targetSpellStore;
 
-        for (uint8 i = 0; i < me->GetPetAutoSpellSize(); ++i)
+        bool const useCreatureSpells = ShouldUseCreatureSpellAutocast(me);
+        uint8 const spellCount = useCreatureSpells ? MAX_CREATURE_SPELLS : me->GetPetAutoSpellSize();
+
+        for (uint8 i = 0; i < spellCount; ++i)
         {
-            uint32 spellID = me->GetPetAutoSpellOnPos(i);
+            uint32 spellID = useCreatureSpells ? me->m_spells[i] : me->GetPetAutoSpellOnPos(i);
             if (!spellID)
                 continue;
 
             SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellID);
-            if (!spellInfo)
+            if (!spellInfo || spellInfo->IsPassive() || (useCreatureSpells && !spellInfo->IsAutocastable()))
                 continue;
 
             if (me->GetSpellHistory()->HasGlobalCooldown(spellInfo))
@@ -225,11 +267,11 @@ void PetAI::UpdateAI(uint32 diff)
                 if (spellInfo->CanBeUsedInCombat())
                 {
                     // Check if we're in combat or commanded to attack
-                    if (!me->IsInCombat() && !me->GetCharmInfo()->IsCommandAttack())
+                    if (!useCreatureSpells && !me->IsInCombat() && !me->GetCharmInfo()->IsCommandAttack())
                         continue;
                 }
 
-                Spell* spell = new Spell(me, spellInfo, TRIGGERED_NONE);
+                Spell* spell = new Spell(me, spellInfo, useCreatureSpells ? TRIGGERED_IGNORE_POWER_AND_REAGENT_COST : TRIGGERED_NONE);
                 bool spellUsed = false;
 
                 // Some spells can target enemy or friendly (DK Ghoul's Leap)
@@ -265,6 +307,9 @@ void PetAI::UpdateAI(uint32 diff)
                         if (!ally)
                             continue;
 
+                        if (useCreatureSpells && IsHealingSpell(spellInfo) && ally->IsFullHealth())
+                            continue;
+
                         if (spell->CanAutoCast(ally))
                         {
                             targetSpellStore.push_back(std::make_pair(ally, spell));
@@ -280,7 +325,7 @@ void PetAI::UpdateAI(uint32 diff)
             }
             else if (me->GetVictim() && CanAttack(me->GetVictim()) && spellInfo->CanBeUsedInCombat())
             {
-                Spell* spell = new Spell(me, spellInfo, TRIGGERED_NONE);
+                Spell* spell = new Spell(me, spellInfo, useCreatureSpells ? TRIGGERED_IGNORE_POWER_AND_REAGENT_COST : TRIGGERED_NONE);
                 if (spell->CanAutoCast(me->GetVictim()))
                     targetSpellStore.push_back(std::make_pair(me->GetVictim(), spell));
                 else

--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -391,8 +391,21 @@ void Guardian::InitStats(uint32 duration)
 
     InitStatsForLevel(GetOwner()->GetLevel());
 
-    if (GetOwner()->GetTypeId() == TYPEID_PLAYER && HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))
-        m_charmInfo->InitCharmCreateSpells();
+    if (GetOwner()->GetTypeId() == TYPEID_PLAYER)
+    {
+        bool hasCreatureSpells = false;
+        for (uint32 spellId : m_spells)
+        {
+            if (spellId)
+            {
+                hasCreatureSpells = true;
+                break;
+            }
+        }
+
+        if (HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN) || hasCreatureSpells)
+            InitCharmInfo()->InitCharmCreateSpells();
+    }
 
     SetReactState(REACT_AGGRESSIVE);
 }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6658,10 +6658,13 @@ SpellCastResult Spell::CheckPetCast(Unit* target)
 
     // check power requirement
     // this would be zero until ::prepare normally, we set it here (it gets reset in ::prepare)
-    m_powerCost = m_spellInfo->CalcPowerCost(m_caster, m_spellSchoolMask);
-    SpellCastResult failReason = CheckPower();
-    if (failReason != SPELL_CAST_OK)
-        return failReason;
+    if (!(_triggeredCastFlags & TRIGGERED_IGNORE_POWER_AND_REAGENT_COST))
+    {
+        m_powerCost = m_spellInfo->CalcPowerCost(m_caster, m_spellSchoolMask);
+        SpellCastResult failReason = CheckPower();
+        if (failReason != SPELL_CAST_OK)
+            return failReason;
+    }
 
     // check cooldown
     if (Creature* creatureCaster = m_caster->ToCreature())


### PR DESCRIPTION
### Motivation

- Enable guardians that have spells defined on their creature template to autocast those spells when owned by a player, even if they are not traditional `Pet` entries. 
- Ensure spells coming from creature spell slots behave correctly when autocast by bypassing pet-specific power/reagent requirements and avoid needless casting (e.g., healing full-health targets).

### Description

- Added helper functions in `PetAI.cpp` to detect creature-defined spells, identify player-owned spell-guardians, determine when to use creature spells for autocast, and detect healing effects. 
- Updated `Permissible` in `PetAI` to treat player-owned guardians that have creature spells as `PERMIT_BASE_PROACTIVE`. 
- Extended the autocast loop to optionally use creature spells from `m_spells` (iterating up to `MAX_CREATURE_SPELLS`) instead of `GetPetAutoSpellOnPos`, and skip non-autocastable or passive spells. 
- When creating `Spell` objects for creature spells, set the trigger flag to `TRIGGERED_IGNORE_POWER_AND_REAGENT_COST` so `Spell::CheckPetCast` skips power/reagent checks. 
- Avoid casting healing spells on allies at full health when using creature spells. 
- In `Guardian::InitStats` call `InitCharmCreateSpells()` when the guardian owner is a player and the guardian either is controlable or has creature spells. 
- Modified `Spell::CheckPetCast` to respect the `TRIGGERED_IGNORE_POWER_AND_REAGENT_COST` flag by skipping power cost checks when set.

### Testing

- Project build was executed with `make` and completed successfully. 
- Automated test suite run via `ctest` succeeded, including modules covering `Spell` and `AI` behavior. 
- Targeted automated checks for pet/guardian autocast behavior passed, validating that creature-defined spells are considered and that power/reagent checks are bypassed for triggered creature spells.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a275741ddf483279e231f2a37efdead)