### PR TITLE
Move custom Gurubashi chest spawn

### DIFF
--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -69,7 +69,7 @@ char const* const GURUBASHI_EXIT_KILL_WHISPERS[] =
     "Enemy players impede the exit from the Battle Ring."
 };
 
-Position const ChestSpawnPosition = { -13204.609f, 272.2056f, 21.858f, 1.022f };
+Position const ChestSpawnPosition = { -13205.281250f, 273.045685f, 20.550077f, 4.423725f };
 char const* const GURUBASHI_REENTRY_RULE_WHISPER = "You died while the chest is active. No re-entry to the Battle Ring until the chest is looted or despawns.";
 char const* const GURUBASHI_LATE_ENTRY_RULE_WHISPER = "You were not part of this chest battle. Entering the Battle Ring now is forbidden.";
 


### PR DESCRIPTION
### Motivation
- Place the custom Gurubashi arena chest at the requested Battle Ring coordinates so the spawned chest appears at the correct in-world location.

### Description
- Updated `ChestSpawnPosition` in `src/server/scripts/Custom/custom_gurubashi_arena.cpp` to `{ -13205.281250f, 273.045685f, 20.550077f, 4.423725f }` (map 0, zone 33 Battle Ring).

### Testing
- Ran `git diff --check` and `rg -n "ChestSpawnPosition" src/server/scripts/Custom/custom_gurubashi_arena.cpp` and both completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46ba0b73688327834af65f9ca9a71e)