### PR TITLE
Handle stale aura application cleanup

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3978,8 +3978,17 @@ void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMo
 
 void Unit::_UnapplyAura(AuraApplication* aurApp, AuraRemoveMode removeMode)
 {
-    // aura can be removed from unit only if it's applied on it, shouldn't happen
-    ASSERT(aurApp->GetBase()->GetApplicationOfTarget(GetGUID()) == aurApp);
+    // Aura can be removed from a unit only if the Aura still maps this target to
+    // the same application.  When cleanup is already recovering from stale aura
+    // application state, do not assert before the caller has a chance to detach
+    // the stale aura-side entry.
+    if (!aurApp || aurApp->GetBase()->GetApplicationOfTarget(GetGUID()) != aurApp)
+    {
+        TC_LOG_ERROR("spells",
+            "Unit::_UnapplyAura, target: {}, found stale aura application (app: {}, spell: {}). Skipping direct unapply.",
+            GetGUID().ToString(), static_cast<void const*>(aurApp), aurApp && aurApp->GetBase() ? aurApp->GetBase()->GetId() : 0);
+        return;
+    }
 
     uint32 spellId = aurApp->GetBase()->GetId();
     AuraApplicationMapBoundsNonConst range = m_appliedAuras.equal_range(spellId);

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -708,8 +708,31 @@ void Aura::_Remove(AuraRemoveMode removeMode)
     ApplicationMap::iterator appItr = m_applications.begin();
     for (appItr = m_applications.begin(); appItr != m_applications.end();)
     {
-        AuraApplication * aurApp = appItr->second;
-        Unit* target = aurApp->GetTarget();
+        ObjectGuid const applicationGuid = appItr->first;
+        AuraApplication* aurApp = appItr->second;
+        Unit* target = aurApp ? aurApp->GetTarget() : nullptr;
+
+        // A previous inconsistent reapply/removal can leave Aura::m_applications
+        // pointing at an AuraApplication that no longer matches the target stored
+        // on the application itself.  Calling Unit::_UnapplyAura(AuraApplication*)
+        // in that state asserts before it can erase this map entry, which turns
+        // logout or pet cleanup into a crash loop.  Drop only the stale aura-side
+        // entry here; the target's own applied-aura list, if it still references
+        // this application, is handled by Unit removal paths.
+        if (!target || aurApp->GetBase() != this || applicationGuid != target->GetGUID() || GetApplicationOfTarget(target->GetGUID()) != aurApp)
+        {
+            TC_LOG_ERROR("spells",
+                "Aura::_Remove, owner: {}, spell: {} found stale application entry (map target: {}, app target: {}, app: {}). Detaching stale application.",
+                GetOwner() ? GetOwner()->GetGUID().ToString() : "0", GetSpellInfo()->Id, applicationGuid.ToString(),
+                target ? target->GetGUID().ToString() : "0", static_cast<void const*>(aurApp));
+
+            m_applications.erase(appItr);
+            if (aurApp && std::find(_removedApplications.begin(), _removedApplications.end(), aurApp) == _removedApplications.end())
+                _removedApplications.push_back(aurApp);
+            appItr = m_applications.begin();
+            continue;
+        }
+
         target->_UnapplyAura(aurApp, removeMode);
         appItr = m_applications.begin();
     }


### PR DESCRIPTION
### Motivation
- Prevent server crashes during aura cleanup when an Aura::m_applications entry becomes stale and no longer matches the target's application pointer, which caused assertions and segfaults during logout/pet cleanup.

### Description
- Guard `Unit::_UnapplyAura(AuraApplication*)` to detect when the provided `AuraApplication` is stale and log+skip instead of asserting. (changes in `src/server/game/Entities/Unit/Unit.cpp`).
- Update `Aura::_Remove` to detect stale entries in `m_applications`, detach those stale application entries, queue them for removal, and continue cleaning valid applications, avoiding crash loops. (changes in `src/server/game/Spells/Auras/SpellAuras.cpp`).
- Added diagnostic logging when stale application entries are found to aid future debugging.

### Testing
- Ran `git diff --check` which produced no errors and the changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0586e5108327b5208621b14c109d)