### PR TITLE
Playerbot: Mind Flay stationary handling, Starfire movement, and BM Mongoose Bite priority

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -3117,6 +3117,30 @@ void ScheduleWandDiagnostics(Player*, Unit*, uint32)
     // Intentionally silent; delayed wand diagnostics were temporary.
 }
 
+bool IsMindFlaySpell(SpellInfo const* spellInfo)
+{
+    if (!spellInfo)
+        return false;
+
+    SpellInfo const* firstRank = spellInfo->GetFirstRankSpell();
+    return firstRank && firstRank->Id == 15407;
+}
+
+bool IsPlayerbotStationaryChannel(SpellInfo const* spellInfo)
+{
+    if (!spellInfo || !spellInfo->IsChanneled())
+        return false;
+
+    // Mind Flay must be treated like Drain Life for playerbot movement even on
+    // DBC/custom data where the generic channel flags look movable.
+    return !spellInfo->IsMoveAllowedChannel() || IsMindFlaySpell(spellInfo);
+}
+
+bool IsPlayerbotMovableCastTimeSpell(Player const* player, SpellInfo const* spellInfo)
+{
+    return player && spellInfo && spellInfo->IsStarfire() && player->GetStarfireSnareSpeedRate() > 0.0f;
+}
+
 bool HasActiveStationaryChannel(Player const* player)
 {
     if (!player)
@@ -3126,8 +3150,7 @@ bool HasActiveStationaryChannel(Player const* player)
     if (!channel || channel->getState() == SPELL_STATE_FINISHED)
         return false;
 
-    SpellInfo const* spellInfo = channel->GetSpellInfo();
-    return spellInfo && spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel();
+    return IsPlayerbotStationaryChannel(channel->GetSpellInfo());
 }
 
 void StopPlayerbotForStationaryCast(Player* player)
@@ -4149,8 +4172,9 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     // left the bot inching or stuck.
     bool const isFoodOrDrinkSpell = resolvedSpellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_EAT || resolvedSpellId == SPELL_PLAYERBOT_OUT_OF_COMBAT_DRINK;
     bool const isHunterStationaryCastTimeAction = player->GetClass() == CLASS_HUNTER && IsHunterCastTimeShot(player, spellInfo);
-    bool const requiresStationaryCast = spellInfo->CalcCastTime() > 0 || spellInfo->IsAutoRepeatRangedSpell() || isFoodOrDrinkSpell ||
-        isHunterStationaryCastTimeAction || (spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel());
+    bool const movableCastTimeSpell = IsPlayerbotMovableCastTimeSpell(player, spellInfo);
+    bool const requiresStationaryCast = (spellInfo->CalcCastTime() > 0 && !movableCastTimeSpell) || spellInfo->IsAutoRepeatRangedSpell() || isFoodOrDrinkSpell ||
+        isHunterStationaryCastTimeAction || IsPlayerbotStationaryChannel(spellInfo);
 
     if (isHunterStationaryCastTimeAction)
     {
@@ -4399,7 +4423,7 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     if (player->GetClass() == CLASS_HUNTER && IsHunterBreakableCrowdControlSpell(spellInfo))
         StopHunterDamageOnBreakableCrowdControl(player, target, "hunter_breakable_cc_cast_stop_autoshot");
 
-    if (spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel())
+    if (IsPlayerbotStationaryChannel(spellInfo))
         StopPlayerbotForStationaryCast(player);
 
     ResumeDruidShapeshiftMovement(player, shapeshiftMovementResume, resolvedSpellId);

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -3951,9 +3951,8 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
          player->HasAuraWithMechanic(1 << MECHANIC_FEAR) ||
          player->IsPolymorphed() ||
          player->HasAuraType(SPELL_AURA_MOD_CONFUSE));
-    bool const bmReadyToBiteKillTarget = isBeastMasteryHunter && activeTarget &&
-        HasAuraFromSpellChain(activeTarget, 25295) && !IsSpellReady(player, 14287) &&
-        !IsSpellReady(player, 25294) && !IsRootedOrSnared(player);
+    bool const bmHasBitePrimerOnKillTarget = isBeastMasteryHunter && activeTarget && HasAuraFromSpellChain(activeTarget, 25295);
+    bool const bmReadyToBiteKillTarget = bmHasBitePrimerOnKillTarget && !IsRootedOrSnared(player);
     Unit const* manaTarget = isSurvivalHunter
         ? SelectNearbyEnemyManaTarget(player, activeTarget, GetConfiguredLongRange(), 0.0f)
         : SelectNearbyEnemyTarget(player, activeTarget, GetConfiguredLongRange());
