### PR TITLE
Allow playerbots to path over steep slopes instead of dropping

### DIFF
--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -30,7 +30,7 @@
 PathGenerator::PathGenerator(WorldObject const* owner) :
     _polyLength(0), _type(PATHFIND_BLANK), _useStraightPath(false),
     _forceDestination(false), _pointPathLimit(MAX_POINT_PATH_LENGTH), _useRaycast(false),
-    _endPosition(G3D::Vector3::zero()), _source(owner), _navMesh(nullptr),
+    _allowSteepSlopes(false), _endPosition(G3D::Vector3::zero()), _source(owner), _navMesh(nullptr),
     _navMeshQuery(nullptr)
 {
     memset(_pathPolyRefs, 0, sizeof(_pathPolyRefs));
@@ -644,6 +644,12 @@ void PathGenerator::BuildShortcut()
     _type = PATHFIND_SHORTCUT;
 }
 
+void PathGenerator::SetAllowSteepSlopes(bool allowSteepSlopes)
+{
+    _allowSteepSlopes = allowSteepSlopes;
+    UpdateFilter();
+}
+
 void PathGenerator::CreateFilter()
 {
     uint16 includeFlags = 0;
@@ -686,6 +692,9 @@ void PathGenerator::UpdateFilter()
 
             _filter.setIncludeFlags(includedFlags);
         }
+
+        if (_allowSteepSlopes)
+            _filter.setIncludeFlags(_filter.getIncludeFlags() | NAV_GROUND_STEEP);
 
         if (Creature const* _sourceCreature = _source->ToCreature())
             if (_sourceCreature->IsInCombat() || _sourceCreature->IsInEvadeMode())

--- a/src/server/game/Movement/PathGenerator.h
+++ b/src/server/game/Movement/PathGenerator.h
@@ -69,6 +69,7 @@ class TC_GAME_API PathGenerator
         void SetUseStraightPath(bool useStraightPath) { _useStraightPath = useStraightPath; }
         void SetPathLengthLimit(float distance) { _pointPathLimit = std::min<uint32>(uint32(distance/SMOOTH_PATH_STEP_SIZE), MAX_POINT_PATH_LENGTH); }
         void SetUseRaycast(bool useRaycast) { _useRaycast = useRaycast; }
+        void SetAllowSteepSlopes(bool allowSteepSlopes);
 
         // result getters
         G3D::Vector3 const& GetStartPosition() const { return _startPosition; }
@@ -94,6 +95,7 @@ class TC_GAME_API PathGenerator
         bool _forceDestination; // when set, we will always arrive at given point
         uint32 _pointPathLimit; // limit point path size; min(this, MAX_POINT_PATH_LENGTH)
         bool _useRaycast;       // use raycast if true for a straight line path
+        bool _allowSteepSlopes; // include steep ground polygons in path searches
 
         G3D::Vector3 _startPosition;        // {x, y, z} of current location
         G3D::Vector3 _endPosition;          // {x, y, z} of the destination

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -483,6 +483,7 @@ bool TryBuildStrictHumanSegmentDestination(Player* player, Position const& desir
         Position const safeDestination = BuildCollisionSafeDestination(player, requestedDestination);
 
         PathGenerator path(player);
+        path.SetAllowSteepSlopes(true);
         path.SetPathLengthLimit(90.0f);
         bool pathOk = path.CalculatePath(safeDestination.GetPositionX(), safeDestination.GetPositionY(), safeDestination.GetPositionZ(), true);
         PathType pathType = path.GetPathType();
@@ -492,6 +493,7 @@ bool TryBuildStrictHumanSegmentDestination(Player* player, Position const& desir
         if ((pathType & PATHFIND_SHORTCUT) != 0)
         {
             PathGenerator retryPath(player);
+            retryPath.SetAllowSteepSlopes(true);
             retryPath.SetPathLengthLimit(90.0f);
             bool const retryOk = retryPath.CalculatePath(safeDestination.GetPositionX(), safeDestination.GetPositionY(), safeDestination.GetPositionZ(), false);
             PathType const retryType = retryPath.GetPathType();
@@ -1138,6 +1140,7 @@ RangedPathProbeResult ProbeChasePath(Player* player, Unit* target)
         player->UpdateAllowedPositionZ(probe.destX, probe.destY, probe.destZ);
 
     PathGenerator path(player);
+    path.SetAllowSteepSlopes(true);
     probe.success = path.CalculatePath(probe.destX, probe.destY, probe.destZ, player->CanFly());
     probe.pathType = uint32(path.GetPathType());
     probe.pointCount = uint32(path.GetPath().size());
@@ -1159,6 +1162,7 @@ RangedPathProbeResult ProbeFollowPath(Player* player, Unit* target, float edgeRa
         player->UpdateAllowedPositionZ(probe.destX, probe.destY, probe.destZ);
 
     PathGenerator path(player);
+    path.SetAllowSteepSlopes(true);
     probe.success = path.CalculatePath(probe.destX, probe.destY, probe.destZ, false);
     probe.pathType = uint32(path.GetPathType());
     probe.pointCount = uint32(path.GetPath().size());

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -806,38 +806,6 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
         return BuildCollisionSafeDestination(player, probe);
     }
 
-    bool ShouldPreferDirectDropShortcut(Player* player, Position const& destination)
-    {
-        if (!player)
-            return false;
-
-        float const destinationDistance = player->GetDistance(destination);
-        if (destinationDistance < 15.0f || destinationDistance > 120.0f)
-            return false;
-
-        float const verticalDrop = player->GetPositionZ() - destination.GetPositionZ();
-        if (verticalDrop < 8.0f)
-            return false;
-
-        PathGenerator path(player);
-        path.SetPathLengthLimit(PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT);
-        if (!path.CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), true))
-            return false;
-
-        if (IsForbiddenBattlegroundPathType(path.GetPathType()))
-            return false;
-
-        Movement::PointsArray const& points = path.GetPath();
-        if (points.size() < 2)
-            return false;
-
-        float pathLength = 0.0f;
-        for (std::size_t i = 1; i < points.size(); ++i)
-            pathLength += (points[i] - points[i - 1]).length();
-
-        return pathLength > destinationDistance * 1.35f;
-    }
-
     bool BuildNavPathSegmentDestination(Player const* player, Movement::PointsArray const& points, float orientation, Position& segmentDestination)
     {
         if (!player || points.size() < 2)
@@ -884,6 +852,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
             Position const collisionSafeDestination = BuildCollisionSafeDestination(player, requestedDestination);
 
             PathGenerator path(player);
+            path.SetAllowSteepSlopes(true);
             // Allow longer battleground route segments so bots can commit to
             // meaningful navmesh progress toward distant enemies instead of
             // repeatedly selecting tiny local hops that catch on terrain.
@@ -896,6 +865,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
             if ((pathType & PATHFIND_SHORTCUT) != 0)
             {
                 PathGenerator retryPath(player);
+                retryPath.SetAllowSteepSlopes(true);
                 retryPath.SetPathLengthLimit(PLAYERBOT_BG_PATH_CALCULATION_LENGTH_LIMIT);
                 bool const retryOk = retryPath.CalculatePath(collisionSafeDestination.GetPositionX(), collisionSafeDestination.GetPositionY(), collisionSafeDestination.GetPositionZ(), false);
                 PathType const retryType = retryPath.GetPathType();
@@ -1118,25 +1088,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
                 }
             }
 
-            if (allowDirectDrop && nowMs >= directDropState.suppressUntilMs && ShouldPreferDirectDropShortcut(player, safeDestination))
-            {
-                Position const shortcutDestination = BuildDownhillEscapeDestination(player, safeDestination);
-                motionMaster->MovePoint(0, shortcutDestination, false);
-                EmitBattlegroundGmDebug(player,
-                    "movepoint=direct-drop-shortcut destDist=" + std::to_string(int32(player->GetDistance(safeDestination))) +
-                    " stepDist=" + std::to_string(int32(player->GetDistance(shortcutDestination))), 0);
-                directDropState.startPosition = player->GetPosition();
-                directDropState.issueMs = nowMs;
-                directDropState.pending = true;
-
-                state.lastDestination = destination;
-                state.lastIssueMs = nowMs;
-                return true;
-            }
-            else
-            {
-                directDropState.pending = false;
-            }
+            directDropState.pending = false;
 
             Position segmentDestination;
             PathType pathType = PathType(0);
@@ -1154,19 +1106,15 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
                     return true;
                 }
 
