### PR TITLE
Use MECHANIC_SAPPED for Classic Sap and add diagnostic logging script

### DIFF
--- a/sql/updates/world/3.3.5/2026_06_16_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_06_16_00_world.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (6770, 2070, 11297) AND `ScriptName`='spell_rog_sap_diagnostic';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(6770, 'spell_rog_sap_diagnostic'),
+(2070, 'spell_rog_sap_diagnostic'),
+(11297, 'spell_rog_sap_diagnostic');

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4839,6 +4839,24 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->ManaPerSecond = 0;
     });
 
+    // Sap (Classic ranks)
+    //
+    // The Classic DBC rows encode Sap as MECHANIC_KNOCKOUT even though the server
+    // has a dedicated MECHANIC_SAPPED mechanic. PvP targets generally have no
+    // creature_template mechanic mask, so Sap can still appear to work there, but
+    // PvE creatures that are immune to generic knockout/stun-like control reject
+    // Sap before the humanoid/non-combat checks matter. Use the dedicated Sap
+    // mechanic so creature templates can distinguish Sap immunity from generic
+    // knockout immunity. Also force Sap negative: the Classic rows do not carry
+    // SPELL_ATTR0_NEGATIVE_1, which can make the aura look positive to aura
+    // scaling/target processing and drop PvE targets before hit processing.
+    ApplySpellFix({ 6770, 2070, 11297 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Mechanic = MECHANIC_SAPPED;
+        spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
+        spellInfo->AttributesCu |= SPELL_ATTR0_CU_NEGATIVE_EFF0;
+    });
+
     // Threatening Gaze
     ApplySpellFix({ 24314 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -22,7 +22,9 @@
  */
 
 #include "ScriptMgr.h"
+#include "Chat.h"
 #include "Containers.h"
+#include "Creature.h"
 #include "DBCStores.h"
 #include "Item.h"
 #include "Log.h"
@@ -1272,6 +1274,96 @@ class spell_rog_imp_sap : public AuraScript
     }
 };
 
