### PR TITLE
Force The Battle Ring (30232) as FFA PvP area

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7388,7 +7388,7 @@ void Player::UpdateArea(uint32 newArea)
 
     if (!isFFAArea)
     {
-        static std::array<uint32, 1> const customFFAAreas = { 3217 }; // The Maul (Dire Maul arena)
+        static std::array<uint32, 2> const customFFAAreas = { 3217, 30232 }; // The Maul (Dire Maul arena), The Battle Ring (Gurubashi Arena WMO area)
 
         for (uint32 customArea : customFFAAreas)
         {


### PR DESCRIPTION
### Motivation
- Ensure area `30232` (The Battle Ring / Gurubashi Arena WMO area) is always treated as FFA PvP because its DBC area flags do not mark it as an arena.

### Description
- Add `30232` to the `customFFAAreas` list in `src/server/game/Entities/Player/Player.cpp` so `UpdateArea` will mark The Battle Ring as an FFA PvP area.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46c39a18988327a56a262db0d5fd6b)