### PR TITLE
Gurubashi: spawn temporary Shadow Sight GOs during chest event and handle arena trap entries

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -47,6 +47,14 @@
 #include <G3D/CoordinateFrame.h>
 #include <G3D/Quat.h>
 
+namespace
+{
+bool IsArenaShadowSightObject(uint32 entry)
+{
+    return entry == 184663 || entry == 184664;
+}
+}
+
 void GameObjectTemplate::InitializeQueryData()
 {
     for (uint8 loc = LOCALE_enUS; loc < TOTAL_LOCALES; ++loc)
@@ -821,9 +829,19 @@ void GameObject::Update(uint32 diff)
 
                         // Battleground gameobjects have data2 == 0 && data5 == 3
                         if (!goInfo->trap.diameter && goInfo->trap.cooldown == 3)
+                        {
+                            Battleground* bg = nullptr;
                             if (Player* player = target->ToPlayer())
-                                if (Battleground* bg = player->GetBattleground())
-                                    bg->HandleTriggerBuff(GetGUID());
+                                bg = player->GetBattleground();
+
+                            if (bg)
+                                bg->HandleTriggerBuff(GetGUID());
+                            else if (IsArenaShadowSightObject(GetEntry()))
+                            {
+                                DespawnOrUnsummon();
+                                break;
+                            }
+                        }
                     }
                     break;
                 }
@@ -1693,6 +1711,17 @@ void GameObject::Use(Unit* user)
 
             if (goInfo->trap.type == 1)         // Deactivate after trigger
                 SetLootState(GO_JUST_DEACTIVATED);
+            else if (IsArenaShadowSightObject(GetEntry()))
+            {
+                Battleground* bg = nullptr;
+                if (Player* player = user->ToPlayer())
+                    bg = player->GetBattleground();
+
+                if (bg)
+                    bg->HandleTriggerBuff(GetGUID());
+                else
+                    DespawnOrUnsummon();
+            }
 
             return;
         }

--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -36,6 +36,7 @@
 #include "TemporarySummon.h"
 #include "Util.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -44,6 +45,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 using namespace std::chrono_literals;
@@ -53,6 +55,7 @@ namespace
 constexpr uint32 GURUBASHI_ARENA_MAP_ID = 0;
 constexpr uint32 STRANGLETHORN_VALE_ZONE_ID = 33;
 constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
+constexpr uint32 SHADOW_SIGHT_ENTRY = 184663;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
 constexpr uint32 CHROMIE_ENTRY = 10667;
 constexpr uint32 PVP_CONSUMABLE_ITEM_LIMIT_CATEGORY = 5;
@@ -61,7 +64,12 @@ constexpr uint32 FORCED_DEATH_STARFIRE_SPELL_ID = 48465;
 constexpr uint32 REQUIRED_PLAYER_COUNT = 5;
 constexpr float GURUBASHI_BATTLE_RING_FLOOR_REFERENCE_Z = 20.613464f;
 constexpr float GURUBASHI_BATTLE_RING_FLOOR_GRACE_YARDS = 5.0f;
+constexpr float SHADOW_SIGHT_PLAYER_CLEARANCE = 5.0f;
+constexpr float SHADOW_SIGHT_MAX_SPAWN_RADIUS = 30.0f;
+constexpr uint8 SHADOW_SIGHT_SPAWN_ATTEMPTS = 128;
 constexpr Seconds CHEST_DESPAWN_TIME = 15min;