-                // Recovery path for segmented-nav failures (for example, after a
-                // partial drop where local nav probing can't find a legal segment):
-                // issue a direct movement order so the bot keeps progressing
-                // instead of stalling in place waiting on nav segment recovery.
-                Position const fallbackDestination = BuildDownhillEscapeDestination(player, safeDestination);
-                motionMaster->MovePoint(0, fallbackDestination, false);
+                // Keep bots on path-generated movement instead of intentionally
+                // stepping off ledges when nav segmentation cannot produce a
+                // shorter intermediate destination.
+                motionMaster->MovePoint(0, safeDestination, true);
                 EmitBattlegroundGmDebug(player,
-                    "movepoint=blocked-no-nav fallback=direct destDist=" + std::to_string(int32(player->GetDistance(safeDestination))) +
-                    " stepDist=" + std::to_string(int32(player->GetDistance(fallbackDestination))), 0);
+                    "movepoint=blocked-no-nav fallback=full-path steep-slopes=enabled destDist=" +
+                    std::to_string(int32(player->GetDistance(safeDestination))), 0);
 
-                directDropState.startPosition = player->GetPosition();
-                directDropState.issueMs = nowMs;
-                directDropState.pending = true;
+                directDropState.pending = false;
                 directDropState.suppressUntilMs = std::max(directDropState.suppressUntilMs, nowMs + 2500);
 
                 state.lastDestination = destination;


### PR DESCRIPTION
### Motivation

- Make playerbot movement prefer walking down slopes and accept steeper navmesh polygons instead of attempting direct-drops/falls when path segmentation fails, reducing stalled or unnatural fall behavior in battlegrounds and follow/chase probes.

### Description

- Added an opt-in flag and API `PathGenerator::SetAllowSteepSlopes(bool)` and a backing field `_allowSteepSlopes` so callers can include `NAV_GROUND_STEEP` in the navmesh filter without changing the global default pathing behavior (`src/server/game/Movement/PathGenerator.h|cpp`).
- `PathGenerator::UpdateFilter()` now includes `NAV_GROUND_STEEP` when `_allowSteepSlopes` is set, while retaining the existing combat/evade behavior that also enables steep ground.
- Enabled steep-slope pathing for playerbot PvP movement and path probes by calling `path.SetAllowSteepSlopes(true)` in battleground segment generation, retry paths, chase/follow path probes, and strict human-like segment building (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and `PlayerbotPvpClassActions.cpp`).
- Changed battleground fallback behavior to prefer path-generated movement (full-path fallback to `safeDestination`) instead of issuing downhill/direct-drop escape hops when segmentation cannot produce an intermediate point, removing the aggressive direct-drop shortcut logic.

### Testing

- Ran `git diff --check` on the working tree and it completed with no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309251c01483278f1ec5e014d521eb)