### PR TITLE
Pets follow owners onto transports and use transport-relative movement/pathing

### DIFF
--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -27,6 +27,7 @@
 #include "ScriptMgr.h"
 #include "Spline.h"
 #include "Player.h"
+#include "Pet.h"
 #include "Totem.h"
 #include "UpdateData.h"
 #include "Vehicle.h"
@@ -259,7 +260,24 @@ void Transport::AddPassenger(WorldObject* passenger)
         TC_LOG_DEBUG("entities.transport", "Object {} boarded transport {}.", passenger->GetName(), GetName());
 
         if (Player* plr = passenger->ToPlayer())
+        {
+            if (Pet* pet = plr->GetPet())
+            {
+                if (pet->IsInWorld() && pet->GetTransport() != this)
+                {
+                    float x = pet->GetPositionX();
+                    float y = pet->GetPositionY();
+                    float z = pet->GetPositionZ();
+                    float o = pet->GetOrientation();
+                    CalculatePassengerOffset(x, y, z, &o);
+                    pet->m_movementInfo.transport.pos.Relocate(x, y, z, o);
+                    pet->SetTransportHomePosition(pet->m_movementInfo.transport.pos);
+                    AddPassenger(pet);
+                }
+            }
+
             sScriptMgr->OnAddPassenger(this, plr);
+        }
     }
 }
 
@@ -290,6 +308,10 @@ void Transport::RemovePassenger(WorldObject* passenger)
 
         if (Player* plr = passenger->ToPlayer())
         {
+            if (Pet* pet = plr->GetPet())
+                if (pet->GetTransport() == this)
+                    RemovePassenger(pet);
+
             sScriptMgr->OnRemovePassenger(this, plr);
             plr->SetFallInformation(0, plr->GetPositionZ());
         }

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -259,6 +259,20 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
             if (owner->IsHovering())
                 owner->UpdateAllowedPositionZ(x, y, z);
 
+            if (owner->GetTransport() && owner->GetTransport() == target->GetTransport())
+            {
+                LogPlayerbotChaseDiag(owner, target, "same_transport_direct_move", _range, angle, minRange, maxRange, _movingTowards);
+                owner->AddUnitState(UNIT_STATE_CHASE_MOVE);
+                AddFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
+
+                Movement::MoveSplineInit init(owner);
+                init.MoveTo(x, y, z, false);
+                init.SetWalk(target->IsWalking());
+                init.SetFacing(target->GetOrientation());
+                init.Launch();
+                return true;
+            }
+
             bool success = _path->CalculatePath(x, y, z, owner->CanFly());
             TC_LOG_DEBUG("playerbots.pvp.classspell",
                 "PB chase path: owner={} target={} move_toward={} path_ok={} path_type={} points={} dest=({}, {}, {}) edge_dist={} exact_dist={} max_target={} max_range={}.",

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -177,6 +177,20 @@ bool FollowMovementGenerator::Update(Unit* owner, uint32 diff)
             if (owner->IsHovering())
                 owner->UpdateAllowedPositionZ(x, y, z);
 
+            if (owner->GetTransport() && owner->GetTransport() == target->GetTransport())
+            {
+                LogPlayerbotFollowDiag(owner, target, "same_transport_direct_move", _range, _angle);
+                owner->AddUnitState(UNIT_STATE_FOLLOW_MOVE);
+                AddFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
+
+                Movement::MoveSplineInit init(owner);
+                init.MoveTo(x, y, z, false);
+                init.SetWalk(target->IsWalking());
+                init.SetFacing(target->GetOrientation());
+                init.Launch();
+                return true;
+            }
+
             // pets are allowed to "cheat" on pathfinding when following their master
             bool allowShortcut = false;
             if (Pet* oPet = owner->ToPet())

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -45,6 +45,7 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
+#include "Transport.h"
 #include "Vehicle.h"
 #include "PetAI.h"
 
@@ -120,14 +121,22 @@ class spell_pet_moveto : public SpellScript
         // The client shows an area as unreachable once the target destination is 4 yards above your position
         WorldLocation const* destination = GetExplTargetDest();
 
-        PathGenerator path(pet);
-        if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
-            return SPELL_FAILED_NOPATH;
+        // Transport floors are not represented in regular map navigation data.
+        // When both owner and pet are on the same transport, let pet movement use
+        // transport-relative spline coordinates instead of rejecting the command as
+        // an unreachable world-space path.
+        bool const onSameTransport = pet->GetTransport() && pet->GetTransport() == GetCaster()->GetTransport();
+        if (!onSameTransport)
+        {
+            PathGenerator path(pet);
+            if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
+                return SPELL_FAILED_NOPATH;
 
-        PathType const pathType = path.GetPathType();
-        if ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
-            (path.HasNavigationData() && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))
-            return SPELL_FAILED_NOPATH;
+            PathType const pathType = path.GetPathType();
+            if ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+                (path.HasNavigationData() && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))
+                return SPELL_FAILED_NOPATH;
+        }
         // Do a mini Spell::CheckCasterAuras on the pet, no other way of doing this
         SpellCastResult result = SPELL_CAST_OK;
         uint32 const unitflag = pet->GetUnitFlags();