+constexpr Seconds SHADOW_SIGHT_DESPAWN_TIME = 30s;
+constexpr Seconds SHADOW_SIGHT_RESPAWN_INTERVAL = 30s;
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
 char const* const GURUBASHI_EXIT_KILL_WHISPERS[] =
 {
@@ -77,6 +85,7 @@ char const* const GURUBASHI_LATE_ENTRY_RULE_WHISPER = "You were not part of this
 
 void ClearChestDeathLockouts();
 void ClearChestParticipants();
+void StopGurubashiShadowSightSpawns();
 void MarkChestParticipants(std::vector<ObjectGuid> const& participantGuids);
 bool IsChestParticipant(ObjectGuid guid);
 
@@ -293,13 +302,12 @@ Position BuildRandomBattleRingPosition(Player* player)
     if (!player)
         return destination;
 
-    constexpr float maxRadius = 30.0f;
     constexpr float twoPi = 6.28318530718f;
 
     for (uint8 attempt = 0; attempt < 8; ++attempt)
     {
         float const angle = frand(0.0f, twoPi);
-        float const radius = frand(3.0f, maxRadius);
+        float const radius = frand(3.0f, SHADOW_SIGHT_MAX_SPAWN_RADIUS);
 
         float const x = ChestSpawnPosition.GetPositionX() + std::cos(angle) * radius;
         float const y = ChestSpawnPosition.GetPositionY() + std::sin(angle) * radius;
@@ -313,6 +321,59 @@ Position BuildRandomBattleRingPosition(Player* player)
     }
 
     return destination;
+}
+
+bool IsBattleRingPointClearOfPlayers(Map const* map, Position const& position)
+{
+    if (!map)
+        return false;
+
+    std::shared_lock<std::shared_mutex> guard(*HashMapHolder<Player>::GetLock());
+    for (auto const& playerPair : ObjectAccessor::GetPlayers())
+    {
+        Player* player = playerPair.second;
+        if (!player || !player->IsInWorld() || !player->IsAlive())
+            continue;
+
+        if (player->GetMap() != map || GetGurubashiAreaState(player, player->GetZoneId(), player->GetAreaId()) != GurubashiAreaState::BattleRing)
+            continue;
+
+        if (player->GetExactDist2d(position.GetPositionX(), position.GetPositionY()) < SHADOW_SIGHT_PLAYER_CLEARANCE)
+            return false;
+    }
+
+    return true;
+}
+
+bool BuildRandomShadowSightPosition(Player* summoner, Position& destination)
+{
+    if (!summoner || !summoner->GetMap())
+        return false;
+
+    constexpr float twoPi = 6.28318530718f;
+    Map* map = summoner->GetMap();
+
+    for (uint8 attempt = 0; attempt < SHADOW_SIGHT_SPAWN_ATTEMPTS; ++attempt)
+    {
+        float const angle = frand(0.0f, twoPi);
+        // sqrt keeps selection uniform across the circular battle-ring surface.
+        float const radius = std::sqrt(frand(0.0f, 1.0f)) * SHADOW_SIGHT_MAX_SPAWN_RADIUS;
+        float const x = ChestSpawnPosition.GetPositionX() + std::cos(angle) * radius;
+        float const y = ChestSpawnPosition.GetPositionY() + std::sin(angle) * radius;
+        float const z = map->GetHeight(summoner->GetPhaseMask(), x, y, ChestSpawnPosition.GetPositionZ() + 6.0f);
+
+        if (!std::isfinite(z))
+            continue;
+
+        Position candidate(x, y, z + 0.25f, frand(0.0f, twoPi));
+        if (!IsBattleRingPointClearOfPlayers(map, candidate))
+            continue;
+
+        destination = candidate;
+        return true;
+    }
+
+    return false;
 }
 
 void TeleportStranglethornPlayersToBattleRing()
@@ -414,6 +475,7 @@ public:
             _rewardGranted = true;
             ClearChestDeathLockouts();
             ClearChestParticipants();
+            StopGurubashiShadowSightSpawns();
             me->DespawnOrUnsummon();
         }
 
@@ -458,6 +520,7 @@ public:
     void OnShutdown() override
     {
         _scheduler.CancelAll();
+        StopShadowSightSpawns();
         _currentChestGuid.Clear();
         _nextCheckTimeMs = 0;
         _lastEligibleCount = 0;
@@ -469,11 +532,13 @@ public:
     void OnUpdate(uint32 diff) override
     {
         _scheduler.Update(diff);
+        _shadowSightScheduler.Update(diff);
 
         if (_chestActive && !IsChestGuidActiveInWorld(_currentChestGuid))
         {
             _currentChestGuid.Clear();
             _chestActive = false;
+            StopShadowSightSpawns();
             ClearChestDeathLockouts();
             ClearChestParticipants();
         }
@@ -509,6 +574,13 @@ public:
     bool IsChestActive() const
     {
         return _currentChestGuid && _chestActive;
+    }
+
+    void OnChestLooted()
+    {
+        _currentChestGuid.Clear();
+        _chestActive = false;
+        StopShadowSightSpawns();
     }
 
 private:
@@ -571,6 +643,7 @@ private:
 
             _currentChestGuid.Clear();
             _chestActive = false;
+            StopShadowSightSpawns();
             ClearChestDeathLockouts();
             ClearChestParticipants();
         }
@@ -584,6 +657,7 @@ private:
             _chestActive = true;
             ClearChestDeathLockouts();
             TeleportStranglethornPlayersToBattleRing();
+            ScheduleShadowSightSpawns();
             YellFromChromie();
             return SpawnResult::Success;
         }
@@ -591,17 +665,103 @@ private:
         return SpawnResult::MapNotAvailable;
     }
 
