### PR TITLE
Use MECHANIC_SAPPED for Classic Sap; add Sap diagnostic script and DB updates

### DIFF
--- a/sql/updates/world/3.3.5/2026_06_16_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_06_16_00_world.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (6770, 2070, 11297) AND `ScriptName`='spell_rog_sap_diagnostic';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(6770, 'spell_rog_sap_diagnostic'),
+(2070, 'spell_rog_sap_diagnostic'),
+(11297, 'spell_rog_sap_diagnostic');

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4839,6 +4839,20 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->ManaPerSecond = 0;
     });
 
+    // Sap (Classic ranks)
+    //
+    // The Classic DBC rows encode Sap as MECHANIC_KNOCKOUT even though the server
+    // has a dedicated MECHANIC_SAPPED mechanic. PvP targets generally have no
+    // creature_template mechanic mask, so Sap can still appear to work there, but
+    // PvE creatures that are immune to generic knockout/stun-like control reject
+    // Sap before the humanoid/non-combat checks matter. Use the dedicated Sap
+    // mechanic so creature templates can distinguish Sap immunity from generic
+    // knockout immunity.
+    ApplySpellFix({ 6770, 2070, 11297 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Mechanic = MECHANIC_SAPPED;
+    });
+
     // Threatening Gaze
     ApplySpellFix({ 24314 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -22,7 +22,9 @@
  */
 
 #include "ScriptMgr.h"
+#include "Chat.h"
 #include "Containers.h"
+#include "Creature.h"
 #include "DBCStores.h"
 #include "Item.h"
 #include "Log.h"
@@ -1272,6 +1274,48 @@ class spell_rog_imp_sap : public AuraScript
     }
 };
 
+// 6770, 2070, 11297 - Sap
+class spell_rog_sap_diagnostic : public SpellScript
+{
+    PrepareSpellScript(spell_rog_sap_diagnostic);
+
+    SpellCastResult CheckCast()
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Unit* unitTarget = GetExplTargetUnit();
+        Creature* target = unitTarget ? unitTarget->ToCreature() : nullptr;
+        if (!player || !target)
+            return SPELL_CAST_OK;
+
+        SpellInfo const* spellInfo = GetSpellInfo();
+        SpellCastResult targetCheck = spellInfo->CheckTarget(player, target, false);
+        bool fullImmune = target->IsImmunedToSpell(spellInfo, player);
+
+        uint8 immuneEffectMask = 0;
+        for (SpellEffectInfo const& effect : spellInfo->GetEffects())
+            if (effect.IsEffect() && target->IsImmunedToSpellEffect(spellInfo, effect, player))
+                immuneEffectMask |= 1 << effect.EffectIndex;
+
+        ChatHandler handler(player->GetSession());
+        handler.PSendSysMessage("[SapDiag] spell=%u mechanic=%u target=%s entry=%u type=%u typeMask=0x%08X requiredTypeMask=0x%08X",
+            spellInfo->Id, spellInfo->Mechanic, target->GetName().c_str(), target->GetEntry(), target->GetCreatureType(),
+            target->GetCreatureTypeMask(), spellInfo->TargetCreatureType);
+        handler.PSendSysMessage("[SapDiag] targetCheck=%u alive=%u inCombat=%u petInCombatFlag=%u targetFlags=0x%08X templateMechanicImmuneMask=0x%08X",
+            uint32(targetCheck), target->IsAlive(), target->IsInCombat(), target->HasUnitFlag(UNIT_FLAG_PET_IN_COMBAT),
+            uint32(target->GetUnitFlags()), target->GetCreatureTemplate()->MechanicImmuneMask);
+        handler.PSendSysMessage("[SapDiag] fullImmune=%u immuneEffectMask=0x%02X aura0=%u effect0Mechanic=%u casterInCombat=%u casterStealthed=%u",
+            fullImmune, immuneEffectMask, spellInfo->GetEffect(EFFECT_0).ApplyAuraName, spellInfo->GetEffect(EFFECT_0).Mechanic,
+            player->IsInCombat(), player->HasAura(SPELL_ROGUE_STEALTH));
+
+        return SPELL_CAST_OK;
+    }
+
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_rog_sap_diagnostic::CheckCast);
+    }
+};
+
 class spell_rog_deadly_shot : public SpellScript
 {
     PrepareSpellScript(spell_rog_deadly_shot);
@@ -1363,6 +1407,7 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellScript(spell_rog_turn_the_tables);
     RegisterSpellScript(spell_rog_vanish);
     RegisterSpellScript(spell_rog_imp_sap);
+    RegisterSpellScript(spell_rog_sap_diagnostic);
     RegisterSpellScript(spell_rog_poison);
     RegisterSpellScript(spell_rog_evasion);
     RegisterSpellScript(spell_rog_deadly_shot);


### PR DESCRIPTION
### Motivation
- Classic Sap ranks use a generic knockout mechanic in DBC which prevents distinguishing Sap immunity from generic knockout immunity on creature templates, so use the dedicated Sap mechanic to allow correct PvE behavior.
- Add a diagnostic spell script to help debug Sap cast/target immunities and reveal why a target may reject Sap.
- Persist the diagnostic script mapping to the database so the diagnostic script can be invoked in-game for the Classic Sap ranks.

### Description
- Change `SpellMgr::LoadSpellInfoCorrections` to set `Mechanic = MECHANIC_SAPPED` for spell IDs `6770`, `2070`, and `11297` so Classic Sap uses the dedicated mechanic.
- Add `spell_rog_sap_diagnostic` in `src/server/scripts/Spells/spell_rogue.cpp` which logs detailed target checks, immunity masks, creature template mechanic immunity, and caster/target state to the caster's chat for debugging Sap failures.
- Register the new `spell_rog_sap_diagnostic` script in the rogue spell script registration list and add the required includes (`Chat.h`, `Creature.h`) used by the diagnostic script.
- Add a SQL update `sql/updates/world/3.3.5/2026_06_16_00_world.sql` which removes any existing `spell_rog_sap_diagnostic` entries and inserts the mapping for spell IDs `6770`, `2070`, and `11297` into `spell_script_names`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3185750d9483279630a95773bd0479)