### PR TITLE
Prevent enhancement shaman Ghost Wolf flicker by gating Rehgar's Fury usability

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -4873,10 +4873,16 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target, Unit c
     bool const enhNeedsGapClose = isEnhancementShaman && hasHostileTarget && target && !player->IsWithinMeleeRange(target);
     bool const shamanInGhostWolf = HasAuraFromSpellChain(player, 2645);
     bool const enhInGhostWolf = isEnhancementShaman && shamanInGhostWolf;
+    SpellInfo const* rehgarsFuryInfo = sSpellMgr->GetSpellInfo(81910);
+    bool const canRehgarsFuryTarget = isEnhancementShaman && hasHostileTarget && target && rehgarsFuryInfo &&
+        player->IsValidAttackTarget(target, rehgarsFuryInfo) && player->IsWithinLOSInMap(target) &&
+        (rehgarsFuryInfo->GetMaxRange(false) <= 0.0f || player->IsWithinDistInMap(target, rehgarsFuryInfo->GetMaxRange(false))) &&
+        (rehgarsFuryInfo->GetMinRange(false) <= 0.0f || !player->IsWithinDistInMap(target, rehgarsFuryInfo->GetMinRange(false)));
+    bool const canUseRehgarsFury = canRehgarsFuryTarget && IsSpellReady(player, 81910);
 
     if (shamanInGhostWolf)
     {
-        if (hasHostileTarget && target && IsSpellReady(player, 81910))
+        if (canUseRehgarsFury)
             return { "shaman rehgar's fury", "only allowed action while in ghost wolf form", 81910, playerbot::PvpClassSpellContext::TargetMode::Enemy };
 
         const_cast<Player*>(player)->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
@@ -4929,9 +4935,9 @@ SpellDecision SelectShamanSpell(Player const* player, Unit const* target, Unit c
         { "shaman grounding totem", "maintain a nearby grounding totem", 81478, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, isRestoShaman && SelectNearbyMeleeTarget(player, target, 8.0f) && player->HealthBelowPct(50) && IsSpellReady(player, 2645), 52.4f,
         { "shaman ghost wolf", "escape melee pressure while endangered", 2645, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, enhNeedsGapClose && !enhInGhostWolf && IsSpellReady(player, 2645), 59.6f,
+    AddDecisionCandidate(candidates, enhNeedsGapClose && !enhInGhostWolf && canUseRehgarsFury && IsSpellReady(player, 2645), 59.6f,
         { "shaman ghost wolf", "shift to close the gap with rehgar's fury", 2645, playerbot::PvpClassSpellContext::TargetMode::Self });
-    AddDecisionCandidate(candidates, enhNeedsGapClose && enhInGhostWolf && IsSpellReady(player, 81910), 59.5f,
+    AddDecisionCandidate(candidates, enhNeedsGapClose && enhInGhostWolf && canUseRehgarsFury, 59.5f,
         { "shaman rehgar's fury", "charge the kill target while in ghost wolf form", 81910, playerbot::PvpClassSpellContext::TargetMode::Enemy });
     AddDecisionCandidate(candidates, player->HealthBelowPct(50) && IsSpellReady(player, 10468), 52.0f,
         { "shaman lesser healing wave", "self-sustain while focused", 10468, playerbot::PvpClassSpellContext::TargetMode::Self });


### PR DESCRIPTION
### Motivation
- Enhancement playerbots were entering Ghost Wolf to cast Rehgar's Fury but repeatedly toggling because the charge was not actually usable on the current target.

### Description
- Add a `SpellInfo` lookup for Rehgar's Fury (81910) and compute `canRehgarsFuryTarget` that validates attackability, LOS, and min/max range against the target. 
- Combine the above with `IsSpellReady` into `canUseRehgarsFury` to represent full castability. 
- Use `canUseRehgarsFury` when deciding to shift into Ghost Wolf and when already in Ghost Wolf so the bot only stays shifted if the charge can actually be selected. 
- Changes are localized to `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` where the Shaman decision candidates are built.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge errors, and the check completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a541b54779483279687253ead02c588)