### PR TITLE
Obsidian Colosseum: use instant clickable flagstand and update flag spell/objects

### DIFF
--- a/sql/updates/world/3.3.5/2026_07_13_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_07_13_00_world.sql
@@ -1,0 +1,6 @@
+-- Obsidian Colosseum: use an instant-click Netherstorm flagstand without a second visual flag.
+DELETE FROM `gameobject_template` WHERE `entry` = 300206;
+INSERT INTO `gameobject_template` (`entry`, `type`, `displayId`, `name`, `IconName`, `castBarCaption`, `unk1`, `size`, `Data0`, `Data1`, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `Data8`, `Data9`, `Data10`, `Data11`, `Data12`, `Data13`, `Data14`, `Data15`, `Data16`, `Data17`, `Data18`, `Data19`, `Data20`, `Data21`, `Data22`, `Data23`, `AIName`, `ScriptName`, `VerifiedBuild`)
+SELECT 300206, `type`, `displayId`, 'OBC Netherstorm Flag', `IconName`, '', `unk1`, `size`, 0, 0, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `Data8`, `Data9`, `Data10`, `Data11`, `Data12`, `Data13`, `Data14`, `Data15`, `Data16`, `Data17`, `Data18`, `Data19`, `Data20`, `Data21`, `Data22`, `Data23`, `AIName`, `ScriptName`, `VerifiedBuild`
+FROM `gameobject_template`
+WHERE `entry` = 184141;

--- a/sql/updates/world/3.3.5/2026_07_13_01_world.sql
+++ b/sql/updates/world/3.3.5/2026_07_13_01_world.sql
@@ -1,0 +1,4 @@
+-- Obsidian Colosseum: remove the flagstand lock as well as the pickup spell so the client uses instant gameobject interaction.
+UPDATE `gameobject_template`
+SET `Data0` = 0, `Data1` = 0, `castBarCaption` = ''
+WHERE `entry` = 300206;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp
@@ -241,10 +241,6 @@ bool BattlegroundOBC::SetupBattleground()
             OBC_FLAG_X, OBC_FLAG_Y, OBC_FLAG_Z, OBC_FLAG_O,
             0.0f, 0.0f, std::sin(OBC_FLAG_O / 2.0f), std::cos(OBC_FLAG_O / 2.0f),
             RESPAWN_ONE_DAY)
-        || !AddObject(BG_OBC_OBJECT_FLAG_VISUAL, BG_OBC_FLAG_VISUAL_ENTRY,
-            3245.6f, 536.403f, 58.9864f, OBC_FLAG_O,
-            0.0f, 0.0f, std::sin(OBC_FLAG_O / 2.0f), std::cos(OBC_FLAG_O / 2.0f),
-            RESPAWN_IMMEDIATELY)
         || !AddObject(BG_OBC_OBJECT_LIGHT_ALLIANCE_BASE, BG_OBC_LIGHT_BEAM_ENTRY,
             OBC_LIGHT_ALLIANCE_X, OBC_LIGHT_ALLIANCE_Y, OBC_LIGHT_ALLIANCE_Z, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f,
@@ -283,9 +279,6 @@ void BattlegroundOBC::ApplyNonInteractableObjectFlags()
         if (GameObject* gate = GetBGObject(type))
             gate->SetFlag(GO_FLAG_NOT_SELECTABLE);
 
-    if (GameObject* flagVisual = GetBGObject(BG_OBC_OBJECT_FLAG_VISUAL))
-        flagVisual->SetFlag(GO_FLAG_NOT_SELECTABLE);
-
     if (GameObject* allianceLight = GetBGObject(BG_OBC_OBJECT_LIGHT_ALLIANCE_BASE))
         allianceLight->SetFlag(GO_FLAG_NOT_SELECTABLE);
 
@@ -300,8 +293,6 @@ void BattlegroundOBC::StartingEventCloseDoors()
         DoorClose(type);
         SpawnBGObject(type, RESPAWN_IMMEDIATELY);
     }
-
-    SpawnBGObject(BG_OBC_OBJECT_FLAG_VISUAL, RESPAWN_IMMEDIATELY);
 
     // Flag and objective lights stay hidden until the match starts.
     SpawnBGObject(BG_OBC_OBJECT_FLAG, RESPAWN_ONE_DAY);
@@ -401,7 +392,7 @@ void BattlegroundOBC::EventPlayerClickedOnFlag(Player* player, GameObject* targe
 
     _flagState = BG_OBC_FLAG_STATE_ON_PLAYER;
     SetFlagPicker(player->GetGUID());
-    player->CastSpell(player, BG_OBC_NETHERSTORM_FLAG_SPELL, true);
+    player->CastSpell(player, BG_OBC_COLOSSEUM_FLAG_SPELL, true);
     player->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_ENTER_PVP_COMBAT);
 
     UpdateObjectiveLights();
@@ -429,7 +420,7 @@ void BattlegroundOBC::EventPlayerDroppedFlag(Player* player)
         if (IsFlagPickedup() && GetFlagPickerGUID() == player->GetGUID())
         {
             SetFlagPicker(ObjectGuid::Empty);
-            player->RemoveAurasDueToSpell(BG_OBC_NETHERSTORM_FLAG_SPELL);
+            player->RemoveAurasDueToSpell(BG_OBC_COLOSSEUM_FLAG_SPELL);
         }
         return;
     }