+    void ScheduleShadowSightSpawns()
+    {
+        _shadowSightScheduler.CancelAll();
+        _shadowSightScheduler.Schedule(SHADOW_SIGHT_RESPAWN_INTERVAL, [this](TaskContext context)
+        {
+            if (!IsChestActive())
+                return;
+
+            AttemptShadowSightSpawn();
+            context.Repeat(SHADOW_SIGHT_RESPAWN_INTERVAL);
+        });
+    }
+
+    void StopShadowSightSpawns()
+    {
+        _shadowSightScheduler.CancelAll();
+        DespawnShadowSights();
+    }
+
+    void DespawnShadowSights()
+    {
+        if (_shadowSightGuids.empty())
+            return;
+
+        std::vector<ObjectGuid> shadowSightGuids = std::move(_shadowSightGuids);
+        _shadowSightGuids.clear();
+
+        sMapMgr->DoForAllMaps([&shadowSightGuids](Map* map)
+        {
+            for (ObjectGuid const& guid : shadowSightGuids)
+                if (GameObject* shadowSight = map->GetGameObject(guid))
+                    shadowSight->DespawnOrUnsummon();
+        });
+    }
+
+    void PruneShadowSightGuids()
+    {
+        _shadowSightGuids.erase(std::remove_if(_shadowSightGuids.begin(), _shadowSightGuids.end(), [](ObjectGuid const& guid)
+        {
+            bool active = false;
+            sMapMgr->DoForAllMaps([&](Map* map)
+            {
+                if (active)
+                    return;
+
+                if (GameObject* shadowSight = map->GetGameObject(guid))
+                    active = shadowSight->IsInWorld();
+            });
+            return !active;
+        }), _shadowSightGuids.end());
+    }
+
+    void AttemptShadowSightSpawn()
+    {
+        PruneShadowSightGuids();
+
+        ObjectGuid summonerGuid;
+        CountEligiblePlayers(&summonerGuid);
+        Player* summoner = FindEligibleSummoner(summonerGuid);
+        if (!summoner || !summoner->IsInWorld())
+            return;
+
+        Position shadowSightPosition;
+        if (!BuildRandomShadowSightPosition(summoner, shadowSightPosition))
+            return;
+
+        DespawnShadowSights();
+
+        if (GameObject* shadowSight = summoner->SummonGameObject(SHADOW_SIGHT_ENTRY, shadowSightPosition, QuaternionData::fromEulerAnglesZYX(shadowSightPosition.GetOrientation(), 0.f, 0.f), SHADOW_SIGHT_DESPAWN_TIME))
+        {
+            summoner->RemoveGameObject(shadowSight, false);
+            shadowSight->SetRespawnTime(0);
+            _shadowSightGuids.push_back(shadowSight->GetGUID());
+        }
+    }
+
     TaskScheduler _scheduler;
+    TaskScheduler _shadowSightScheduler;
     ObjectGuid _currentChestGuid;
     uint32 _nextCheckTimeMs = 0;
     bool _chestActive = false;
     uint32 _lastEligibleCount = 0;
+    std::vector<ObjectGuid> _shadowSightGuids;
 
     static gurubashi_arena_hourly_event* s_Instance;
 };
 
 gurubashi_arena_hourly_event* gurubashi_arena_hourly_event::s_Instance = nullptr;
 
+namespace
+{
+void StopGurubashiShadowSightSpawns()
+{
+    if (gurubashi_arena_hourly_event* event = gurubashi_arena_hourly_event::GetInstance())
+        event->OnChestLooted();
+}
+}
 
 namespace
 {


### PR DESCRIPTION
### Motivation
- Add dynamic "Shadow Sight" gameobjects around the Gurubashi Arena chest event to provide temporary gameplay effects while the chest is active. 
- Ensure special-case trap gameobjects used for arena mechanics (shadow sight entries) behave correctly when triggered outside a Battleground. 

### Description
- Added `IsArenaShadowSightObject` helper and special-case handling in `GameObject::Update` and `GameObject::Use` so arena shadow-sight trap entries (IDs `184663`/`184664`) call `Battleground::HandleTriggerBuff` when triggered by a battleground player and otherwise `DespawnOrUnsummon()` when not inside a battleground. 
- Implemented a Gurubashi custom script extension to spawn short-lived shadow-sight gameobjects while the hourly chest is active, including: randomized spawn position generation (`BuildRandomShadowSightPosition`), player-clearance checks (`IsBattleRingPointClearOfPlayers`), spawn scheduling (`ScheduleShadowSightSpawns`), despawn/prune logic (`DespawnShadowSights`, `PruneShadowSightGuids`) and stop hooks when the chest is looted or despawns. 
- Integrated shadow-sight lifecycle into the existing hourly event flow: spawns are scheduled when the chest appears (`AttemptSpawn`) and canceled/cleaned up on chest loot, chest end, or shutdown (`StopShadowSightSpawns` / `StopGurubashiShadowSightSpawns`). 
- Added constants and tuning parameters for spawn behavior like `SHADOW_SIGHT_MAX_SPAWN_RADIUS`, `SHADOW_SIGHT_DESPAWN_TIME`, `SHADOW_SIGHT_RESPAWN_INTERVAL`, and limits on spawn attempts. 

### Testing
- Built the server (`make`) and ran the automated unit/test suite (`ctest`) with no failures reported. 
- Executed an automated integration smoke test that calls the event `ForceSpawn()` and verified scheduled shadow-sight spawns, their timed despawn, and cleanup when the chest is looted, and no regressions were observed. 
- Ran the server startup smoke test to ensure script registration and shutdown hooks run cleanly with the new scheduling logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46bcb623908327a7e6133b792d8fdd)