### PR TITLE
Playerbot: avoid cancelling active gap-closer splines by detecting in-flight movement

### DIFF
--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -36,6 +36,7 @@
 #include "Log.h"
 #include "Map.h"
 #include "MotionMaster.h"
+#include "MoveSpline.h"
 #include "MovementTypedefs.h"
 #include "Opcodes.h"
 #include "ObjectAccessor.h"
@@ -514,6 +515,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
 
     bool MoveTowardUnit(Player* player, Unit* target, float desiredDistance);
     float GetAggressiveCombatScanDistance(Player const* player, float fallbackDistance);
+    bool HasPlayerbotGapCloserInFlight(Player const* player);
     bool CanIssueBotMovement(Player* player);
     bool HunterIsHardCastingStationaryShot(Player const* player);
     void WhisperHunterAimedLifecycleDiagnostic(Player* player, Unit* target, char const* phase, char const* extra, uint32 throttleMs);
@@ -1066,7 +1068,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
 
         MotionMaster* motionMaster = player->GetMotionMaster();
         MovementGeneratorType const currentMovement = motionMaster->GetCurrentMovementGeneratorType();
-        if (player->InBattleground() && botCurrentlyMoving && currentMovement == EFFECT_MOTION_TYPE)
+        if (player->InBattleground() && currentMovement == EFFECT_MOTION_TYPE && HasPlayerbotGapCloserInFlight(player))
             return true;
 
         if (currentMovement == FOLLOW_MOTION_TYPE || currentMovement == DISTRACT_MOTION_TYPE)
@@ -1077,9 +1079,11 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
             currentMovement != IDLE_MOTION_TYPE &&
             currentMovement != CHASE_MOTION_TYPE &&
             currentMovement != POINT_MOTION_TYPE &&
-            // Charge/Intercept movement is issued through effect generators.
-            // Clear stale effect movement only once charge state has ended.
-            (currentMovement != EFFECT_MOTION_TYPE || !player->HasUnitState(UNIT_STATE_CHARGING)))
+            // Charge/Intercept/Rehgar's Fury movement is issued through effect
+            // generators. Clear stale effect movement only once its spline has
+            // actually ended; some jump-dest effects do not keep
+            // UNIT_STATE_CHARGING set for the full visual travel.
+            (currentMovement != EFFECT_MOTION_TYPE || !HasPlayerbotGapCloserInFlight(player)))
         {
             EmitBattlegroundGmDebug(player,
                 "movepoint=clear-stale-generator motionType=" + std::to_string(uint32(currentMovement)), 1000);
@@ -1676,6 +1680,19 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
         return spellInfo && spellInfo->IsChanneled() && (!spellInfo->IsMoveAllowedChannel() || IsMindFlaySpell(spellInfo));
     }
 
+    bool HasPlayerbotGapCloserInFlight(Player const* player)
+    {
+        if (!player)
+            return false;
+
+        MotionMaster const* motionMaster = player->GetMotionMaster();
+        if (!motionMaster || motionMaster->GetCurrentMovementGeneratorType() != EFFECT_MOTION_TYPE)
+            return false;
+
+        bool const hasActiveSpline = player->movespline && player->movespline->Initialized() && !player->movespline->Finalized();
+        return hasActiveSpline || player->HasUnitState(UNIT_STATE_CHARGING) || player->isMoving();
+    }
+
     bool CanIssueBotMovement(Player* player)
     {
         if (!player || !player->IsAlive() || player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GHOST))
@@ -1719,8 +1736,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
         // cast, independent of movement), but the bot never visibly performs the
         // charge motion and just appears to run at the target. Withhold
         // positioning movement until the charge spline itself completes.
-        if (player->HasUnitState(UNIT_STATE_CHARGING) &&
-            player->GetMotionMaster()->GetCurrentMovementGeneratorType() == EFFECT_MOTION_TYPE)
+        if (HasPlayerbotGapCloserInFlight(player))
         {
             return false;
         }
@@ -3556,6 +3572,17 @@ namespace playerbot
         // (or rely on melee/auto attacks) can stay mounted and fail to engage.
         if (player->IsMounted())
             ForcePlayerbotDismount(player);
+
+        // Playerbots run tactical/lifecycle engagement every fast tick. That
+        // loop can select the same enemy immediately after a class gap-closer
+        // cast (Charge, Intercept, Rehgar's Fury, etc.) and call Attack() below
+        // before the EFFECT_MOTION_TYPE spline has delivered MovementInform.
+        // Attack() may install normal chase movement for virtual sessions,
+        // replacing the still-active leap/charge generator. Let the effect
+        // movement finish first; the class action code will start melee after
+        // the spline lands.
+        if (HasPlayerbotGapCloserInFlight(player))
+            return true;
 
         CombatPositioningProfile const profile = GetCombatPositioningProfile(player);
         bool const useMeleeAttack = !profile.primarilyRanged || profile.meleeFallbackAcceptable;


### PR DESCRIPTION
### Motivation

- Prevent playerbots from cancelling charge/intercept/heroic-leap-style movement when the visual/effect spline is still in flight because some effects do not keep `UNIT_STATE_CHARGING` set for their full travel. 
- Ensure lifecycle/tactical code waits for actual spline completion before issuing follow/chase/attack moves to preserve correct animations and avoid replacing effect generators with normal chase movement.

### Description

- Added `#include "MoveSpline.h"` and implemented `HasPlayerbotGapCloserInFlight(Player const* player)` which detects active effect splines via `player->movespline` and falls back to `UNIT_STATE_CHARGING`/`isMoving()` as needed. 
- Replaced ad-hoc checks for effect motion/charging with calls to `HasPlayerbotGapCloserInFlight` in movement issuance and `CanIssueBotMovement` to withhold positioning while a gap-closer is in flight. 
- Early-return in engagement logic when a gap-closer spline is active to avoid calling `Attack()` (which can install normal chase movement) until the effect movement finishes, and updated comments to explain the rationale.

### Testing

- Project build completed successfully with the changes and produced no compile errors. 
- Existing automated unit test suite was executed and passed. 
- Automated PvP/battleground simulation tests targeting playerbot gap-closer behavior were run and showed bots no longer cancel or replace charge/leap splines prematurely (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a547754a04c8327b15261978850e405)