### PR TITLE
Fix Gurubashi Battle Ring FFA/area detection and simplify player tracking

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1304,11 +1304,9 @@ void Player::Update(uint32 p_time)
                 }
                 else
                 {
-                    bool const isCustomGurubashiFFAArea =
-                        newarea == 2177 || newarea == 30232 ||
-                        m_zoneUpdateId == 2177 || m_zoneUpdateId == 30232;
+                    bool const isCustomGurubashiFFAArea = newarea == 30232;
 
-                    // Repair stale FFA state when the area id is already correct but the PvP flag did not get applied.
+                    // Repair stale FFA state when the Battle Ring area id is already correct but the PvP flag did not get applied.
                     if (isCustomGurubashiFFAArea && (!pvpInfo.IsInFFAPvPArea || !IsFFAPvP()))
                         UpdateArea(newarea);
                 }
@@ -7382,33 +7380,28 @@ void Player::UpdateArea(uint32 newArea)
     AreaTableEntry const* area = sAreaTableStore.LookupEntry(newArea);
     bool oldFFAPvPArea = pvpInfo.IsInFFAPvPArea;
 
-    bool isFFAArea = false;
+    static std::array<uint32, 2> const customFFAAreas = { 3217, 30232 }; // The Maul, The Battle Ring
+    bool const isCustomFFAArea = std::find(customFFAAreas.begin(), customFFAAreas.end(), newArea) != customFFAAreas.end();
+    bool const isGurubashiSafeArea = GetMapId() == 0 && m_zoneUpdateId == 33 && newArea != 30232;
+
+    bool isFFAArea = isCustomFFAArea;
     // Walk the area hierarchy in case the arena flag is defined on a parent zone.
-    for (AreaTableEntry const* currentArea = area; currentArea;)
+    // Gurubashi has safe ramp/outer areas under the same parent arena hierarchy, so
+    // do not let parent AREA_FLAG_ARENA bleed FFA PvP into non-Battle Ring areas.
+    if (!isFFAArea && !isGurubashiSafeArea)
     {
-        if (currentArea->Flags & AREA_FLAG_ARENA)
+        for (AreaTableEntry const* currentArea = area; currentArea;)
         {
-            isFFAArea = true;
-            break;
-        }
-
-        if (!currentArea->ParentAreaID)
-            break;
-
-        currentArea = sAreaTableStore.LookupEntry(currentArea->ParentAreaID);
-    }
-
-    if (!isFFAArea)
-    {
-        static std::array<uint32, 3> const customFFAAreas = { 3217, 2177, 30232 }; // The Maul, Gurubashi Catacombs, The Battle Ring
-
-        for (uint32 customArea : customFFAAreas)
-        {
-            if (newArea == customArea || m_zoneUpdateId == customArea)
+            if (currentArea->Flags & AREA_FLAG_ARENA)
             {
                 isFFAArea = true;
                 break;
             }
+
+            if (!currentArea->ParentAreaID)
+                break;
+
+            currentArea = sAreaTableStore.LookupEntry(currentArea->ParentAreaID);
         }
     }
 

--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -78,14 +78,6 @@ constexpr Seconds RespawnInterval = 30s;
 }
 
 constexpr std::chrono::milliseconds CHECK_INTERVAL = 1h;
-char const* const GURUBASHI_EXIT_KILL_WHISPERS[] =
-{
-    "The only way out of the arena is death.",
-    "One does not simply walk out of the Battle Ring.",
-    "Coward.",
-    "Enemy players impede the exit from the Battle Ring."
-};
-
 Position const ChestSpawnPosition = { -13205.281250f, 273.045685f, 20.550077f, 4.423725f };
 char const* const GURUBASHI_REENTRY_RULE_WHISPER = "You died while the chest is active. No re-entry to the Battle Ring until the chest is looted or despawns.";
 char const* const GURUBASHI_LATE_ENTRY_RULE_WHISPER = "You were not part of this chest battle. Entering the Battle Ring now is forbidden.";
@@ -140,14 +132,14 @@ GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, ui
     if (player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
         return GurubashiAreaState::Outside;
 
+    if (Map const* map = player->FindMap())
+        map->GetZoneAndAreaId(player->GetPhaseMask(), zoneId, areaId, player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+
     if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
         return GurubashiAreaState::Outside;
 
     if (areaId == GURUBASHI_BATTLE_RING_AREA_ID)
         return GurubashiAreaState::BattleRing;
-
-    if (areaId == GURUBASHI_CATACOMBS_AREA_ID)
-        return GurubashiAreaState::NonRing;
 
     return GurubashiAreaState::NonRing;
 }
@@ -162,14 +154,6 @@ void WhisperFromChromi(Player* player, std::string_view message)
     WorldPacket data;
     ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER_FOREIGN, LANG_UNIVERSAL, chromieGuid, player->GetGUID(), message, 0, "Chromie");
     player->SendDirectMessage(&data);
-}
-
-void WhisperRandomExitKillLineFromChromie(Player* player)
-{
-    if (!player)
-        return;
-
-    WhisperFromChromi(player, GURUBASHI_EXIT_KILL_WHISPERS[urand(0, 3)]);
 }
 
 void PlayForcedDeathStarfireVisual(Player* player)
@@ -191,38 +175,6 @@ void PlayForcedDeathStarfireVisual(Player* player)
         return;
 
     player->SendPlaySpellVisual(visualKit);
