### PR TITLE
Handle stale aura applications during unapply

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -670,8 +670,23 @@ void Aura::_UnapplyForTarget(Unit* target, Unit* caster, AuraApplication* auraAp
         return;
     }
 
-    // aura has to be already applied
-    ASSERT(itr->second == auraApp);
+    // aura has to be already applied.  If the owning Unit has a stale
+    // AuraApplication pointer, do not let cleanup/logout crash while holding
+    // on to the valid application in this aura map.  This can happen after an
+    // earlier inconsistent reapplication overwrote the per-target entry but
+    // left the old application in Unit::m_appliedAuras.  The stale application
+    // has already been detached from the Unit by Unit::_UnapplyAura, so queue
+    // only that object for deletion and keep the current application mapped.
+    if (itr->second != auraApp)
+    {
+        TC_LOG_ERROR("spells",
+            "Aura::_UnapplyForTarget, target: {}, caster: {}, spell:{} found mismatched aura application for owner map (expected: {}, found: {}). Queuing stale application for deletion.",
+            target->GetGUID().ToString(), caster ? caster->GetGUID().ToString() : "0", auraApp->GetBase()->GetSpellInfo()->Id,
+            static_cast<void const*>(auraApp), static_cast<void const*>(itr->second));
+        _removedApplications.push_back(auraApp);
+        return;
+    }
+
     m_applications.erase(itr);
 
     _removedApplications.push_back(auraApp);


### PR DESCRIPTION
### Motivation
- Prevent a fatal assertion/segfault observed during logout/cleanup when an AuraApplication being unapplied is stale while the aura's per-target map points at a different, newer application.
- The crash stack indicated `Aura::_UnapplyForTarget` asserted that the map entry matched the application being removed; this change avoids crashing in that cleanup path.

### Description
- Replace the hard `ASSERT` in `Aura::_UnapplyForTarget` with a runtime check that detects a mismatched `AuraApplication` pointer and handles it safely.
- When a mismatch is detected the code now logs an error with both the expected and found application pointers and queues only the stale `AuraApplication` for deletion, returning early to preserve the valid mapped application.
- The change is implemented in `src/server/game/Spells/Auras/SpellAuras.cpp` around `Aura::_UnapplyForTarget` and adds a diagnostic log message to aid debugging.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it completed successfully.
- Verified repository status with `git status --short` and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f031a6b9483278f64af7631011c4d)