### PR TITLE
Halve lava environmental damage for virtual-session players in OBC battleground

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -843,6 +843,14 @@ uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
     if (IsImmuneToEnvironmentalDamage())
         return 0;
 
+    if (type == DAMAGE_LAVA)
+    {
+        WorldSession const* session = GetSession();
+        Battleground const* battleground = GetBattleground();
+        if (session && session->IsVirtualSession() && battleground && battleground->GetTypeID(true) == BATTLEGROUND_OBC)
+            damage = (damage + 1) / 2;
+    }
+
     // Absorb, resist some environmental damage type
     uint32 absorb = 0;
     uint32 resist = 0;


### PR DESCRIPTION
### Motivation
- Apply a balance/sanity-rule so that players in virtual sessions inside the OBC battleground take reduced lava damage.

### Description
- Add a pre-absorb/resist check in `Player::EnvironmentalDamage` that detects `DAMAGE_LAVA` and, when `GetSession()` is a virtual session and `GetBattleground()->GetTypeID(true) == BATTLEGROUND_OBC`, halves the incoming damage via `damage = (damage + 1) / 2`.
- Use `GetSession()` and `GetBattleground()` to determine the context and only apply the reduction for the targeted battleground and session type.

### Testing
- Project build completed successfully using the normal build (`make`) with the change. 
- Automated unit/integration tests were executed and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a547c674a008327836a4d59a3d1ebea)