### PR TITLE
Adjust Plainsrunning (89153) mounted run speed using riding skill thresholds

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6214,6 +6214,30 @@ void Player::UpdateWeaponsSkillsToMaxSkillsForLevel()
     }
 }
 
+namespace
+{
+uint32 constexpr SPELL_PLAINSRUNNING_MOUNT = 89153;
+
+bool IsRidingSkillForPlainsrunning(uint32 skill)
+{
+    switch (skill)
+    {
+        case SKILL_RIDING:
+        case SKILL_RIDING_HORSE:
+        case SKILL_RIDING_WOLF:
+        case SKILL_RIDING_TIGER:
+        case SKILL_RIDING_RAM:
+        case SKILL_RIDING_RAPTOR:
+        case SKILL_RIDING_MECHANOSTRIDER:
+        case SKILL_RIDING_UNDEAD_HORSE:
+        case SKILL_RIDING_KODO:
+            return true;
+        default:
+            return false;
+    }
+}
+}
+
 // This functions sets a skill line value (and adds if doesn't exist yet)
 // To "remove" a skill line, set it's values to zero
 void Player::SetSkill(uint32 id, uint16 step, uint16 newVal, uint16 maxVal)
@@ -6245,6 +6269,9 @@ void Player::SetSkill(uint32 id, uint16 step, uint16 newVal, uint16 maxVal)
                 UpdateSkillEnchantments(id, currVal, newVal);
             UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL, id);
             UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL, id);
+
+            if (IsRidingSkillForPlainsrunning(id) && HasAura(SPELL_PLAINSRUNNING_MOUNT))
+                UpdateSpeed(MOVE_RUN);
         }
         else                                                //remove
         {
@@ -6265,6 +6292,9 @@ void Player::SetSkill(uint32 id, uint16 step, uint16 newVal, uint16 maxVal)
             if (std::vector<SkillLineAbilityEntry const*> const* skillLineAbilities = GetSkillLineAbilitiesBySkill(id))
                 for (SkillLineAbilityEntry const* skillLineAbility : *skillLineAbilities)
                     RemoveSpell(sSpellMgr->GetFirstSpellInChain(skillLineAbility->Spell));
+
+            if (IsRidingSkillForPlainsrunning(id) && HasAura(SPELL_PLAINSRUNNING_MOUNT))
+                UpdateSpeed(MOVE_RUN);
         }
     }
     else if (newVal)                                        //add
@@ -6314,6 +6344,10 @@ void Player::SetSkill(uint32 id, uint16 step, uint16 newVal, uint16 maxVal)
                 LearnSkillRewardedSpells(id, newVal);
                 UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_REACH_SKILL_LEVEL, id);
                 UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL, id);
+
+                if (IsRidingSkillForPlainsrunning(id) && HasAura(SPELL_PLAINSRUNNING_MOUNT))
+                    UpdateSpeed(MOVE_RUN);
+
                 return;
             }
         }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9291,6 +9291,38 @@ void Unit::SetVisible(bool x)
     UpdateObjectVisibility();
 }
 
+namespace
+{
+uint32 constexpr SPELL_PLAINSRUNNING_MOUNT = 89153;
+
+uint16 GetHighestRidingSkillValue(Player const* player)
+{
+    uint16 ridingSkill = player->GetBaseSkillValue(SKILL_RIDING);
+    ridingSkill = std::max(ridingSkill, player->GetBaseSkillValue(SKILL_RIDING_HORSE));
+    ridingSkill = std::max(ridingSkill, player->GetBaseSkillValue(SKILL_RIDING_WOLF));
+    ridingSkill = std::max(ridingSkill, player->GetBaseSkillValue(SKILL_RIDING_TIGER));
+    ridingSkill = std::max(ridingSkill, player->GetBaseSkillValue(SKILL_RIDING_RAM));
+    ridingSkill = std::max(ridingSkill, player->GetBaseSkillValue(SKILL_RIDING_RAPTOR));
+    ridingSkill = std::max(ridingSkill, player->GetBaseSkillValue(SKILL_RIDING_MECHANOSTRIDER));
+    ridingSkill = std::max(ridingSkill, player->GetBaseSkillValue(SKILL_RIDING_UNDEAD_HORSE));
+    ridingSkill = std::max(ridingSkill, player->GetBaseSkillValue(SKILL_RIDING_KODO));
+    return ridingSkill;
+}
+
+int32 GetPlainsrunningMountSpeedMod(Player const* player)
+{
+    uint16 const ridingSkill = GetHighestRidingSkillValue(player);
+
+    if (ridingSkill >= 100)
+        return 100;
+
+    if (ridingSkill >= 75)
+        return 40;
+
+    return 20;
+}
+}
+
 void Unit::UpdateSpeed(UnitMoveType mtype)
 {
     int32 main_speed_mod  = 0;
@@ -9311,6 +9343,11 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
             if (IsMounted()) // Use on mount auras
             {
                 main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED);
+
+                if (Player const* player = ToPlayer())
+                    if (player->HasAura(SPELL_PLAINSRUNNING_MOUNT))
+                        main_speed_mod = GetPlainsrunningMountSpeedMod(player);
+
                 stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS);
                 non_stack_bonus += GetMaxPositiveAuraModifier(SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK) / 100.0f;
             }


### PR DESCRIPTION
### Motivation
- Plainsrunning mount (spell `89153`) should use riding-skill thresholds: base 20, 40 at 75 riding, and 100 at 100 riding. 
- Legacy per-race riding skill lines must be considered when determining effective riding skill.
- Run speed must update immediately if a relevant riding skill is added/changed/removed while Plainsrunning is active.

### Description
- Add helper functions in `Unit.cpp`: `GetHighestRidingSkillValue` to compute the highest among generic and legacy riding skills and `GetPlainsrunningMountSpeedMod` to map that value to `20/40/100`. 
- Apply the Plainsrunning-specific speed override in `Unit::UpdateSpeed` when the unit `IsMounted()` and the player `HasAura(SPELL_PLAINSRUNNING_MOUNT)` (spell `89153`).
- Add `IsRidingSkillForPlainsrunning` helper and `SPELL_PLAINSRUNNING_MOUNT` constant in `Player.cpp` and call `UpdateSpeed(MOVE_RUN)` when relevant riding skills are added, changed, or removed to refresh the active speed immediately.
- Modified files: `src/server/game/Entities/Unit/Unit.cpp` and `src/server/game/Entities/Player/Player.cpp`.

### Testing
- Built the `game` target with `cmake --build build --target game -- -j2`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28ddd35b908327b3ccf117bcc29e58)