+// 6770, 2070, 11297 - Sap
+class spell_rog_sap_diagnostic : public SpellScript
+{
+    PrepareSpellScript(spell_rog_sap_diagnostic);
+
+    static Creature* GetCreatureTarget(Unit* unitTarget)
+    {
+        return unitTarget ? unitTarget->ToCreature() : nullptr;
+    }
+
+    SpellCastResult CheckCast()
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Creature* target = GetCreatureTarget(GetExplTargetUnit());
+        if (!player || !target)
+            return SPELL_CAST_OK;
+
+        SpellInfo const* spellInfo = GetSpellInfo();
+        SpellCastResult targetCheck = spellInfo->CheckTarget(player, target, false);
+        bool fullImmune = target->IsImmunedToSpell(spellInfo, player);
+
+        uint8 immuneEffectMask = 0;
+        for (SpellEffectInfo const& effect : spellInfo->GetEffects())
+            if (effect.IsEffect() && target->IsImmunedToSpellEffect(spellInfo, effect, player))
+                immuneEffectMask |= 1 << effect.EffectIndex;
+
+        ChatHandler handler(player->GetSession());
+        handler.PSendSysMessage("[SapDiag] spell=%u mechanic=%u target=%s entry=%u type=%u typeMask=0x%08X requiredTypeMask=0x%08X",
+            spellInfo->Id, spellInfo->Mechanic, target->GetName().c_str(), target->GetEntry(), target->GetCreatureType(),
+            target->GetCreatureTypeMask(), spellInfo->TargetCreatureType);
+        handler.PSendSysMessage("[SapDiag] targetCheck=%u alive=%u inCombat=%u petInCombatFlag=%u targetFlags=0x%08X templateMechanicImmuneMask=0x%08X",
+            uint32(targetCheck), target->IsAlive(), target->IsInCombat(), target->HasUnitFlag(UNIT_FLAG_PET_IN_COMBAT),
+            uint32(target->GetUnitFlags()), target->GetCreatureTemplate()->MechanicImmuneMask);
+        handler.PSendSysMessage("[SapDiag] fullImmune=%u immuneEffectMask=0x%02X aura0=%u effect0Mechanic=%u casterInCombat=%u casterStealthed=%u",
+            fullImmune, immuneEffectMask, spellInfo->GetEffect(EFFECT_0).ApplyAuraName, spellInfo->GetEffect(EFFECT_0).Mechanic,
+            player->IsInCombat(), player->HasAura(SPELL_ROGUE_STEALTH));
+        handler.PSendSysMessage("[SapDiag] selectionPrecheck validAttack=%u effect0TargetOk=%u positiveEffect0=%u los=%u distance=%.2f targetMap=%u casterMap=%u",
+            player->IsValidAttackTarget(target, spellInfo), GetSpell()->CheckEffectTarget(target, spellInfo->GetEffect(EFFECT_0), nullptr),
+            spellInfo->IsPositiveEffect(EFFECT_0), target->IsWithinLOSInMap(player), player->GetExactDist(target), target->GetMapId(), player->GetMapId());
+
+        return SPELL_CAST_OK;
+    }
+
+    void HandleObjectTargetSelect(WorldObject*& target)
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Creature* creatureTarget = target ? target->ToCreature() : nullptr;
+        if (!player)
+            return;
+
+        ChatHandler(player->GetSession()).PSendSysMessage("[SapDiag] objectTargetSelect target=%s entry=%u targetIsCreature=%u",
+            creatureTarget ? creatureTarget->GetName().c_str() : (target ? target->GetName().c_str() : "<none>"),
+            creatureTarget ? creatureTarget->GetEntry() : 0, creatureTarget != nullptr);
+    }
+
+    void HandleBeforeHit(SpellMissInfo missInfo)
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Creature* target = GetCreatureTarget(GetHitUnit());
+        if (!player || !target)
+            return;
+
+        ChatHandler(player->GetSession()).PSendSysMessage("[SapDiag] hitPhase target=%s entry=%u missInfo=%u",
+            target->GetName().c_str(), target->GetEntry(), uint32(missInfo));
+    }
+
+    void HandleAfterHit()
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Creature* target = GetCreatureTarget(GetHitUnit());
+        if (!player || !target)
+            return;
+
+        Aura* hitAura = GetHitAura();
+        Aura* sapAura = target->GetAura(GetSpellInfo()->Id, player->GetGUID());
+        ChatHandler(player->GetSession()).PSendSysMessage("[SapDiag] afterHit target=%s entry=%u hitAura=%u targetHasSapAura=%u sapAuraDuration=%d stunned=%u confused=%u rooted=%u unitFlags=0x%08X",
+            target->GetName().c_str(), target->GetEntry(), hitAura ? hitAura->GetId() : 0, sapAura != nullptr,
+            sapAura ? sapAura->GetDuration() : 0, target->HasUnitState(UNIT_STATE_STUNNED),
+            target->HasUnitState(UNIT_STATE_CONFUSED), target->HasUnitState(UNIT_STATE_ROOT), uint32(target->GetUnitFlags()));
+    }
+
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_rog_sap_diagnostic::CheckCast);
+        OnObjectTargetSelect += SpellObjectTargetSelectFn(spell_rog_sap_diagnostic::HandleObjectTargetSelect, EFFECT_0, TARGET_UNIT_TARGET_ENEMY);
+        BeforeHit += BeforeSpellHitFn(spell_rog_sap_diagnostic::HandleBeforeHit);
+        AfterHit += SpellHitFn(spell_rog_sap_diagnostic::HandleAfterHit);
+    }
+};
+
 class spell_rog_deadly_shot : public SpellScript
 {
     PrepareSpellScript(spell_rog_deadly_shot);
@@ -1363,6 +1455,7 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellScript(spell_rog_turn_the_tables);
     RegisterSpellScript(spell_rog_vanish);
     RegisterSpellScript(spell_rog_imp_sap);
+    RegisterSpellScript(spell_rog_sap_diagnostic);
     RegisterSpellScript(spell_rog_poison);
     RegisterSpellScript(spell_rog_evasion);
     RegisterSpellScript(spell_rog_deadly_shot);


### PR DESCRIPTION
### Motivation
- Classic Sap ranks were encoded with a generic knockout mechanic which caused PvE creatures with knockout immunities to reject Sap prematurely. 
- A diagnostic SpellScript is needed to observe target checks, immunity masks and hit/aura behavior when Sap is used on creatures. 
- A migration is required to hook the new diagnostic script into the three Classic Sap spells. 

### Description
- Change `SpellMgr::LoadSpellInfoCorrections` to apply a fix for spell IDs `6770`, `2070`, and `11297` that sets `Mechanic` to `MECHANIC_SAPPED`, marks the spells negative with `SPELL_ATTR0_NEGATIVE_1`, and sets `SPELL_ATTR0_CU_NEGATIVE_EFF0` on `AttributesCu`. 
- Add a new diagnostic spell script `spell_rog_sap_diagnostic` in `src/server/scripts/Spells/spell_rogue.cpp` that logs detailed runtime information during `CheckCast`, object target selection, `BeforeHit`, and `AfterHit` to help debug Sap interactions with creature immunities and flags. 
- Register the diagnostic script in `AddSC_rogue_spell_scripts()` and add the required includes (`Chat.h`, `Creature.h`). 
- Add a DB migration `sql/updates/world/3.3.5/2026_06_16_00_world.sql` that removes any existing `spell_rog_sap_diagnostic` entries for the three spells and inserts the new `spell_script_names` entries linking the diagnostic script to spell IDs `6770`, `2070`, and `11297`. 

### Testing
- Built the server (`cmake`/`make`) after the changes and the build completed successfully. 
- Ran the project's automated test suite (`ctest`) and recorded no failures. 
- Applied the SQL migration in a test world DB and verified the `spell_script_names` rows for the three Sap spell IDs were updated as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3185750d9483279630a95773bd0479)