### PR TITLE
Remove player AOE per-target damage cap in Spell::DoEffectOnLaunchTarget

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -8339,14 +8339,6 @@ void Spell::DoEffectOnLaunchTarget(TargetInfo& targetInfo, float multiplier, Spe
         if (spellEffectInfo.IsTargetingArea() || spellEffectInfo.IsAreaAuraEffect() || spellEffectInfo.IsEffect(SPELL_EFFECT_PERSISTENT_AREA_AURA))
         {
             m_damage = unit->CalculateAOEAvoidance(m_damage, m_spellInfo->SchoolMask, m_originalCaster->GetGUID());
-
-            if (m_originalCaster->GetTypeId() == TYPEID_PLAYER)
-            {
-                // cap damage of player AOE
-                uint32 targetAmount = m_UniqueTargetInfo.size();
-                if (targetAmount > 10)
-                    m_damage = m_damage * 10 / targetAmount;
-            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Remove an artificial per-target damage cap that reduced player AOE damage when more than 10 targets were hit to avoid incorrect double-scaling and allow only `CalculateAOEAvoidance` to adjust AOE damage.

### Description
- Deleted the block that checked `originalCaster->GetTypeId() == TYPEID_PLAYER` and applied `m_damage = m_damage * 10 / targetAmount` inside `Spell::DoEffectOnLaunchTarget` for area effects, leaving `CalculateAOEAvoidance` as the sole AOE adjustment.

### Testing
- Project compiled successfully after the change and automated unit tests were executed; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350ed7fb588327bf5c286cdcb51852)