### PR TITLE
Prevent bots diving below terrain and add capped downhill teleport nudge for BG chases

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -535,7 +535,17 @@ bool TryBuildStrictHumanSegmentDestination(Player* player, Position const& desir
         float const dy = resolvedDestination.GetPositionY() - player->GetPositionY();
         float const planarDelta = std::sqrt(dx * dx + dy * dy);
         float const verticalDelta = std::fabs(resolvedDestination.GetPositionZ() - player->GetPositionZ());
+        float const downwardDelta = player->GetPositionZ() - resolvedDestination.GetPositionZ();
         if (planarDelta < 0.5f || verticalDelta > std::max(8.0f, planarDelta * 0.75f + 2.0f))
+            return false;
+
+        // Never accept a strict movement segment that snaps sharply below the
+        // bot. Battleground floors, bridges, and ramps can have map-height
+        // samples below the walkable surface; issuing a MovePoint to that lower
+        // sample makes bots dive through the floor instead of pathing like a
+        // player. Real descents still work by chaining short, path-generated
+        // segments whose Z changes are proportional to their horizontal travel.
+        if (!player->IsInWater() && downwardDelta > std::max(4.0f, planarDelta * 0.35f + 1.0f))
             return false;
 
         return true;
@@ -1757,12 +1767,14 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
 
     // Battleground cliff descent recovery:
     // When chasing a distant lower target from elevated terrain, repeatedly
-    // issuing CHASE/FOLLOW can route bots back uphill. Force a short direct
-    // downhill step toward the target to commit the descent before resuming
-    // target-relative pathing.
+    // issuing CHASE/FOLLOW can route bots back uphill. Move the bot only a short
+    // downhill step, then resume normal target-relative pathing on the next
+    // update. Do not teleport all the way to the target/midfield.
+    bool const downhillTeleportReady = !sameStallTarget || stallState.lastIssueMs == 0 || lastIssueAgeMs >= 3000;
     bool const shouldForceDownhillCommit =
         battleground &&
         strictPathing &&
+        downhillTeleportReady &&
         verticalDeltaToTarget > 8.0f &&
         planarDistanceToTarget > 30.0f &&
         !currentlyMoving &&
@@ -1770,15 +1782,22 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         !player->HasUnitState(UNIT_STATE_FOLLOW_MOVE);
     if (shouldForceDownhillCommit)
     {
-        float const stepDistance = std::min(16.0f, std::max(6.0f, planarDistanceToTarget * 0.3f));
-        float const invPlanar = 1.0f / std::max(0.01f, planarDistanceToTarget);
-        Position downhillProbe(
-            player->GetPositionX() + dxToTarget * invPlanar * stepDistance,
-            player->GetPositionY() + dyToTarget * invPlanar * stepDistance,
-            player->GetPositionZ() - std::min(12.0f, std::max(4.0f, verticalDeltaToTarget * 0.5f)),
-            player->GetOrientation());
-        Position const downhillDestination = BuildCollisionSafeDestination(player, downhillProbe);
-        motionMaster->MovePoint(0, downhillDestination, false);
+        float const teleportStep = std::clamp(planarDistanceToTarget * 0.20f, 12.0f, 35.0f);
+        float const teleportFraction = std::min(teleportStep / std::max(0.01f, planarDistanceToTarget), 1.0f);
+        float const teleportX = player->GetPositionX() + dxToTarget * teleportFraction;
+        float const teleportY = player->GetPositionY() + dyToTarget * teleportFraction;
+        float const teleportZ = player->GetPositionZ() - std::min(10.0f, verticalDeltaToTarget * teleportFraction);
+
+        // Do not call GetNearPoint/BuildCollisionSafeDestination here: both can
+        // call UpdateAllowedPositionZ(), which may sample the terrain below a
+        // bridge/platform and put the bot under the walkable surface. This is a
+        // capped downhill nudge from the bot's current position, not a teleport
+        // to the distant target.
+        Position teleportDestination(teleportX, teleportY, teleportZ, player->GetOrientation());
+
+        float const preTeleportDistance = player->GetDistance(teleportDestination);
+        motionMaster->Clear(MOTION_SLOT_ACTIVE);
+        player->NearTeleportTo(teleportDestination, false);
 
         stallState.targetGuid = target->GetGUID();
         stallState.lastDistance = currentDistance;
@@ -1788,11 +1807,13 @@ void IssueRangedApproachMovement(Player* player, Unit* target, float desiredDist
         stallState.lastIssuedMode = 1;
 
         std::ostringstream diag;
-        diag << BuildRangedMovementDiag(player, target, "bg_downhill_commit_direct",
-            safeDistance, safeDistance, targetLos, targetAttackable, true, initialMotionType, "direct")
+        diag << BuildRangedMovementDiag(player, target, "bg_downhill_commit_teleport",
+            safeDistance, safeDistance, targetLos, targetAttackable, true, initialMotionType, "teleport")
              << " vertical_delta=" << verticalDeltaToTarget
              << " planar_delta=" << planarDistanceToTarget
-             << " commit_dist=" << player->GetDistance(downhillDestination);
+             << " teleport_dist=" << preTeleportDistance
+             << " teleport_step=" << teleportStep
+             << " cooldown_ms=3000";
         SetLastMovementDebugStatus(player, diag.str());
         return;
     }


### PR DESCRIPTION
### Motivation
- Prevent strict movement segments and ad-hoc downhill steps from snapping bots to map-height samples below the walkable surface which could make them fall through floors. 
- Make battleground downhill descents more reliable by committing a short, capped downhill nudge that avoids routing bots back uphill.

### Description
- Added a downward delta reject in `TryBuildStrictHumanSegmentDestination` to refuse strict movement segments that snap sharply below the bot unless the bot is in water. 
- In `IssueRangedApproachMovement` introduced a `downhillTeleportReady` cooldown check and replaced the previous direct `MovePoint` commit with a capped teleport nudge computed via `teleportStep`/`teleportFraction` and executed with `player->NearTeleportTo(...)`, avoiding calls to `GetNearPoint`/`BuildCollisionSafeDestination` that can sample terrain under bridges. 
- Updated diagnostics and logging keys from `bg_downhill_commit_direct` to `bg_downhill_commit_teleport` and added `teleport_dist`, `teleport_step`, and a `cooldown_ms` value in the debug output. 
- Added explanatory comments for why collision/height sampling is avoided for this operation.

### Testing
- Performed a full project build (`make`) which completed successfully. 
- Ran the automated server test suite (`make test`) and the playerbot-related tests, and observed no regressions or failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4874cacef88327bef02461ab629a25)