### PR TITLE
Apply resurrection sickness via server-side aura and robustly resolve spell ID

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -119,7 +119,19 @@ namespace
     constexpr float MinStarfireSnareSpeedRate = 0.01f;
     constexpr float MaxStarfireSnareSpeedRate = 1.0f;
     constexpr uint8 StarfireSnareRemovalGraceUpdates = 2;
+    constexpr uint32 SpellResurrectionSickness = 15007;
     UnitMoveType const StarfireSnareMoveTypes[] = { MOVE_RUN, MOVE_RUN_BACK, MOVE_SWIM, MOVE_SWIM_BACK };
+
+    uint32 GetResurrectionSicknessSpellId(Player const* player)
+    {
+        ChrRacesEntry const* raceEntry = sChrRacesStore.LookupEntry(player->GetRace());
+        if (raceEntry && raceEntry->ResSicknessSpellID && sSpellMgr->GetSpellInfo(raceEntry->ResSicknessSpellID))
+            return raceEntry->ResSicknessSpellID;
+
+        // Classic data should point every playable race at this shared spell, but
+        // keep spirit-healer resurrects working if the DBC field is empty or stale.
+        return SpellResurrectionSickness;
+    }
 }
 #include "ArenaSpectator.h"
 
@@ -4767,22 +4779,26 @@ void Player::ResurrectPlayer(float restore_percent, bool applySickness)
     //for each level they are above 10.
     //Characters level 20 and up suffer from ten minutes of sickness.
     int32 startLevel = sWorld->getIntConfig(CONFIG_DEATH_SICKNESS_LEVEL);
-    ChrRacesEntry const* raceEntry = sChrRacesStore.AssertEntry(GetRace());
+    uint32 resSicknessSpellId = GetResurrectionSicknessSpellId(this);
 
     if (int32(GetLevel()) >= startLevel)
     {
-        // set resurrection sickness
-        CastSpell(this, raceEntry->ResSicknessSpellID, true);
+        // Set resurrection sickness directly. Spirit healer resurrections are server-side
+        // consequences of CMSG_SPIRIT_HEALER_ACTIVATE, and using a normal self cast can
+        // be rejected by spell targeting/positivity rules before the aura is attached.
+        Aura* resSickness = AddAura(resSicknessSpellId, this);
+        if (!resSickness)
+        {
+            TC_LOG_ERROR("entities.player", "Player::ResurrectPlayer: failed to apply resurrection sickness spell {} to player '{}' ({})",
+                resSicknessSpellId, GetName(), GetGUID().ToString());
+            return;
+        }
 
         // not full duration
         if (int32(GetLevel()) < startLevel + 9)
         {
             int32 delta = (int32(GetLevel()) - startLevel + 1) * MINUTE;
-
-            if (Aura* aur = GetAura(raceEntry->ResSicknessSpellID, GetGUID()))
-            {
-                aur->SetDuration(delta * IN_MILLISECONDS);
-            }
+            resSickness->SetDuration(delta * IN_MILLISECONDS);
         }
     }
 }
@@ -18715,10 +18731,10 @@ void Player::_LoadAuras(PreparedQueryResult result, uint32 timediff)
                 continue;
             }
 
-            ChrRacesEntry const* raceEntry = sChrRacesStore.AssertEntry(GetRace());
+            uint32 resSicknessSpellId = GetResurrectionSicknessSpellId(this);
 
             // negative effects should continue counting down after logout
-            if (remaintime != -1 && ((!spellInfo->IsPositive() && spellInfo->Id != raceEntry->ResSicknessSpellID) || spellInfo->HasAttribute(SPELL_ATTR4_FADES_WHILE_LOGGED_OUT))) // Resurrection sickness should not fade while logged out
+            if (remaintime != -1 && ((!spellInfo->IsPositive() && spellInfo->Id != resSicknessSpellId) || spellInfo->HasAttribute(SPELL_ATTR4_FADES_WHILE_LOGGED_OUT))) // Resurrection sickness should not fade while logged out
             {
                 if (remaintime / IN_MILLISECONDS <= int32(timediff))
                     continue;


### PR DESCRIPTION
### Motivation

- Ensure resurrection sickness is applied reliably for spirit-healer (server-side) resurrections and when DBC race entries are missing or stale.
- Prevent resurrection sickness from being treated like a normal positive self-cast that could be rejected by spell targeting rules.
- Keep resurrection sickness aura from counting down while the player is logged out using a consistent, validated spell id.

### Description

- Added a fallback constant `SpellResurrectionSickness = 15007` and introduced `GetResurrectionSicknessSpellId(Player const*)` to validate and return the appropriate resurrection-sickness spell id from `ChrRaces` or fall back to the shared spell.
- Replaced `CastSpell` usage in `Player::ResurrectPlayer` with direct server-side application via `AddAura(resSicknessSpellId, this)` and log an error if adding the aura fails.
- Adjusted the short-duration logic to call `SetDuration` on the returned `Aura*` instead of modifying an aura found via `GetAura`.
- Updated aura loading in `Player::_LoadAuras` to use the resolved resurrection-sickness id so that the sickness aura is excluded from logout fade logic consistently.

### Testing

- Project compiled successfully with `make` and no build errors were reported.
- The automated test suite was executed with `make test` and completed with all tests passing.
- Server startup basic smoke tests (automated) ran and completed without errors related to aura application or player resurrection paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d0ede239083279664b42271adc33e)