### PR TITLE
Fix pet movement on transports

### DIFF
--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -27,6 +27,7 @@
 #include "ScriptMgr.h"
 #include "Spline.h"
 #include "Player.h"
+#include "Pet.h"
 #include "Totem.h"
 #include "UpdateData.h"
 #include "Vehicle.h"
@@ -259,7 +260,24 @@ void Transport::AddPassenger(WorldObject* passenger)
         TC_LOG_DEBUG("entities.transport", "Object {} boarded transport {}.", passenger->GetName(), GetName());
 
         if (Player* plr = passenger->ToPlayer())
+        {
+            if (Pet* pet = plr->GetPet())
+            {
+                if (pet->IsInWorld() && pet->GetTransport() != this)
+                {
+                    float x = pet->GetPositionX();
+                    float y = pet->GetPositionY();
+                    float z = pet->GetPositionZ();
+                    float o = pet->GetOrientation();
+                    CalculatePassengerOffset(x, y, z, &o);
+                    pet->m_movementInfo.transport.pos.Relocate(x, y, z, o);
+                    pet->SetTransportHomePosition(pet->m_movementInfo.transport.pos);
+                    AddPassenger(pet);
+                }
+            }
+
             sScriptMgr->OnAddPassenger(this, plr);
+        }
     }
 }
 
@@ -290,6 +308,10 @@ void Transport::RemovePassenger(WorldObject* passenger)
 
         if (Player* plr = passenger->ToPlayer())
         {
+            if (Pet* pet = plr->GetPet())
+                if (pet->GetTransport() == this)
+                    RemovePassenger(pet);
+
             sScriptMgr->OnRemovePassenger(this, plr);
             plr->SetFallInformation(0, plr->GetPositionZ());
         }

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -45,6 +45,7 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
+#include "Transport.h"
 #include "Vehicle.h"
 #include "PetAI.h"
 
@@ -120,14 +121,22 @@ class spell_pet_moveto : public SpellScript
         // The client shows an area as unreachable once the target destination is 4 yards above your position
         WorldLocation const* destination = GetExplTargetDest();
 
-        PathGenerator path(pet);
-        if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
-            return SPELL_FAILED_NOPATH;
+        // Transport floors are not represented in regular map navigation data.
+        // When both owner and pet are on the same transport, let pet movement use
+        // transport-relative spline coordinates instead of rejecting the command as
+        // an unreachable world-space path.
+        bool const onSameTransport = pet->GetTransport() && pet->GetTransport() == GetCaster()->GetTransport();
+        if (!onSameTransport)
+        {
+            PathGenerator path(pet);
+            if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
+                return SPELL_FAILED_NOPATH;
 
-        PathType const pathType = path.GetPathType();
-        if ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
-            (path.HasNavigationData() && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))
-            return SPELL_FAILED_NOPATH;
+            PathType const pathType = path.GetPathType();
+            if ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+                (path.HasNavigationData() && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))
+                return SPELL_FAILED_NOPATH;
+        }
         // Do a mini Spell::CheckCasterAuras on the pet, no other way of doing this
         SpellCastResult result = SPELL_CAST_OK;
         uint32 const unitflag = pet->GetUnitFlags();
@@ -161,7 +170,13 @@ class spell_pet_moveto : public SpellScript
         charmInfo->SetIsFollowing(false);
         charmInfo->SetIsReturning(false);
         const WorldLocation* stayPos = GetExplTargetDest();
-        charmInfo->SetStayPosition(stayPos->GetPositionX(), stayPos->GetPositionY(), stayPos->GetPositionZ());
+        float x = stayPos->GetPositionX();
+        float y = stayPos->GetPositionY();
+        float z = stayPos->GetPositionZ();
+        if (Transport* transport = pet->GetTransport())
+            if (transport == GetCaster()->GetTransport())
+                transport->CalculatePassengerOffset(x, y, z);
+        charmInfo->SetStayPosition(x, y, z);
         //pet->GetMotionMaster()->MoveChase();
         CreatureAI* AI = pet->ToCreature()->AI();
         if (PetAI* petAI = dynamic_cast<PetAI*>(AI))


### PR DESCRIPTION
### Motivation
- Pets were left behind when their owners boarded transports because pets were not automatically added as transport passengers and stay destinations were calculated in world-space instead of transport-relative coordinates.
- `pet move-to` failed on transports due to regular navmesh pathfinding rejecting transport floors that are not represented in world navigation data.

### Description
- Added `Pet` handling in `Transport::AddPassenger` so when a `Player` boards a transport their active pet is also added as a passenger with transport-relative offsets computed via `CalculatePassengerOffset` and `SetTransportHomePosition` (changes in `src/server/game/Entities/Transport/Transport.cpp`).
- Cleaned up pet state in `Transport::RemovePassenger` to remove the pet from the transport when its owner leaves the transport (changes in `src/server/game/Entities/Transport/Transport.cpp`).
- Updated `spell_pet_moveto` in `src/server/scripts/Spells/spell_generic.cpp` to bypass regular pathfinding when the pet and owner share the same transport and to convert `MoveTo`/stay destinations to transport-relative offsets via `Transport::CalculatePassengerOffset` before storing the pet stay position.

### Testing
- Ran `git diff --check` to ensure no whitespace or trivial diff issues; it passed.
- Attempted to build with `cmake --build build --target game -- -j2` but the `build` directory is not present in this checkout so a full build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd390d0808327af22e33b27a9a572)