### PR TITLE
Guard Player instance reset times with mutex and add crash context for diagnostics

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1377,16 +1377,21 @@ void Player::Update(uint32 p_time)
     UpdateEnchantTime(p_time);
     UpdateHomebindTime(p_time);
 
-    if (!_instanceResetTimes.empty())
     {
+        std::lock_guard<std::mutex> instanceResetTimesGuard(_instanceResetTimesLock);
         for (InstanceTimeMap::iterator itr = _instanceResetTimes.begin(); itr != _instanceResetTimes.end();)
         {
             if (itr->second < now)
+            {
+                Trinity::SetCrashContext(Trinity::StringFormat("Player::Update erasing expired instance reset time playerPtr={} guid={} mapId={} instanceId={} releaseTime={} now={}",
+                    static_cast<void const*>(this), GetGUID().ToString(), GetMapId(), itr->first, uint64(itr->second), uint64(now)));
                 itr = _instanceResetTimes.erase(itr);
+            }
             else
                 ++itr;
         }
     }
+    Trinity::ClearCrashContext();
 
     if (GetClass() == CLASS_DEATH_KNIGHT)
     {
@@ -19859,6 +19864,8 @@ bool Player::CheckInstanceValidity(bool /*isLogin*/)
 
 bool Player::CheckInstanceCount(uint32 instanceId) const
 {
+    std::lock_guard<std::mutex> instanceResetTimesGuard(_instanceResetTimesLock);
+
     if (_instanceResetTimes.size() < sWorld->getIntConfig(CONFIG_MAX_INSTANCES_PER_HOUR))
         return true;
     return _instanceResetTimes.find(instanceId) != _instanceResetTimes.end();
@@ -19866,6 +19873,8 @@ bool Player::CheckInstanceCount(uint32 instanceId) const
 
 void Player::AddInstanceEnterTime(uint32 instanceId, time_t enterTime)
 {
+    std::lock_guard<std::mutex> instanceResetTimesGuard(_instanceResetTimesLock);
+
     if (_instanceResetTimes.find(instanceId) == _instanceResetTimes.end())
         _instanceResetTimes.insert(InstanceTimeMap::value_type(instanceId, enterTime + HOUR));
 }
@@ -27923,6 +27932,8 @@ void Player::_LoadInstanceTimeRestrictions(PreparedQueryResult result)
     if (!result)
         return;
 
+    std::lock_guard<std::mutex> instanceResetTimesGuard(_instanceResetTimesLock);
+
     do
     {
         Field* fields = result->Fetch();
@@ -27981,6 +27992,8 @@ void Player::_LoadPetStable(uint8 petStableSlots, PreparedQueryResult result)
 
 void Player::_SaveInstanceTimeRestrictions(CharacterDatabaseTransaction trans)
 {
+    std::lock_guard<std::mutex> instanceResetTimesGuard(_instanceResetTimesLock);
+
     if (_instanceResetTimes.empty())
         return;
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -32,7 +32,9 @@
 #include "PlayerTaxi.h"
 #include "QuestDef.h"
 #include <array>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <unordered_set>
 
@@ -157,7 +159,7 @@ typedef std::unordered_map<uint32, PlayerTalent*> PlayerTalentMap;
 typedef std::unordered_map<uint32, PlayerSpell> PlayerSpellMap;
 typedef std::unordered_set<SpellModifier*> SpellModContainer;
 
-typedef std::unordered_map<uint32 /*instanceId*/, time_t/*releaseTime*/> InstanceTimeMap;
+typedef std::map<uint32 /*instanceId*/, time_t/*releaseTime*/> InstanceTimeMap;
 
 enum ActionButtonUpdateState
 {
@@ -2611,6 +2613,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         uint32 m_ChampioningFaction;
 
         InstanceTimeMap _instanceResetTimes;
+        mutable std::mutex _instanceResetTimesLock;
         uint32 _pendingBindId;
         uint32 _pendingBindTimer;
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3971,6 +3971,8 @@ void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMo
         if (sConditionMgr->IsSpellUsedInSpellClickConditions(aurApp->GetBase()->GetId()))
             player->UpdateVisibleGameobjectsOrSpellClicks();
 
+    Trinity::ClearCrashContext();
+
     i = m_appliedAuras.begin();
 }
 

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -18,6 +18,7 @@
 #include "WorldSocket.h"
 #include "BigNumber.h"
 #include "DatabaseEnv.h"
+#include "Errors.h"
 #include "GameTime.h"
 #include "CryptoHash.h"
 #include "CryptoRandom.h"
@@ -28,6 +29,7 @@
 #include "RBAC.h"
 #include "Realm.h"
 #include "ScriptMgr.h"
+#include "StringFormat.h"
 #include "World.h"
 #include "WorldSession.h"
 #include <memory>
@@ -87,6 +89,9 @@ bool WorldSocket::Update()
     MessageBuffer buffer(_sendBufferSize);
     while (_bufferQueue.Dequeue(queued))
     {
+        Trinity::SetCrashContext(Trinity::StringFormat("WorldSocket::Update dequeued packet socketPtr={} packetPtr={} opcode={} size={} encrypt={} remote={}:{}",
+            static_cast<void const*>(this), static_cast<void const*>(queued), queued->GetOpcode(), queued->size(), queued->NeedsEncryption(), GetRemoteIpAddress().to_string(), GetRemotePort()));
+
         ServerPktHeader header(queued->size() + 2, queued->GetOpcode());
         if (queued->NeedsEncryption())
             _authCrypt.EncryptSend(header.header, header.getHeaderLength());
@@ -113,7 +118,10 @@ bool WorldSocket::Update()
             QueuePacket(std::move(packetBuffer));
         }
 
+        Trinity::SetCrashContext(Trinity::StringFormat("WorldSocket::Update deleting packet socketPtr={} packetPtr={} opcode={} size={} remote={}:{}",
+            static_cast<void const*>(this), static_cast<void const*>(queued), queued->GetOpcode(), queued->size(), GetRemoteIpAddress().to_string(), GetRemotePort()));
         delete queued;
+        Trinity::ClearCrashContext();
     }
 
     if (buffer.GetActiveSize() > 0)


### PR DESCRIPTION
### Motivation
- Prevent data races and crashes when accessing `_instanceResetTimes` concurrently and improve crash diagnostics for instance reset handling and packet queue operations.
- Add contextual crash information to aid post-mortem debugging of packet dequeue/delete and aura unapply code paths.

### Description
- Introduced a mutex ` _instanceResetTimesLock` and switched `InstanceTimeMap` from `std::unordered_map` to `std::map` in `Player` to serialize access and provide deterministic iteration.
- Added `std::lock_guard<std::mutex>` protection around all accesses to `_instanceResetTimes` in `Player::Update`, `Player::CheckInstanceCount`, `Player::AddInstanceEnterTime`, `Player::_LoadInstanceTimeRestrictions`, and `Player::_SaveInstanceTimeRestrictions`.
- Added `Trinity::SetCrashContext(...)` calls with detailed formatted state before erasing expired instance reset entries and around packet dequeue/delete in `WorldSocket::Update`, and corresponding `Trinity::ClearCrashContext()` calls to clear the context.
- Added a `Trinity::ClearCrashContext()` call at the end of `Unit::_UnapplyAura` to ensure stale crash context is removed.
- Added required includes (`Errors.h`, `StringFormat.h`, and `<mutex>`), and small bookkeeping changes to support the above modifications.

### Testing
- Project compiled successfully with the updated code using the normal build (`cmake`/`make`) pipeline.
- Automated unit and integration tests run via `ctest` completed without failures.
- Automated server startup/smoke tests covering packet processing and instance restriction loading completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed0103e6c8327904325293e04f013)