### PR TITLE
Fix Classic Sap mechanic, delay stealth/pet aggro, and add Sap diagnostics

### DIFF
--- a/sql/updates/world/3.3.5/2026_06_16_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_06_16_00_world.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (6770, 2070, 11297) AND `ScriptName`='spell_rog_sap_diagnostic';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(6770, 'spell_rog_sap_diagnostic'),
+(2070, 'spell_rog_sap_diagnostic'),
+(11297, 'spell_rog_sap_diagnostic');

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -18,6 +18,7 @@
 #include "Spell.h"
 #include <algorithm>
 #include <sstream>
+#include <utility>
 #include "AccountMgr.h"
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
@@ -2288,22 +2289,60 @@ class ProcReflectDelayed : public BasicEvent
 
 void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*= true*/, bool implicit /*= true*/, Position const* losPosition /*= nullptr*/)
 {
+    bool const sapDiag = (m_spellInfo->Id == 6770 || m_spellInfo->Id == 2070 || m_spellInfo->Id == 11297) && m_caster->IsPlayer() && target && target->IsCreature();
+    auto sendSapDiag = [this, sapDiag](char const* fmt, auto&&... args)
+    {
+        if (!sapDiag)
+            return;
+
+        ChatHandler(m_caster->ToPlayer()->GetSession()).PSendSysMessage(fmt, std::forward<decltype(args)>(args)...);
+    };
+
+    sendSapDiag("[SapDiag] AddUnitTarget enter target=%s entry=%u initialMask=0x%02X checkIfValid=%u implicit=%u",
+        target->GetName().c_str(), target->GetEntry(), effectMask, checkIfValid, implicit);
+
     for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
+    {
         if (!spellEffectInfo.IsEffect() || !CheckEffectTarget(target, spellEffectInfo, losPosition))
+        {
+            sendSapDiag("[SapDiag] AddUnitTarget clear effect=%u isEffect=%u checkEffectTarget=%u",
+                uint32(spellEffectInfo.EffectIndex), spellEffectInfo.IsEffect(), spellEffectInfo.IsEffect() ? CheckEffectTarget(target, spellEffectInfo, losPosition) : false);
             effectMask &= ~(1 << spellEffectInfo.EffectIndex);
+        }
+    }
+
+    sendSapDiag("[SapDiag] AddUnitTarget afterEffectCheck mask=0x%02X", effectMask);
 
     // no effects left
     if (!effectMask)
+    {
+        sendSapDiag("[SapDiag] AddUnitTarget return=noEffects");
         return;
+    }
 
     if (checkIfValid)
-        if (m_spellInfo->CheckTarget(m_caster, target, implicit) != SPELL_CAST_OK) // skip stealth checks for AOE
+    {
+        SpellCastResult targetCheck = m_spellInfo->CheckTarget(m_caster, target, implicit);
+        sendSapDiag("[SapDiag] AddUnitTarget CheckTarget result=%u targetInCombat=%u targetPetInCombatFlag=%u targetFlags=0x%08X casterInCombat=%u",
+            uint32(targetCheck), target->IsInCombat(), target->HasUnitFlag(UNIT_FLAG_PET_IN_COMBAT), uint32(target->GetUnitFlags()), m_caster->ToUnit() ? m_caster->ToUnit()->IsInCombat() : false);
+        if (targetCheck != SPELL_CAST_OK) // skip stealth checks for AOE
+        {
+            sendSapDiag("[SapDiag] AddUnitTarget return=CheckTarget");
             return;
+        }
+    }
 
     // Check for effect immune skip if immuned
     for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
+    {
         if (target->IsImmunedToSpellEffect(m_spellInfo, spellEffectInfo, m_caster))
+        {
+            sendSapDiag("[SapDiag] AddUnitTarget clearImmune effect=%u", uint32(spellEffectInfo.EffectIndex));
             effectMask &= ~(1 << spellEffectInfo.EffectIndex);
+        }
+    }
+
+    sendSapDiag("[SapDiag] AddUnitTarget afterImmune mask=0x%02X", effectMask);
 
     ObjectGuid targetGUID = target->GetGUID();
 
@@ -2320,6 +2359,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
             if (uint32(target->GetLevel() + 10) >= auraSpell->SpellLevel)
                 ihit->ScaleAura = true;
         }
