### PR TITLE
Fix vision removal and client mover cleanup to avoid duplicate world-switch and dangling controller

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7065,22 +7065,42 @@ void Unit::RemovePlayerFromVision(Player* player)
 
 void Unit::RemoveAllPlayersFromVision()
 {
+    bool needsFinalVisibilityUpdate = false;
+
     while (!m_sharedVision.empty())
     {
         Player* player = m_sharedVision.front();
 
         if (player && player->GetViewpoint() == this)
+        {
             player->SetViewpoint(this, false);
 
-        // SetViewpoint(false) normally removes the player through
-        // RemovePlayerFromVision. If the farsight update is already
-        // inconsistent, remove the stale entry here so despawning units cannot
-        // reach the destructor with shared vision still attached.
+            // SetViewpoint(false) normally removes the player through
+            // RemovePlayerFromVision. If it removed the last viewer, that path
+            // already queued the world-object switch and doing it again would
+            // trip Map::AddObjectToSwitchList's duplicate-switch assertion.
+            if (m_sharedVision.empty())
+                needsFinalVisibilityUpdate = false;
+            else if (m_sharedVision.front() == player)
+            {
+                m_sharedVision.remove(player);
+                needsFinalVisibilityUpdate = true;
+            }
+
+            continue;
+        }
+
+        // Stale entries cannot be cleared through Player::SetViewpoint(), so do
+        // the final active/world-object update after the list has been drained.
         m_sharedVision.remove(player);
+        needsFinalVisibilityUpdate = true;
     }
 
-    setActive(false);
-    SetWorldObject(false);
+    if (needsFinalVisibilityUpdate)
+    {
+        setActive(false);
+        SetWorldObject(false);
+    }
 }
 
 void Unit::RemoveBindSightAuras()
@@ -10378,6 +10398,17 @@ void Unit::RemoveFromWorld()
 
         if (IsVehicle())
             RemoveVehicleKit();
+
+        // A possessed/charmed creature can reach removal after its charm aura was
+        // already cleared by another cleanup path. In that case the player's
+        // GameClient may still list this unit as an allowed mover, which leaves a
+        // dangling controller pointer and trips Unit::~Unit when the creature is
+        // deleted. Always sever non-player client movement ownership before the
+        // unit leaves the world; normal charm cleanup may do this earlier, but this
+        // is the last safe point before destruction.
+        if (GetTypeId() != TYPEID_PLAYER)
+            if (GameClient* gameClient = GetGameClientMovingMe())
+                gameClient->RemoveAllowedMover(this);
 
         RemoveCharmAuras();
         RemoveBindSightAuras();


### PR DESCRIPTION
### Motivation

- Prevent duplicate world-object switch assertions when draining `m_sharedVision` while `Player::SetViewpoint(false)` already performed removal.
- Prevent a dangling `GameClient` controller pointer on non-player units that can remain listed as an allowed mover after charm/possession cleanup, which can cause destructor crashes.

### Description

- Update `Unit::RemoveAllPlayersFromVision` to track a `needsFinalVisibilityUpdate` flag and only call `setActive(false)`/`SetWorldObject(false)` once after draining the list to avoid duplicate switch operations.
- Adjust the loop in `RemoveAllPlayersFromVision` to handle the case where `player->SetViewpoint(this, false)` already removed the player and to explicitly remove stale entries that cannot be cleared via `SetViewpoint`.
- Add a safety step in `Unit::RemoveFromWorld` to sever non-player client movement ownership by calling `GetGameClientMovingMe()` and `GameClient::RemoveAllowedMover(this)` before the unit leaves the world.
- Preserve existing cleanup calls (`RemoveCharmAuras`, `RemoveBindSightAuras`, `RemoveAllPlayersFromVision`, etc.) and ensure they run in the same removal sequence.

### Testing

- Project was compiled successfully and server binary built without errors.
- Unit tests and server integration tests were executed and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cb1b4a30c8327a18eb82d5b20a77d)