### PR TITLE
Fix pet transport behavior and pathfinding for same-transport movement

### DIFF
--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -27,10 +27,13 @@
 #include "ScriptMgr.h"
 #include "Spline.h"
 #include "Player.h"
+#include "Pet.h"
+#include "PetDefines.h"
 #include "Totem.h"
 #include "UpdateData.h"
 #include "Vehicle.h"
 #include <G3D/Vector3.h>
+#include <cmath>
 
 Transport::Transport() : GameObject(),
     _transportInfo(nullptr), _isMoving(true), _pendingStop(false),
@@ -259,7 +262,27 @@ void Transport::AddPassenger(WorldObject* passenger)
         TC_LOG_DEBUG("entities.transport", "Object {} boarded transport {}.", passenger->GetName(), GetName());
 
         if (Player* plr = passenger->ToPlayer())
+        {
+            if (Pet* pet = plr->GetPet())
+            {
+                if (pet->IsInWorld() && pet->GetTransport() != this)
+                {
+                    float x = plr->GetTransOffsetX();
+                    float y = plr->GetTransOffsetY();
+                    float z = plr->GetTransOffsetZ();
+                    float o = plr->GetTransOffsetO();
+                    x += std::cos(o + pet->GetFollowAngle()) * PET_FOLLOW_DIST;
+                    y += std::sin(o + pet->GetFollowAngle()) * PET_FOLLOW_DIST;
+                    pet->m_movementInfo.transport.pos.Relocate(x, y, z, o);
+                    pet->SetTransportHomePosition(pet->m_movementInfo.transport.pos);
+                    CalculatePassengerPosition(x, y, z, &o);
+                    GetMap()->CreatureRelocation(pet, x, y, z, o, false);
+                    AddPassenger(pet);
+                }
+            }
+
             sScriptMgr->OnAddPassenger(this, plr);
+        }
     }
 }
 
@@ -290,6 +313,10 @@ void Transport::RemovePassenger(WorldObject* passenger)
 
         if (Player* plr = passenger->ToPlayer())
         {
+            if (Pet* pet = plr->GetPet())
+                if (pet->GetTransport() == this)
+                    RemovePassenger(pet);
+
             sScriptMgr->OnRemovePassenger(this, plr);
             plr->SetFallInformation(0, plr->GetPositionZ());
         }

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -259,6 +259,20 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
             if (owner->IsHovering())
                 owner->UpdateAllowedPositionZ(x, y, z);
 
+            if (owner->GetTransport() && owner->GetTransport() == target->GetTransport())
+            {
+                LogPlayerbotChaseDiag(owner, target, "same_transport_direct_move", _range, angle, minRange, maxRange, _movingTowards);
+                owner->AddUnitState(UNIT_STATE_CHASE_MOVE);
+                AddFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
+
+                Movement::MoveSplineInit init(owner);
+                init.MoveTo(x, y, z, false);
+                init.SetWalk(target->IsWalking());
+                init.SetFacing(target->GetOrientation());
+                init.Launch();
+                return true;
+            }
+
             bool success = _path->CalculatePath(x, y, z, owner->CanFly());
             TC_LOG_DEBUG("playerbots.pvp.classspell",
                 "PB chase path: owner={} target={} move_toward={} path_ok={} path_type={} points={} dest=({}, {}, {}) edge_dist={} exact_dist={} max_target={} max_range={}.",

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -177,6 +177,20 @@ bool FollowMovementGenerator::Update(Unit* owner, uint32 diff)
             if (owner->IsHovering())
                 owner->UpdateAllowedPositionZ(x, y, z);
 
+            if (owner->GetTransport() && owner->GetTransport() == target->GetTransport())
+            {
+                LogPlayerbotFollowDiag(owner, target, "same_transport_direct_move", _range, _angle);
+                owner->AddUnitState(UNIT_STATE_FOLLOW_MOVE);
+                AddFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
+
+                Movement::MoveSplineInit init(owner);
+                init.MoveTo(x, y, z, false);
+                init.SetWalk(target->IsWalking());
+                init.SetFacing(target->GetOrientation());
+                init.Launch();
+                return true;
+            }
+
             // pets are allowed to "cheat" on pathfinding when following their master
             bool allowShortcut = false;
             if (Pet* oPet = owner->ToPet())

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -35,6 +35,7 @@
 #include "LFGMgr.h"
 #include "Log.h"
 #include "MotionMaster.h"
+#include "MoveSpline.h"
 #include "ObjectAccessor.h"
 #include "ObjectMgr.h"
 #include "Pet.h"
@@ -45,8 +46,11 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
+#include "Transport.h"
+#include "PetDefines.h"
 #include "Vehicle.h"
 #include "PetAI.h"
+#include <cmath>
 
 class spell_gen_absorb0_hitlimit1 : public AuraScript
 {
@@ -120,14 +124,22 @@ class spell_pet_moveto : public SpellScript
         // The client shows an area as unreachable once the target destination is 4 yards above your position
         WorldLocation const* destination = GetExplTargetDest();
 
-        PathGenerator path(pet);
-        if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
-            return SPELL_FAILED_NOPATH;
+        // Transport floors are not represented in regular map navigation data.
+        // When both owner and pet are on the same transport, let pet movement use
+        // transport-relative spline coordinates instead of rejecting the command as
+        // an unreachable world-space path.
+        bool const onSameTransport = GetCaster()->GetTransport() && (!pet->GetTransport() || pet->GetTransport() == GetCaster()->GetTransport());
+        if (!onSameTransport)
+        {
+            PathGenerator path(pet);
+            if (!path.CalculatePath(destination->GetPositionX(), destination->GetPositionY(), destination->GetPositionZ()))
+                return SPELL_FAILED_NOPATH;
 
-        PathType const pathType = path.GetPathType();
-        if ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
-            (path.HasNavigationData() && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))
-            return SPELL_FAILED_NOPATH;
+            PathType const pathType = path.GetPathType();
+            if ((pathType & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE)) ||
+                (path.HasNavigationData() && (pathType & (PATHFIND_NOT_USING_PATH | PATHFIND_SHORTCUT))))
+                return SPELL_FAILED_NOPATH;
+        }
         // Do a mini Spell::CheckCasterAuras on the pet, no other way of doing this
         SpellCastResult result = SPELL_CAST_OK;
         uint32 const unitflag = pet->GetUnitFlags();
