### PR TITLE
Add diagnostics and recovery for stale AuraApplication in Unit::_UnapplyAura

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3978,10 +3978,68 @@ void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMo
 
 void Unit::_UnapplyAura(AuraApplication* aurApp, AuraRemoveMode removeMode)
 {
-    // aura can be removed from unit only if it's applied on it, shouldn't happen
-    ASSERT(aurApp->GetBase()->GetApplicationOfTarget(GetGUID()) == aurApp);
+    ASSERT(aurApp);
 
-    uint32 spellId = aurApp->GetBase()->GetId();
+    Aura* aura = aurApp->GetBase();
+    ASSERT(aura);
+
+    AuraApplication* mappedAurApp = aura->GetApplicationOfTarget(GetGUID());
+    if (mappedAurApp != aurApp)
+    {
+        std::stringstream crashContext;
+        crashContext << "Unit::_UnapplyAura stale application recovery"
+            << " unitPtr=" << static_cast<void const*>(this)
+            << " unitGuid=" << GetGUID().ToString()
+            << " unitMapId=" << GetMapId()
+            << " unitHasMap=" << (FindMap() ? 1 : 0)
+            << " auraAppPtr=" << static_cast<void const*>(aurApp)
+            << " mappedAuraAppPtr=" << static_cast<void const*>(mappedAurApp)
+            << " auraAppTargetPtr=" << static_cast<void const*>(aurApp->GetTarget())
+            << " auraAppTargetGuid=" << (aurApp->GetTarget() ? aurApp->GetTarget()->GetGUID().ToString() : "none")
+            << " auraPtr=" << static_cast<void const*>(aura)
+            << " spellId=" << (aura->GetSpellInfo() ? aura->GetSpellInfo()->Id : 0)
+            << " auraOwnerPtr=" << static_cast<void const*>(aura->GetOwner())
+            << " casterGuid=" << aura->GetCasterGUID().ToString()
+            << " auraRemoved=" << aura->IsRemoved()
+            << " auraEffectMask=" << uint32(aura->GetEffectMask())
+            << " auraAppRemoveMode=" << uint32(aurApp->GetRemoveMode())
+            << " auraAppEffectMask=" << uint32(aurApp->GetEffectMask())
+            << " auraAppEffectsToApply=" << uint32(aurApp->GetEffectsToApply())
+            << " requestedRemoveMode=" << uint32(removeMode);
+        Trinity::SetCrashContext(crashContext.str());
+
+        TC_LOG_ERROR("spells", "{}", crashContext.str());
+
+        // Prefer the Unit-owned application list when it still contains this
+        // exact AuraApplication.  The iterator overload removes all secondary
+        // Unit references before asking Aura to detach the per-target entry.
+        uint32 spellId = aura->GetId();
+        AuraApplicationMapBoundsNonConst range = m_appliedAuras.equal_range(spellId);
+        for (AuraApplicationMap::iterator iter = range.first; iter != range.second; ++iter)
+        {
+            if (iter->second == aurApp)
+            {
+                _UnapplyAura(iter, removeMode);
+                return;
+            }
+        }
+
+        // The Aura still references an application that the target no longer
+        // owns.  Do not assert during logout/delete cleanup; detach that stale
+        // per-target entry so Aura::_Remove can make progress and the removed
+        // application can be reclaimed by Aura's removed-application queue.
+        if (!aurApp->GetRemoveMode())
+        {
+            aurApp->SetRemoveMode(removeMode);
+            aurApp->_Remove();
+        }
+
+        aura->_UnapplyForTarget(this, aura->GetCaster(), aurApp);
+        Trinity::ClearCrashContext();
+        return;
+    }
+
+    uint32 spellId = aura->GetId();
     AuraApplicationMapBoundsNonConst range = m_appliedAuras.equal_range(spellId);
 
     for (AuraApplicationMap::iterator iter = range.first; iter != range.second;)
@@ -3994,7 +4052,28 @@ void Unit::_UnapplyAura(AuraApplication* aurApp, AuraRemoveMode removeMode)
         else
             ++iter;
     }
-    ABORT();
+
+    std::stringstream crashContext;
+    crashContext << "Unit::_UnapplyAura missing Unit application"
+        << " unitPtr=" << static_cast<void const*>(this)
+        << " unitGuid=" << GetGUID().ToString()
+        << " unitMapId=" << GetMapId()
+        << " auraAppPtr=" << static_cast<void const*>(aurApp)
+        << " auraPtr=" << static_cast<void const*>(aura)
+        << " spellId=" << spellId
+        << " casterGuid=" << aura->GetCasterGUID().ToString()
+        << " removeMode=" << uint32(removeMode);
+    Trinity::SetCrashContext(crashContext.str());
+    TC_LOG_ERROR("spells", "{}", crashContext.str());
+
+    if (!aurApp->GetRemoveMode())
+    {
+        aurApp->SetRemoveMode(removeMode);
+        aurApp->_Remove();
+    }
+
+    aura->_UnapplyForTarget(this, aura->GetCaster(), aurApp);
+    Trinity::ClearCrashContext();
 }
 
 void Unit::_RemoveNoStackAurasDueToAura(Aura* aura, bool owned)


### PR DESCRIPTION
### Motivation
- A hard `ASSERT` in `Unit::_UnapplyAura(AuraApplication*)` was crashing the server during logout/cleanup when an Aura's per-target application pointer and the Unit's applied-aura map became inconsistent. 
- The goal is to add diagnostics to capture rich context for debugging and avoid terminating the process during cleanup by recovering from stale/mismatched application pointers.

### Description
- Replace the direct assertion with defensive checks and `ASSERT` for the incoming pointer, retrieve `Aura* aura = aurApp->GetBase()`, and validate the mapped per-target application via `aura->GetApplicationOfTarget(GetGUID())`.
- When the mapped application differs, build a detailed `crashContext` string (unit, map, aura, spell, caster, mapped/stale pointers, effect/remove masks) and call `Trinity::SetCrashContext()` and `TC_LOG_ERROR()` to record diagnostics.
- Prefer the Unit-owned application entry by scanning `m_appliedAuras` for the exact `AuraApplication` and route through the iterator-based `_UnapplyAura` if present; otherwise detach the stale application by setting its remove mode and calling `_Remove()` and `aura->_UnapplyForTarget(...)` to allow cleanup to proceed safely.
- Add a similar diagnostic/error path for the case where the Unit-owned application is missing, log context, ensure the application is removed, call `aura->_UnapplyForTarget(...)`, and clear the crash context.

### Testing
- Ran whitespace/static check with `git diff --check`, which produced no errors and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0626e86c8327a7267216eacae787)