### PR TITLE
Fix Gurubashi Battle Ring area handling

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1304,11 +1304,9 @@ void Player::Update(uint32 p_time)
                 }
                 else
                 {
-                    bool const isCustomGurubashiFFAArea =
-                        newarea == 2177 || newarea == 30232 ||
-                        m_zoneUpdateId == 2177 || m_zoneUpdateId == 30232;
+                    bool const isCustomGurubashiFFAArea = newarea == 30232;
 
-                    // Repair stale FFA state when the area id is already correct but the PvP flag did not get applied.
+                    // Repair stale FFA state when the Battle Ring area id is already correct but the PvP flag did not get applied.
                     if (isCustomGurubashiFFAArea && (!pvpInfo.IsInFFAPvPArea || !IsFFAPvP()))
                         UpdateArea(newarea);
                 }
@@ -7400,11 +7398,11 @@ void Player::UpdateArea(uint32 newArea)
 
     if (!isFFAArea)
     {
-        static std::array<uint32, 3> const customFFAAreas = { 3217, 2177, 30232 }; // The Maul, Gurubashi Catacombs, The Battle Ring
+        static std::array<uint32, 2> const customFFAAreas = { 3217, 30232 }; // The Maul, The Battle Ring
 
         for (uint32 customArea : customFFAAreas)
         {
-            if (newArea == customArea || m_zoneUpdateId == customArea)
+            if (newArea == customArea)
             {
                 isFFAArea = true;
                 break;

--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -140,14 +140,14 @@ GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, ui
     if (player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
         return GurubashiAreaState::Outside;
 
+    if (Map const* map = player->FindMap())
+        map->GetZoneAndAreaId(player->GetPhaseMask(), zoneId, areaId, player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+
     if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
         return GurubashiAreaState::Outside;
 
     if (areaId == GURUBASHI_BATTLE_RING_AREA_ID)
         return GurubashiAreaState::BattleRing;
-
-    if (areaId == GURUBASHI_CATACOMBS_AREA_ID)
-        return GurubashiAreaState::NonRing;
 
     return GurubashiAreaState::NonRing;
 }


### PR DESCRIPTION
### Motivation
- Players touching ramps or nearby safe geometry were still treated as inside the Gurubashi Battle Ring FFA area and were being killed or flagged PvP when they should be safe. 
- The intent is to make FFA PvP entry/exit and the stale-flag repair logic depend on the player's actual resolved terrain area and to restrict the special-case logic to the Battle Ring only.

### Description
- Restrict the stale FFA repair path in `Player::Update` to run only when the resolved `newarea` equals the Battle Ring area id (`30232`) instead of also treating catacombs/zone-id matches as FFA (`src/server/game/Entities/Player/Player.cpp`).
- Remove the Gurubashi Catacombs (`2177`) from the custom FFA area list and stop considering `m_zoneUpdateId` in the custom-area loop so custom matching is area-id based (`src/server/game/Entities/Player/Player.cpp`).
- Resolve the Gurubashi arena area from the player's current map coordinates by calling `Map::GetZoneAndAreaId` inside `GetGurubashiAreaState`, ensuring exit/entry kill rules use the actual terrain area, and remove the redundant catacombs branch (`src/server/scripts/Custom/custom_gurubashi_arena.cpp`).

### Testing
- Ran `git diff --check` to verify there are no whitespace or trivial diff issues, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51b82c30dc83278cac7c22db49f647)