### PR TITLE
Handle charge-spell ranges and ghost wolf / Rehgar logic in Playerbot PvP core

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -1201,13 +1201,25 @@ bool IsDecisionImmediatelyCastable(Player const* player, SpellDecision const& de
     if (!player->IsWithinLOSInMap(resolvedTarget))
         return false;
 
-    float const maxRange = spellInfo->GetMaxRange(false);
-    if (maxRange > 0.0f && !player->IsWithinDistInMap(resolvedTarget, maxRange))
-        return false;
+    bool const isPlayerbotChargeSpell = decision.spellId == 16979 || decision.spellId == 49376 || decision.spellId == 81910;
+    if (isPlayerbotChargeSpell)
+    {
+        float const minChargeRange = decision.spellId == 81910 ? 5.0f : 8.0f;
+        float const maxChargeRange = decision.spellId == 81910 ? 15.0f : 25.0f;
+        float const distance = player->GetExactDist(resolvedTarget);
+        if (distance < minChargeRange || distance > maxChargeRange)
+            return false;
+    }
+    else
+    {
+        float const maxRange = spellInfo->GetMaxRange(false);
+        if (maxRange > 0.0f && !player->IsWithinDistInMap(resolvedTarget, maxRange))
+            return false;
 
-    float const minRange = spellInfo->GetMinRange(false);
-    if (minRange > 0.0f && player->IsWithinDistInMap(resolvedTarget, minRange))
-        return false;
+        float const minRange = spellInfo->GetMinRange(false);
+        if (minRange > 0.0f && player->IsWithinDistInMap(resolvedTarget, minRange))
+            return false;
+    }
 
     // Skip decisions we cannot currently pay for so the fallback chain can
     // choose a castable alternative (wand, movement, etc.) instead of
@@ -4608,7 +4620,8 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target, Unit c
     Unit const* earthShieldTarget = isRestoShaman && IsSpellReady(player, 32593) && !playerbot::PvpClassActions::IsCasterSpellCooldownActive(player, 32593) ? SelectFriendlyHealthTarget(player, 40.0f, 100.0f) : nullptr;
     Unit const* purgeTarget = isRestoShaman && hasHostileTarget && IsSpellReady(player, 81325) ? SelectEnemyDispelTarget(player, DISPEL_MAGIC, target, 30.0f) : nullptr;
     Unit const* allyMagicTarget = isRestoShaman && IsSpellReady(player, 81325) ? SelectFriendlyDispelTarget(player, DISPEL_MAGIC, 40.0f) : nullptr;
-    Unit const* rehgarsFuryThreat = hasHostileTarget && IsSpellReady(player, 81910) ? SelectNearbyMeleeTarget(player, target, 10.0f) : nullptr;
+    bool const inGhostWolf = HasAuraFromSpellChain(player, 2645);
+    Unit const* rehgarsFuryThreat = hasHostileTarget && inGhostWolf && IsSpellReady(player, 81910) ? SelectEnemyGapCloserTarget(player, target, 5.0f, 15.0f, false) : nullptr;
 
     std::vector<PrioritizedSpellDecision> candidates;
     // Disabled: auto-casting Windfury Weapon from PvP loop while investigating weapon-dependent aura crashes.
@@ -4647,7 +4660,7 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target, Unit c
         { "shaman poison cleansing totem", "maintain a nearby poison cleansing totem", 81477, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, isRestoShaman && !HasActiveAirTotem(player) && IsSpellReady(player, 81478), 52.5f,
         { "shaman grounding totem", "maintain a nearby grounding totem", 81478, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, isRestoShaman && SelectNearbyMeleeTarget(player, target, 8.0f) && player->HealthBelowPct(50) && IsSpellReady(player, 2645), 52.4f,
+    AddDecisionCandidate(candidates, isRestoShaman && !inGhostWolf && SelectNearbyMeleeTarget(player, target, 8.0f) && player->HealthBelowPct(50) && IsSpellReady(player, 2645), 52.4f,
         { "shaman ghost wolf", "escape melee pressure while endangered", 2645, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, rehgarsFuryThreat && !HasBreakableCrowdControl(rehgarsFuryThreat), 59.5f,
         { "shaman rehgar's fury", "escape nearby melee pressure", 81910, playerbot::PvpClassSpellContext::TargetMode::Enemy, rehgarsFuryThreat ? rehgarsFuryThreat->GetGUID() : ObjectGuid::Empty });


### PR DESCRIPTION
### Motivation
- Fix incorrect distance validation for charge-style spells and tighten Shaman PvP decision logic to avoid redundant or invalid casts.
- Prevent the bot from attempting to enter `Ghost Wolf` when already in that form and refine selection of targets for Rehgar's Fury (`81910`).

### Description
- Update `IsDecisionImmediatelyCastable` to special-case charge spells (`16979`, `49376`, `81910`) by checking an explicit `min`/`max` range with `GetExactDist` instead of the generic `GetMaxRange`/`GetMinRange` checks.
- Keep existing generic range checks for non-charge spells and preserve min-range validation in the else branch of the new conditional.
- In `SelectShamanSpell`, add `inGhostWolf = HasAuraFromSpellChain(player, 2645)` and require `inGhostWolf` while selecting a Rehgar's Fury threat using `SelectEnemyGapCloserTarget` (ranges `5.0f`/`15.0f`) instead of the previous nearby melee selector.
- Prevent auto-casting `Ghost Wolf` when already in Ghost Wolf by adding a `!inGhostWolf` condition to that decision candidate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455b74b06c8327bf070d67c77f1aeb)