@@ -4022,6 +4021,8 @@ SpellDecision SelectHunterSpell(Player const* player, Unit const* target, bool i
         { "hunter serpent sting", "apply ranged dot pressure", 25295, playerbot::PvpClassSpellContext::TargetMode::Enemy, rogueTarget ? rogueTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !activeTargetDeadZone && !targetBreakableCrowdControl && isMarksmanshipHunter && rangedMode && !enemyNear && IsSpellReady(player, 20904), 18.0f,
         { "hunter aimed shot", "long cast pressure from range", 20904, playerbot::PvpClassSpellContext::TargetMode::Enemy });
+    AddDecisionCandidate(candidates, bmHasBitePrimerOnKillTarget && activeTarget && player->IsWithinMeleeRange(activeTarget) && IsSpellReady(player, 81285), 27.0f,
+        { "hunter mongoose bite", "consume serpent sting for beast mastery melee burst", 81285, playerbot::PvpClassSpellContext::TargetMode::Enemy, activeTarget ? activeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !activeTargetDeadZone && !targetBreakableCrowdControl && (isSurvivalHunter || isBeastMasteryHunter) && rangedMode && !inMelee && activeTarget && IsSpellReady(player, 14287), 17.5f,
         { "hunter arcane shot", "instant pressure on kill target", 14287, playerbot::PvpClassSpellContext::TargetMode::Enemy, activeTarget ? activeTarget->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, !activeTargetDeadZone && !targetBreakableCrowdControl && rangedMode && !inMelee && IsSpellReady(player, 25294), 17.0f,

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1651,6 +1651,15 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
 
     void StopVirtualPlayerbotMovement(Player* player);
 
+    bool IsMindFlaySpell(SpellInfo const* spellInfo)
+    {
+        if (!spellInfo)
+            return false;
+
+        SpellInfo const* firstRank = spellInfo->GetFirstRankSpell();
+        return firstRank && firstRank->Id == 15407;
+    }
+
     bool HasActiveStationaryChannel(Player const* player)
     {
         if (!player)
@@ -1661,7 +1670,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
             return false;
 
         SpellInfo const* spellInfo = channel->GetSpellInfo();
-        return spellInfo && spellInfo->IsChanneled() && !spellInfo->IsMoveAllowedChannel();
+        return spellInfo && spellInfo->IsChanneled() && (!spellInfo->IsMoveAllowedChannel() || IsMindFlaySpell(spellInfo));
     }
 
     bool CanIssueBotMovement(Player* player)


### PR DESCRIPTION
### Motivation
- Playerbot movement and casting logic treated some channeled spells as movable when they should be stationary (e.g., Mind Flay vs Drain Life), causing casts to be clipped or blocked.  
- Druids with Starfire should be able to keep moving when a Starfire snare rate applies, but were forced to stop.  
- Beast Mastery hunters were not reliably using Mongoose Bite as a melee burst when the target was primed by Serpent Sting.

### Description
- Add `IsMindFlaySpell`, `IsPlayerbotStationaryChannel`, and `IsPlayerbotMovableCastTimeSpell` helpers and use them to classify channels/casts in playerbot code (files changed: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp`).  
- Treat Mind Flay (spell id chain containing `15407`) as a stationary channel for playerbot movement even when DBC/custom data reports the channel as move-allowed.  
- Allow Starfire casts to be treated as movable when `player->GetStarfireSnareSpeedRate() > 0.0f`, avoiding an unnecessary server-side stop before cast.  
- Replace direct `IsChanneled() && !IsMoveAllowedChannel()` checks with the new playerbot-specific checks and call `StopPlayerbotForStationaryCast` only when appropriate.  
- Improve Beast Mastery selection logic in `SelectHunterSpell` (`src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`) by detecting when the kill target is primed by Serpent Sting and adding a higher-priority melee `mongoose bite` candidate that allows approach/consume behavior without waiting on ranged cooldowns.

### Testing
- Ran `git diff --check` to validate no whitespace/merge issues and it completed without errors.  
- Ran `git status --short` to confirm the working tree state and it showed no outstanding changes after staging.  
- Verified local diffs to ensure the intended replacements and additions applied to `PlayerbotPvpClassActions.cpp`, `PlayerbotPvpLifecycleActions.cpp`, and `PlayerbotPvpCore.cpp` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540b6904ac8327b2e386b081147664)