### PR TITLE
Keep NPC shaman engaged when totem dies

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11974,10 +11974,23 @@ bool Unit::InitTamedPet(Pet* pet, uint8 level, uint32 spell_id)
                 killerPlayer->GetCombatManager().RefreshPvPCombatTimer(killedPlayer);
 
             if (victim->IsTotem())
+            {
                 if (Unit* totemOwner = victim->GetCharmerOrOwner())
+                {
                     if (totemOwner->IsControlledByPlayer())
+                    {
                         // Keep the attacker in combat for the PvP timeout while not flagging the shaman owner
                         killerPlayer->GetCombatManager().SetInCombatWith(totemOwner, true);
+                    }
+                    else if (totemOwner->IsAlive())
+                    {
+                        // Killing an NPC shaman's totem must keep the shaman engaged with the killer.
+                        // Totems cannot own threat lists, so their death can otherwise leave the owner
+                        // with no selectable hostile and cause an immediate evade reset.
+                        totemOwner->EngageWithTarget(attacker);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent NPC shamans from immediately leaving combat and entering evade when one of their totems is killed by ensuring the NPC owner is re-engaged so they retain a selectable hostile target, while preserving existing PvP behavior for player-owned totems.

### Description
- Add handling in `src/server/game/Entities/Unit/Unit.cpp` inside the kill handling path so that when `victim->IsTotem()` we keep the existing `SetInCombatWith` call for player-controlled totem owners and call `totemOwner->EngageWithTarget(attacker)` for non-player (NPC) totem owners that are alive to re-establish engagement.

### Testing
- Ran `git diff --check` which produced no issues, and attempted `cmake --build` but no local `build` directory was available so a full compile could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b48b2b6248327b537384abd2bd9f3)