### PR TITLE
Make OBC playerbots target flag carriers

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp
@@ -22,6 +22,7 @@
 #include "Battleground.h"
 #include "BattlegroundMgr.h"
 #include "BattlegroundEY.h"
+#include "BattlegroundOBC.h"
 #include "BattlegroundTP.h"
 #include "BattlegroundWS.h"
 #include "Configuration/Config.h"
@@ -894,9 +895,8 @@ void PopulateObjectiveStateTriggers(Player const* player, playerbot::PvpValues& 
         return;
     }
 
-    if (BattlegroundEY* bgEy = dynamic_cast<BattlegroundEY*>(battleground))
+    auto populateNeutralFlagCarrierValues = [&](ObjectGuid const& carrierGuid)
     {
-        ObjectGuid const carrierGuid = bgEy->GetFlagPickerGUID();
         if (carrierGuid.IsEmpty())
             return;
 
@@ -912,7 +912,16 @@ void PopulateObjectiveStateTriggers(Player const* player, playerbot::PvpValues& 
             values.enemyFlagCarrierActive = true;
             values.enemyFlagCarrierNear = player->IsWithinDistInMap(carrier, 100.0f);
         }
+    };
+
+    if (BattlegroundEY* bgEy = dynamic_cast<BattlegroundEY*>(battleground))
+    {
+        populateNeutralFlagCarrierValues(bgEy->GetFlagPickerGUID());
+        return;
     }
+
+    if (BattlegroundOBC* bgObc = dynamic_cast<BattlegroundOBC*>(battleground))
+        populateNeutralFlagCarrierValues(bgObc->GetFlagPickerGUID());
 }
 
 struct SpellDecision

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -23,6 +23,7 @@
 #include "Battleground.h"
 #include "BattlegroundQueue.h"
 #include "BattlegroundEY.h"
+#include "BattlegroundOBC.h"
 #include "BattlegroundTP.h"
 #include "BattlegroundWS.h"
 #include "DBCStores.h"
@@ -2783,9 +2784,8 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
             return ObjectAccessor::FindConnectedPlayer(carrierGuid);
         }
 
-        if (BattlegroundEY* bgEy = dynamic_cast<BattlegroundEY*>(battleground))
+        auto findNeutralFlagCarrierForDirective = [&](ObjectGuid const& carrierGuid) -> Player*
         {
-            ObjectGuid const carrierGuid = bgEy->GetFlagPickerGUID();
             if (carrierGuid.IsEmpty())
                 return nullptr;
 
@@ -2797,7 +2797,15 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
                 return carrier;
             if (directive == playerbot::FlagCarrierDirective::ProtectTeamCarrier && carrier->GetTeamId() == botTeam)
                 return carrier;
-        }
+
+            return nullptr;
+        };
+
+        if (BattlegroundEY* bgEy = dynamic_cast<BattlegroundEY*>(battleground))
+            return findNeutralFlagCarrierForDirective(bgEy->GetFlagPickerGUID());
+
+        if (BattlegroundOBC* bgObc = dynamic_cast<BattlegroundOBC*>(battleground))
+            return findNeutralFlagCarrierForDirective(bgObc->GetFlagPickerGUID());
 
         return nullptr;
     }


### PR DESCRIPTION
### Motivation
- Playerbots currently chase flag carriers in Warsong/Twin Peaks but do not treat the Obsidian Colosseum (OBC) neutral flag carrier the same way, so bots do not pursue or protect carriers in OBC as intended.
- Reuse the existing neutral-flag handling used for Eye of the Storm so OBC bots get consistent attack/protect behavior without adding bespoke movement cases.

### Description
- Add `#include "BattlegroundOBC.h"` and extend `PopulateObjectiveStateTriggers` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpCore.cpp` to reuse a `populateNeutralFlagCarrierValues` lambda for neutral-flag battlegrounds and call it for OBC via `GetFlagPickerGUID`.
- Add `#include "BattlegroundOBC.h"` and extend `FindFlagCarrierForDirective` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` with a `findNeutralFlagCarrierForDirective` lambda and handle OBC by passing `bgObc->GetFlagPickerGUID()` so attack/protect directives resolve OBC carriers.
- Changes reuse existing Eye of the Storm logic so no new per-battleground movement primitives were introduced.

### Testing
- Ran repository checks `git diff --check` which reported no issues.
- Inspected repository status with `git status --short` to verify the intended files were modified and the changes are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5476af49a083279a0228e03bbd4364)