### PR TITLE
Fix quest item objective double-counting

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16901,10 +16901,13 @@ void Player::RefreshQuestItemCounts(uint32 entry, uint32 addedCount /*= 0*/)
                 uint16 curitemcount = q_status.ItemCount[j];
                 uint32 const totalCount = GetItemCount(entry, true);
                 uint16 const expectedCount = std::min<uint16>(totalCount, reqitemcount);
+                bool const syncedFromInventory = curitemcount != expectedCount;
 
                 // When the item was added through an alternate path (or the quest counter drifted),
-                // re-sync the quest's objective counter to the player's actual inventory.
-                if (curitemcount != expectedCount)
+                // re-sync the quest's objective counter to the player's actual inventory.  In the
+                // normal loot path the item has already been stored by the time this function runs,
+                // so applying addedCount after this resync would double-count the newly looted item.
+                if (syncedFromInventory)
                 {
                     q_status.ItemCount[j] = expectedCount;
                     m_QuestStatusSave[questid] = QUEST_DEFAULT_SAVE_TYPE;
@@ -16912,12 +16915,12 @@ void Player::RefreshQuestItemCounts(uint32 entry, uint32 addedCount /*= 0*/)
 
                 curitemcount = q_status.ItemCount[j];
 
-                // If we were called from ItemAddedQuestCheck directly, maintain the legacy increment
-                // behavior so partial updates still work when the resync already matches.
-                if (addedCount && curitemcount < reqitemcount)
-                    q_status.ItemCount[j] = std::min<uint16>(uint16(curitemcount + addedCount), reqitemcount);
-                if (curitemcount < reqitemcount)
+                // Some callers may still notify before the item is visible in inventory.  Preserve
+                // that legacy fallback only when the inventory resync did not already account for
+                // the added items.
+                if (addedCount && !syncedFromInventory && curitemcount < reqitemcount)
                 {
+                    q_status.ItemCount[j] = uint16(std::min<uint32>(uint32(curitemcount) + addedCount, reqitemcount));
                     m_QuestStatusSave[questid] = QUEST_DEFAULT_SAVE_TYPE;
                 }
                 if (CanCompleteQuest(questid))


### PR DESCRIPTION
### Motivation
- Players reported delivery quests resolving early because quest item counters were being incremented before the looted item appeared in inventory, causing the quest to double-count the same item.

### Description
- In `Player::RefreshQuestItemCounts` introduced a `syncedFromInventory` flag to detect when the quest counter was already resynchronized from the player's inventory and avoid applying the legacy `addedCount` increment in that case.
- Preserve the legacy pre-store notification fallback so callers that report progress before the item is visible in inventory still increment the counter, but only when the inventory resync did not already account for the added item.
- Adjusted the temporary addition arithmetic to use an explicit `uint32` min and cast back to `uint16` to avoid narrowing issues when applying `addedCount`.

### Testing
- Ran `git diff --check` to verify there are no whitespace or diff-check issues and it completed successfully.
- Built the modified translation unit with `ninja -C build src/server/game/CMakeFiles/game.dir/Entities/Player/Player.cpp.o` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28a99052b08327859f6eca71f1975c)