### PR TITLE
Handle stale and null AuraApplication pointers when unapplying auras to prevent crashes

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3978,8 +3978,20 @@ void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMo
 
 void Unit::_UnapplyAura(AuraApplication* aurApp, AuraRemoveMode removeMode)
 {
-    // aura can be removed from unit only if it's applied on it, shouldn't happen
-    ASSERT(aurApp->GetBase()->GetApplicationOfTarget(GetGUID()) == aurApp);
+    if (!aurApp)
+    {
+        TC_LOG_ERROR("spells", "Unit::_UnapplyAura, target: {} received a null aura application.", GetGUID().ToString());
+        return;
+    }
+
+    // AuraApplication ownership can be inconsistent while recovering from a
+    // stale reapply/removal.  Prefer the Unit's applied-aura list as the source
+    // of truth here: the iterator overload can detach this Unit-side pointer and
+    // Aura::_UnapplyForTarget will reconcile the Aura-side target map.
+    if (aurApp->GetBase()->GetApplicationOfTarget(GetGUID()) != aurApp)
+        TC_LOG_ERROR("spells",
+            "Unit::_UnapplyAura, target: {}, spell: {} has stale aura target mapping for application {}. Continuing Unit-side detach.",
+            GetGUID().ToString(), aurApp->GetBase()->GetId(), static_cast<void const*>(aurApp));
 
     uint32 spellId = aurApp->GetBase()->GetId();
     AuraApplicationMapBoundsNonConst range = m_appliedAuras.equal_range(spellId);

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -671,20 +671,27 @@ void Aura::_UnapplyForTarget(Unit* target, Unit* caster, AuraApplication* auraAp
         return;
     }
 
-    // aura has to be already applied.  If the owning Unit has a stale
-    // AuraApplication pointer, do not let cleanup/logout crash while holding
-    // on to the valid application in this aura map.  This can happen after an
-    // earlier inconsistent reapplication overwrote the per-target entry but
-    // left the old application in Unit::m_appliedAuras.  The stale application
-    // has already been detached from the Unit by Unit::_UnapplyAura, so queue
-    // only that object for deletion and keep the current application mapped.
+    // Aura has to be already applied. If the owning Unit has a stale
+    // AuraApplication pointer, detach every Aura-side entry that still points
+    // at that stale application. Keep the current per-target application mapped
+    // so the valid application can be removed by its own Unit cleanup path.
     if (itr->second != auraApp)
     {
         TC_LOG_ERROR("spells",
-            "Aura::_UnapplyForTarget, target: {}, caster: {}, spell:{} found mismatched aura application for owner map (expected: {}, found: {}). Queuing stale application for deletion.",
+            "Aura::_UnapplyForTarget, target: {}, caster: {}, spell:{} found mismatched aura application for owner map (expected: {}, found: {}). Detaching stale application entries.",
             target->GetGUID().ToString(), caster ? caster->GetGUID().ToString() : "0", auraApp->GetBase()->GetSpellInfo()->Id,
             static_cast<void const*>(auraApp), static_cast<void const*>(itr->second));
-        _removedApplications.push_back(auraApp);
+
+        for (ApplicationMap::iterator staleItr = m_applications.begin(); staleItr != m_applications.end();)
+        {
+            if (staleItr->second == auraApp)
+                staleItr = m_applications.erase(staleItr);
+            else
+                ++staleItr;
+        }
+
+        if (std::find(_removedApplications.begin(), _removedApplications.end(), auraApp) == _removedApplications.end())
+            _removedApplications.push_back(auraApp);
         return;
     }
 


### PR DESCRIPTION
### Motivation

- Prevent crashes and inconsistent state when detaching auras that have stale or null `AuraApplication` pointers during unapply/cleanup paths.
- Prefer the Unit-side applied-aura list as the source of truth when reconciling mismatched per-target mappings between `Unit` and `Aura`.

### Description

- Add a null-check in `Unit::_UnapplyAura(AuraApplication* aurApp, AuraRemoveMode)` that logs an error and returns if `aurApp` is null.
- Log and tolerate mismatched AuraApplication ownership in `Unit::_UnapplyAura`, continuing with the Unit-side detach when the Aura's per-target mapping is stale.
- Change `Aura::_UnapplyForTarget` to detach all Aura-side entries that still point at a stale application instead of only queueing it for deletion, and keep the current valid per-target application mapped for proper Unit-side cleanup.
- Ensure stale applications are added to `_removedApplications` only once and update log messages to reflect the new detach behavior.

### Testing

- Project was compiled successfully after the changes (`build` succeeded).
- Existing automated unit tests were executed and completed without failures.
- Aura-related behaviors were exercised locally to verify no immediate crashes occur during unapply paths involving stale or null applications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0586e5108327b5208621b14c109d)