### PR TITLE
Fix duplicate vision switch during despawn

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7065,22 +7065,42 @@ void Unit::RemovePlayerFromVision(Player* player)
 
 void Unit::RemoveAllPlayersFromVision()
 {
+    bool needsFinalVisibilityUpdate = false;
+
     while (!m_sharedVision.empty())
     {
         Player* player = m_sharedVision.front();
 
         if (player && player->GetViewpoint() == this)
+        {
             player->SetViewpoint(this, false);
 
-        // SetViewpoint(false) normally removes the player through
-        // RemovePlayerFromVision. If the farsight update is already
-        // inconsistent, remove the stale entry here so despawning units cannot
-        // reach the destructor with shared vision still attached.
+            // SetViewpoint(false) normally removes the player through
+            // RemovePlayerFromVision. If it removed the last viewer, that path
+            // already queued the world-object switch and doing it again would
+            // trip Map::AddObjectToSwitchList's duplicate-switch assertion.
+            if (m_sharedVision.empty())
+                needsFinalVisibilityUpdate = false;
+            else if (m_sharedVision.front() == player)
+            {
+                m_sharedVision.remove(player);
+                needsFinalVisibilityUpdate = true;
+            }
+
+            continue;
+        }
+
+        // Stale entries cannot be cleared through Player::SetViewpoint(), so do
+        // the final active/world-object update after the list has been drained.
         m_sharedVision.remove(player);
+        needsFinalVisibilityUpdate = true;
     }
 
-    setActive(false);
-    SetWorldObject(false);
+    if (needsFinalVisibilityUpdate)
+    {
+        setActive(false);
+        SetWorldObject(false);
+    }
 }
 
 void Unit::RemoveBindSightAuras()


### PR DESCRIPTION
### Motivation
- Prevent a crash triggered when a possessed shadow-wraith is despawned while the priest dies/loses the aura, which caused Map::AddObjectToSwitchList to abort due to a duplicate world-object switch queued for the same object.

### Description
- Change `Unit::RemoveAllPlayersFromVision()` to track whether a final active/world-object update is required via `needsFinalVisibilityUpdate` and avoid calling `SetWorldObject(false)` when `Player::SetViewpoint(false)` already removed the last viewer and queued the same switch.
- When `SetViewpoint(false)` removed the last shared-vision entry, skip doing the world-object switch a second time; still perform the final `setActive(false); SetWorldObject(false);` when stale entries were removed directly.
- Modified file: `src/server/game/Entities/Unit/Unit.cpp` (adjusted loop that drains `m_sharedVision`).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cb1b4a30c8327a18eb82d5b20a77d)