### PR TITLE
Fix Shadow Wraith cleanup to avoid races and ensure proper charm teardown

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1744,29 +1744,51 @@ namespace ShadowPriestWraith
     }
 
 
+    void ReleaseWraithControl(Player* player, Creature* wraith)
+    {
+        if (!player || !wraith)
+            return;
+
+        // Use the core's normal player charm teardown first.  Death cleanup also
+        // enters through this path, and StopCastingCharm() is hardened for cases
+        // where the charm aura was already removed while the player was dying.
+        if (player->GetCharmedGUID() == wraith->GetGUID())
+            player->StopCastingCharm();
+
+        // If the helper aura was removed outside the normal player charm path, make
+        // sure the reverse side is not left pointing at the priest before despawn.
+        if (wraith->GetCharmerGUID() == player->GetGUID())
+            wraith->RemoveCharmedBy(player);
+    }
+
     void FinishWraithCleanup(Player* player, Creature* wraith)
     {
         if (!player)
             return;
 
-        if (wraith)
-        {
-            wraith->RemoveAurasDueToSpell(SPELL_PRIEST_SHADOW_WRAITH_CHARM);
-            wraith->RemoveAurasDueToSpell(SPELL_PRIEST_SHADOW_WRAITH_VISUAL);
-
-            if (wraith->GetCharmerGUID() == player->GetGUID())
-                wraith->RemoveCharmedBy(player);
-        }
-
         StopChannelVisual(player);
         player->RemoveAurasDueToSpell(SPELL_PRIEST_SHADOW_WRAITH_UNSTOPPABLE);
         ApplyUnstoppable(player, false);
-        player->SetControlled(false, UNIT_STATE_ROOT);
+
+        if (player->IsAlive())
+            player->SetControlled(false, UNIT_STATE_ROOT);
+        else
+            player->ClearUnitState(UNIT_STATE_ROOT);
 
         LPlusShadowWraithMovement::ClearClientWraithPosition(player);
 
         if (wraith)
+        {
+            // The wraith owns delayed visual/channel/speed refresh events. Kill them
+            // before charm release/despawn so death-time cleanup cannot execute a
+            // queued refresh against a creature that is being torn down.
+            wraith->m_Events.KillAllEvents(false);
+
+            wraith->RemoveAurasDueToSpell(SPELL_PRIEST_SHADOW_WRAITH_VISUAL);
+            ReleaseWraithControl(player, wraith);
+            wraith->RemoveAurasDueToSpell(SPELL_PRIEST_SHADOW_WRAITH_CHARM);
             wraith->DespawnOrUnsummon();
+        }
     }
 
     void ScheduleWraithCleanup(Player* player, Creature* wraith)


### PR DESCRIPTION
### Motivation
- Make wraith possession cleanup more robust during teleport and player death to avoid race conditions and dangling charmer pointers and to ensure client/channel visuals are correctly cleared.

### Description
- Added `ReleaseWraithControl(Player*, Creature*)` to centralize charm teardown and call `player->StopCastingCharm()` when the player still charmed the wraith.
- Reworked `FinishWraithCleanup` to call `StopChannelVisual`, remove the `SPELL_PRIEST_SHADOW_WRAITH_UNSTOPPABLE` aura, clear client wraith position, and handle `UNIT_STATE_ROOT` differently depending on whether the player is alive.
- Kill pending wraith events with `wraith->m_Events.KillAllEvents(false)` before charm release/despawn to prevent queued visual/channel/speed refreshes from running against a torn-down creature.
- Added additional null checks and adjusted the order of aura removals and `DespawnOrUnsummon` to avoid leaving reversed charm state or running operations on invalid objects.

### Testing
- Built the server and ran the project's automated unit tests; the build completed and unit tests passed.
- Executed an automated integration scenario exercising shadow wraith summon/possession/teleport/death and observed no crashes, no lingering charmer links, and correct visual/channel cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cb369b4dc83279be41f7bbe19f7ff)