### PR TITLE
Fix deliver quest item counts completing early

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16870,12 +16870,12 @@ void Player::GroupEventHappens(uint32 questId, WorldObject const* pEventObject)
         AreaExploredOrEventHappens(questId);
 }
 
-void Player::ItemAddedQuestCheck(uint32 entry, uint32 count)
+void Player::ItemAddedQuestCheck(uint32 entry, uint32 /*count*/)
 {
-    RefreshQuestItemCounts(entry, count);
+    RefreshQuestItemCounts(entry);
 }
 
-void Player::RefreshQuestItemCounts(uint32 entry, uint32 addedCount /*= 0*/)
+void Player::RefreshQuestItemCounts(uint32 entry, uint32 /*addedCount = 0*/)
 {
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
@@ -16912,14 +16912,11 @@ void Player::RefreshQuestItemCounts(uint32 entry, uint32 addedCount /*= 0*/)
 
                 curitemcount = q_status.ItemCount[j];
 
-                // If we were called from ItemAddedQuestCheck directly, maintain the legacy increment
-                // behavior so partial updates still work when the resync already matches.
-                if (addedCount && curitemcount < reqitemcount)
-                    q_status.ItemCount[j] = std::min<uint16>(uint16(curitemcount + addedCount), reqitemcount);
+                // The quest objective counter is derived from the actual inventory count above.
+                // Do not add the just-looted count again here, or deliver objectives can complete
+                // one item early while the player still has fewer items than the quest requires.
                 if (curitemcount < reqitemcount)
-                {
                     m_QuestStatusSave[questid] = QUEST_DEFAULT_SAVE_TYPE;
-                }
                 if (CanCompleteQuest(questid))
                     CompleteQuest(questid);
             }


### PR DESCRIPTION
### Motivation
- Deliver-type quests could be marked complete one item early because `ItemAddedQuestCheck` forwarded the just-added count and `RefreshQuestItemCounts` applied an additional additive bump after already syncing to the real inventory.  
- This produced reports like `7/8` scorpid tails or similar where the client shows one fewer actual items than the quest counter.

### Description
- Stop passing the added count through: `ItemAddedQuestCheck(uint32 entry, uint32)` now ignores the `count` and calls `RefreshQuestItemCounts(entry)` instead.  
- Remove the legacy incremental bump from `RefreshQuestItemCounts` so the quest objective counter is derived only from `GetItemCount(...)` and not further incremented.  
- Updated comments to document the reasoning and avoid double-counting.  
- Changed file: `src/server/game/Entities/Player/Player.cpp` (adjusted `ItemAddedQuestCheck` and `RefreshQuestItemCounts`).

### Testing
- Ran `git diff --check` to validate there were no whitespace or trivial diff issues and it passed.  
- Compiled the modified compilation unit with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/Player/Player.cpp.o`, which completed successfully for the object file build.  
- No automated unit tests were added or modified; changes are limited to quest item counting logic and compiled cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28a9262978832799604caa86f83a12)