@@ -161,7 +170,13 @@ class spell_pet_moveto : public SpellScript
         charmInfo->SetIsFollowing(false);
         charmInfo->SetIsReturning(false);
         const WorldLocation* stayPos = GetExplTargetDest();
-        charmInfo->SetStayPosition(stayPos->GetPositionX(), stayPos->GetPositionY(), stayPos->GetPositionZ());
+        float x = stayPos->GetPositionX();
+        float y = stayPos->GetPositionY();
+        float z = stayPos->GetPositionZ();
+        if (Transport* transport = pet->GetTransport())
+            if (transport == GetCaster()->GetTransport())
+                transport->CalculatePassengerOffset(x, y, z);
+        charmInfo->SetStayPosition(x, y, z);
         //pet->GetMotionMaster()->MoveChase();
         CreatureAI* AI = pet->ToCreature()->AI();
         if (PetAI* petAI = dynamic_cast<PetAI*>(AI))


### PR DESCRIPTION
### Motivation

- Fix cases where a player's pet would not board the same `Transport` or would be blocked by pathfinding when owner and pet are on the same transport.
- Allow `Follow`/`Chase` movement generators to move directly using transport-relative splines when both units share a `Transport` to avoid failing navigation on transport floors.
- Prevent `spell_pet_moveto` from rejecting valid pet move commands when both caster and pet are on the same transport and ensure stay positions are transport-relative.

### Description

- Added `#include "Pet.h"` and `#include "Transport.h"` where needed to access pet and transport APIs.
- When a `Player` is added as a passenger, automatically detect and add their `Pet` to the same `Transport` by calculating and assigning transport-relative passenger offsets via `CalculatePassengerOffset` and `SetTransportHomePosition`, then call `AddPassenger` for the pet.
- When a `Player` is removed from a `Transport`, also remove the `Pet` if it is on the same `Transport` by calling `RemovePassenger` for the pet.
- In `ChaseMovementGenerator::Update` and `FollowMovementGenerator::Update`, if `owner` and `target` are on the same `Transport` the code now bypasses normal pathfinding and launches a direct `Movement::MoveSplineInit` to the computed local destination while setting appropriate unit state flags and facing.
- In `spell_pet_moveto`, skip global pathfinding checks when the pet and caster are on the same `Transport`, and compute transport-relative stay coordinates via `transport->CalculatePassengerOffset` before calling `CharmInfo::SetStayPosition`.

### Testing

- Built the server codebase after changes with a full compile, and the build completed successfully without errors.
- Ran existing automated unit/regression tests related to movement, pathfinding, and transport boarding, and they passed.
- Executed automated movement integration tests for `Follow`/`Chase` scenarios and `spell_pet_moveto` on transports, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd390d0808327af22e33b27a9a572)