### PR TITLE
Correct Gurubashi Battle Ring FFA detection and exit handling

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1304,12 +1304,14 @@ void Player::Update(uint32 p_time)
                 }
                 else
                 {
-                    bool const isCustomGurubashiFFAArea =
-                        newarea == 2177 || newarea == 30232 ||
-                        m_zoneUpdateId == 2177 || m_zoneUpdateId == 30232;
+                    bool const isCustomGurubashiArea = GetMapId() == 0 && m_zoneUpdateId == 33 && newarea == 30232;
+                    bool const isCustomGurubashiFFAArea = isCustomGurubashiArea && GetPositionZ() <= 27.0f;
 
-                    // Repair stale FFA state when the area id is already correct but the PvP flag did not get applied.
-                    if (isCustomGurubashiFFAArea && (!pvpInfo.IsInFFAPvPArea || !IsFFAPvP()))
+                    // Repair stale FFA state when vertical movement keeps the same Battle Ring area id
+                    // but moves between the FFA floor and safe ramp/outer geometry above it.
+                    if (isCustomGurubashiArea &&
+                        ((isCustomGurubashiFFAArea && (!pvpInfo.IsInFFAPvPArea || !IsFFAPvP())) ||
+                         (!isCustomGurubashiFFAArea && (pvpInfo.IsInFFAPvPArea || IsFFAPvP()))))
                         UpdateArea(newarea);
                 }
 
@@ -7382,33 +7384,30 @@ void Player::UpdateArea(uint32 newArea)
     AreaTableEntry const* area = sAreaTableStore.LookupEntry(newArea);
     bool oldFFAPvPArea = pvpInfo.IsInFFAPvPArea;
 
-    bool isFFAArea = false;
+    bool const isGurubashiBattleRing = GetMapId() == 0 && m_zoneUpdateId == 33 && newArea == 30232 && GetPositionZ() <= 27.0f;
+    bool const isGurubashiSafeArea = GetMapId() == 0 && m_zoneUpdateId == 33 && !isGurubashiBattleRing;
+
+    static std::array<uint32, 1> const customFFAAreas = { 3217 }; // The Maul
+    bool const isCustomFFAArea = std::find(customFFAAreas.begin(), customFFAAreas.end(), newArea) != customFFAAreas.end();
+
+    bool isFFAArea = isCustomFFAArea || isGurubashiBattleRing;
     // Walk the area hierarchy in case the arena flag is defined on a parent zone.
-    for (AreaTableEntry const* currentArea = area; currentArea;)
+    // Gurubashi has safe ramp/outer areas under the same parent arena hierarchy, so
+    // do not let parent AREA_FLAG_ARENA bleed FFA PvP into non-Battle Ring areas.
+    if (!isFFAArea && !isGurubashiSafeArea)
     {
-        if (currentArea->Flags & AREA_FLAG_ARENA)
+        for (AreaTableEntry const* currentArea = area; currentArea;)
         {
-            isFFAArea = true;
-            break;
-        }
-
-        if (!currentArea->ParentAreaID)
-            break;
-
-        currentArea = sAreaTableStore.LookupEntry(currentArea->ParentAreaID);
-    }
-
-    if (!isFFAArea)
-    {
-        static std::array<uint32, 3> const customFFAAreas = { 3217, 2177, 30232 }; // The Maul, Gurubashi Catacombs, The Battle Ring
-
-        for (uint32 customArea : customFFAAreas)
-        {
-            if (newArea == customArea || m_zoneUpdateId == customArea)
+            if (currentArea->Flags & AREA_FLAG_ARENA)
             {
                 isFFAArea = true;
                 break;
             }
+
+            if (!currentArea->ParentAreaID)
+                break;
+
+            currentArea = sAreaTableStore.LookupEntry(currentArea->ParentAreaID);
         }
     }
 

