### PR TITLE
Prevent playerbots from stacking breakable crowd control

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp
@@ -80,6 +80,32 @@ bool IsSpiritOfRedemptionFreeHeal(Player const* player, SpellInfo const* spellIn
         player->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION);
 }
 
+bool SpellAppliesBreakableByDamageCrowdControl(SpellInfo const* spellInfo)
+{
+    if (!spellInfo || !(spellInfo->AuraInterruptFlags & AURA_INTERRUPT_FLAG_TAKE_DAMAGE))
+        return false;
+
+    for (SpellEffectInfo const& effectInfo : spellInfo->GetEffects())
+    {
+        if (effectInfo.Effect != SPELL_EFFECT_APPLY_AURA)
+            continue;
+
+        switch (effectInfo.ApplyAuraName)
+        {
+            case SPELL_AURA_MOD_CONFUSE:
+            case SPELL_AURA_MOD_FEAR:
+            case SPELL_AURA_MOD_STUN:
+            case SPELL_AURA_MOD_ROOT:
+            case SPELL_AURA_TRANSFORM:
+                return true;
+            default:
+                break;
+        }
+    }
+
+    return false;
+}
+
 bool HasAuraInSpellChain(Unit const* unit, uint32 baseSpellId)
 {
     if (!unit || !baseSpellId)
@@ -4130,6 +4156,14 @@ bool CastDirectSpell(Player* player, playerbot::PvpClassSpellContext const& cont
     if ((!target || !target->IsAlive()))
     {
         failureReason = "target_invalid_or_dead";
+        return false;
+    }
+
+    if (context.targetMode == playerbot::PvpClassSpellContext::TargetMode::Enemy &&
+        target->HasBreakableByDamageCrowdControlAura() &&
+        SpellAppliesBreakableByDamageCrowdControl(spellInfo))
+    {
+        failureReason = "target_already_breakable_crowd_controlled";
         return false;
     }
 


### PR DESCRIPTION
### Motivation

- Playerbot PvP logic could select damage-breakable crowd-control spells (Blind, Seduce, etc.) against a target already under a breakable CC (e.g. polymorph), which wastes the CC and can produce undesirable behavior.

### Description

- Add `SpellAppliesBreakableByDamageCrowdControl(SpellInfo const*)` in `src/server/scripts/Playerbot/Pvp/PlayerbotPvpClassActions.cpp` to detect spells that apply damage-breakable CC by checking `AuraInterruptFlags` and `SpellEffectInfo::ApplyAuraName` for common CC aura types.
- Add a pre-cast guard in `CastDirectSpell` to reject enemy-targeted casts when the target already `HasBreakableByDamageCrowdControlAura()` and the spell would apply a breakable-by-damage CC, returning failure reason `target_already_breakable_crowd_controlled`.

### Testing

- Ran `git diff --check`, which reported no problems and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a547ec4a9f883278d0cf9b370e38a3e)