### PR TITLE
playerbot: chain Nature's Grasp before Balance Wrath

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -4469,8 +4469,8 @@ SpellDecision SelectDruidSpell(Player const* player, Unit const* target, Classic
     // root if it is still pressured, then disengage toward a nearby ally.
     AddDecisionCandidate(candidates, isBalanceDruid && balanceMeleeRangeTarget && IsSpellReady(player, 82423), 41.5f,
         { "druid moon bash", "strike an enemy that has closed to melee range", 82423, playerbot::PvpClassSpellContext::TargetMode::Enemy, balanceMeleeRangeTarget ? balanceMeleeRangeTarget->GetGUID() : ObjectGuid::Empty });
-    AddDecisionCandidate(candidates, isBalanceDruid && balanceMeleeRangeTarget && !HasAuraFromSpellChain(player, 17329) && IsSpellReady(player, 17329), 41.0f,
-        { "druid natures grasp", "root the next melee attacker while still pressured", 17329, playerbot::PvpClassSpellContext::TargetMode::Self });
+    AddDecisionCandidate(candidates, isBalanceDruid && target && balanceUnderMeleePressure && !HasAuraFromSpellChain(player, 17329) && IsSpellReady(player, 17329), 41.0f,
+        { "druid natures grasp", "root the next melee attacker before casting wrath under close pressure", 17329, playerbot::PvpClassSpellContext::TargetMode::Self });
     AddDecisionCandidate(candidates, isBalanceDruid && balanceMeleeRangeTarget && balanceEscapeAlly && IsSpellReady(player, 83111), 40.5f,
         { "druid leap", "disengage toward a nearby ally while still under melee pressure", 83111, playerbot::PvpClassSpellContext::TargetMode::Ally, balanceEscapeAlly ? balanceEscapeAlly->GetGUID() : ObjectGuid::Empty });
     AddDecisionCandidate(candidates, isBalanceDruid && target && balanceUnderMeleePressure && IsSpellReady(player, 5176), 40.0f,

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp
@@ -1809,13 +1809,15 @@ void RandomBotParticipationLifecycle::ProcessLifecycleEntryPoint(Player* player)
     if (didExecuteClassSpell &&
         (classSpellContext.spellId == 16166 ||
          classSpellContext.spellId == 17116 ||
-         // Amplify Curse (18288) precedes Curse of Agony, and Arcane Power
-         // (12042) / Presence of Mind (12043) precede the rest of the
-         // arcane burst chain (see SelectWarlockSpell / SelectMageSpell) -
-         // all four are off the global cooldown and are meant to land back
-         // to back with their follow-up cast rather than waiting a full
-         // cadence tick.
+         // Amplify Curse (18288) precedes Curse of Agony, Nature's Grasp
+         // (17329) precedes Balance Wrath under close pressure, and Arcane
+         // Power (12042) / Presence of Mind (12043) precede the rest of the
+         // arcane burst chain (see SelectWarlockSpell / SelectDruidSpell /
+         // SelectMageSpell) - all are off the global cooldown and are meant
+         // to land back to back with their follow-up cast rather than waiting
+         // a full cadence tick.
          classSpellContext.spellId == 18288 ||
+         classSpellContext.spellId == 17329 ||
          classSpellContext.spellId == 12042 ||
          classSpellContext.spellId == 12043 ||
          PvpClassActions::IsPetSpellAction(player, classSpellContext)))


### PR DESCRIPTION
### Motivation
- Ensure Balance druids cast `Nature's Grasp` before following up with `Wrath` when melee pressure is present so the root lands prior to the ranged nuke. 

### Description
- Tighten the Balance druid decision condition in `SelectDruidSpell` to require the same close-pressure window used for `Wrath` and prefer `Nature's Grasp` first by adding `target && balanceUnderMeleePressure` and updating the decision label in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp`.
- Add `Nature's Grasp` (spell id `17329`) to the random-bot lifecycle cadence bypass so off-GCD setup casts are allowed to run back-to-back with their follow-ups in `src/server/scripts/Playerbot/Pvp/PlayerbotRandomBotParticipation.cpp`.

### Testing
- Ran `git diff --check` to verify no whitespace or diff issues and it succeeded. 
- No build or runtime tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5444cf7fd883279b000c6028963fce)