### PR TITLE
Fix Sap mechanic for PvE targets

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4839,6 +4839,20 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->ManaPerSecond = 0;
     });
 
+    // Sap (Classic ranks)
+    //
+    // The Classic DBC rows encode Sap as MECHANIC_KNOCKOUT even though the server
+    // has a dedicated MECHANIC_SAPPED mechanic. PvP targets generally have no
+    // creature_template mechanic mask, so Sap can still appear to work there, but
+    // PvE creatures that are immune to generic knockout/stun-like control reject
+    // Sap before the humanoid/non-combat checks matter. Use the dedicated Sap
+    // mechanic so creature templates can distinguish Sap immunity from generic
+    // knockout immunity.
+    ApplySpellFix({ 6770, 2070, 11297 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Mechanic = MECHANIC_SAPPED;
+    });
+
     // Threatening Gaze
     ApplySpellFix({ 24314 }, [](SpellInfo* spellInfo)
     {


### PR DESCRIPTION
### Motivation
- Classic Sap ranks were loaded with the generic `MECHANIC_KNOCKOUT`, causing PvE creatures with knockout-like immunities to reject Sap even when they were valid humanoid/non-combat targets, while PvP appeared to work because those targets often lack creature mechanic masks.

### Description
- Add a spell-info correction in `SpellMgr::LoadSpellInfoCorrections` to set `Mechanic = MECHANIC_SAPPED` for spell IDs `6770`, `2070`, and `11297`.
- Include a short comment explaining that Classic DBC encodes Sap as knockout and the change lets creature templates distinguish Sap immunity from generic knockout immunity.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues, which succeeded.
- Verified repository state with `git status --short` and `git log -1 --oneline` to confirm the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3185750d9483279630a95773bd0479)