### PR TITLE
Prevent movement/attack from cancelling playerbot gap-closers (Charge/Intercept/etc.)

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -1676,6 +1676,17 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
         return spellInfo && spellInfo->IsChanneled() && (!spellInfo->IsMoveAllowedChannel() || IsMindFlaySpell(spellInfo));
     }
 
+    bool HasPlayerbotGapCloserInFlight(Player const* player)
+    {
+        if (!player)
+            return false;
+
+        MotionMaster const* motionMaster = player->GetMotionMaster();
+        return motionMaster &&
+            motionMaster->GetCurrentMovementGeneratorType() == EFFECT_MOTION_TYPE &&
+            player->HasUnitState(UNIT_STATE_CHARGING);
+    }
+
     bool CanIssueBotMovement(Player* player)
     {
         if (!player || !player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
@@ -1719,8 +1730,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
         // cast, independent of movement), but the bot never visibly performs the
         // charge motion and just appears to run at the target. Withhold
         // positioning movement until the charge spline itself completes.
-        if (player->HasUnitState(UNIT_STATE_CHARGING) &&
-            player->GetMotionMaster()->GetCurrentMovementGeneratorType() == EFFECT_MOTION_TYPE)
+        if (HasPlayerbotGapCloserInFlight(player))
         {
             return false;
         }
@@ -3556,6 +3566,17 @@ namespace playerbot
         // (or rely on melee/auto attacks) can stay mounted and fail to engage.
         if (player->IsMounted())
             ForcePlayerbotDismount(player);
+
+        // Playerbots run tactical/lifecycle engagement every fast tick. That
+        // loop can select the same enemy immediately after a class gap-closer
+        // cast (Charge, Intercept, Rehgar's Fury, etc.) and call Attack() below
+        // before the EFFECT_MOTION_TYPE spline has delivered MovementInform.
+        // Attack() may install normal chase movement for virtual sessions,
+        // replacing the still-active leap/charge generator. Let the effect
+        // movement finish first; the class action code will start melee after
+        // the spline lands.
+        if (HasPlayerbotGapCloserInFlight(player))
+            return true;
 
         CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
         bool const useMeleeAttack = !profile.primarilyRanged || profile.meleeFallbackAcceptable;


### PR DESCRIPTION
### Motivation

- Prevent playerbot movement or Attack() calls from cancelling in-flight gap-closer splines (Charge/Intercept/Heroic Leap) which causes the bot to lose the visible charge motion.  
- Ensure tactical/lifecycle engagement does not replace an active `EFFECT_MOTION_TYPE` generator with a normal chase while the spline is still executing.

### Description

- Add utility `HasPlayerbotGapCloserInFlight(Player const*)` to encapsulate the check for `EFFECT_MOTION_TYPE` movement plus `UNIT_STATE_CHARGING`.
- Use `HasPlayerbotGapCloserInFlight` in `CanIssueBotMovement` to block positioning movement while a charge/intercept/leap is in flight.  
- Add an early return in the engagement flow (before calling `Attack()`) to avoid issuing `Attack()` while a gap-closer spline is still active so the charge motion is allowed to complete.  
- Add explanatory comments documenting the rationale for withholding movement/attack while the effect movement completes.

### Testing

- Performed a full project build using `make`, which completed successfully.  
- Ran the existing automated test suite (`make test` / `ctest`), and all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a547754a04c8327b15261978850e405)