--- a/src/server/scripts/Custom/custom_gurubashi_arena.cpp
+++ b/src/server/scripts/Custom/custom_gurubashi_arena.cpp
@@ -54,8 +54,8 @@ namespace
 {
 constexpr uint32 GURUBASHI_ARENA_MAP_ID = 0;
 constexpr uint32 STRANGLETHORN_VALE_ZONE_ID = 33;
-constexpr uint32 GURUBASHI_CATACOMBS_AREA_ID = 2177;
 constexpr uint32 GURUBASHI_BATTLE_RING_AREA_ID = 30232;
+constexpr float GURUBASHI_BATTLE_RING_MAX_Z = 27.0f;
 constexpr uint32 GURUBASHI_CHEST_ENTRY = 179697;
 constexpr uint32 SHADOW_SIGHT_ENTRY = 184663;
 constexpr uint32 LEGIONNAIRE_MARK_OF_HONOR = 20558;
@@ -140,14 +140,14 @@ GurubashiAreaState GetGurubashiAreaState(Player const* player, uint32 zoneId, ui
     if (player->GetMapId() != GURUBASHI_ARENA_MAP_ID)
         return GurubashiAreaState::Outside;
 
+    if (Map const* map = player->FindMap())
+        map->GetZoneAndAreaId(player->GetPhaseMask(), zoneId, areaId, player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
+
     if (zoneId != STRANGLETHORN_VALE_ZONE_ID)
         return GurubashiAreaState::Outside;
 
-    if (areaId == GURUBASHI_BATTLE_RING_AREA_ID)
+    if (areaId == GURUBASHI_BATTLE_RING_AREA_ID && player->GetPositionZ() <= GURUBASHI_BATTLE_RING_MAX_Z)
         return GurubashiAreaState::BattleRing;
-
-    if (areaId == GURUBASHI_CATACOMBS_AREA_ID)
-        return GurubashiAreaState::NonRing;
 
     return GurubashiAreaState::NonRing;
 }
@@ -208,16 +208,15 @@ bool HasLivingHostileInGurubashiBattleRing(Player const* player)
         if (other->GetMapId() != player->GetMapId() || other->GetZoneId() != STRANGLETHORN_VALE_ZONE_ID)
             continue;
 
-        if (GetGurubashiAreaState(other, other->GetZoneId(), other->GetAreaId()) != GurubashiAreaState::BattleRing)
+        bool const otherInBattleRingFfa =
+            GetGurubashiAreaState(other, other->GetZoneId(), other->GetAreaId()) == GurubashiAreaState::BattleRing ||
+            (other->pvpInfo.IsInFFAPvPArea && !other->pvpInfo.IsInNoPvPArea) || other->IsFFAPvP();
+        if (!otherInBattleRingFfa)
             continue;
 
-        // Stealthed/invisible players should not block non-lethal exits from the ring.
         if (other->HasStealthAura() || other->HasInvisibilityAura())
             continue;
 
-        // Evaluate hostility without relying on transient FFA flags.
-        // When a player steps out of the ring, FFA can drop before this check runs,
-        // but the exit rule should still treat non-group/raid players in the ring as hostile.
         if (!player->IsInSameRaidWith(other))
             return true;
     }
@@ -1053,9 +1052,12 @@ public:
 
             processedPlayers.insert(guid);
 
-            TrackedState& tracked = _trackedPlayers[guid];
+            auto trackedResult = _trackedPlayers.emplace(guid, TrackedState{});
+            TrackedState& tracked = trackedResult.first->second;
             Position const currentPosition = player->GetPosition();
             GurubashiAreaState const currentState = GetGurubashiAreaState(player, player->GetZoneId(), player->GetAreaId());
+            bool const currentInBattleRingFfa = currentState == GurubashiAreaState::BattleRing ||
+                (player->pvpInfo.IsInFFAPvPArea && !player->pvpInfo.IsInNoPvPArea);
 
             gurubashi_arena_hourly_event* event = gurubashi_arena_hourly_event::GetInstance();
             bool const chestActive = event && event->IsChestActive();
@@ -1078,7 +1080,8 @@ public:
                 float const distance2d = tracked.LastPosition.GetExactDist2d(currentPosition);
                 bool const isTeleportTransition = player->IsBeingTeleported() || tracked.MapId != player->GetMapId() || distance2d > 45.0f;
                 bool const crossedBattleRingBoundary =
-                    tracked.AreaState == GurubashiAreaState::BattleRing && currentState == GurubashiAreaState::NonRing;
+                    (tracked.AreaState == GurubashiAreaState::BattleRing || tracked.InBattleRingFfa) &&
+                    currentState == GurubashiAreaState::NonRing && !currentInBattleRingFfa;
 
                 if (crossedBattleRingBoundary && !isTeleportTransition && !player->IsGameMaster() && player->IsAlive() &&
                     HasLivingHostileInGurubashiBattleRing(player))
@@ -1092,6 +1095,7 @@ public:
             }
 
             tracked.AreaState = currentState;
+            tracked.InBattleRingFfa = currentInBattleRingFfa;
             tracked.LastPosition = currentPosition;
             tracked.MapId = player->GetMapId();
             tracked.HasPosition = true;
@@ -1108,6 +1112,7 @@ private:
     struct TrackedState
     {
         GurubashiAreaState AreaState = GurubashiAreaState::Outside;
+        bool InBattleRingFfa = false;
         Position LastPosition;
         uint32 MapId = 0;
         bool HasPosition = false;


### PR DESCRIPTION
### Motivation

- Fix cases where the Gurubashi Battle Ring FFA state becomes stale when players move vertically between the Battle Ring floor and the safe ramps/outer geometry that share the same area id. 
- Prevent parent `AREA_FLAG_ARENA` from erroneously enabling FFA PvP for non-ring sub-areas in Gurubashi while keeping custom FFA areas like The Maul. 
- Make the custom Gurubashi exit/kill logic robust to transient FFA flags and to ensure tracking doesn't miss cross-boundary transitions.

### Description

- Update `Player::Update` to detect Gurubashi transitions by map/zone/area and Z coordinate using `GetPositionZ()` and only trigger `UpdateArea` when the vertical boundary change requires it. 
- Rework `Player::UpdateArea` to treat Gurubashi Battle Ring specially by adding `isGurubashiBattleRing` and `isGurubashiSafeArea` checks, introduce a `customFFAAreas` array for hard-coded custom FFA areas, and avoid propagating parent `AREA_FLAG_ARENA` into safe-ring sub-areas. 
- In `custom_gurubashi_arena.cpp` add explicit constants (`GURUBASHI_BATTLE_RING_MAX_Z` etc.), recompute zone/area via the map in `GetGurubashiAreaState`, and classify Battle Ring state only when the player's Z is below the threshold. 
- Make hostile-presence checks in `HasLivingHostileInGurubashiBattleRing` consider players flagged by `pvpInfo.IsInFFAPvPArea` or `IsFFAPvP()` as being in FFA, and preserve stealth/invisibility exemptions when determining blocking players. 
- Improve tracking loop by using `emplace` to avoid default-reconstruction overhead, add `InBattleRingFfa` to `TrackedState`, and compute `crossedBattleRingBoundary` using both prior tracked FFA state and current FFA classification so vertical moves are handled correctly.

### Testing

- Project compiled successfully after the changes (`build` completed without errors). 
- Existing automated unit/test suite was executed and completed with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51b82c30dc83278cac7c22db49f647)