### PR TITLE
Fix polearm inner aura resync after disarm

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -47,6 +47,12 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include <numeric>
+
+namespace PolearmStaffInnerAuras
+{
+    void OnEquipmentChanged(Player* player);
+}
+
 namespace
 {
     bool IsFollowFearSpell(SpellInfo const* spellInfo)
@@ -2416,6 +2422,8 @@ void AuraEffect::HandleAuraModDisarm(AuraApplication const* aurApp, uint8 mode, 
                 if (!apply) // apply case already handled on item dependent aura removal (if any)
                     player->UpdateWeaponDependentAuras(attackType);
             }
+
+            PolearmStaffInnerAuras::OnEquipmentChanged(player);
         }
     }
 

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -120,7 +120,7 @@ bool IsPolearmOrStaffEquipped(Player const* player)
     if (!player)
         return false;
 
-    Item const* weapon = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+    Item const* weapon = player->GetUseableItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
     if (!weapon)
         return false;
 


### PR DESCRIPTION
### Motivation
- Polearm Specialization inner auras were not being re-applied when a player was disarmed and then regained use of their main-hand weapon, causing passive inner auras to remain out of sync with the actual usable weapon state.

### Description
- Invoke `PolearmStaffInnerAuras::OnEquipmentChanged(player)` from `AuraEffect::HandleAuraModDisarm` so inner auras are re-evaluated after weapon-dependent auras and damage updates are applied. 
- Change the polearm/staff check in `IsPolearmOrStaffEquipped` to use `Player::GetUseableItemByPos` so a disarmed main-hand weapon is treated as unusable when deciding whether to apply inner auras, and add a forward declaration for the hook in `SpellAuraEffects.cpp`.

### Testing
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34a331c7d48327bb46f58453edd0f1)