### PR TITLE
Prevent playerbots stopping in hazardous liquids

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -54,6 +54,7 @@ namespace
 void SetLastMovementDebugStatus(Player const* player, std::string const& status);
 void WhisperHunterCastDiagnostic(Player* player, Unit* target, char const* phase, uint32 spellId, char const* extra);
 bool HasActiveMovementEffectSpline(Player const* player);
+bool TryMoveOutOfHazardousLiquid(Player* player);
 
 bool IsLifeTapSpell(SpellInfo const* spellInfo)
 {
@@ -1655,6 +1656,9 @@ void StopHunterDamageOnBreakableCrowdControl(Player* player, Unit* target, char 
 void StopHunterAndStartAutoShot(Player* player, Unit* target, char const* reason)
 {
     if (!player || !target || !target->IsAlive())
+        return;
+
+    if (TryMoveOutOfHazardousLiquid(player))
         return;
 
     if (target->HasBreakableByDamageCrowdControlAura())
@@ -3483,6 +3487,76 @@ bool HasActiveMovementEffectSpline(Player const* player)
     return hasActiveSpline || player->HasUnitState(UNIT_STATE_CHARGING) || player->isMoving();
 }
 
+bool IsInHazardousLiquid(Player const* player)
+{
+    if (!player)
+        return false;
+
+    Map const* map = player->FindMap();
+    if (!map)
+        return false;
+
+    LiquidData liquidData{};
+    ZLiquidStatus const status = map->GetLiquidStatus(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(),
+        player->GetPositionZ() + 0.5f, MAP_ALL_LIQUIDS, &liquidData, player->GetCollisionHeight());
+    if ((status & MAP_LIQUID_STATUS_IN_CONTACT) == 0)
+        return false;
+
+    return (liquidData.type_flags & (MAP_LIQUID_TYPE_MAGMA | MAP_LIQUID_TYPE_SLIME)) != 0;
+}
+
+bool IsHazardousLiquidDestination(Player const* player, Position const& destination)
+{
+    if (!player)
+        return false;
+
+    Map const* map = player->FindMap();
+    if (!map)
+        return false;
+
+    LiquidData liquidData{};
+    ZLiquidStatus const status = map->GetLiquidStatus(player->GetPhaseMask(), destination.GetPositionX(), destination.GetPositionY(),
+        destination.GetPositionZ() + 0.5f, MAP_ALL_LIQUIDS, &liquidData, player->GetCollisionHeight());
+    return (status & MAP_LIQUID_STATUS_IN_CONTACT) != 0 &&
+        (liquidData.type_flags & (MAP_LIQUID_TYPE_MAGMA | MAP_LIQUID_TYPE_SLIME)) != 0;
+}
+
+bool TryMoveOutOfHazardousLiquid(Player* player)
+{
+    if (!IsInHazardousLiquid(player))
+        return false;
+
+    float const baseAngle = player->GetOrientation();
+    std::array<float, 12> const probeAngles =
+    {
+        0.0f, float(M_PI), float(M_PI_2), -float(M_PI_2),
+        float(M_PI_4), -float(M_PI_4), float(3.0f * M_PI_4), -float(3.0f * M_PI_4),
+        float(M_PI / 6.0f), -float(M_PI / 6.0f), float(5.0f * M_PI / 6.0f), -float(5.0f * M_PI / 6.0f)
+    };
+    std::array<float, 4> const probeDistances = { 8.0f, 12.0f, 16.0f, 24.0f };
+
+    for (float distance : probeDistances)
+    {
+        for (float offset : probeAngles)
+        {
+            Position destination = player->GetPosition();
+            float const angle = baseAngle + offset;
+            destination.RelocateOffset({ std::cos(angle) * distance, std::sin(angle) * distance, 0.0f, 0.0f });
+            destination = BuildCollisionSafeDestination(player, destination);
+            if (IsHazardousLiquidDestination(player, destination))
+                continue;
+
+            if (IssueStrictHumanMove(player, destination, 1.0f, 0))
+            {
+                SetLastMovementDebugStatus(player, "hazardous_liquid_stop_prevented_move_out");
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 void StopPlayerbotForStationaryCast(Player* player)
 {
     if (!player)
@@ -3500,6 +3574,13 @@ void StopPlayerbotForStationaryCast(Player* player)
     // the caller's SPELL_FAILED_MOVING retry path already handles waiting a
     // tick for a stationary cast, so this is a short defer, not a stall.
     if (HasActiveMovementEffectSpline(player))
+        return;
+
+    // Magma/slime is acceptable as a transit route when a path requires
+    // swimming through it, but it must never become a place where a bot plants
+    // for a stationary cast or ranged hold. If a stop request arrives while in
+    // hazardous liquid, convert that stop into a generic "get out" move.
+    if (TryMoveOutOfHazardousLiquid(player))
         return;
 
     player->StopMoving();

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -996,6 +996,83 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
         return false;
     }
 
+    bool IsInHazardousLiquid(Player const* player)
+    {
+        if (!player)
+            return false;
+
+        Map const* map = player->FindMap();
+        if (!map)
+            return false;
+
+        LiquidData liquidData{};
+        ZLiquidStatus const status = map->GetLiquidStatus(player->GetPhaseMask(), player->GetPositionX(), player->GetPositionY(),
+            player->GetPositionZ() + 0.5f, MAP_ALL_LIQUIDS, &liquidData, player->GetCollisionHeight());
+        if ((status & MAP_LIQUID_STATUS_IN_CONTACT) == 0)
+            return false;
+
+        return (liquidData.type_flags & (MAP_LIQUID_TYPE_MAGMA | MAP_LIQUID_TYPE_SLIME)) != 0;
+    }
+
+    bool IsHazardousLiquidDestination(Player const* player, Position const& destination)
+    {
+        if (!player)
+            return false;
+
+        Map const* map = player->FindMap();
+        if (!map)
+            return false;
+
+        LiquidData liquidData{};
+        ZLiquidStatus const status = map->GetLiquidStatus(player->GetPhaseMask(), destination.GetPositionX(), destination.GetPositionY(),
+            destination.GetPositionZ() + 0.5f, MAP_ALL_LIQUIDS, &liquidData, player->GetCollisionHeight());
+        return (status & MAP_LIQUID_STATUS_IN_CONTACT) != 0 &&
+            (liquidData.type_flags & (MAP_LIQUID_TYPE_MAGMA | MAP_LIQUID_TYPE_SLIME)) != 0;
+    }
+
+    bool TryMoveOutOfHazardousLiquid(Player* player)
+    {
+        if (!IsInHazardousLiquid(player))
+            return false;
+
+        MotionMaster* motionMaster = player->GetMotionMaster();
+        if (!motionMaster)
+            return false;
+
+        float const baseAngle = player->GetOrientation();
+        std::array<float, 12> const probeAngles =
+        {
+            0.0f, float(M_PI), float(M_PI_2), -float(M_PI_2),
+            float(M_PI_4), -float(M_PI_4), float(3.0f * M_PI_4), -float(3.0f * M_PI_4),
+            float(M_PI / 6.0f), -float(M_PI / 6.0f), float(5.0f * M_PI / 6.0f), -float(5.0f * M_PI / 6.0f)
+        };
+        std::array<float, 4> const probeDistances = { 8.0f, 12.0f, 16.0f, 24.0f };
+
+        for (float distance : probeDistances)
+        {
+            for (float offset : probeAngles)
+            {
+                Position destination = player->GetPosition();
+                float const angle = baseAngle + offset;
+                destination.RelocateOffset({ std::cos(angle) * distance, std::sin(angle) * distance, 0.0f, 0.0f });
+                destination = BuildCollisionSafeDestination(player, destination);
+                if (IsHazardousLiquidDestination(player, destination))
+                    continue;
+
+                Position segmentDestination;
+                if (TryBuildBattlegroundSegmentDestination(player, destination, segmentDestination) ||
+                    (!player->InBattleground() && player->GetDistance(destination) > 0.5f))
+                {
+                    motionMaster->Clear(MOTION_SLOT_ACTIVE);
+                    motionMaster->MovePoint(0, player->InBattleground() ? segmentDestination : destination, true);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     bool IssueHumanLikeFollow(Player* player, Unit* target, float desiredDistance, float destinationChangeThreshold, uint32 minReissueMs)
     {
         if (!player || !target)
@@ -1800,6 +1877,9 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
     void StopVirtualPlayerbotMovement(Player* player)
     {
         if (!player)
+            return;
+
+        if (TryMoveOutOfHazardousLiquid(player))
             return;
 
         player->StopMoving();


### PR DESCRIPTION
### Motivation
- Playerbots may currently stop and perform stationary casts in magma/slime areas (hazardous liquids) in battlegrounds such as OBC, which is dangerous and undesirable; the intent is to let bots transit through hazardous liquid but never remain stopped there. 

### Description
- Added liquid checks and helpers: `IsInHazardousLiquid`, `IsHazardousLiquidDestination`, and `TryMoveOutOfHazardousLiquid` to probe nearby safe points and issue movement out of magma/slime. 
- Integrated the move-out behavior into stationary-stop and hold code paths by calling the probe before `StopPlayerbotForStationaryCast`, before hunter autoshot hold (`StopHunterAndStartAutoShot`), and before lifecycle virtual stop (`StopVirtualPlayerbotMovement`). 
- Implemented battleground-aware probing that prefers `TryBuildBattlegroundSegmentDestination` when in battlegrounds and falls back to strict/pathed or direct `MovePoint` movement so bots can still swim through hazardous areas when needed but will not plant there. 
- Modified files: `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` and `src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp` and added a forward declaration for `TryMoveOutOfHazardousLiquid` in the class actions file.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors and succeeded. 
- Attempted `cmake --build build --target scripts -- -j2` but the build could not be executed in this environment because the `/workspace/TrinityCore112/build` directory is not present, so compilation was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a547c674a008327836a4d59a3d1ebea)