### PR TITLE
Fix battleground compile errors

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp
@@ -11,7 +11,6 @@
 #include "WorldPacket.h"
 #include "WorldStatePackets.h"
 #include "WorldSession.h"
-#include "Battlegrounds/BattlegroundMap.h"
 
 #include <cmath>
 

--- a/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
+++ b/src/server/scripts/Playerbot/Pvp/PlayerbotPvpLifecycleActions.cpp
@@ -77,6 +77,7 @@ namespace playerbot
     uint64 BuildBattlegroundInstanceKey(Battleground const* battleground);
     Player* FindNearestEnemyBattlegroundPlayer(Player* player, float maxDistance, uint32* scannedPlayers = nullptr, uint32* attackableEnemies = nullptr);
     bool EngageNearestEnemyPlayer(Player* player, float scanDistance);
+    bool TryGetObjectivePosition(Battleground* battleground, Player* player, Position& destination);
 }
 
 namespace
@@ -522,7 +523,6 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
     void WhisperHunterAimedLifecycleDiagnostic(Player* player, Unit* target, char const* phase, char const* extra, uint32 throttleMs);
     bool BreakExpiredHunterFeignDeath(Player* player);
     bool IssueMovePointThrottled(Player* player, Position const& destination, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000);
-    bool TryGetObjectivePosition(Battleground* battleground, Player* player, Position& destination);
     Position BuildFollowDestination(Player* player, Unit* target, float desiredDistance);
     bool IssueHumanLikeFollow(Player* player, Unit* target, float desiredDistance, float destinationChangeThreshold = 6.0f, uint32 minReissueMs = 2000);
     void EmitBattlegroundGmDebug(Player* bot, std::string const& detail, uint32 throttleMs);
@@ -617,7 +617,7 @@ constexpr uint32 kPlayerbotShadowmeldGraceToken = 900007;
             return false;
 
         Position destination;
-        if (!TryGetObjectivePosition(battleground, player, destination))
+        if (!playerbot::TryGetObjectivePosition(battleground, player, destination))
             return false;
 
         if (player->IsWithinDist3d(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ(), 12.0f))


### PR DESCRIPTION
### Motivation

- The build failed due to an invalid include of `Battlegrounds/BattlegroundMap.h` in `BattlegroundOBC.cpp` that is unnecessary in this tree and prevented compilation. 
- A linkage warning arose because `TryGetObjectivePosition` was forward-declared in an anonymous namespace but defined in the `playerbot` namespace, causing an unresolved/internal linkage mismatch.

### Description

- Removed the stale `#include "Battlegrounds/BattlegroundMap.h"` from `src/server/game/Battlegrounds/Zones/BattlegroundOBC.cpp` since `BattlegroundMap` is available via `Map.h` in this tree. 
- Moved the `TryGetObjectivePosition(Battleground*, Player*, Position&)` declaration into the `playerbot` namespace and removed the anonymous-namespace forward-declaration, and updated call sites to use `playerbot::TryGetObjectivePosition`. 
- Minor commit recorded with message `Fix battleground compile errors` containing these edits.

### Testing

- Ran `git diff --check` to validate the patch formatting and no whitespace errors, which succeeded.
- The repository-level commit completed successfully; no full rebuild/test run was performed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55078c99fc832799a4d08e15613529)