### PR TITLE
Fix OBC playerbot queue-only config

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -174,9 +174,8 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
         return session && session->IsVirtualSession();
     }
 
-    std::unordered_set<uint32> ParseAccountIdSetFromConfig(char const* key)
+    void AppendAccountIdsFromConfig(std::unordered_set<uint32>& accountIds, char const* key)
     {
-        std::unordered_set<uint32> accountIds;
         std::string const raw = sConfigMgr->GetStringDefault(key, "");
         for (std::string_view token : Trinity::Tokenize(raw, ',', false))
         {
@@ -184,7 +183,20 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
                 if (*accountId > 0)
                     accountIds.insert(*accountId);
         }
+    }
 
+    std::unordered_set<uint32> ParseAccountIdSetFromConfig(char const* key)
+    {
+        std::unordered_set<uint32> accountIds;
+        AppendAccountIdsFromConfig(accountIds, key);
+        return accountIds;
+    }
+
+    std::unordered_set<uint32> ParseAccountIdSetFromConfig(char const* primaryKey, char const* fallbackKey)
+    {
+        std::unordered_set<uint32> accountIds;
+        AppendAccountIdsFromConfig(accountIds, primaryKey);
+        AppendAccountIdsFromConfig(accountIds, fallbackKey);
         return accountIds;
     }
 
@@ -203,7 +215,8 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
         if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneAccounts").count(accountId))
             return BATTLEGROUND_BRT;
 
-        if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.ObsidianColosseumAccounts").count(accountId))
+        if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.ObsidianColosseumAccounts",
+            "Playerbot.PvpLifecycle.QueueOnly.ObsidianColosseum").count(accountId))
             return BATTLEGROUND_OBC;
 
         if (ParseAccountIdSetFromConfig("Playerbot.PvpLifecycle.QueueOnly.BattleForGilneasAccounts").count(accountId))

--- a/src/server/worldserver/playerbots.conf.dist
+++ b/src/server/worldserver/playerbots.conf.dist
@@ -57,6 +57,7 @@ Playerbot.PvpLifecycle.Enable = 0
 
 #    Playerbot.PvpLifecycle.QueueOnly.ScarletChapelAccounts
 #    Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneAccounts
+#    Playerbot.PvpLifecycle.QueueOnly.ObsidianColosseumAccounts
 #    Playerbot.PvpLifecycle.QueueOnly.BattleForGilneasAccounts
 #    Playerbot.PvpLifecycle.QueueOnly.TwinPeaksAccounts
 #    Playerbot.PvpLifecycle.QueueOnly.ArathiBasinAccounts
@@ -70,6 +71,7 @@ Playerbot.PvpLifecycle.Enable = 0
 
 Playerbot.PvpLifecycle.QueueOnly.ScarletChapelAccounts =
 Playerbot.PvpLifecycle.QueueOnly.BlackrockThroneAccounts =
+Playerbot.PvpLifecycle.QueueOnly.ObsidianColosseumAccounts =
 Playerbot.PvpLifecycle.QueueOnly.BattleForGilneasAccounts =
 Playerbot.PvpLifecycle.QueueOnly.TwinPeaksAccounts =
 Playerbot.PvpLifecycle.QueueOnly.ArathiBasinAccounts =


### PR DESCRIPTION
### Motivation
- The playerbot lifecycle code did not accept the previously used Obsidian Colosseum config key, causing account-based queue segmentation for OBC to be ignored and managed bots to miss OBC queues.

### Description
- Add `AppendAccountIdsFromConfig` and a two-key overload `ParseAccountIdSetFromConfig(primary,fallback)` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` to merge account IDs from a primary and fallback config key.
- Update the OBC branch to call the new overload so both `Playerbot.PvpLifecycle.QueueOnly.ObsidianColosseumAccounts` and the legacy `Playerbot.PvpLifecycle.QueueOnly.ObsidianColosseum` are recognized.
- Add the canonical `Playerbot.PvpLifecycle.QueueOnly.ObsidianColosseumAccounts` entry to `src/server/worldserver/playerbots.conf.dist` so the distributed config documents the correct key.

### Testing
- Ran `git diff --check` which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a546d7ce34c83279488e1141a3c7e78)