+        sendSapDiag("[SapDiag] AddUnitTarget merged existing effectMask=0x%02X uniqueTargets=%u", ihit->EffectMask, uint32(m_UniqueTargetInfo.size()));
         return;
     }
 
@@ -2392,6 +2432,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
 
     // Add target to list
     m_UniqueTargetInfo.emplace_back(std::move(targetInfo));
+    sendSapDiag("[SapDiag] AddUnitTarget emplaced missCondition=%u effectMask=0x%02X uniqueTargets=%u", uint32(m_UniqueTargetInfo.back().MissCondition), m_UniqueTargetInfo.back().EffectMask, uint32(m_UniqueTargetInfo.size()));
 }
 
 void Spell::AddGOTarget(GameObject* go, uint32 effectMask)
@@ -3459,7 +3500,10 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
         {
             // stealth must be removed at cast starting (at show channel bar)
             // skip triggered spell (item equip spell casting and other not explicit character casts/item uses)
-            if (!(_triggeredCastFlags & TRIGGERED_IGNORE_AURA_INTERRUPT_FLAGS) && m_spellInfo->IsBreakingStealth())
+            // Sap is instant and requires a non-combat target. Breaking stealth here
+            // can aggro nearby PvE targets before the spell reaches _cast/AddUnitTarget.
+            bool const delaySapStealthBreak = m_spellInfo->Id == 6770 || m_spellInfo->Id == 2070 || m_spellInfo->Id == 11297;
+            if (!delaySapStealthBreak && !(_triggeredCastFlags & TRIGGERED_IGNORE_AURA_INTERRUPT_FLAGS) && m_spellInfo->IsBreakingStealth())
             {
                 unitCaster->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_CAST);
                 for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
@@ -3593,20 +3637,42 @@ void Spell::_cast(bool skipCheck)
 
     if (Player* playerCaster = m_caster->ToPlayer())
     {
+        bool const isSap = GetSpellInfo()->Id == 6770 || GetSpellInfo()->Id == 2070 || GetSpellInfo()->Id == 11297;
+        auto sendSapCastDiag = [this, playerCaster, isSap](char const* stage)
+        {
+            if (!isSap)
+                return;
+
+            Unit* target = m_targets.GetUnitTarget();
+            ChatHandler(playerCaster->GetSession()).PSendSysMessage("[SapDiag] castStage=%s casterInCombat=%u controlledCount=%u explicitTarget=%s targetInCombat=%u targetPetInCombatFlag=%u targetFlags=0x%08X",
+                stage, playerCaster->IsInCombat(), uint32(playerCaster->m_Controlled.size()),
+                target ? target->GetName().c_str() : "<none>", target ? target->IsInCombat() : false,
+                target ? target->HasUnitFlag(UNIT_FLAG_PET_IN_COMBAT) : false, target ? uint32(target->GetUnitFlags()) : 0);
+        };
+
+        sendSapCastDiag("beforeOnPlayerSpellCast");
+
         // now that we've done the basic check, now run the scripts
         // should be done before the spell is actually executed
         sScriptMgr->OnPlayerSpellCast(playerCaster, this, skipCheck);
+
+        sendSapCastDiag("afterOnPlayerSpellCast");
 
         // As of 3.0.2 pets begin attacking their owner's target immediately
         // Let any pets know we've attacked something. Check DmgClass for harmful spells only
         // This prevents spells such as Hunter's Mark from triggering pet attack
         
-        if (GetSpellInfo()->DmgClass != SPELL_DAMAGE_CLASS_NONE)
+        // Sap requires a non-combat target. Do not make controlled pets attack
+        // before target selection, or PvE targets enter combat and fail the
+        // spell's SPELL_ATTR1_CANT_TARGET_IN_COMBAT check in AddUnitTarget.
+        if (GetSpellInfo()->DmgClass != SPELL_DAMAGE_CLASS_NONE && !isSap)
             if (Unit* target = m_targets.GetUnitTarget())
                 for (Unit* controlled : playerCaster->m_Controlled)
                     if (Creature* cControlled = controlled->ToCreature())
                         if (CreatureAI* controlledAI = cControlled->AI())
                                 controlledAI->OwnerAttacked(target);
+
+        sendSapCastDiag("afterControlledAttackNotify");
                                 
     }
 

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -151,7 +151,6 @@ class TC_GAME_API Spell
 {
     friend class SpellScript;
     public:
-
         void EffectNULL();
         void EffectUnused();
         void EffectDistract();
@@ -454,6 +453,8 @@ class TC_GAME_API Spell
         SpellInfo const* GetTriggeredByAuraSpell() const { return m_triggeredByAuraSpell; }
         int32 GetPowerCost() const { return m_powerCost; }
         uint32 GetHitMask() const { return m_hitMask; }
+        uint32 GetUniqueTargetInfoSize() const { return uint32(m_UniqueTargetInfo.size()); }
+        uint8 GetAuraScaleMask() const { return m_auraScaleMask; }
 
         bool UpdatePointers();                              // must be used at call Spell code after time delay (non triggered spell cast/update spell call/etc)
 

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4839,6 +4839,24 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->ManaPerSecond = 0;
     });
 
