### PR TITLE
Randomize managed bot mass-battleground queue order and add unit test

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -2930,6 +2930,8 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
             }
         }
 
+        Trinity::Containers::RandomShuffle(managedBotGuids);
+
         uint32 queuedCount = 0;
         for (ObjectGuid const& guid : managedBotGuids)
         {

--- a/tests/game/PlayerbotRandomPopulation.cpp
+++ b/tests/game/PlayerbotRandomPopulation.cpp
@@ -74,6 +74,13 @@ TEST_CASE("Playerbot battleground queue target remains Warsong", "[playerbot][po
     CHECK(source.find("BATTLEGROUND_WS") != std::string::npos);
 }
 
+TEST_CASE("Playerbot mass battleground queue order is randomized", "[playerbot][population]")
+{
+    std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp");
+    CHECK(source.find("RandomShuffle(managedBotGuids)") != std::string::npos);
+    CHECK(source.find("for (ObjectGuid const& guid : managedBotGuids)") != std::string::npos);
+}
+
 TEST_CASE("Playerbot class spell decision cadence is once per second", "[playerbot][pvp]")
 {
     std::string const source = ReadFile("src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp");


### PR DESCRIPTION
### Motivation
- Prevent deterministic ordering when mass-queueing managed bots so queuing isn't biased and bots don't remain perpetually ineligible due to fixed iteration order.

### Description
- Call `Trinity::Containers::RandomShuffle(managedBotGuids);` in `QueueEligibleManagedBotsForBattleground` to randomize the order of `managedBotGuids` before processing.
- Add a unit test `Playerbot mass battleground queue order is randomized` in `tests/game/PlayerbotRandomPopulation.cpp` that checks for the presence of `RandomShuffle(managedBotGuids)` and the subsequent `for (ObjectGuid const& guid : managedBotGuids)` loop.

### Testing
- Executed the `PlayerbotRandomPopulation` test suite including the new `Playerbot mass battleground queue order is randomized` test, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c4735d34083279e1443024d45b080)