### PR TITLE
Fix Obsidian Colosseum compile includes

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp
@@ -4,6 +4,7 @@
 #include "DBCStores.h"
 #include "GameObject.h"
 #include "Log.h"
+#include "Map.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "World.h"

--- a/src/server/game/Battlegrounds/Zones/BattlegroundOBC.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundOBC.h
@@ -14,6 +14,7 @@
 
 #include "Battleground.h"
 #include "BattlegroundScore.h"
+#include "Object.h"
 
 enum BG_OBC_WorldStates
 {


### PR DESCRIPTION
### Motivation
- Resolve compile errors in the Obsidian Colosseum battleground where `IN_MILLISECONDS` and `BattlegroundMap` members were undeclared, causing build failures in `BattlegroundOBC`.

### Description
- Add `#include "Object.h"` to `src/server/game/Battlegrounds/Zones/BattlegroundOBC.h` so `IN_MILLISECONDS` is available for `BG_OBC_FLAG_RESPAWN_TIME`.
- Add `#include "Map.h"` to `src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp` so `GetBgMap()->GetGameObject` is used against a complete `BattlegroundMap` type.

### Testing
- Ran `git diff --check` to verify no whitespace or simple diff issues and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54680d57188327be7a833cae37035b)