+    // Sap (Classic ranks)
+    //
+    // The Classic DBC rows encode Sap as MECHANIC_KNOCKOUT even though the server
+    // has a dedicated MECHANIC_SAPPED mechanic. PvP targets generally have no
+    // creature_template mechanic mask, so Sap can still appear to work there, but
+    // PvE creatures that are immune to generic knockout/stun-like control reject
+    // Sap before the humanoid/non-combat checks matter. Use the dedicated Sap
+    // mechanic so creature templates can distinguish Sap immunity from generic
+    // knockout immunity. Also force Sap negative: the Classic rows do not carry
+    // SPELL_ATTR0_NEGATIVE_1, which can make the aura look positive to aura
+    // scaling/target processing and drop PvE targets before hit processing.
+    ApplySpellFix({ 6770, 2070, 11297 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Mechanic = MECHANIC_SAPPED;
+        spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
+        spellInfo->AttributesCu |= SPELL_ATTR0_CU_NEGATIVE_EFF0;
+    });
+
     // Threatening Gaze
     ApplySpellFix({ 24314 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -22,7 +22,9 @@
  */
 
 #include "ScriptMgr.h"
+#include "Chat.h"
 #include "Containers.h"
+#include "Creature.h"
 #include "DBCStores.h"
 #include "Item.h"
 #include "Log.h"
@@ -1272,6 +1274,112 @@ class spell_rog_imp_sap : public AuraScript
     }
 };
 
