### PR TITLE
Improve crash breadcrumbs for aura unapply and WorldSocket packet cleanup

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3971,6 +3971,8 @@ void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMo
         if (sConditionMgr->IsSpellUsedInSpellClickConditions(aurApp->GetBase()->GetId()))
             player->UpdateVisibleGameobjectsOrSpellClicks();
 
+    Trinity::ClearCrashContext();
+
     i = m_appliedAuras.begin();
 }
 

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -18,6 +18,7 @@
 #include "WorldSocket.h"
 #include "BigNumber.h"
 #include "DatabaseEnv.h"
+#include "Errors.h"
 #include "GameTime.h"
 #include "CryptoHash.h"
 #include "CryptoRandom.h"
@@ -28,6 +29,7 @@
 #include "RBAC.h"
 #include "Realm.h"
 #include "ScriptMgr.h"
+#include "StringFormat.h"
 #include "World.h"
 #include "WorldSession.h"
 #include <memory>
@@ -87,6 +89,9 @@ bool WorldSocket::Update()
     MessageBuffer buffer(_sendBufferSize);
     while (_bufferQueue.Dequeue(queued))
     {
+        Trinity::SetCrashContext(Trinity::StringFormat("WorldSocket::Update dequeued packet socketPtr={} packetPtr={} opcode={} size={} encrypt={} remote={}:{}",
+            static_cast<void const*>(this), static_cast<void const*>(queued), queued->GetOpcode(), queued->size(), queued->NeedsEncryption(), GetRemoteIpAddress().to_string(), GetRemotePort()));
+
         ServerPktHeader header(queued->size() + 2, queued->GetOpcode());
         if (queued->NeedsEncryption())
             _authCrypt.EncryptSend(header.header, header.getHeaderLength());
@@ -113,7 +118,10 @@ bool WorldSocket::Update()
             QueuePacket(std::move(packetBuffer));
         }
 
+        Trinity::SetCrashContext(Trinity::StringFormat("WorldSocket::Update deleting packet socketPtr={} packetPtr={} opcode={} size={} remote={}:{}",
+            static_cast<void const*>(this), static_cast<void const*>(queued), queued->GetOpcode(), queued->size(), GetRemoteIpAddress().to_string(), GetRemotePort()));
         delete queued;
+        Trinity::ClearCrashContext();
     }
 
     if (buffer.GetActiveSize() > 0)


### PR DESCRIPTION
### Motivation
- Crash logs showed allocator/free-time segfaults with stale `Unit::_UnapplyAura` breadcrumbs and opaque crashes inside packet deletion in `WorldSocket::Update`, making root-cause diagnosis difficult.
- Provide clearer, shorter-lived crash breadcrumbs around risky points so future crashes include the active object/packet context instead of misleading stale data.

### Description
- Clear the aura breadcrumb at the end of `Unit::_UnapplyAura` by calling `Trinity::ClearCrashContext()` to avoid leaving stale context after successful aura removal (`src/server/game/Entities/Unit/Unit.cpp`).
- Add packet-level crash breadcrumbs in `WorldSocket::Update` by calling `Trinity::SetCrashContext(...)` when a queued `EncryptablePacket` is dequeued and immediately before it is deleted, and clear the context after deletion (`src/server/game/Server/WorldSocket.cpp`).
- Add required includes (`Errors.h` and `StringFormat.h`) to `WorldSocket.cpp` to support the new crash-context calls.

### Testing
- Ran `git diff --check` to verify there are no whitespace/format issues and it completed successfully.
- No automated build or unit tests were executed in this change; the edits are limited to adding diagnostic breadcrumbs and headers and do not alter runtime logic beyond crash-context bookkeeping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed0103e6c8327904325293e04f013)