### PR TITLE
Fix taunt/immunity handling for ATTACK_ME and fear effects in Unit::IsImmunedToSpellEffect

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8598,9 +8598,32 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo co
         });
     };
 
+    bool const isAttackMeEffect = spellEffectInfo.IsEffect(SPELL_EFFECT_ATTACK_ME);
+    bool const isAttackMeFearSpell = spellInfo->HasEffect(SPELL_EFFECT_ATTACK_ME) &&
+        spellInfo->HasAura(SPELL_AURA_MOD_FEAR);
+    bool const isAttackMeFearAura = spellEffectInfo.ApplyAuraName == SPELL_AURA_MOD_FEAR &&
+        isAttackMeFearSpell;
+    bool const isRegularTauntEffect = spellEffectInfo.ApplyAuraName == SPELL_AURA_MOD_TAUNT ||
+        (isAttackMeEffect && !isAttackMeFearSpell);
+
+    // Players cannot be affected by regular taunts. ATTACK_ME + FEAR spells are
+    // player-targeted forced-taunts, so do not reject those here.
+    if (GetTypeId() == TYPEID_PLAYER && isRegularTauntEffect)
+        return true;
+
     // If m_immuneToEffect type contain this effect type, IMMUNE effect.
     SpellImmuneContainer const& effectList = m_spellImmune[IMMUNITY_EFFECT];
     if (hasImmunity(effectList, spellEffectInfo.Effect))
+        return true;
+
+    bool const usePveAttackMeFearTauntImmunity = GetTypeId() != TYPEID_PLAYER && isAttackMeFearSpell;
+    if (isAttackMeFearAura && usePveAttackMeFearTauntImmunity &&
+        hasImmunity(effectList, SPELL_EFFECT_ATTACK_ME))
+        return true;
+
+    SpellImmuneContainer const& stateList = m_spellImmune[IMMUNITY_STATE];
+    if ((isRegularTauntEffect || (usePveAttackMeFearTauntImmunity && isAttackMeEffect)) &&
+        hasImmunity(stateList, SPELL_AURA_MOD_TAUNT))
         return true;
 
     if (uint32 mechanic = spellEffectInfo.Mechanic)
@@ -8614,8 +8637,11 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo co
     {
         if (!spellInfo->HasAttribute(SPELL_ATTR3_IGNORE_HIT_RESULT))
         {
-            SpellImmuneContainer const& list = m_spellImmune[IMMUNITY_STATE];
-            if (hasImmunity(list, aura))
+            if (hasImmunity(stateList, aura))
+                return true;
+
+            if (isAttackMeFearAura && usePveAttackMeFearTauntImmunity &&
+                hasImmunity(stateList, SPELL_AURA_MOD_TAUNT))
                 return true;
         }
 


### PR DESCRIPTION
### Motivation

- Correct handling of taunt and `ATTACK_ME` effects so player targets are not affected by regular taunts while preserving forced-taunt behavior for `ATTACK_ME + FEAR` spells.
- Ensure non-player (PvE) creatures respect immunity entries for `SPELL_EFFECT_ATTACK_ME` and `SPELL_AURA_MOD_TAUNT` in the appropriate immunity containers.
- Reduce duplicated lookups and centralize state/effect immunity checks to avoid incorrect rejection of valid spell applications.

### Description

- Introduced local predicates `isAttackMeEffect`, `isAttackMeFearSpell`, `isAttackMeFearAura`, and `isRegularTauntEffect` to classify taunt-related effects and spells.
- Early-return for player units when the effect is a regular taunt while allowing `ATTACK_ME + FEAR` forced-taunts to proceed.
- Added checks that consult `m_spellImmune[IMMUNITY_EFFECT]` for `SPELL_EFFECT_ATTACK_ME` and `m_spellImmune[IMMUNITY_STATE]` for `SPELL_AURA_MOD_TAUNT` for PvE targets when handling `ATTACK_ME + FEAR` cases.
- Reused `stateList` and reorganized immunity checks to avoid redundant container lookups and to ensure taunt-specific immunity is evaluated in the correct order before aura application logic.

### Testing

- Compiled the server to ensure the changes build cleanly and the binary was produced successfully.
- Ran automated unit tests via `make test`, and they completed successfully with no regressions observed.
- Executed automated spell/taunt-related test cases to verify player immunity to regular taunts and PvE immunity behavior for `ATTACK_ME + FEAR`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28d652fe088327ac5f6d5476858b6d)