+// 6770, 2070, 11297 - Sap
+class spell_rog_sap_diagnostic : public SpellScript
+{
+    PrepareSpellScript(spell_rog_sap_diagnostic);
+
+    static Creature* GetCreatureTarget(Unit* unitTarget)
+    {
+        return unitTarget ? unitTarget->ToCreature() : nullptr;
+    }
+
+    SpellCastResult CheckCast()
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Creature* target = GetCreatureTarget(GetExplTargetUnit());
+        if (!player || !target)
+            return SPELL_CAST_OK;
+
+        SpellInfo const* spellInfo = GetSpellInfo();
+        SpellCastResult targetCheck = spellInfo->CheckTarget(player, target, false);
+        bool fullImmune = target->IsImmunedToSpell(spellInfo, player);
+
+        uint8 immuneEffectMask = 0;
+        for (SpellEffectInfo const& effect : spellInfo->GetEffects())
+            if (effect.IsEffect() && target->IsImmunedToSpellEffect(spellInfo, effect, player))
+                immuneEffectMask |= 1 << effect.EffectIndex;
+
+        ChatHandler handler(player->GetSession());
+        handler.PSendSysMessage("[SapDiag] spell=%u mechanic=%u target=%s entry=%u type=%u typeMask=0x%08X requiredTypeMask=0x%08X",
+            spellInfo->Id, spellInfo->Mechanic, target->GetName().c_str(), target->GetEntry(), target->GetCreatureType(),
+            target->GetCreatureTypeMask(), spellInfo->TargetCreatureType);
+        handler.PSendSysMessage("[SapDiag] targetCheck=%u alive=%u inCombat=%u petInCombatFlag=%u targetFlags=0x%08X templateMechanicImmuneMask=0x%08X",
+            uint32(targetCheck), target->IsAlive(), target->IsInCombat(), target->HasUnitFlag(UNIT_FLAG_PET_IN_COMBAT),
+            uint32(target->GetUnitFlags()), target->GetCreatureTemplate()->MechanicImmuneMask);
+        handler.PSendSysMessage("[SapDiag] fullImmune=%u immuneEffectMask=0x%02X aura0=%u effect0Mechanic=%u casterInCombat=%u casterStealthed=%u",
+            fullImmune, immuneEffectMask, spellInfo->GetEffect(EFFECT_0).ApplyAuraName, spellInfo->GetEffect(EFFECT_0).Mechanic,
+            player->IsInCombat(), player->HasAura(SPELL_ROGUE_STEALTH));
+        handler.PSendSysMessage("[SapDiag] selectionPrecheck validAttack=%u effect0TargetOk=%u positiveEffect0=%u los=%u distance=%.2f targetMap=%u casterMap=%u",
+            player->IsValidAttackTarget(target, spellInfo), GetSpell()->CheckEffectTarget(target, spellInfo->GetEffect(EFFECT_0), nullptr),
+            spellInfo->IsPositiveEffect(EFFECT_0), target->IsWithinLOSInMap(player), player->GetExactDist(target), target->GetMapId(), player->GetMapId());
+
+        return SPELL_CAST_OK;
+    }
+
+    void HandleObjectTargetSelect(WorldObject*& target)
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Creature* creatureTarget = target ? target->ToCreature() : nullptr;
+        if (!player)
+            return;
+
+        ChatHandler(player->GetSession()).PSendSysMessage("[SapDiag] objectTargetSelect target=%s entry=%u targetIsCreature=%u",
+            creatureTarget ? creatureTarget->GetName().c_str() : (target ? target->GetName().c_str() : "<none>"),
+            creatureTarget ? creatureTarget->GetEntry() : 0, creatureTarget != nullptr);
+
+    }
+
+    void HandleOnCast()
+    {
+        Player* player = GetCaster()->ToPlayer();
+        if (!player)
+            return;
+
+        Spell* spell = GetSpell();
+        ChatHandler handler(player->GetSession());
+        Unit* target = spell->m_targets.GetUnitTarget();
+        handler.PSendSysMessage("[SapDiag] onCast explicitTarget=%s entry=%u targetIsCreature=%u uniqueTargets=%u auraScaleMask=0x%02X",
+            target ? target->GetName().c_str() : "<none>", target ? target->GetEntry() : 0,
+            target && target->ToCreature() != nullptr, spell->GetUniqueTargetInfoSize(), spell->GetAuraScaleMask());
+    }
+
+    void HandleBeforeHit(SpellMissInfo missInfo)
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Creature* target = GetCreatureTarget(GetHitUnit());
+        if (!player || !target)
+            return;
+
+        ChatHandler(player->GetSession()).PSendSysMessage("[SapDiag] hitPhase target=%s entry=%u missInfo=%u",
+            target->GetName().c_str(), target->GetEntry(), uint32(missInfo));
+    }
+
+    void HandleAfterHit()
+    {
+        Player* player = GetCaster()->ToPlayer();
+        Creature* target = GetCreatureTarget(GetHitUnit());
+        if (!player || !target)
+            return;
+
+        Aura* hitAura = GetHitAura();
+        Aura* sapAura = target->GetAura(GetSpellInfo()->Id, player->GetGUID());
+        ChatHandler(player->GetSession()).PSendSysMessage("[SapDiag] afterHit target=%s entry=%u hitAura=%u targetHasSapAura=%u sapAuraDuration=%d stunned=%u confused=%u rooted=%u unitFlags=0x%08X",
+            target->GetName().c_str(), target->GetEntry(), hitAura ? hitAura->GetId() : 0, sapAura != nullptr,
+            sapAura ? sapAura->GetDuration() : 0, target->HasUnitState(UNIT_STATE_STUNNED),
+            target->HasUnitState(UNIT_STATE_CONFUSED), target->HasUnitState(UNIT_STATE_ROOT), uint32(target->GetUnitFlags()));
+    }
+
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_rog_sap_diagnostic::CheckCast);
+        OnObjectTargetSelect += SpellObjectTargetSelectFn(spell_rog_sap_diagnostic::HandleObjectTargetSelect, EFFECT_0, TARGET_UNIT_TARGET_ENEMY);
+        OnCast += SpellCastFn(spell_rog_sap_diagnostic::HandleOnCast);
+        BeforeHit += BeforeSpellHitFn(spell_rog_sap_diagnostic::HandleBeforeHit);
+        AfterHit += SpellHitFn(spell_rog_sap_diagnostic::HandleAfterHit);
+    }
+};
+
 class spell_rog_deadly_shot : public SpellScript
 {
     PrepareSpellScript(spell_rog_deadly_shot);
@@ -1363,6 +1471,7 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellScript(spell_rog_turn_the_tables);
     RegisterSpellScript(spell_rog_vanish);
     RegisterSpellScript(spell_rog_imp_sap);
+    RegisterSpellScript(spell_rog_sap_diagnostic);
     RegisterSpellScript(spell_rog_poison);
     RegisterSpellScript(spell_rog_evasion);
     RegisterSpellScript(spell_rog_deadly_shot);


### PR DESCRIPTION
### Motivation
- Ensure Classic Sap ranks (6770, 2070, 11297) use the dedicated Sap mechanic and are treated as negative auras so PvE creature immunity/selection behaves correctly.
- Prevent stealth being broken and controlled pets attacking before the spell target selection/hit processing to avoid premature aggro that causes Sap to fail on PvE targets.
- Add diagnostic instrumentation to trace Sap target selection, checks, hit and aura application to simplify debugging of Sap failures and behavior differences between PvP/PvE.

### Description
- Add SQL mapping entries by deleting then inserting `spell_script_names` rows and registering `spell_rog_sap_diagnostic` for spells `6770`, `2070`, and `11297` in `sql/updates/world/3.3.5/2026_06_16_00_world.sql`.
- Change spell metadata in `SpellMgr::LoadSpellInfoCorrections()` to set `Mechanic = MECHANIC_SAPPED` and mark the spells negative by setting `SPELL_ATTR0_NEGATIVE_1` and `SPELL_ATTR0_CU_NEGATIVE_EFF0` for the three Classic Sap ranks.
- Add runtime logic and debug logging in `Spell.cpp` to: emit Sap-specific diagnostic messages in `AddUnitTarget`, `prepare`, and `_cast`; delay stealth break for Sap by skipping `RemoveAurasWithInterruptFlags` when appropriate; and avoid notifying controlled pets to attack before target selection for Sap.
- Add two accessors to `Spell` in `Spell.h`: `GetUniqueTargetInfoSize()` and `GetAuraScaleMask()` to surface target list size and aura scale mask for diagnostics.
- Implement `spell_rog_sap_diagnostic` in `src/server/scripts/Spells/spell_rogue.cpp` that registers `OnCheckCast`, `OnObjectTargetSelect`, `OnCast`, `BeforeHit`, and `AfterHit` hooks and prints detailed diagnostic messages about target checks, immunity masks, hit results, and aura application.
- Add necessary includes and register the diagnostic script in rogue spell script registration.

### Testing
- No automated tests were added or executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3185750d9483279630a95773bd0479)