### PR TITLE
BattlegroundBRT: normalize buff group enums to Speed/Regen/Berserk and update spawns

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBRT.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBRT.cpp
@@ -166,51 +166,51 @@ bool BattlegroundBRT::SetupBattleground()
             1380.52f, -834.296f, -86.6783f, 1.5708f,
             0.0f, 0.0f, 0.707108f, 0.707106f,
             RESPAWN_IMMEDIATELY)
-        || !AddObject(BG_BRT_OBJECT_BUFF1_VARIANT_A, BG_OBJECTID_REGENBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF1_SPEED, BG_OBJECTID_SPEEDBUFF_ENTRY,
             1356.120850f, -726.623169f, -91.981697f, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF1_VARIANT_B, BG_OBJECTID_BERSERKERBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF1_REGEN, BG_OBJECTID_REGENBUFF_ENTRY,
             1356.120850f, -726.623169f, -91.981697f, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF1_VARIANT_C, BG_OBJECTID_REGENBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF1_BERSERK, BG_OBJECTID_BERSERKERBUFF_ENTRY,
             1356.120850f, -726.623169f, -91.981697f, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF2_VARIANT_A, BG_OBJECTID_BERSERKERBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF2_SPEED, BG_OBJECTID_SPEEDBUFF_ENTRY,
             1404.745361f, -726.598328f, -91.981483f, 3.14159f,
             0.0f, 0.0f, 1.0f, 0.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF2_VARIANT_B, BG_OBJECTID_REGENBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF2_REGEN, BG_OBJECTID_REGENBUFF_ENTRY,
             1404.745361f, -726.598328f, -91.981483f, 3.14159f,
             0.0f, 0.0f, 1.0f, 0.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF2_VARIANT_C, BG_OBJECTID_BERSERKERBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF2_BERSERK, BG_OBJECTID_BERSERKERBUFF_ENTRY,
             1404.745361f, -726.598328f, -91.981483f, 3.14159f,
             0.0f, 0.0f, 1.0f, 0.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF3_VARIANT_A, BG_OBJECTID_REGENBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF3_SPEED, BG_OBJECTID_SPEEDBUFF_ENTRY,
             1356.383423f, -818.263794f, -91.981094f, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF3_VARIANT_B, BG_OBJECTID_BERSERKERBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF3_REGEN, BG_OBJECTID_REGENBUFF_ENTRY,
             1356.383423f, -818.263794f, -91.981094f, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF3_VARIANT_C, BG_OBJECTID_REGENBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF3_BERSERK, BG_OBJECTID_BERSERKERBUFF_ENTRY,
             1356.383423f, -818.263794f, -91.981094f, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF4_VARIANT_A, BG_OBJECTID_BERSERKERBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF4_SPEED, BG_OBJECTID_SPEEDBUFF_ENTRY,
             1404.938232f, -818.510925f, -91.981621f, 3.14159f,
             0.0f, 0.0f, 1.0f, 0.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF4_VARIANT_B, BG_OBJECTID_REGENBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF4_REGEN, BG_OBJECTID_REGENBUFF_ENTRY,
             1404.938232f, -818.510925f, -91.981621f, 3.14159f,
             0.0f, 0.0f, 1.0f, 0.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
-        || !AddObject(BG_BRT_OBJECT_BUFF4_VARIANT_C, BG_OBJECTID_BERSERKERBUFF_ENTRY,
+        || !AddObject(BG_BRT_OBJECT_BUFF4_BERSERK, BG_OBJECTID_BERSERKERBUFF_ENTRY,
             1404.938232f, -818.510925f, -91.981621f, 3.14159f,
             0.0f, 0.0f, 1.0f, 0.0f,
             BG_BRT_BUFF_RESPAWN_TIME)
@@ -277,14 +277,14 @@ void BattlegroundBRT::ApplyNonInteractableObjectFlags()
         ghostWall->SetFlag(GO_FLAG_NOT_SELECTABLE);
 }
 
-void BattlegroundBRT::SpawnRandomBuffSet(uint32 variantAIndex)
+void BattlegroundBRT::SpawnRandomBuffSet(uint32 speedTypeIndex)
 {
-    SpawnBGObject(variantAIndex + 0, RESPAWN_ONE_DAY);
-    SpawnBGObject(variantAIndex + 1, RESPAWN_ONE_DAY);
-    SpawnBGObject(variantAIndex + 2, RESPAWN_ONE_DAY);
+    SpawnBGObject(speedTypeIndex + 0, RESPAWN_ONE_DAY);
+    SpawnBGObject(speedTypeIndex + 1, RESPAWN_ONE_DAY);
+    SpawnBGObject(speedTypeIndex + 2, RESPAWN_ONE_DAY);
 
     uint8 const buff = urand(0, 2);
-    SpawnBGObject(variantAIndex + buff, RESPAWN_IMMEDIATELY);
+    SpawnBGObject(speedTypeIndex + buff, RESPAWN_IMMEDIATELY);
 }
 
 void BattlegroundBRT::StartingEventCloseDoors()
@@ -303,7 +303,7 @@ void BattlegroundBRT::StartingEventCloseDoors()
     SpawnBGObject(BG_BRT_OBJECT_TRAMPOLINE_3, RESPAWN_IMMEDIATELY);
     SpawnBGObject(BG_BRT_OBJECT_TRAMPOLINE_4, RESPAWN_IMMEDIATELY);
 
-    for (uint32 type = BG_BRT_OBJECT_BUFF1_VARIANT_A; type <= BG_BRT_OBJECT_BUFF4_VARIANT_C; ++type)
+    for (uint32 type = BG_BRT_OBJECT_BUFF1_SPEED; type <= BG_BRT_OBJECT_BUFF4_BERSERK; ++type)
         SpawnBGObject(type, RESPAWN_ONE_DAY);
 
     ApplyNonInteractableObjectFlags();
@@ -315,10 +315,10 @@ void BattlegroundBRT::StartingEventOpenDoors()
     DoorOpen(BG_BRT_OBJECT_ALLIANCE_GATE_RIGHT);
     DoorOpen(BG_BRT_OBJECT_HORDE_GATE);
 
-    SpawnRandomBuffSet(BG_BRT_OBJECT_BUFF1_VARIANT_A);
-    SpawnRandomBuffSet(BG_BRT_OBJECT_BUFF2_VARIANT_A);
-    SpawnRandomBuffSet(BG_BRT_OBJECT_BUFF3_VARIANT_A);
-    SpawnRandomBuffSet(BG_BRT_OBJECT_BUFF4_VARIANT_A);
+    SpawnRandomBuffSet(BG_BRT_OBJECT_BUFF1_SPEED);
+    SpawnRandomBuffSet(BG_BRT_OBJECT_BUFF2_SPEED);
+    SpawnRandomBuffSet(BG_BRT_OBJECT_BUFF3_SPEED);
+    SpawnRandomBuffSet(BG_BRT_OBJECT_BUFF4_SPEED);
 
     ApplyNonInteractableObjectFlags();
 }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundBRT.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBRT.h
