### PR TITLE
Fix OBC Netherstorm flag spawning and instant pickup

### DIFF
--- a/sql/updates/world/3.3.5/2026_07_13_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_07_13_00_world.sql
@@ -1,0 +1,6 @@
+-- Obsidian Colosseum: use an instant-click Netherstorm flagstand without a second visual flag.
+DELETE FROM `gameobject_template` WHERE `entry` = 300206;
+INSERT INTO `gameobject_template` (`entry`, `type`, `displayId`, `name`, `IconName`, `castBarCaption`, `unk1`, `size`, `Data0`, `Data1`, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `Data8`, `Data9`, `Data10`, `Data11`, `Data12`, `Data13`, `Data14`, `Data15`, `Data16`, `Data17`, `Data18`, `Data19`, `Data20`, `Data21`, `Data22`, `Data23`, `AIName`, `ScriptName`, `VerifiedBuild`)
+SELECT 300206, `type`, `displayId`, 'OBC Netherstorm Flag', `IconName`, '', `unk1`, `size`, `Data0`, 0, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `Data8`, `Data9`, `Data10`, `Data11`, `Data12`, `Data13`, `Data14`, `Data15`, `Data16`, `Data17`, `Data18`, `Data19`, `Data20`, `Data21`, `Data22`, `Data23`, `AIName`, `ScriptName`, `VerifiedBuild`
+FROM `gameobject_template`
+WHERE `entry` = 184141;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp
@@ -241,10 +241,6 @@ bool BattlegroundOBC::SetupBattleground()
             OBC_FLAG_X, OBC_FLAG_Y, OBC_FLAG_Z, OBC_FLAG_O,
             0.0f, 0.0f, std::sin(OBC_FLAG_O / 2.0f), std::cos(OBC_FLAG_O / 2.0f),
             RESPAWN_ONE_DAY)
-        || !AddObject(BG_OBC_OBJECT_FLAG_VISUAL, BG_OBC_FLAG_VISUAL_ENTRY,
-            3245.6f, 536.403f, 58.9864f, OBC_FLAG_O,
-            0.0f, 0.0f, std::sin(OBC_FLAG_O / 2.0f), std::cos(OBC_FLAG_O / 2.0f),
-            RESPAWN_IMMEDIATELY)
         || !AddObject(BG_OBC_OBJECT_LIGHT_ALLIANCE_BASE, BG_OBC_LIGHT_BEAM_ENTRY,
             OBC_LIGHT_ALLIANCE_X, OBC_LIGHT_ALLIANCE_Y, OBC_LIGHT_ALLIANCE_Z, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f,
@@ -283,9 +279,6 @@ void BattlegroundOBC::ApplyNonInteractableObjectFlags()
         if (GameObject* gate = GetBGObject(type))
             gate->SetFlag(GO_FLAG_NOT_SELECTABLE);
 
-    if (GameObject* flagVisual = GetBGObject(BG_OBC_OBJECT_FLAG_VISUAL))
-        flagVisual->SetFlag(GO_FLAG_NOT_SELECTABLE);
-
     if (GameObject* allianceLight = GetBGObject(BG_OBC_OBJECT_LIGHT_ALLIANCE_BASE))
         allianceLight->SetFlag(GO_FLAG_NOT_SELECTABLE);
 
@@ -300,8 +293,6 @@ void BattlegroundOBC::StartingEventCloseDoors()
         DoorClose(type);
         SpawnBGObject(type, RESPAWN_IMMEDIATELY);
     }
-
-    SpawnBGObject(BG_OBC_OBJECT_FLAG_VISUAL, RESPAWN_IMMEDIATELY);
 
     // Flag and objective lights stay hidden until the match starts.
     SpawnBGObject(BG_OBC_OBJECT_FLAG, RESPAWN_ONE_DAY);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundOBC.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundOBC.h
@@ -58,7 +58,6 @@ enum BG_OBC_Objects
     BG_OBC_OBJECT_GATE_A_4,
 
     BG_OBC_OBJECT_FLAG,               // clickable flag stand at the arena center
-    BG_OBC_OBJECT_FLAG_VISUAL,        // static flag base prop at the center
 
     // Objective light beams. Exactly one is visible while the flag is
     // carried: the light marks the ENEMY base the carrier must reach.
@@ -71,9 +70,8 @@ enum BG_OBC_Objects
 enum BG_OBC_ObjectEntries
 {
     BG_OBC_GATE_ENTRY         = 185483,
-    BG_OBC_FLAG_STAND_ENTRY   = 184141, // Netherstorm Flag (GAMEOBJECT_TYPE_FLAGSTAND)
+    BG_OBC_FLAG_STAND_ENTRY   = 300206, // OBC Netherstorm Flag (instant GAMEOBJECT_TYPE_FLAGSTAND)
     BG_OBC_FLAG_DROP_ENTRY    = 184142, // Netherstorm Flag (GAMEOBJECT_TYPE_FLAGDROP)
-    BG_OBC_FLAG_VISUAL_ENTRY  = 184493, // Netherstorm Flag base visual
     BG_OBC_LIGHT_BEAM_ENTRY   = 300010  // BG Objective Light Beam
 };
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2161,7 +2161,7 @@ void Spell::EffectOpenLock()
             // in battleground check
             if (Battleground* bg = player->GetBattleground())
             {
-                if (bg->GetTypeID(true) == BATTLEGROUND_EY)
+                if (bg->GetTypeID(true) == BATTLEGROUND_EY || bg->GetTypeID(true) == BATTLEGROUND_OBC)
                     bg->EventPlayerClickedOnFlag(player, gameObjTarget);
                 return;
             }


### PR DESCRIPTION
### Motivation
- The Obsidian Colosseum (OBC) was spawning two Netherstorm flag objects (stand + separate visual) resulting in duplicate visible flags. 
- The flagstand required a pickup cast/bar instead of being instant, causing incorrect pickup behavior. 
- The goal is to spawn a single clickable flag in OBC and make pickup instantaneous without changing other battlegrounds.

### Description
- Introduce an OBC-specific Netherstorm flag gameobject entry `300206` by copying the existing Netherstorm flagstand (`184141`) but clearing the pickup/cast data so interaction is instant via `sql/updates/world/3.3.5/2026_07_13_00_world.sql`.
- Update OBC to use the new `BG_OBC_FLAG_STAND_ENTRY = 300206` and remove the separate static flag visual from the OBC object list and spawn logic in `src/server/game/Battlegrounds/Zones/BattlegroundOBC.h` and `BattlegroundOBC.cpp` so only one flag is present.
- Remove references and non-selectable flags for the removed visual object and stop spawning `BG_OBC_OBJECT_FLAG_VISUAL` during start/close events in `BattlegroundOBC.cpp`.
- Allow the flagstand interaction path handled by the open-lock/spell route to dispatch OBC flag clicks as well by extending the check in `src/server/game/Spells/SpellEffects.cpp` to include `BATTLEGROUND_OBC`.

### Testing
- Ran static checks with `git diff --check` and no issues were reported.  
- No full build or runtime battleground tests were executed in this change; manual or CI build/run is recommended to verify in-game behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a546dc3cf7c8327a7e7fedeb1079e40)