### PR TITLE
Prevent bots snapping below walkable surface and use teleport for battleground downhill commits

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -535,7 +535,17 @@ bool TryBuildStrictHumanSegmentDestination(Player* player, Position const& desir
         float const dy = resolvedDestination.GetPositionY() - player->GetPositionY();
         float const planarDelta = std::sqrt(dx * dx + dy * dy);
         float const verticalDelta = std::fabs(resolvedDestination.GetPositionZ() - player->GetPositionZ());
+        float const downwardDelta = player->GetPositionZ() - resolvedDestination.GetPositionZ();
         if (planarDelta < 0.5f || verticalDelta > std::max(8.0f, planarDelta * 0.75f + 2.0f))
+            return false;
+
+        // Never accept a strict movement segment that snaps sharply below the
+        // bot. Battleground floors, bridges, and ramps can have map-height
+        // samples below the walkable surface; issuing a MovePoint to that lower
+        // sample makes bots dive through the floor instead of pathing like a
+        // player. Real descents still work by chaining short, path-generated
+        // segments whose Z changes are proportional to their horizontal travel.
+        if (!player->IsInWater() && downwardDelta > std::max(4.0f, planarDelta * 0.35f + 1.0f))
             return false;
 
         return true;
@@ -1757,9 +1767,9 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
 
     // Battleground cliff descent recovery:
     // When chasing a distant lower target from elevated terrain, repeatedly
-    // issuing CHASE/FOLLOW can route bots back uphill. Force a short direct
-    // downhill step toward the target to commit the descent before resuming
-    // target-relative pathing.
+    // issuing CHASE/FOLLOW can route bots back uphill. Move the bot downhill
+    // immediately by teleporting it to a legal point near the lower target,
+    // then resume normal target-relative pathing on the next update.
     bool const shouldForceDownhillCommit =
         battleground &&
         strictPathing &&
@@ -1770,15 +1780,21 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE);
     if (shouldForceDownhillCommit)
     {
-        float const stepDistance = std::min(16.0f, std::max(6.0f, planarDistanceToTarget * 0.3f));
-        float const invPlanar = 1.0f / std::max(0.01f, planarDistanceToTarget);
-        Position downhillProbe(
-            player->GetPositionX() + dxToTarget * invPlanar * stepDistance,
-            player->GetPositionY() + dyToTarget * invPlanar * stepDistance,
-            player->GetPositionZ() - std::min(12.0f, std::max(4.0f, verticalDeltaToTarget * 0.5f)),
-            player->GetOrientation());
-        Position const downhillDestination = BuildCollisionSafeDestination(player, downhillProbe);
-        motionMaster->MovePoint(0, downhillDestination, false);
+        float teleportX = target->GetPositionX();
+        float teleportY = target->GetPositionY();
+        float const teleportRange = std::clamp(safeDistance, 2.0f, 12.0f);
+        target->GetNearPoint2D(player, teleportX, teleportY, teleportRange, target->GetAbsoluteAngle(player));
+
+        // Do not call GetNearPoint/BuildCollisionSafeDestination here: both can
+        // call UpdateAllowedPositionZ(), which may sample the terrain below a
+        // bridge/platform and put the bot under the walkable surface. The target
+        // is already standing on the lower playable surface, so preserve its Z
+        // and only let normal movement resume after the teleport.
+        Position teleportDestination(teleportX, teleportY, target->GetPositionZ(), player->GetOrientation());
+
+        float const preTeleportDistance = player->GetDistance(teleportDestination);
+        motionMaster->Clear(MOTION_SLOT_ACTIVE);
+        player->NearTeleportTo(teleportDestination, false);
 
         stallState.targetGuid = target->GetGUID();
         stallState.lastDistance = currentDistance;
@@ -1788,11 +1804,11 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         stallState.lastIssuedMode = 1;
 
         std::ostringstream diag;
-        diag << BuildRangedMovementDiag(player, target, "bg_downhill_commit_direct",
-            safeDistance, safeDistance, targetLos, targetAttackable, true, initialMotionType, "direct")
+        diag << BuildRangedMovementDiag(player, target, "bg_downhill_commit_teleport",
+            safeDistance, safeDistance, targetLos, targetAttackable, true, initialMotionType, "teleport")
              << " vertical_delta=" << verticalDeltaToTarget
              << " planar_delta=" << planarDistanceToTarget
-             << " commit_dist=" << player->GetDistance(downhillDestination);
+             << " teleport_dist=" << preTeleportDistance;
         SetLastMovementDebugStatus(player, diag.str());
         return;
     }


### PR DESCRIPTION
### Motivation
- Prevent strict movement segments that snap sharply below the bot and cause bots to dive through floors or bridges due to low map-height samples. 
- Improve battleground downhill commit behavior so bots reliably descend to lower playable surfaces without being routed back uphill by pathing.

### Description
- Add `downwardDelta` and reject strict movement segments that move the bot sharply downward (unless `IsInWater()`), returning `false` for unsafe snaps. 
- Replace the previous short `MovePoint` downhill step with an immediate teleport near the lower target by calling `target->GetNearPoint2D(...)` and `player->NearTeleportTo(...)`, preserving the target's Z to avoid sampling under walkable surfaces. 
- Avoid calls to `GetNearPoint`/`BuildCollisionSafeDestination` during the downhill commit to prevent `UpdateAllowedPositionZ()` from moving bots under platforms, and update diagnostic label from `bg_downhill_commit_direct` to `bg_downhill_commit_teleport`.
- Add explanatory comments and adjust related distance/teleport range calculations using `std::clamp`.

### Testing
- Built the server project successfully using the standard build (`cmake` + `make -j`) with the changes applied. 
- Ran the automated playerbot movement/PvP test suite targeting ranged approach and downhill scenarios and observed the tests passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4874cacef88327bef02461ab629a25)