### PR TITLE
Add Nefarian arena start gameobject (entry 179118)

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundNL.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundNL.cpp
@@ -33,7 +33,9 @@ void BattlegroundNL::StartingEventCloseDoors()
     SpawnBGObject(BG_NL_OBJECT_DOOR_2, RESPAWN_IMMEDIATELY);
     SpawnBGObject(BG_NL_OBJECT_WALL_1, RESPAWN_IMMEDIATELY);
 
-    // Hide Shadow Sight until the arena begins.
+    // Hide the start object and Shadow Sight until the arena begins.
+    SpawnBGObject(BG_NL_OBJECT_START_OBJECT, RESPAWN_ONE_DAY);
+
     SpawnBGObject(BG_NL_OBJECT_BUFF_1, RESPAWN_ONE_DAY);
     SpawnBGObject(BG_NL_OBJECT_BUFF_2, RESPAWN_ONE_DAY);
 
@@ -48,6 +50,8 @@ void BattlegroundNL::StartingEventOpenDoors()
     // in the source BWL spawn, state 1 is open and player use toggles it shut.
     SetNefarianDoorOpen(BG_NL_OBJECT_DOOR_1);
     SetNefarianDoorOpen(BG_NL_OBJECT_DOOR_2);
+
+    SpawnBGObject(BG_NL_OBJECT_START_OBJECT, RESPAWN_IMMEDIATELY);
 
     SpawnBGObject(BG_NL_OBJECT_BUFF_1, 60);
     SpawnBGObject(BG_NL_OBJECT_BUFF_2, 60);
@@ -87,6 +91,11 @@ bool BattlegroundNL::SetupBattleground()
             -7464.000000f, -1103.550049f, 480.029999f, 0.610865f,
             0.0f, 0.0f, 0.300706f, 0.953717f,
             RESPAWN_IMMEDIATELY, GO_STATE_READY)
+        // Start object, from requested BWL gameobject 35829.
+        || !AddObject(BG_NL_OBJECT_START_OBJECT, BG_NL_OBJECT_TYPE_START,
+            -7587.760000f, -1261.430000f, 482.000000f, 0.577301f,
+            0.0f, 0.0f, 0.284659f, 0.958629f,
+            RESPAWN_ONE_DAY)
         // Shadow Sight objects.
         || !AddObject(BG_NL_OBJECT_BUFF_1, BG_NL_OBJECT_TYPE_BUFF_1,
             -7571.823242f, -1250.127808f, 476.800140f, 0.628354f,
@@ -117,6 +126,9 @@ void BattlegroundNL::ApplyNonInteractableObjectFlags()
 
     if (GameObject* wall = GetBGObject(BG_NL_OBJECT_WALL_1, false))
         wall->SetFlag(GO_FLAG_NOT_SELECTABLE);
+
+    if (GameObject* startObject = GetBGObject(BG_NL_OBJECT_START_OBJECT, false))
+        startObject->SetFlag(GO_FLAG_NOT_SELECTABLE);
 }
 
 void BattlegroundNL::SetNefarianDoorClosed(uint32 type)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundNL.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundNL.h
@@ -23,18 +23,20 @@
 // Custom arena type 103 / map 1572.
 enum BattlegroundNLObjectTypes
 {
-    BG_NL_OBJECT_DOOR_1      = 0,
-    BG_NL_OBJECT_DOOR_2      = 1,
-    BG_NL_OBJECT_WALL_1      = 2,
-    BG_NL_OBJECT_BUFF_1      = 3,
-    BG_NL_OBJECT_BUFF_2      = 4,
-    BG_NL_OBJECT_MAX         = 5
+    BG_NL_OBJECT_DOOR_1       = 0,
+    BG_NL_OBJECT_DOOR_2       = 1,
+    BG_NL_OBJECT_WALL_1       = 2,
+    BG_NL_OBJECT_START_OBJECT = 3,
+    BG_NL_OBJECT_BUFF_1       = 4,
+    BG_NL_OBJECT_BUFF_2       = 5,
+    BG_NL_OBJECT_MAX          = 6
 };
 
 enum BattlegroundNLGameObjects
 {
     BG_NL_OBJECT_TYPE_DOOR   = 176966, // BWL Portcullis
     BG_NL_OBJECT_TYPE_WALL   = 179117, // BWL Portcullis / permanent blocker
+    BG_NL_OBJECT_TYPE_START  = 179118, // BWL arena start object
     BG_NL_OBJECT_TYPE_BUFF_1 = 184663, // Shadow Sight
     BG_NL_OBJECT_TYPE_BUFF_2 = 184664  // Shadow Sight
 };


### PR DESCRIPTION
### Motivation
- Add the requested Blackwing Lair start gameobject so the Nefarian arena shows the start pedestal when the match begins. 
- Ensure the object is hidden during arena preparation and appears when doors open to match original BWL behavior.

### Description
- Added a new object slot `BG_NL_OBJECT_START_OBJECT` and increased `BG_NL_OBJECT_MAX` in `BattlegroundNL` to track the start pedestal. 
- Introduced `BG_NL_OBJECT_TYPE_START = 179118` to represent the BWL start gameobject entry in `src/server/game/Battlegrounds/Zones/BattlegroundNL.h`. 
- Spawn logic in `src/server/game/Battlegrounds/Zones/BattlegroundNL.cpp` now creates the start object at `-7587.76, -1261.43, 482` with the supplied orientation/rotation and `RESPAWN_ONE_DAY` during prep and `RESPAWN_IMMEDIATELY` when doors open. 
- The start object is also marked non-selectable in `ApplyNonInteractableObjectFlags()` so it behaves like the other arena objects.

### Testing
- Ran `git diff --check` to validate source changes and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45acf658fc832792f850cf67ba2ac2)