@@ -438,7 +429,7 @@ void BattlegroundOBC::EventPlayerDroppedFlag(Player* player)
         return;
 
     SetFlagPicker(ObjectGuid::Empty);
-    player->RemoveAurasDueToSpell(BG_OBC_NETHERSTORM_FLAG_SPELL);
+    player->RemoveAurasDueToSpell(BG_OBC_COLOSSEUM_FLAG_SPELL);
     _flagState = BG_OBC_FLAG_STATE_ON_GROUND;
     _flagResetTimer = BG_OBC_FLAG_RESPAWN_TIME;
 
@@ -462,7 +453,7 @@ void BattlegroundOBC::EventPlayerCapturedFlag(Player* player)
         return;
 
     SetFlagPicker(ObjectGuid::Empty);
-    player->RemoveAurasDueToSpell(BG_OBC_NETHERSTORM_FLAG_SPELL);
+    player->RemoveAurasDueToSpell(BG_OBC_COLOSSEUM_FLAG_SPELL);
     _flagState = BG_OBC_FLAG_STATE_WAIT_RESPAWN;
     _flagResetTimer = BG_OBC_FLAG_RESPAWN_TIME;
 

--- a/src/server/game/Battlegrounds/Zones/BattlegroundOBC.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundOBC.h
@@ -58,7 +58,6 @@ enum BG_OBC_Objects
     BG_OBC_OBJECT_GATE_A_4,
 
     BG_OBC_OBJECT_FLAG,               // clickable flag stand at the arena center
-    BG_OBC_OBJECT_FLAG_VISUAL,        // static flag base prop at the center
 
     // Objective light beams. Exactly one is visible while the flag is
     // carried: the light marks the ENEMY base the carrier must reach.
@@ -71,15 +70,14 @@ enum BG_OBC_Objects
 enum BG_OBC_ObjectEntries
 {
     BG_OBC_GATE_ENTRY         = 185483,
-    BG_OBC_FLAG_STAND_ENTRY   = 184141, // Netherstorm Flag (GAMEOBJECT_TYPE_FLAGSTAND)
+    BG_OBC_FLAG_STAND_ENTRY   = 300206, // OBC Netherstorm Flag (instant GAMEOBJECT_TYPE_FLAGSTAND)
     BG_OBC_FLAG_DROP_ENTRY    = 184142, // Netherstorm Flag (GAMEOBJECT_TYPE_FLAGDROP)
-    BG_OBC_FLAG_VISUAL_ENTRY  = 184493, // Netherstorm Flag base visual
     BG_OBC_LIGHT_BEAM_ENTRY   = 300010  // BG Objective Light Beam
 };
 
 enum BG_OBC_Spells
 {
-    BG_OBC_NETHERSTORM_FLAG_SPELL    = 34976, // carrier visual aura
+    BG_OBC_COLOSSEUM_FLAG_SPELL      = 89798, // Colosseum Flag carrier visual aura
     BG_OBC_PLAYER_DROPPED_FLAG_SPELL = 34991  // summons the ground flag (184142); NOT a debuff
 };
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2161,7 +2161,7 @@ void Spell::EffectOpenLock()
             // in battleground check
             if (Battleground* bg = player->GetBattleground())
             {
-                if (bg->GetTypeID(true) == BATTLEGROUND_EY)
+                if (bg->GetTypeID(true) == BATTLEGROUND_EY || bg->GetTypeID(true) == BATTLEGROUND_OBC)
                     bg->EventPlayerClickedOnFlag(player, gameObjTarget);
                 return;
             }


### PR DESCRIPTION
### Motivation
- Replace the two-part flag (visual + stand with pickup lock) with an instant clickable flagstand so the client uses immediate interaction and to simplify Obsidian Colosseum flag handling.
- Use the Colosseum carrier visual aura/spell and ensure the server routes flagstand clicks for OBC the same way as other BGs that use flagstands.

### Description
- Add SQL migrations to create a new `gameobject_template` entry `300206` copied from `184141` and then clear `Data0`, `Data1` and `castBarCaption` for instant interaction (`sql/updates/world/3.3.5/2026_07_13_00_world.sql` and `2026_07_13_01_world.sql`).
- Remove the separate flag visual object from code and enums by deleting `BG_OBC_OBJECT_FLAG_VISUAL` and its entry, and stop spawning or toggling that visual in `BattlegroundOBC` (spawning/flag and apply flags changes in `BattlegroundOBC.cpp`/`.h`).
- Change the flagstand entry constant to `BG_OBC_FLAG_STAND_ENTRY = 300206` and replace usages of the old Netherstorm flag aura with `BG_OBC_COLOSSEUM_FLAG_SPELL = 89798` across the battleground logic (`BattlegroundOBC.*`).
- Allow `Spell::EffectOpenLock()` to treat `BATTLEGROUND_OBC` the same as `BATTLEGROUND_EY` so flagstand clicks forward to `EventPlayerClickedOnFlag` (`SpellEffects.cpp`).

### Testing
- Performed a full project build which completed successfully.
- Executed battleground-related automated tests (including BG click handling and `BattlegroundOBC` scenarios) via the test suite and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a546dc3cf7c8327a7e7fedeb1079e40)