@@ -160,8 +172,47 @@ class spell_pet_moveto : public SpellScript
         charmInfo->SetIsCommandFollow(false);
         charmInfo->SetIsFollowing(false);
         charmInfo->SetIsReturning(false);
+        if (Transport* transport = GetCaster()->GetTransport())
+        {
+            if (pet->GetTransport() != transport)
+            {
+                float petX = GetCaster()->GetTransOffsetX();
+                float petY = GetCaster()->GetTransOffsetY();
+                float petZ = GetCaster()->GetTransOffsetZ();
+                float petO = GetCaster()->GetTransOffsetO();
+                petX += std::cos(petO + pet->GetFollowAngle()) * PET_FOLLOW_DIST;
+                petY += std::sin(petO + pet->GetFollowAngle()) * PET_FOLLOW_DIST;
+                pet->m_movementInfo.transport.pos.Relocate(petX, petY, petZ, petO);
+                pet->SetTransportHomePosition(pet->m_movementInfo.transport.pos);
+                transport->CalculatePassengerPosition(petX, petY, petZ, &petO);
+                pet->GetMap()->CreatureRelocation(pet, petX, petY, petZ, petO, false);
+                transport->AddPassenger(pet);
+            }
+        }
+
         const WorldLocation* stayPos = GetExplTargetDest();
-        charmInfo->SetStayPosition(stayPos->GetPositionX(), stayPos->GetPositionY(), stayPos->GetPositionZ());
+        float x = stayPos->GetPositionX();
+        float y = stayPos->GetPositionY();
+        float z = stayPos->GetPositionZ();
+        bool const moveOnTransport = pet->GetTransport() && pet->GetTransport() == GetCaster()->GetTransport();
+
+        float stayX = x;
+        float stayY = y;
+        float stayZ = z;
+        if (moveOnTransport && pet->movespline->onTransport)
+            pet->GetTransport()->CalculatePassengerOffset(stayX, stayY, stayZ);
+        charmInfo->SetStayPosition(stayX, stayY, stayZ);
+
+        if (moveOnTransport)
+        {
+            charmInfo->SetIsReturning(true);
+            if (pet->HasUnitState(UNIT_STATE_CHASE))
+                pet->GetMotionMaster()->Remove(CHASE_MOTION_TYPE);
+
+            pet->GetMotionMaster()->MovePoint(pet->GetGUID().GetCounter(), x, y, z, false);
+            return;
+        }
+
         //pet->GetMotionMaster()->MoveChase();
         CreatureAI* AI = pet->ToCreature()->AI();
         if (PetAI* petAI = dynamic_cast<PetAI*>(AI))


### PR DESCRIPTION
### Motivation
- Ensure pets correctly board and leave transports with their owners and avoid false unreachable/pathfinding failures when owner and pet are on the same transport.
- Allow direct spline-based movement when both follower and leader share the same transport to avoid unnecessary or failing pathfinding.

### Description
- Added necessary includes (`Pet.h`, `PetDefines.h`, `MoveSpline.h`, `Transport.h`, `<cmath>`) and used trigonometry to compute pet offsets on transports when boarding. 
- `Transport::AddPassenger` now automatically boards a player's pet when the player boards and relocates the pet to the correct transport-relative position, and `RemovePassenger` will remove the pet when the owner leaves the transport. 
- `ChaseMovementGenerator` and `FollowMovementGenerator` detect when `owner` and `target` are on the same transport and perform a direct `MoveSplineInit` to the computed transport-relative point with appropriate unit states instead of running full pathfinding. 
- `spell_pet_moveto` bypasses world-pathfinding when owner and pet are on the same transport, auto-boards the pet to the caster's transport when issuing a move, adjusts stay positions using `CalculatePassengerOffset` for transport-relative movement, and uses `MovePoint` for on-transport movement.

### Testing
- Project compiled successfully using the standard build (`make`) after the changes. 
- Automated unit/functional test suite (`ctest`/`make test`) covering movement, pet behavior and spell handling was executed and completed without failures. 
- Movement and pet-related tests that previously exercised pathfinding and transport scenarios passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd390d0808327af22e33b27a9a572)