@@ -47,25 +47,25 @@ enum BG_BRT_Objects
     BG_BRT_OBJECT_GHOST_WALL_CENTER,
     BG_BRT_OBJECT_IMPERIAL_THRONE,
 
-    // Buff group 1 must stay contiguous for Battleground buff respawn logic.
-    BG_BRT_OBJECT_BUFF1_VARIANT_A,
-    BG_BRT_OBJECT_BUFF1_VARIANT_B,
-    BG_BRT_OBJECT_BUFF1_VARIANT_C,
+    // Buff group 1 must stay contiguous in Speed/Regen/Berserk order for m_BuffChange logic.
+    BG_BRT_OBJECT_BUFF1_SPEED,
+    BG_BRT_OBJECT_BUFF1_REGEN,
+    BG_BRT_OBJECT_BUFF1_BERSERK,
 
-    // Buff group 2 must stay contiguous for Battleground buff respawn logic.
-    BG_BRT_OBJECT_BUFF2_VARIANT_A,
-    BG_BRT_OBJECT_BUFF2_VARIANT_B,
-    BG_BRT_OBJECT_BUFF2_VARIANT_C,
+    // Buff group 2 must stay contiguous in Speed/Regen/Berserk order for m_BuffChange logic.
+    BG_BRT_OBJECT_BUFF2_SPEED,
+    BG_BRT_OBJECT_BUFF2_REGEN,
+    BG_BRT_OBJECT_BUFF2_BERSERK,
 
