### PR TITLE
Restore hunter pet happiness decay

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -718,7 +718,7 @@ void Pet::Update(uint32 diff)
 
             if (m_happinessTimer <= diff)
             {
-                SetMaxHappiness();
+                LoseHappiness();
                 m_happinessTimer = 7500;
             }
             else
@@ -732,16 +732,17 @@ void Pet::Update(uint32 diff)
     Creature::Update(diff);
 }
 
-void Pet::SetMaxHappiness()
+void Pet::LoseHappiness()
 {
     uint32 curValue = GetPower(POWER_HAPPINESS);
-    int32 maxPower = (int32)GetMaxPower(POWER_HAPPINESS);
-    ModifyPower(POWER_HAPPINESS, maxPower); //just keep pet happy tbh
     if (curValue <= 0)
         return;
+
     int32 addvalue = 670;                                   //value is 70/35/17/8/4 (per min) * 1000 / 8 (timer 7.5 secs)
     if (IsInCombat())                                        //we know in combat happiness fades faster, multiplier guess
         addvalue = int32(addvalue * 1.5f);
+
+    ModifyPower(POWER_HAPPINESS, -addvalue);
 }
 
 HappinessState Pet::GetHappinessState()

--- a/src/server/game/Entities/Pet/Pet.h
+++ b/src/server/game/Entities/Pet/Pet.h
@@ -80,7 +80,7 @@ class TC_GAME_API Pet : public Guardian
                 return m_autospells[pos];
         }
 
-        void SetMaxHappiness();
+        void LoseHappiness();
         HappinessState GetHappinessState();
         void GivePetXP(uint32 xp);
         void GivePetLevel(uint8 level);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1894,7 +1894,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
                         for (uint8 i = POWER_MANA; i < MAX_POWERS; ++i)
                         {
                             Powers powerType = Powers(i);
-                            if (pet->GetMaxPower(powerType))
+                            if (powerType != POWER_HAPPINESS && pet->GetMaxPower(powerType))
                                 pet->SetPower(powerType, pet->GetMaxPower(powerType));
                         }
                     }
@@ -26859,7 +26859,7 @@ void Player::ResummonPetTemporaryUnSummonedIfAny()
                 for (uint8 i = POWER_MANA; i < MAX_POWERS; ++i)
                 {
                     Powers powerType = Powers(i);
-                    if (pet->GetMaxPower(powerType))
+                    if (powerType != POWER_HAPPINESS && pet->GetMaxPower(powerType))
                         pet->SetPower(powerType, pet->GetMaxPower(powerType));
                 }
 


### PR DESCRIPTION
### Motivation
- Hunter pets were being forced back to maximum happiness periodically instead of decaying over time, removing intended happiness degradation mechanics.
- Teleportation/resummon code could overwrite pet powers and inadvertently restore `POWER_HAPPINESS` to max, defeating decay logic.

### Description
- Replace the periodic max-happiness refresh with a proper decay call by calling `LoseHappiness()` from `Pet::Update` instead of `SetMaxHappiness()`. (`src/server/game/Entities/Pet/Pet.cpp`)
- Implement `Pet::LoseHappiness()` to decrement `POWER_HAPPINESS` by the configured amount and declare it in `Pet.h` (replaced `SetMaxHappiness()` with `LoseHappiness()`). (`src/server/game/Entities/Pet/Pet.h`, `src/server/game/Entities/Pet/Pet.cpp`)
- Prevent arena/teleport and temporary-resummon logic from forcibly restoring `POWER_HAPPINESS` by skipping `POWER_HAPPINESS` when restoring powers to max in `Player::TeleportTo` and `Player::ResummonPetTemporaryUnSummonedIfAny`. (`src/server/game/Entities/Player/Player.cpp`)

### Testing
- Ran `git diff --check` with no issues reported (success).
- Searched for the old forced-max-happiness pattern using `rg` and confirmed no occurrences of `SetMaxHappiness` or `ModifyPower(POWER_HAPPINESS, maxPower)` remain (success).
- Attempted a build check but skipped compile because no build directory was present on the runner (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b8b33c0cc8327ac7d4e7458f55318)