### PR TITLE
Avoid iterator erase while expiring instance reset times

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1379,13 +1379,21 @@ void Player::Update(uint32 p_time)
 
     if (!_instanceResetTimes.empty())
     {
-        for (InstanceTimeMap::iterator itr = _instanceResetTimes.begin(); itr != _instanceResetTimes.end();)
+        // Rebuild the instance reset map instead of erasing while iterating.
+        // Player::Update can run after spell/aura processing that may trigger
+        // map or instance state changes; rebuilding avoids depending on an
+        // iterator that can be invalidated before unordered_map::erase walks
+        // the bucket chain.
+        InstanceTimeMap activeInstanceResetTimes;
+        activeInstanceResetTimes.reserve(_instanceResetTimes.size());
+
+        for (InstanceTimeMap::value_type const& instanceResetTime : _instanceResetTimes)
         {
-            if (itr->second < now)
-                itr = _instanceResetTimes.erase(itr);
-            else
-                ++itr;
+            if (instanceResetTime.second >= now)
+                activeInstanceResetTimes.insert(instanceResetTime);
         }
+
+        _instanceResetTimes.swap(activeInstanceResetTimes);
     }
 
     if (GetClass() == CLASS_DEATH_KNIGHT)


### PR DESCRIPTION
### Motivation

- A crash stacktrace showed `unordered_map::erase` being hit from `Player::Update` after spell/aura processing, indicating iterator invalidation or an unsafe erase path when expiring instance reset times.
- Rebuilding the active instance reset map avoids iterator invalidation and the observed crash window while preserving unexpired entries.

### Description

- Replaced the in-place erase-while-iterating loop in `Player::Update` with a rebuild-and-swap approach for `_instanceResetTimes` in `src/server/game/Entities/Player/Player.cpp`.
- The new code creates an `InstanceTimeMap activeInstanceResetTimes`, reserves capacity, inserts only entries with `second >= now`, and then swaps into `_instanceResetTimes` to drop expired entries.

### Testing

- Ran `git diff --check` to validate the working tree and formatting, which succeeded.
- The change was committed locally as part of the patch to `Player::Update` and no compile/runtime tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f198ce20c83278c762af9e26aeeb7)