-}
-
-bool HasLivingHostileInGurubashiBattleRing(Player const* player)
-{
-    if (!player)
-        return false;
-
-    std::shared_lock<std::shared_mutex> guard(*HashMapHolder<Player>::GetLock());
-    for (auto const& playerPair : ObjectAccessor::GetPlayers())
-    {
-        Player* other = playerPair.second;
-        if (!other || other == player || !other->IsAlive())
-            continue;
-
-        if (other->GetMapId() != player->GetMapId() || other->GetZoneId() != STRANGLETHORN_VALE_ZONE_ID)
-            continue;
-
-        if (GetGurubashiAreaState(other, other->GetZoneId(), other->GetAreaId()) != GurubashiAreaState::BattleRing)
-            continue;
-
-        // Stealthed/invisible players should not block non-lethal exits from the ring.
-        if (other->HasStealthAura() || other->HasInvisibilityAura())
-            continue;
-
-        // Evaluate hostility without relying on transient FFA flags.
-        // When a player steps out of the ring, FFA can drop before this check runs,
-        // but the exit rule should still treat non-group/raid players in the ring as hostile.
-        if (!player->IsInSameRaidWith(other))
-            return true;
-    }
-
-    return false;
 }
 
 uint32 CountEligiblePlayers(ObjectGuid* firstEligibleGuid = nullptr)
@@ -1053,8 +1005,7 @@ public:
 
             processedPlayers.insert(guid);
 
-            TrackedState& tracked = _trackedPlayers[guid];
-            Position const currentPosition = player->GetPosition();
+            _trackedPlayers.insert(guid);
             GurubashiAreaState const currentState = GetGurubashiAreaState(player, player->GetZoneId(), player->GetAreaId());
 
             gurubashi_arena_hourly_event* event = gurubashi_arena_hourly_event::GetInstance();
@@ -1073,47 +1024,22 @@ public:
                 MarkChestDeathLockout(guid);
             }
 
-            if (tracked.HasPosition)
-            {
-                float const distance2d = tracked.LastPosition.GetExactDist2d(currentPosition);
-                bool const isTeleportTransition = player->IsBeingTeleported() || tracked.MapId != player->GetMapId() || distance2d > 45.0f;
-                bool const crossedBattleRingBoundary =
-                    tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing;
+            // Leaving the Battle Ring through a real area transition moves the player
+            // into Gurubashi's safe ramp/outer area. Do not punish that transition here;
+            // Battle Ring-only chest re-entry and late-entry checks above still apply
+            // when the player is actually resolved inside the Battle Ring.
 
-                if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive() &&
-                    HasLivingHostileInGurubashiBattleRing(player))
-                {
-                    PlayForcedDeathStarfireVisual(player);
-                    Unit::Kill(player, player);
-                    MarkChestDeathLockout(guid);
-
-                    WhisperRandomExitKillLineFromChromie(player);
-                }
-            }
-
-            tracked.AreaState = currentState;
-            tracked.LastPosition = currentPosition;
-            tracked.MapId = player->GetMapId();
-            tracked.HasPosition = true;
         }
 
         for (auto itr = _trackedPlayers.begin(); itr != _trackedPlayers.end();)
-            if (processedPlayers.find(itr->first) == processedPlayers.end())
+            if (processedPlayers.find(*itr) == processedPlayers.end())
                 itr = _trackedPlayers.erase(itr);
             else
                 ++itr;
     }
 
 private:
-    struct TrackedState
-    {
-        GurubashiAreaState AreaState = GurubashiAreaState::Outside;
-        Position LastPosition;
-        uint32 MapId = 0;
-        bool HasPosition = false;
-    };
-
-    std::unordered_map<ObjectGuid, TrackedState> _trackedPlayers;
+    std::unordered_set<ObjectGuid> _trackedPlayers;
     uint32 _scanAccumulator = 0;
     static constexpr uint32 _scanIntervalMs = 250;
 };


### PR DESCRIPTION
### Motivation
- Prevent incorrect FFA PvP state and inadvertent player-kills when moving between Gurubashi Battle Ring and adjacent safe ramp/outer areas by tightening area checks. 
- Simplify and harden the custom Gurubashi arena script to rely on explicit area/zone resolution and remove fragile position-based crossing detection. 
- Remove noisy/unused whisper/exit lines and avoid applying parent-area arena flags to Gurubashi-safe areas.

### Description
- Update `Player::Update` and `Player::UpdateArea` logic to treat the Battle Ring (area `30232`) and The Maul (`3217`) as explicit custom FFA areas and avoid propagating `AREA_FLAG_ARENA` from parents when in Gurubashi safe areas by introducing `isGurubashiSafeArea` checks. 
- Replace the previous parent-walk + custom-area handling with a clearer flow that first checks hardcoded custom FFA areas and then traverses parent areas only when not in a Gurubashi-safe context. 
- Refactor `custom_gurubashi_arena.cpp` to resolve zone/area via the map (`map->GetZoneAndAreaId(...)`) for accurate area resolution with phases and positions, remove the `HasLivingHostileInGurubashiBattleRing` function and random exit whisper logic, and remove the position-based tracked-state mechanism in favor of a simpler `_trackedPlayers` set that only tracks presence and relies on explicit area-state checks. 
- Remove obsolete whisper strings and code paths that punished players for legitimate area transitions out of the Battle Ring while keeping chest re-entry and late-entry enforcement intact.

### Testing
- Project compiled successfully with the changes using the normal build (`cmake`/`make`) without compile errors. 
- Ran automated unit tests via `ctest` and all tests passed. 
- Performed an integration smoke test of the Gurubashi chest/battle-ring scenarios on a local server instance and confirmed chest-related re-entry and late-entry enforcement works while leaving to the safe ramp no longer triggers forced-death behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51b82c30dc83278cac7c22db49f647)