### PR TITLE
Exclude low Gurubashi positions from arena checks

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -59,6 +59,8 @@ constexpr uint32 PVP_CONSUMABLE_ITEM_LIMIT_CATEGORY = 5;
 constexpr uint32 TELEPORT_VISUAL_SPELL = 64446;
 constexpr uint32 FORCED_DEATH_STARFIRE_SPELL_ID = 48465;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
+constexpr float GURUBASHI_BATTLE_RING_FLOOR_REFERENCE_Z = 20.613464f;
+constexpr float GURUBASHI_BATTLE_RING_FLOOR_GRACE_YARDS = 5.0f;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
 char const* const GURUBASHI_EXIT_KILL_WHISPERS[] =
@@ -90,12 +92,25 @@ uint32 GetChestMarkRewardCount()
     return localTime.tm_hour == 21 ? 3u : 1u;
 }
 
+bool IsBelowGurubashiBattleRingFloor(Player const* player)
+{
+    if (!player)
+        return false;
+
+    return player->GetPositionZ() < GURUBASHI_BATTLE_RING_FLOOR_REFERENCE_Z - GURUBASHI_BATTLE_RING_FLOOR_GRACE_YARDS;
+}
+
 bool IsInGurubashiBattleRingByPvpState(Player const* player, uint32 zoneId)
 {
     if (!player)
         return false;
 
     if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
+        return false;
+
+    // Players deep below the Battle Ring floor can retain the FFA PvP state,
+    // but should not count as being inside Gurubashi Arena for arena checks.
+    if (IsBelowGurubashiBattleRingFloor(player))
         return false;
 
     // The server already maintains authoritative FFA arena membership.


### PR DESCRIPTION
### Motivation
- Prevent players who are substantially below the Gurubashi Battle Ring floor from being treated as "inside the arena" for arena-specific checks, since they can retain FFA PvP state while effectively being out of the ring.

### Description
- Added constants `GURUBASHI_BATTLE_RING_FLOOR_REFERENCE_Z` and `GURUBASHI_BATTLE_RING_FLOOR_GRACE_YARDS` to `src/server/scripts/Custom/custom_gurubashi_arena.cpp` and initialized them to `20.613464f` and `5.0f` respectively.
- Implemented helper `IsBelowGurubashiBattleRingFloor(Player const*)` which returns true when a player's Z is more than the grace distance below the reference floor.
- Updated `IsInGurubashiBattleRingByPvpState` to return false for players where `IsBelowGurubashiBattleRingFloor` is true so those players are not considered inside the arena even if FFA PvP state remains set.

### Testing
- Ran `git diff --check` to validate the diff formatting and found no issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45fd5258f0832798f4ae9a8d2528fa)