### PR TITLE
Restore spirit healer resurrection sickness fallback

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -119,7 +119,19 @@ namespace
     constexpr float MinStarfireSnareSpeedRate = 0.01f;
     constexpr float MaxStarfireSnareSpeedRate = 1.0f;
     constexpr uint8 StarfireSnareRemovalGraceUpdates = 2;
+    constexpr uint32 SpellResurrectionSickness = 15007;
     UnitMoveType const StarfireSnareMoveTypes[] = { MOVE_RUN, MOVE_RUN_BACK, MOVE_SWIM, MOVE_SWIM_BACK };
+
+    uint32 GetResurrectionSicknessSpellId(Player const* player)
+    {
+        ChrRacesEntry const* raceEntry = sChrRacesStore.LookupEntry(player->GetRace());
+        if (raceEntry && raceEntry->ResSicknessSpellID && sSpellMgr->GetSpellInfo(raceEntry->ResSicknessSpellID))
+            return raceEntry->ResSicknessSpellID;
+
+        // Classic data should point every playable race at this shared spell, but
+        // keep spirit-healer resurrects working if the DBC field is empty or stale.
+        return SpellResurrectionSickness;
+    }
 }
 #include "ArenaSpectator.h"
 
@@ -4767,19 +4779,19 @@ void Player::ResurrectPlayer(float restore_percent, bool applySickness)
     //for each level they are above 10.
     //Characters level 20 and up suffer from ten minutes of sickness.
     int32 startLevel = sWorld->getIntConfig(CONFIG_DEATH_SICKNESS_LEVEL);
-    ChrRacesEntry const* raceEntry = sChrRacesStore.AssertEntry(GetRace());
+    uint32 resSicknessSpellId = GetResurrectionSicknessSpellId(this);
 
     if (int32(GetLevel()) >= startLevel)
     {
         // set resurrection sickness
-        CastSpell(this, raceEntry->ResSicknessSpellID, true);
+        CastSpell(this, resSicknessSpellId, true);
 
         // not full duration
         if (int32(GetLevel()) < startLevel + 9)
         {
             int32 delta = (int32(GetLevel()) - startLevel + 1) * MINUTE;
 
-            if (Aura* aur = GetAura(raceEntry->ResSicknessSpellID, GetGUID()))
+            if (Aura* aur = GetAura(resSicknessSpellId, GetGUID()))
             {
                 aur->SetDuration(delta * IN_MILLISECONDS);
             }
@@ -18715,10 +18727,10 @@ void Player::_LoadAuras(PreparedQueryResult result, uint32 timediff)
                 continue;
             }
 
-            ChrRacesEntry const* raceEntry = sChrRacesStore.AssertEntry(GetRace());
+            uint32 resSicknessSpellId = GetResurrectionSicknessSpellId(this);
 
             // negative effects should continue counting down after logout
-            if (remaintime != -1 && ((!spellInfo->IsPositive() && spellInfo->Id != raceEntry->ResSicknessSpellID) || spellInfo->HasAttribute(SPELL_ATTR4_FADES_WHILE_LOGGED_OUT))) // Resurrection sickness should not fade while logged out
+            if (remaintime != -1 && ((!spellInfo->IsPositive() && spellInfo->Id != resSicknessSpellId) || spellInfo->HasAttribute(SPELL_ATTR4_FADES_WHILE_LOGGED_OUT))) // Resurrection sickness should not fade while logged out
             {
                 if (remaintime / IN_MILLISECONDS <= int32(timediff))
                     continue;


### PR DESCRIPTION
### Motivation
- Spirit-healer resurrects could skip applying Resurrection Sickness when the race `ResSicknessSpellID` DBC field is empty or stale, so a safe fallback is needed to ensure players receive sickness on spirit-healer resurrections.

### Description
- Add a resolver `GetResurrectionSicknessSpellId(Player const*)` that returns the race DBC `ResSicknessSpellID` when valid and falls back to the shared Classic resurrection sickness spell `15007` otherwise, defined as `SpellResurrectionSickness`.
- Use the resolver when applying resurrection sickness in `Player::ResurrectPlayer` (cast sickness and set shortened duration for low levels) instead of directly reading the DBC field.
- Use the resolver in `Player::_LoadAuras` when deciding which auras should continue counting down while logged out so resurrection sickness remains exempt from logout-fade logic.
- Change implemented in `src/server/game/Entities/Player/Player.cpp` and wired into existing resurrection handling paths.

### Testing
- Ran whitespace/patch checks with `git diff --check` and a code search for the new symbols using `rg -n "GetResurrectionSicknessSpellId|SpellResurrectionSickness|ResurrectPlayer\(0\.5f, true\)"`, which produced the expected results.
- Attempted a CMake configuration with `cmake -S . -B build -DTOOLS=0 -DSCRIPTS=static` to validate build configuration; configure failed in the container due to missing Boost development components (environment limitation), so a full compile/test run could not be completed here.
- Local code inspection and targeted static checks passed for the modified logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d0ede239083279664b42271adc33e)