-    // Buff group 3 must stay contiguous for Battleground buff respawn logic.
-    BG_BRT_OBJECT_BUFF3_VARIANT_A,
-    BG_BRT_OBJECT_BUFF3_VARIANT_B,
-    BG_BRT_OBJECT_BUFF3_VARIANT_C,
+    // Buff group 3 must stay contiguous in Speed/Regen/Berserk order for m_BuffChange logic.
+    BG_BRT_OBJECT_BUFF3_SPEED,
+    BG_BRT_OBJECT_BUFF3_REGEN,
+    BG_BRT_OBJECT_BUFF3_BERSERK,
 
-    // Buff group 4 must stay contiguous for Battleground buff respawn logic.
-    BG_BRT_OBJECT_BUFF4_VARIANT_A,
-    BG_BRT_OBJECT_BUFF4_VARIANT_B,
-    BG_BRT_OBJECT_BUFF4_VARIANT_C,
+    // Buff group 4 must stay contiguous in Speed/Regen/Berserk order for m_BuffChange logic.
+    BG_BRT_OBJECT_BUFF4_SPEED,
+    BG_BRT_OBJECT_BUFF4_REGEN,
+    BG_BRT_OBJECT_BUFF4_BERSERK,
 
     BG_BRT_OBJECT_TRAMPOLINE_1,
     BG_BRT_OBJECT_TRAMPOLINE_2,
@@ -138,7 +138,7 @@ private:
     void TrackHumanParticipantRemoved(Player const* player, uint32 team);
     void UpdateHumanFaceoffState();
     void ApplyNonInteractableObjectFlags();
-    void SpawnRandomBuffSet(uint32 variantAIndex);
+    void SpawnRandomBuffSet(uint32 speedTypeIndex);
 
     uint32 _allianceKills;
     uint32 _hordeKills;


### PR DESCRIPTION
### Motivation
- Blackrock Throne battleground used "variant" buff enums that didn't match the Speed/Regen/Berserk ordering expected by the generic battleground buff change code, causing inconsistent / overlapping buff spawns.

### Description
- Renamed BRT buff enums from `BG_BRT_OBJECT_BUFF*_VARIANT_*` to `BG_BRT_OBJECT_BUFF*_SPEED/REGEN/BERSERK` and updated the header comment to match the Speed/Regen/Berserk contiguous ordering used by other battlegrounds.
- Updated `AddObject` calls in `BattlegroundBRT.cpp` to use the correct `BG_OBJECTID_*` entries (speed/regen/berserker) and replaced usages of the old enum names with the new ones.
- Changed the `SpawnRandomBuffSet` declaration/definition parameter name (`variantAIndex` -> `speedTypeIndex`) and adjusted spawn/despawn loops and calls (`StartingEventOpenDoors`, `StartingEventCloseDoors`) to use the new enum names and ranges.
- Files modified: `src/server/game/Battlegrounds/Zones/BattlegroundBRT.h` and `src/server/game/Battlegrounds/Zones/BattlegroundBRT.cpp`.

### Testing
- Built the game library with `ninja -C build libgame.a` to validate compilation after changes, and the build completed with source files (including the modified BRT files) compiling successfully; only compiler warnings were emitted and no errors reported.
- Verified repository status with `git status` and inspected the produced `git diff` to confirm the intended changes were applied to the two BRT source files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28695f3ed08327979906bf7c1edf4f)